### PR TITLE
Add support for Atlantis: The Lost Tales (UNSTABLE)

### DIFF
--- a/audio/decoders/apc.cpp
+++ b/audio/decoders/apc.cpp
@@ -154,13 +154,23 @@ void APCStreamImpl::queuePacket(Common::SeekableReadStream *data) {
 int16 APCStreamImpl::decodeIMA(byte code, Status *status) {
 	int32 E = (2 * (code & 0x7) + 1) * status->step / 8;
 	int32 diff = (code & 0x08) ? -E : E;
-	// In Cryo APC data is only truncated and not CLIPed as expected
-	int16 samp = (status->last + diff);
+	// The original Cryo decoder (atlantis.exe FUN_004101ce) accumulates the
+	// predictor in full 32-bit precision and truncates to int16 only when it
+	// emits each sample; the running predictor itself is never clamped or
+	// truncated and is carried at full width from one sample to the next.
+	// Keeping `last` full width is what stops the differential predictor from
+	// diverging.  This code previously stored the truncated int16 back into
+	// the predictor, so a single out-of-range sample wrapped around the
+	// modulus and the wrapped value then fed forward into every following
+	// sample as sustained distortion (audible on loud, dynamic music, but not
+	// on low-dynamic material such as speech, which is why it long went
+	// unnoticed).
+	status->last += diff;
+	int16 samp = (int16)status->last;
 
 	int32 index = status->stepIndex + Ima_ADPCMStream::_stepAdjustTable[code];
 	index = CLIP<int32>(index, 0, ARRAYSIZE(Ima_ADPCMStream::_imaTable) - 1);
 
-	status->last = samp;
 	status->stepIndex = index;
 	status->step = Ima_ADPCMStream::_imaTable[index];
 

--- a/engines/cryomni3d/atlantis/bigfile.cpp
+++ b/engines/cryomni3d/atlantis/bigfile.cpp
@@ -1,0 +1,172 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/archive.h"
+#include "common/file.h"
+#include "common/memstream.h"
+#include "common/textconsole.h"
+
+#include "cryomni3d/atlantis/bigfile.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+BigFileArchive::BigFileArchive() {
+}
+
+BigFileArchive::~BigFileArchive() {
+	close();
+}
+
+bool BigFileArchive::open(const Common::Path &path) {
+	Common::File *file = new Common::File();
+	if (!file->open(path)) {
+		delete file;
+		return false;
+	}
+
+	// Header: "BigFile 1.00\0\0\0\0" (16 bytes)
+	char magic[12];
+	file->read(magic, 12);
+	if (memcmp(magic, "BigFile 1.00", 12) != 0) {
+		warning("BigFileArchive: bad magic in '%s'", path.toString().c_str());
+		file->close();
+		delete file;
+		return false;
+	}
+	file->seek(4, SEEK_CUR); // skip remaining 4 magic bytes
+
+	uint32 numFiles    = file->readUint32LE();
+	/* totalDataSize = */ file->readUint32LE();
+	uint32 dataBase    = file->readUint32LE();
+	/* reserved = */      file->readUint32LE();
+
+	const uint disc = _files.size();
+
+	// Read directory entries; files are stored sequentially in directory order
+	// starting at dataBase.  Each entry is eight uint32 fields followed by the
+	// name.  A name already present from an earlier-mounted disc is skipped —
+	// cross-disc duplicates are byte-identical.
+	uint32 seqOffset = 0;
+	for (uint32 i = 0; i < numFiles; i++) {
+		uint32 nameLen   =   file->readUint32LE();
+		/* unk_a     = */    file->readUint32LE();
+		uint32 size      =   file->readUint32LE(); // size_comp == size_raw (no compression)
+		/* size_unk  = */    file->readUint32LE();
+		/* size_raw  = */    file->readUint32LE();
+		/* unk_b     = */    file->readUint32LE();
+		/* unk_c     = */    file->readUint32LE();
+		/* virt_off  = */    file->readUint32LE();
+
+		Common::String name;
+		for (uint32 j = 0; j < nameLen; j++) {
+			char c = (char)file->readByte();
+			if (c != '\0')
+				name += c;
+		}
+
+		if (!_entries.contains(name)) {
+			Entry e;
+			e.seqOffset = seqOffset;
+			e.size      = size;
+			e.disc      = disc;
+			_entries[name] = e;
+		}
+		seqOffset += size;
+	}
+
+	_files.push_back(file);
+	_dataBases.push_back(dataBase);
+	return true;
+}
+
+void BigFileArchive::close() {
+	for (uint i = 0; i < _files.size(); i++) {
+		_files[i]->close();
+		delete _files[i];
+	}
+	_files.clear();
+	_dataBases.clear();
+	_entries.clear();
+}
+
+// static
+Common::String BigFileArchive::normalizePath(const Common::Path &path) {
+	Common::String s = path.toString('\\');
+	s.toUppercase();
+	return s;
+}
+
+bool BigFileArchive::hasFile(const Common::String &name) const {
+	return _entries.contains(name);
+}
+
+bool BigFileArchive::hasFile(const Common::Path &path) const {
+	return hasFile(normalizePath(path));
+}
+
+int BigFileArchive::listMembers(Common::ArchiveMemberList &list) const {
+	int count = 0;
+	for (Common::HashMap<Common::String, Entry>::const_iterator it = _entries.begin();
+	        it != _entries.end(); ++it) {
+		list.push_back(Common::ArchiveMemberPtr(
+		    new Common::GenericArchiveMember(Common::Path(it->_key), *this)));
+		++count;
+	}
+	return count;
+}
+
+const Common::ArchiveMemberPtr BigFileArchive::getMember(const Common::Path &path) const {
+	if (!hasFile(path))
+		return Common::ArchiveMemberPtr();
+	return Common::ArchiveMemberPtr(new Common::GenericArchiveMember(path, *this));
+}
+
+Common::SeekableReadStream *BigFileArchive::createReadStreamForMember(const Common::Path &path) const {
+	return createReadStreamForMember(normalizePath(path));
+}
+
+Common::SeekableReadStream *BigFileArchive::createReadStreamForMember(const Common::String &name) const {
+	Common::HashMap<Common::String, Entry>::const_iterator it = _entries.find(name);
+	if (it == _entries.end())
+		return nullptr;
+
+	const Entry &e = it->_value;
+	if (e.disc >= _files.size())
+		return nullptr;
+
+	Common::File *file = _files[e.disc];
+	file->seek(_dataBases[e.disc] + e.seqOffset);
+
+	byte *buf = (byte *)malloc(e.size);
+	if (!buf)
+		return nullptr;
+
+	if (file->read(buf, e.size) != e.size) {
+		free(buf);
+		return nullptr;
+	}
+
+	return new Common::MemoryReadStream(buf, e.size, DisposeAfterUse::YES);
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/bigfile.h
+++ b/engines/cryomni3d/atlantis/bigfile.h
@@ -1,0 +1,89 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CRYOMNI3D_ATLANTIS_BIGFILE_H
+#define CRYOMNI3D_ATLANTIS_BIGFILE_H
+
+#include "common/archive.h"
+#include "common/array.h"
+#include "common/file.h"
+#include "common/hash-str.h"
+#include "common/hashmap.h"
+#include "common/path.h"
+#include "common/str.h"
+#include "common/stream.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// Reads files from Atlantis's "BigFile 1.00" archives.
+// All game files are stored sequentially after the directory.
+// Archive entries use uppercase backslash paths (e.g. "WAM\ATLAN1.WAM").
+//
+// The full game spans four discs (BIGCD1-4.BIG); open() is additive, so all
+// four can be mounted into one merged index.  When a file appears on several
+// discs (shared menus, fonts, common scripts) the first-mounted copy wins —
+// duplicates across discs are byte-identical.
+// Implements Common::Archive so it can be registered with SearchMan.
+class BigFileArchive : public Common::Archive {
+public:
+	BigFileArchive();
+	~BigFileArchive() override;
+
+	// Mount one BigFile archive, merging its directory into the index.
+	// Call repeatedly to mount additional discs.  Already-mounted discs are
+	// left intact if a later call fails.
+	bool open(const Common::Path &path);
+	void close();
+
+	// Common::Archive interface.
+	// Incoming paths are normalised (uppercase, backslash) before lookup.
+	bool hasFile(const Common::Path &path) const override;
+	int listMembers(Common::ArchiveMemberList &list) const override;
+	const Common::ArchiveMemberPtr getMember(const Common::Path &path) const override;
+	Common::SeekableReadStream *createReadStreamForMember(const Common::Path &path) const override;
+
+	// Low-level lookup using the exact archive key ("SUBDIR\FILE.EXT").
+	Common::SeekableReadStream *createReadStreamForMember(const Common::String &name) const;
+	bool hasFile(const Common::String &name) const;
+
+	// Number of distinct files across all mounted discs.
+	uint numFiles() const { return _entries.size(); }
+
+private:
+	struct Entry {
+		uint32 seqOffset; // byte offset from the owning disc's data base
+		uint32 size;
+		uint   disc;      // index into _files / _dataBases
+	};
+
+	// Normalise a ScummVM path to the archive key format: uppercase + backslash.
+	static Common::String normalizePath(const Common::Path &path);
+
+	Common::Array<Common::File *> _files;     // one handle per mounted .BIG
+	Common::Array<uint32>         _dataBases; // data-section base, per disc
+	Common::HashMap<Common::String, Entry> _entries;
+};
+
+} // namespace Atlantis
+} // namespace CryOmni3D
+
+#endif // CRYOMNI3D_ATLANTIS_BIGFILE_H

--- a/engines/cryomni3d/atlantis/con_script.cpp
+++ b/engines/cryomni3d/atlantis/con_script.cpp
@@ -1,0 +1,316 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/array.h"
+#include "common/str.h"
+#include "common/textconsole.h"
+#include "common/util.h"
+
+#include "cryomni3d/atlantis/con_script.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// Strip trailing whitespace and carriage returns from a String.
+static void rtrim(Common::String &s) {
+	while (!s.empty()) {
+		char c = s.lastChar();
+		if (c == ' ' || c == '\t' || c == '\r')
+			s.deleteLastChar();
+		else
+			break;
+	}
+}
+
+// Parse a compound condition string of the form:
+//   (key op val)&(key op val)&...
+// where op is '=', '<', or '>'.
+// Keys are lowercased. Unknown/malformed fragments are silently skipped.
+static void parseConditions(const Common::String &str, Common::Array<ConCondition> &out) {
+	const char *p = str.c_str();
+	while (*p) {
+		// Skip to the next '('
+		while (*p && *p != '(') p++;
+		if (!*p) break;
+		p++; // consume '('
+
+		// Find matching ')'
+		const char *start = p;
+		while (*p && *p != ')') p++;
+		if (!*p) break;
+		Common::String cond(start, (uint32)(p - start));
+		p++; // consume ')'
+
+		// Find the operator character
+		const char *cp = cond.c_str();
+		const char *opPtr = nullptr;
+		char op = '=';
+		for (const char *q = cp; *q; q++) {
+			if (*q == '=' || *q == '<' || *q == '>' || *q == '!') {
+				opPtr = q;
+				op = *q;
+				break;
+			}
+		}
+		if (!opPtr) continue;
+
+		ConCondition cc;
+		cc.key = Common::String(cp, (uint32)(opPtr - cp));
+		cc.key.toLowercase();
+		cc.op    = op;
+		cc.value = atoi(opPtr + 1);
+
+		// Record the separator that FOLLOWS this condition, so the evaluator
+		// can decide whether it is an AND-link or an OR-link.  See the comment
+		// on ConCondition for the left-to-right short-circuit semantics this
+		// drives (mirrors atlantis.exe FUN_004298ac).
+		while (*p == ' ') p++;
+		if (*p == '|') {
+			cc.nextSep = '|';
+			p++;
+		} else if (*p == '&') {
+			cc.nextSep = '&';
+			p++;
+		}
+		while (*p == ' ') p++;
+
+		out.push_back(cc);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ConScript
+// ---------------------------------------------------------------------------
+
+void ConScript::reset() {
+	_sections.clear();
+	_initCmds.clear();
+}
+
+void ConScript::parse(const char *buf, uint32 len) {
+	reset();
+
+	const char *p   = buf;
+	const char *end = buf + len;
+	bool inInit     = false;
+	ConSection *cur = nullptr;
+
+	while (p < end) {
+		// Read one line.
+		const char *sol = p;
+		while (p < end && *p != '\r' && *p != '\n') p++;
+		Common::String line(sol, (uint32)(p - sol));
+		while (p < end && (*p == '\r' || *p == '\n')) p++;
+		rtrim(line);
+		if (line.empty()) continue;
+
+		// /INIT / /FININIT markers.
+		if (line.equalsIgnoreCase("/INIT"))    { inInit = true;  cur = nullptr; continue; }
+		if (line.equalsIgnoreCase("/FININIT")) { inInit = false;               continue; }
+
+		if (inInit) {
+			// Collect /set(...) content.
+			if (line.size() > 5 && scumm_strnicmp(line.c_str(), "/set(", 5) == 0) {
+				uint endPos = line.size();
+				if (line.lastChar() == ')') endPos--;
+				if (endPos > 5)
+					_initCmds.push_back(line.substr(5, endPos - 5));
+			}
+			continue;
+		}
+
+		// Section header: /N where every character after / is a digit.
+		if (line[0] == '/' && line.size() >= 2 && Common::isDigit(line[1])) {
+			bool allDigits = true;
+			for (uint i = 1; i < line.size(); i++)
+				if (!Common::isDigit(line[i])) { allDigits = false; break; }
+			if (allDigits) {
+				int sid = atoi(line.c_str() + 1);
+				if (sid == 0) break;  // /000 = end of script
+				_sections.push_back(ConSection());
+				cur = &_sections.back();
+				cur->id = sid;
+				continue;
+			}
+		}
+
+		if (!cur) continue;
+
+		// /con(...) or /con*(...) — player-triggered condition.
+		if (line.size() >= 4 && scumm_strnicmp(line.c_str(), "/con", 4) == 0) {
+			cur->isCon = true;
+			uint i = 4;
+			if (i < line.size() && line[i] == '*') { cur->needsItem = true; i++; }
+			Common::String condStr = (i < line.size()) ? line.substr(i) : Common::String();
+			parseConditions(condStr, cur->conditions);
+			// Extract clicPerso and clicZone for engine lookup.
+			for (const ConCondition &cc : cur->conditions) {
+				if (cc.key == "clicperso") cur->clicPerso = cc.value;
+				if (cc.key == "cliczone")  cur->clicZone  = cc.value;
+			}
+			continue;
+		}
+
+		// /sel(...) — automatic condition (view events, game-state checks).
+		if (line.size() >= 4 && scumm_strnicmp(line.c_str(), "/sel", 4) == 0) {
+			cur->isCon = false;
+			Common::String condStr = (4u < line.size()) ? line.substr(4) : Common::String();
+			parseConditions(condStr, cur->conditions);
+			continue;
+		}
+
+		// /timN(...) — timer-driven automatic condition (timerNum = the digit after /tim).
+		if (line.size() >= 4 && scumm_strnicmp(line.c_str(), "/tim", 4) == 0) {
+			cur->isCon    = false;
+			cur->isTimer  = true;
+			// Extract timer number (digit(s) between "/tim" and "(").
+			uint i = 4;
+			uint numStart = i;
+			while (i < line.size() && Common::isDigit(line[i])) i++;
+			cur->timerNum = (i > numStart) ? atoi(line.c_str() + numStart) : 1;
+			Common::String condStr = (i < line.size()) ? line.substr(i) : Common::String();
+			parseConditions(condStr, cur->conditions);
+			continue;
+		}
+
+		// /sujN[,M[,...]] -- subject gate, supports a comma-separated
+		// list of subject ids.  The section fires when ANY listed
+		// subject is enabled for the clicked perso (see ConSection::sujIds).
+		if (line.size() >= 5 && scumm_strnicmp(line.c_str(), "/suj", 4) == 0
+		        && Common::isDigit(line[4])) {
+			const char *p = line.c_str() + 4;
+			while (*p) {
+				int v = atoi(p);
+				cur->sujIds.push_back(v);
+				while (*p && *p != ',') p++;
+				if (*p == ',') p++;
+			}
+			if (!cur->sujIds.empty())
+				cur->sujId = cur->sujIds[0];
+			continue;
+		}
+
+		// /goN — redirect.
+		if (line.size() >= 4 && scumm_strnicmp(line.c_str(), "/go", 3) == 0
+		        && Common::isDigit(line[3])) {
+			cur->gotoId = atoi(line.c_str() + 3);
+			continue;
+		}
+
+		// /set(...) or /Set(...) — game-state command; preserve position relative to dialog lines.
+		if (line.size() > 5 && scumm_strnicmp(line.c_str(), "/set(", 5) == 0) {
+			uint endPos = line.size();
+			if (line.lastChar() == ')') endPos--;
+			if (endPos > 5) {
+				ConSectionItem item;
+				item.isSet  = true;
+				item.setCmd = line.substr(5, endPos - 5);
+				cur->items.push_back(item);
+			}
+			continue;
+		}
+
+		// [Speaker,params] text — dialog line; preserve position relative to /set commands.
+		if (line[0] == '[') {
+			uint close = 1;
+			while (close < line.size() && line[close] != ']') close++;
+			if (close < line.size()) {
+				Common::String block = line.substr(1, close - 1);
+				Common::String text;
+				if (close + 1 < line.size()) {
+					if (line[close + 1] == ' ')
+						text = line.substr(close + 2);
+					else
+						text = line.substr(close + 1);
+				}
+
+				ConLine cl;
+				uint comma = block.find(',');
+				if (comma == Common::String::npos) {
+					cl.speaker = block;
+				} else {
+					cl.speaker = block.substr(0, comma);
+					cl.params  = block.substr(comma + 1);
+				}
+				cl.text = text;
+
+				// Extract optional numeric angle tokens.  The original CON
+				// syntax is `[Speaker, X, Y, camN]` — the two tokens after
+				// the speaker are pixel-space panorama offsets that the
+				// engine writes directly into the cyclo view (see header
+				// comment on ConLine).  When only `camN` or `off` follows
+				// the speaker, no angle is encoded.
+				//
+				// Implementation: split params by comma, recognise a leading
+				// pair of integer-only tokens as (X, Y).  Anything else (a
+				// "camN", "off", or trailing string token) terminates the
+				// scan.  Tokens are trimmed of surrounding whitespace.
+				if (!cl.params.empty()) {
+					Common::Array<Common::String> partTok;
+					const char *q = cl.params.c_str();
+					while (*q) {
+						while (*q == ' ' || *q == '\t') q++;
+						const char *qe = q;
+						while (*qe && *qe != ',') qe++;
+						const char *trimEnd = qe;
+						while (trimEnd > q &&
+						       (trimEnd[-1] == ' ' || trimEnd[-1] == '\t'))
+							trimEnd--;
+						partTok.push_back(
+						    Common::String(q, (uint32)(trimEnd - q)));
+						if (*qe == ',') q = qe + 1;
+						else q = qe;
+					}
+					auto isIntToken = [](const Common::String &s) -> bool {
+						if (s.empty()) return false;
+						uint i = 0;
+						if (s[0] == '-' || s[0] == '+') i = 1;
+						if (i >= s.size()) return false;
+						for (; i < s.size(); ++i)
+							if (!Common::isDigit(s[i])) return false;
+						return true;
+					};
+					if (partTok.size() >= 2 &&
+					    isIntToken(partTok[0]) && isIntToken(partTok[1])) {
+						cl.hasAngle = true;
+						cl.angleX   = atoi(partTok[0].c_str());
+						cl.angleY   = atoi(partTok[1].c_str());
+					}
+				}
+
+				ConSectionItem item;
+				item.isSet = false;
+				item.line  = cl;
+				cur->items.push_back(item);
+			}
+			continue;
+		}
+
+		// Anything else — ignored.
+	}
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/con_script.h
+++ b/engines/cryomni3d/atlantis/con_script.h
@@ -1,0 +1,147 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// Parser for Atlantis chapter scenario scripts (.CON files in SCENAR\).
+//
+// CON file structure:
+//   /INIT ... /FININIT  — chapter initialisation commands
+//   /N                  — section header (decimal integer)
+//   /con(conditions)    — player-triggered condition (NPC click)
+//   /con*(conditions)   — same but requires item in hand
+//   /sel(conditions)    — automatic condition (departure/arrival/game-state check)
+//   /sujN               — dialog subject/topic ID for subject-menu gating
+//   /goN                — redirect execution to section N
+//   /set(command)       — game-state mutation
+//   [Speaker,params] text — dialog line
+//   /000                — end of script
+//
+// Condition string format (for both /con and /sel):
+//   (key op val)&(key op val)&...   where op is '=', '<', or '>'
+//
+// Well-known condition keys:
+//   departvue   — which WAM zone the player just clicked to depart (/sel only)
+//   vue         — which panoramic place is currently active
+//   arriveevue  — set by engine to the arrived-at place ID when entering a place
+//   clicperso   — which NPC was clicked (/con only)
+//   All other keys are general game variables stored in CryOmni3DEngine_Atlantis::_gameVars.
+
+#ifndef CRYOMNI3D_ATLANTIS_CON_SCRIPT_H
+#define CRYOMNI3D_ATLANTIS_CON_SCRIPT_H
+
+#include "common/array.h"
+#include "common/str.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+struct ConLine {
+	Common::String speaker;  // e.g. "Seth", "Garde13"
+	Common::String params;   // e.g. "cam3", "off" (comma-separated in source)
+	Common::String text;
+
+	// Optional panorama angle hints, sourced directly from the CON dialog
+	// directive — when present, the original engine writes them straight into
+	// the cyclo view's alpha/beta before playing the line (atlantis.exe.c
+	// FUN_004283e7 line 22381+22543, then FUN_00451915 line 47181 stores into
+	// the global current-view angle).  Syntax in CON files:
+	//   [Speaker, X, Y, camN] text       — X,Y present (hasAngle = true)
+	//   [Speaker, camN] text             — no numeric tokens (hasAngle = false)
+	// X is a panorama-pixel offset for the horizontal angle; Y is the vertical
+	// offset.  The dialog renderer converts them to radians using the
+	// panorama dimensions (no hardcoded scale factor).
+	bool hasAngle = false;
+	int  angleX   = 0;
+	int  angleY   = 0;
+};
+
+// One item in a section's ordered execution list.
+// Either a dialog line (!isSet) or a /set command (isSet).
+// Preserves the original CON file ordering so cinematics play before or after dialog
+// exactly as authored.
+struct ConSectionItem {
+	bool           isSet = false;
+	ConLine        line;    // valid when !isSet
+	Common::String setCmd;  // valid when  isSet
+};
+
+// One parsed condition from a /con(...) or /sel(...) compound condition string.
+//
+// Conditions evaluate left-to-right with short-circuit semantics that match
+// the exe (atlantis.exe FUN_004298ac):
+//   nextSep = '&' : if cond fails -> EXIT FAIL ; if passes -> continue
+//   nextSep = '|' : if cond passes -> EXIT SUCCESS ; if fails -> continue
+//   nextSep = '\0': last cond; its result is the overall result.
+// So `A & B | C & D` reads as `A AND (B OR (C AND D))` — neither standard nor
+// OR-tighter precedence; just a left-to-right chain.  All multi-clause CON
+// conditions in the game data (CHAPI*.CON) are authored under this rule, e.g.
+// /sel(parletemp3=3)&(departvue=38)|(56)|(22) gates the OR-list on the
+// leading parletemp3=3 guard the way the exe evaluates it.
+struct ConCondition {
+	Common::String key;    // lowercase key name
+	char           op;     // '=', '<', '>', '!' (not equal)
+	int            value;
+	char           nextSep = '\0';  // '&', '|', or '\0' (end of cond list)
+};
+
+struct ConSection {
+	int  id        = 0;
+	bool isCon     = false;   // /con or /con* (player-triggered)
+	bool needsItem = false;   // /con* (item in hand required)
+	bool isTimer   = false;   // /tim* (timer-driven automatic condition)
+	int  timerNum  = 0;       // timer index (1 or 2) from /tim1 or /tim2
+	int  clicPerso = 0;       // ClicPerso=N from conditions (0 = none); kept for interactNPC()
+	int  clicZone  = 0;       // ClicZone=N from conditions (0 = none); for zone-click /con* sections
+	int  sujId     = 0;       // /sujN subject gate (0 = always available;
+	                          // first id from a comma-list; see sujIds)
+	int  gotoId    = 0;       // /goN redirect (0 = no redirect)
+	mutable bool played = false;  // set after first execution (for one-shot arrival sections)
+
+	// /suj supports a comma-separated list (`/suj1,2` means "this
+	// section fires when ANY of subjects 1 or 2 is enabled for the
+	// clicked perso").  CHAPI005 section 113 is the canonical example:
+	// `/con(FlagChp8=2)&(...) /suj1,2 /go89` -- the game-over branch is
+	// only reachable when interactNPC() treats the section as available
+	// for either suj 1 OR suj 2.  sujId == sujIds[0] for the menu icon.
+	Common::Array<int>             sujIds;
+
+	Common::Array<ConCondition>    conditions;  // all parsed conditions
+	Common::Array<ConSectionItem>  items;       // dialog lines and /set commands in source order
+};
+
+// Parses a CON file buffer into sections and INIT commands.
+class ConScript {
+public:
+	void parse(const char *buf, uint32 len);
+	void reset();
+
+	Common::Array<ConSection>       &sections()  { return _sections; }
+	const Common::Array<ConSection> &sections()  const { return _sections; }
+	const Common::Array<Common::String> &initCmds() const { return _initCmds; }
+
+private:
+	Common::Array<ConSection>    _sections;
+	Common::Array<Common::String> _initCmds;
+};
+
+} // namespace Atlantis
+} // namespace CryOmni3D
+
+#endif // CRYOMNI3D_ATLANTIS_CON_SCRIPT_H

--- a/engines/cryomni3d/atlantis/dialogs_manager.cpp
+++ b/engines/cryomni3d/atlantis/dialogs_manager.cpp
@@ -1,0 +1,61 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/debug.h"
+
+#include "cryomni3d/atlantis/dialogs_manager.h"
+#include "cryomni3d/atlantis/engine.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+Atlantis_DialogsManager::Atlantis_DialogsManager(CryOmni3DEngine_Atlantis *engine) :
+	_engine(engine) {
+}
+
+bool Atlantis_DialogsManager::play(const Common::String &sequence) {
+	bool slowStop = false;
+	return DialogsManager::play(sequence, slowStop);
+}
+
+void Atlantis_DialogsManager::executeShow(const Common::String &show) {
+	debugC(2, kDebugScript, "Atlantis_DialogsManager::executeShow: %s", show.c_str());
+}
+
+void Atlantis_DialogsManager::playDialog(const Common::String &video,
+        const Common::String &sound, const Common::String &text,
+        const SubtitlesSettings &settings) {
+	debugC(2, kDebugScript, "Atlantis_DialogsManager::playDialog: video=%s sound=%s",
+	      video.c_str(), sound.c_str());
+}
+
+void Atlantis_DialogsManager::displayMessage(const Common::String &text) {
+	debugC(2, kDebugScript, "Atlantis_DialogsManager::displayMessage: %s", text.c_str());
+}
+
+uint Atlantis_DialogsManager::askPlayerQuestions(const Common::String &video,
+        const Common::StringArray &questions) {
+	debugC(2, kDebugScript, "Atlantis_DialogsManager::askPlayerQuestions: video=%s", video.c_str());
+	return 0;
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/dialogs_manager.h
+++ b/engines/cryomni3d/atlantis/dialogs_manager.h
@@ -1,0 +1,56 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CRYOMNI3D_ATLANTIS_DIALOGS_MANAGER_H
+#define CRYOMNI3D_ATLANTIS_DIALOGS_MANAGER_H
+
+#include "graphics/managed_surface.h"
+
+#include "cryomni3d/dialogs_manager.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+class CryOmni3DEngine_Atlantis;
+
+class Atlantis_DialogsManager : public DialogsManager {
+public:
+	explicit Atlantis_DialogsManager(CryOmni3DEngine_Atlantis *engine);
+
+	bool play(const Common::String &sequence);
+
+protected:
+	void executeShow(const Common::String &show) override;
+	void playDialog(const Common::String &video, const Common::String &sound,
+	                const Common::String &text, const SubtitlesSettings &settings) override;
+	void displayMessage(const Common::String &text) override;
+	uint askPlayerQuestions(const Common::String &video,
+	                        const Common::StringArray &questions) override;
+
+private:
+	CryOmni3DEngine_Atlantis *_engine;
+	Graphics::ManagedSurface _lastImage;
+};
+
+} // namespace Atlantis
+} // namespace CryOmni3D
+
+#endif // CRYOMNI3D_ATLANTIS_DIALOGS_MANAGER_H

--- a/engines/cryomni3d/atlantis/engine.cpp
+++ b/engines/cryomni3d/atlantis/engine.cpp
@@ -1,0 +1,6121 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "audio/decoders/apc.h"
+#include "audio/mixer.h"
+#include "common/func.h"
+#include "common/memstream.h"
+#include "common/config-manager.h"
+#include "common/str.h"
+#include "common/textconsole.h"
+#include "common/debug.h"
+#include "common/error.h"
+#include "common/events.h"
+#include "common/scummsys.h"
+#include "common/system.h"
+#include "engines/util.h"
+#include "graphics/cursorman.h"
+#include "graphics/font.h"
+#include "graphics/fontman.h"
+#include "graphics/managed_surface.h"
+#include "graphics/paletteman.h"
+#include "gui/saveload.h"
+#include "common/archive.h"
+#include "common/file.h"
+#include "image/png.h"
+#include <stdlib.h>
+
+#include "cryomni3d/fixed_image.h"
+#include "cryomni3d/omni3d.h"
+
+#ifdef USE_HNM
+#include "video/hnm_decoder.h"
+#endif
+
+#include "cryomni3d/atlantis/engine.h"
+#include "cryomni3d/atlantis/f3dc_parser.h"
+#include "cryomni3d/atlantis/f3dc_renderer.h"
+#include "cryomni3d/atlantis/puzzle_eclipse.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+const FixedImageConfiguration CryOmni3DEngine_Atlantis::kFixedImageConfiguration = {
+	45, 223, 243, 238, 226, 198, 136, 145, 99, 113,
+	470
+};
+
+// Chapter initial states: placeId, alpha (horizontal angle), beta (vertical angle).
+// These will be updated with real values from game data analysis.
+const LevelInitialState CryOmni3DEngine_Atlantis::kChapterInitialStates[] = {
+	{  1,  0.f,  0.f },  // chapter 1 — ATLAN1.WAM, first place id=1
+	{ 22,  0.f,  0.f },  // chapter 2 — ATLAN2.WAM, first place id=22
+	{ 58,  0.f,  0.f },  // chapter 3 — ATLAN3.WAM, first place id=58
+	{  1,  0.f,  0.f },  // chapter 4 — ATLAN4.WAM, first place id unknown
+	{  1,  0.f,  0.f },  // chapter 5 — ATLAN5.WAM, first place id unknown
+};
+
+// Map FileType to the subdirectory prefix used within the BigFile archive.
+// Keys are stored with backslash separators as found in BigFile directory entries.
+static const char *const kBigFileSubdirs[] = {
+	"CYCLO\\",         // kFileTypeCyclo
+	"UBB_VUE\\",       // kFileTypeTransition
+	"DIALOG\\",        // kFileTypeDialog
+	"SYC\\",           // kFileTypeSync
+	"FONTS\\",         // kFileTypeFont
+	"SPRLIST\\",       // kFileTypeSprite
+	"WAM\\",           // kFileTypeWAM
+	"OBJETS\\",        // kFileTypeObject
+	"MENU\\",          // kFileTypeMenu
+	"SCENAR\\",        // kFileTypeScript
+	"WAV\\",           // kFileTypeSound
+	"SPRITE\\CYCLO\\", // kFileTypeSpriteCyclo
+	"SPRITE\\UBB\\",   // kFileTypeSpriteUbb
+	"SPRITE\\2D\\",    // kFileTypeSprite2D
+	"IMAGES\\",        // kFileTypeImages
+	"PUZZLES\\",       // kFileTypePuzzles
+};
+
+CryOmni3DEngine_Atlantis::CryOmni3DEngine_Atlantis(OSystem *syst,
+        const CryOmni3DGameDescription *gamedesc) :
+	CryOmni3DEngine(syst, gamedesc),
+	_dialogsMan(this),
+	_fixedImage(nullptr),
+	_mainPalette(nullptr),
+	_transparentPaletteMap(nullptr),
+	_transparentSrcStart(uint(-1)), _transparentSrcStop(uint(-1)),
+	_transparentDstStart(uint(-1)), _transparentDstStop(uint(-1)),
+	_transparentNewStart(uint(-1)), _transparentNewStop(uint(-1)),
+	_isPlaying(false),
+	_abortCommand(kAbortQuit),
+	_loadedSave(uint(-1)),
+	_currentPlayer(0),
+	_autosavePending(false),
+	_currentChapter(uint(-1)),
+	_currentPlaceId(uint(-1)),
+	_nextPlaceId(uint(-1)),
+	_currentPlace(nullptr),
+	_warpLoaded(false),
+	_propAnimFrames(0),
+	_propAnimFrame(0),
+	_propAnimNextMs(0),
+	_wsprAnimActiveIdx(-1),
+	_wsprAnimNextMs(0),
+	_spriteLayerDirty(false),
+	_npcBoundsDirty(false),
+	_dialogGivenObjSprite(-1),
+	_currentCONChapter(0),
+	_chapterStartMs(0),
+	_timerTickNextMs{0, 0},
+	_zoomLastMs(0),
+	_musicCurrentFile(nullptr),
+	_musicRawData(nullptr),
+	_musicRawSize(0),
+	_musicTrackId(0),
+	_warpCursorGroup(0),
+	_warpCursorFrame(-1),
+	_warpCursorNextMs(0),
+	_heroPersoId(0),
+	_dialRng("AtlantisDialCam"),
+	_lastDialCam(0),
+	_conRng("AtlantisConRandom"),
+	_dialBaseAlpha(0.0),
+	_dialBaseAlphaValid(false) {
+	_placeVisits.resize(1500, 0);
+}
+
+CryOmni3DEngine_Atlantis::~CryOmni3DEngine_Atlantis() {
+	_cycloSurface.free();
+	_warpSurface.free();
+	delete[] _mainPalette;
+	delete[] _transparentPaletteMap;
+	delete[] _musicRawData;
+	delete _fixedImage;
+}
+
+bool CryOmni3DEngine_Atlantis::hasFeature(EngineFeature f) const {
+	// No kSupportsSavingDuringRuntime: Atlantis autosaves on chapter
+	// transitions and offers no manual save anywhere — not even via the
+	// ScummVM global menu.  Loading is still permitted.
+	return CryOmni3DEngine::hasFeature(f)
+	       || (f == kSupportsLoadingDuringRuntime);
+}
+
+bool CryOmni3DEngine_Atlantis::showSubtitles() const {
+	return ConfMan.getBool("subtitles");
+}
+
+bool CryOmni3DEngine_Atlantis::shouldAbort() {
+	if (g_engine->shouldQuit()) {
+		_abortCommand = kAbortQuit;
+		return true;
+	}
+	return _isPlaying && _abortCommand != kAbortNoAbort;
+}
+
+Common::String CryOmni3DEngine_Atlantis::getSaveStateName(int slot) const {
+	return Common::String::format("atlantis.%04d", slot + 1);
+}
+
+Common::Error CryOmni3DEngine_Atlantis::loadGameState(int slot) {
+	// Loading a save (e.g. from the ScummVM launcher) selects the player that
+	// owns the slot's block.
+	_currentPlayer = slot / (int)kPlayerSlotStride;
+	if (loadGame(slot + 1)) {
+		_abortCommand = kAbortLoadGame;
+		_loadedSave = slot + 1;
+		return Common::kNoError;
+	}
+	return Common::kReadingFailed;
+}
+
+Common::Error CryOmni3DEngine_Atlantis::saveGameState(int slot, const Common::String &desc,
+        bool isAutosave) {
+	saveGame(slot + 1, desc);
+	return Common::kNoError;
+}
+
+Common::Path CryOmni3DEngine_Atlantis::getFilePath(FileType fileType,
+        const Common::String &baseName) const {
+	// Files outside the BigFile (none currently); placeholder for future expansion.
+	return Common::Path(baseName);
+}
+
+Common::SeekableReadStream *CryOmni3DEngine_Atlantis::openBigFileStream(FileType fileType,
+        const Common::String &baseName) const {
+	uint typeIdx = (uint)fileType;
+	if (typeIdx >= ARRAYSIZE(kBigFileSubdirs))
+		return nullptr;
+
+	Common::String fullName = kBigFileSubdirs[typeIdx];
+	fullName += baseName;
+	// The BigFile stores names case-sensitively as they appear in the DOS archive.
+	// Convert to uppercase to match archive entries.
+	fullName.toUppercase();
+
+	return _bigFile.createReadStreamForMember(fullName);
+}
+
+void CryOmni3DEngine_Atlantis::setupPalette(const byte *colors, uint start, uint num) {
+	setPalette(colors, start, num);
+}
+
+void CryOmni3DEngine_Atlantis::makeTranslucent(Graphics::Surface &dst,
+        const Graphics::Surface &src) const {
+	// Placeholder: copy source to destination without translucency.
+	// Real implementation requires transparent palette mapping.
+	assert(dst.w == src.w && dst.h == src.h);
+	const byte *srcPtr = (const byte *)src.getPixels();
+	byte *dstPtr = (byte *)dst.getPixels();
+	uint size = src.w * src.h;
+	if (_transparentPaletteMap) {
+		for (uint i = 0; i < size; i++) {
+			if (srcPtr[i] >= _transparentSrcStart && srcPtr[i] <= _transparentSrcStop)
+				dstPtr[i] = _transparentPaletteMap[srcPtr[i]];
+			else
+				dstPtr[i] = srcPtr[i];
+		}
+	} else {
+		memcpy(dstPtr, srcPtr, size);
+	}
+}
+
+void CryOmni3DEngine_Atlantis::calculateTransparentMapping() {
+	if (!_transparentPaletteMap || !_mainPalette)
+		return;
+
+	for (uint i = _transparentSrcStart; i <= _transparentSrcStop; i++) {
+		uint r = _mainPalette[3 * i + 0];
+		uint g = _mainPalette[3 * i + 1];
+		uint b = _mainPalette[3 * i + 2];
+		// Find best match in destination range
+		uint bestDist = uint(-1);
+		byte bestIdx = (byte)_transparentNewStart;
+		for (uint j = _transparentNewStart; j <= _transparentNewStop; j++) {
+			uint dr = r > _mainPalette[3 * j] ? r - _mainPalette[3 * j] : _mainPalette[3 * j] - r;
+			uint dg = g > _mainPalette[3 * j + 1] ? g - _mainPalette[3 * j + 1] : _mainPalette[3 * j + 1] - g;
+			uint db = b > _mainPalette[3 * j + 2] ? b - _mainPalette[3 * j + 2] : _mainPalette[3 * j + 2] - b;
+			uint dist = dr * dr + dg * dg + db * db;
+			if (dist < bestDist) {
+				bestDist = dist;
+				bestIdx = (byte)j;
+			}
+		}
+		_transparentPaletteMap[i] = bestIdx;
+	}
+}
+
+void CryOmni3DEngine_Atlantis::syncSoundSettings() {
+	CryOmni3DEngine::syncSoundSettings();
+
+	// Scale every channel by the SONMENU "Volume" master slider, which the
+	// base class knows nothing about.  Absent key → full volume (no-op).
+	const int maxVol = Audio::Mixer::kMaxMixerVolume;
+	int master = ConfMan.hasKey("atlantis_master_volume")
+	             ? ConfMan.getInt("atlantis_master_volume") : maxVol;
+	master = CLIP(master, 0, maxVol);
+	static const Audio::Mixer::SoundType kTypes[] = {
+		Audio::Mixer::kMusicSoundType,
+		Audio::Mixer::kSFXSoundType,
+		Audio::Mixer::kSpeechSoundType,
+	};
+	for (int i = 0; i < 3; i++)
+		_mixer->setVolumeForSoundType(kTypes[i],
+		    _mixer->getVolumeForSoundType(kTypes[i]) * master / maxVol);
+}
+
+void CryOmni3DEngine_Atlantis::loadStaticData() {
+	// Static data (strings, sprite mappings etc.) will be loaded from cryomni3d.dat
+	// once Atlantis entries are added to the dat file.
+}
+
+void CryOmni3DEngine_Atlantis::loadAtlantisExeTables() {
+	// The original engine carries a pointer table at VA 0x004961e0 listing
+	// every named resource it can play: 17 WAM filenames followed by ~137
+	// APC filenames, terminated by a "FIN" sentinel.  The APC portion is
+	// what CON `/set(newsound=N)` indexes into (1-based, so newsound=1 maps
+	// to the first APC, "strange.apc").
+	//
+	// PE section parameters for atlantis.exe (imageBase 0x400000, DGROUP
+	// section at vaddr 0x90000 / rawptr 0x71200) are well-known and stable
+	// for the MD5-checked build we detect against.
+	_newSoundApcNames.clear();
+	Common::File exe;
+	if (!exe.open("atlantis.exe")) {
+		warning("loadAtlantisExeTables: cannot open atlantis.exe");
+		return;
+	}
+	const uint32 kTableFileOff = 0x773e0;
+	const uint32 kImageBase    = 0x400000;
+	const uint32 kDgroupVaddr  = 0x90000;
+	const uint32 kDgroupRawPtr = 0x71200;
+	const int kSkipWams = 17;
+
+	exe.seek(kTableFileOff + kSkipWams * 4);
+	for (int i = 0; i < 200 && !exe.eos(); i++) {
+		uint32 va = exe.readUint32LE();
+		if (va < 0x4b0000 || va > 0x4d0000) break;  // off the end of the data
+		uint32 fileOff = (va - kImageBase - kDgroupVaddr) + kDgroupRawPtr;
+		int64 saved = exe.pos();
+		exe.seek(fileOff);
+		Common::String s;
+		while (!exe.eos()) {
+			byte b = exe.readByte();
+			if (b == 0) break;
+			s += (char)b;
+		}
+		if (s.equalsIgnoreCase("FIN")) break;
+		_newSoundApcNames.push_back(s);
+		exe.seek(saved);
+	}
+	debugC(1, kDebugScript, "loadAtlantisExeTables: %u newsound APC names from atlantis.exe",
+	      _newSoundApcNames.size());
+
+	// Inventory-icon table at VA 0x004967b0: zero-terminated int32 array
+	// where index i is the sprite slot in SPRITE\2D\OBJETS1.SPR and the
+	// value is the world object id that uses that sprite as its inventory
+	// icon.  Empirically 39 entries followed by a 0 terminator for the
+	// MD5-checked English build; the read loop stops at the first non-
+	// positive value or after a generous upper bound so an unexpected
+	// build can't run off the end of the data section.
+	_inventoryObjectIds.clear();
+	const uint32 kInvTableVA = 0x004967b0;
+	const uint32 kInvTableFileOff =
+	    (kInvTableVA - kImageBase - kDgroupVaddr) + kDgroupRawPtr;
+	exe.seek(kInvTableFileOff);
+	for (int i = 0; i < 64 && !exe.eos(); i++) {
+		int32 id = exe.readSint32LE();
+		if (id <= 0)
+			break;
+		_inventoryObjectIds.push_back((uint)id);
+	}
+	debugC(1, kDebugScript, "loadAtlantisExeTables: %u inventory object ids from atlantis.exe",
+	      _inventoryObjectIds.size());
+
+	// Credits font char-width table at VA 0x004966fc: 256 raw bytes indexed
+	// by char code, used for proportional spacing of CREDBLAN.SPR /
+	// CREDBLEU.SPR.  Cross-checked against each sprite's stored `w` field
+	// (exe['A']=9 ↔ sprite[32].w=9, exe['B']=7 ↔ sprite[33].w=7, etc. —
+	// see comment in drawCreditText), so we use the table verbatim with
+	// no overrides; the table's space value (0x20 = 13) is authentic.
+	memset(_creditCharWidths, 0, sizeof(_creditCharWidths));
+	const uint32 kCredWidthsVA = 0x004966fc;
+	const uint32 kCredWidthsFileOff =
+	    (kCredWidthsVA - kImageBase - kDgroupVaddr) + kDgroupRawPtr;
+	exe.seek(kCredWidthsFileOff);
+	exe.read(_creditCharWidths, sizeof(_creditCharWidths));
+	debugC(1, kDebugScript, "loadAtlantisExeTables: credit char-width table loaded");
+}
+
+void CryOmni3DEngine_Atlantis::setupFonts() {
+	loadFontMaxSprites();
+	loadCreditFontSprites();
+}
+
+void CryOmni3DEngine_Atlantis::setupObjects() {
+	// Build the object catalogue from the runtime-extracted inventory table
+	// (atlantis.exe @ VA 0x004967b0).  The array order is the canonical sprite
+	// order in OBJETS1.SPR, so _objects[i] is the icon at sprite slot i — the
+	// invariant drawInventoryIcon() depends on for its pointer-arithmetic
+	// index lookup.
+	_objects.clear();
+	_objects.resize(_inventoryObjectIds.size());
+	for (uint i = 0; i < _inventoryObjectIds.size(); i++)
+		_objects[i].rename(_inventoryObjectIds[i]);
+}
+
+void CryOmni3DEngine_Atlantis::drawMenuTitle(Graphics::ManagedSurface *surface, byte color) {
+	// Placeholder: no game-specific title font yet.
+	(void)surface;
+	(void)color;
+}
+
+uint CryOmni3DEngine_Atlantis::displayFilePicker(const Graphics::Surface *bgFrame, bool saveMode,
+                                                  Common::String &saveName) {
+	(void)bgFrame;
+	// Delegate to the data-driven native picker (SPRLIST\SELEMENU.TXT layout).
+	return displaySavePicker(saveMode, saveName);
+}
+
+uint CryOmni3DEngine_Atlantis::displayOptions() {
+	const Graphics::Font *font = FontMan.getFontByUsage(Graphics::FontManager::kGUIFont);
+	if (!font)
+		font = FontMan.getFontByUsage(Graphics::FontManager::kConsoleFont);
+
+	// Build menu entries depending on whether a game is in progress.
+	struct Entry { const char *label; uint retval; };
+	static const Entry kMenuStartup[] = {
+		{ "New Game",  27 },
+		{ "Load Game", 28 },
+		{ "Quit",      40 },
+	};
+	// Atlantis has no manual save — the game autosaves on every chapter
+	// transition (see autosave()), so the in-game menu offers no "Save Game".
+	static const Entry kMenuInGame[] = {
+		{ "Continue",  0  },
+		{ "Load Game", 28 },
+		{ "New Game",  27 },
+		{ "Quit",      40 },
+	};
+	const Entry *entries = _isPlaying ? kMenuInGame : kMenuStartup;
+	uint numEntries = _isPlaying ? ARRAYSIZE(kMenuInGame) : ARRAYSIZE(kMenuStartup);
+
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+
+	// Load PREINTRO.TGA as menu background; fall back to black if unavailable.
+	Graphics::ManagedSurface bgSurf;
+	{
+		Graphics::Surface *raw = loadTGA(kFileTypeImages, "PREINTRO.TGA");
+		if (raw) {
+			bgSurf.copyFrom(*raw);
+			raw->free();
+			delete raw;
+		} else {
+			bgSurf.create(640, 480, fmt);
+			bgSurf.fillRect(Common::Rect(0, 0, 640, 480), bgSurf.format.RGBToColor(0, 0, 0));
+		}
+	}
+
+	// Overlay the four decorative SPRMENU sprites onto the background.
+	// Positions from SPRLIST\SELEMENU.TXT: /spr=idx,hx,hy,w,h
+	blitMenuSprite(bgSurf,  8, 110, 182);  // left arrow
+	blitMenuSprite(bgSurf,  7, 520, 184);  // right arrow
+	blitMenuSprite(bgSurf,  9, 180, 270);  // top-left corner ornament
+	blitMenuSprite(bgSurf, 10, 450, 340);  // bottom-right corner ornament
+
+	// Render FONTMAX text labels (positions from SPRLIST\SELEMENU.TXT).
+	// y_txt is the bottom of the text box; anchor_x centers the text on screen.
+	// The -11 in FUN_0041fb6c is the hit-box left edge, not the render origin.
+	if (!_fontMaxSprites.empty()) {
+		auto drawCentred = [&](const Common::String &text, int y_txt) {
+			int w  = fontMaxStringWidth(text);
+			int ax = (640 - w) / 2;
+			int ay = y_txt;
+			drawFontMaxText(bgSurf, text, ax, ay);
+		};
+		drawCentred("SELECT PLAYER NAME", 140);
+		drawCentred("DELETE PLAYER NAME", 420);
+		drawCentred("OK",                 470);
+	}
+
+	Graphics::ManagedSurface surf;
+	surf.create(640, 480, fmt);
+	surf.blitFrom(bgSurf);
+
+	const int lineH   = font ? (font->getFontHeight() + 4) : 20;
+	const int blockH  = (int)numEntries * lineH;
+	int y = (480 - blockH) / 2;
+
+	uint32 white  = surf.format.RGBToColor(255, 255, 255);
+	uint32 yellow = surf.format.RGBToColor(255, 255,   0);
+
+	// Draw title text.
+	if (font)
+		font->drawString(&surf, "ATLANTIS: The Lost Tale", 0, y - lineH * 2, 640, white,
+		                 Graphics::TextAlign::kTextAlignCenter);
+
+	// Build hit-test rects.
+	Common::Array<Common::Rect> rects;
+	for (uint i = 0; i < numEntries; i++) {
+		Common::Rect r(160, y + (int)i * lineH, 480, y + (int)(i + 1) * lineH);
+		rects.push_back(r);
+		if (font)
+			font->drawString(&surf, entries[i].label, r.left, r.top, r.width(), white,
+			                 Graphics::TextAlign::kTextAlignCenter);
+	}
+
+	g_system->copyRectToScreen(surf.getPixels(), surf.pitch, 0, 0, 640, 480);
+	g_system->updateScreen();
+
+	showMouse(true);
+	setArrowCursor();
+
+	int hovered = -1;
+	while (!shouldAbort()) {
+		pollEvents();
+		Common::Point mouse = getMousePos();
+
+		// Redraw with hover highlight.
+		int newHovered = -1;
+		for (int i = 0; i < (int)numEntries; i++)
+			if (rects[i].contains(mouse)) { newHovered = i; break; }
+
+		if (newHovered != hovered) {
+			hovered = newHovered;
+			surf.blitFrom(bgSurf);
+			if (font)
+				font->drawString(&surf, "ATLANTIS: The Lost Tale", 0, y - lineH * 2, 640,
+				                 white, Graphics::TextAlign::kTextAlignCenter);
+			for (uint i = 0; i < numEntries; i++) {
+				uint32 col = ((int)i == hovered) ? yellow : white;
+				if (font)
+					font->drawString(&surf, entries[i].label, rects[i].left, rects[i].top,
+					                 rects[i].width(), col,
+					                 Graphics::TextAlign::kTextAlignCenter);
+			}
+			g_system->copyRectToScreen(surf.getPixels(), surf.pitch, 0, 0, 640, 480);
+			g_system->updateScreen();
+		}
+
+		if (getCurrentMouseButton() == 1 && hovered >= 0) {
+			uint retval = entries[hovered].retval;
+
+			// Drain button release.
+			while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+				pollEvents();
+				g_system->delayMillis(10);
+			}
+
+			if (retval == 28) {
+				// Load game: show slot picker; if cancelled, re-show menu.
+				Common::String dummy;
+				uint slot = displayFilePicker(nullptr, false, dummy);
+				if (slot > 0) {
+					_loadedSave = slot;
+					return 28;
+				}
+				// Cancelled — redraw and loop.
+				hovered = -1;
+				continue;
+			} else if (retval == 0) {
+				// Continue — return without changing anything.
+				return 0;
+			} else {
+				return retval;
+			}
+		}
+
+		// Refresh every frame so the software cursor tracks the mouse — the
+		// menu graphics above only redraw on a hover change.
+		g_system->updateScreen();
+		g_system->delayMillis(10);
+	}
+
+	// Aborted (window close).
+	return 40;
+}
+
+Common::Error CryOmni3DEngine_Atlantis::run() {
+	CryOmni3DEngine::run();
+
+	// Open the game's data archives.  The full game spans four discs
+	// (BIGCD1-4.BIG), all merged into one index.  Disc 1 is required; discs
+	// 2-4 are mounted if present, so a disc-1-only install still launches
+	// (with the later chapters' data unavailable).
+	Common::Path bigFilePath("BIGCD1.BIG");
+	if (!_bigFile.open(bigFilePath)) {
+		bigFilePath = Common::Path("bigcd1.big");
+		if (!_bigFile.open(bigFilePath)) {
+			return Common::Error(Common::kPathDoesNotExist, "Cannot open BIGCD1.BIG");
+		}
+	}
+	for (int disc = 2; disc <= 4; disc++) {
+		if (!_bigFile.open(Common::Path(Common::String::format("BIGCD%d.BIG", disc)))
+		        && !_bigFile.open(Common::Path(Common::String::format("bigcd%d.big", disc))))
+			warning("Atlantis: BIGCD%d.BIG not found - its chapters will be unavailable", disc);
+	}
+	debugC(1, kDebugScript, "Atlantis: data archives mounted, %u files total", _bigFile.numFiles());
+
+	// Register with SearchMan so Common::File::open() can find archive files.
+	SearchMan.add("Atlantis_BigFile", &_bigFile, 0, false);
+
+	// Pull data tables embedded in atlantis.exe (currently: the newsound APC
+	// filename table at VA 0x004961e0).  Runs after the BigFile is mounted
+	// so the engine can resolve atlantis.exe via SearchMan.
+	loadAtlantisExeTables();
+
+	// SPRLIST\EPI.TXT — the per-episode checkpoint names shown for each
+	// per-chapter save (autosave() / displaySavePicker()).
+	loadEpisodeNames();
+
+	loadStaticData();
+	setupObjects();
+	loadSubjectSprites();
+	loadCursorSprites();
+	loadObjectSprites();
+	loadInventoryBarSprite();
+	loadMenuSprites();
+	setupFonts();
+
+	loadDialInitData();
+
+	_omni3dMan.init(75. / 180. * M_PI);
+
+	_mainPalette = new byte[3 * 256]();
+	_transparentPaletteMap = new byte[256]();
+	_transparentSrcStart = 0;
+	_transparentSrcStop  = 240;
+	_transparentDstStart = 0;
+	_transparentDstStop  = 248;
+	_transparentNewStart = 248;
+	_transparentNewStop  = 254;
+
+	_inventory.init(20, new Common::Functor1Mem<uint, void, Atlantis_Toolbar>(
+	                        &_toolbar, &Atlantis_Toolbar::inventoryChanged));
+	_gameVariables.resize(50, 0);
+
+	_fixedImage = new ZonFixedImage(*this, _inventory, _sprites, &kFixedImageConfiguration);
+
+	// Atlantis uses HNM6 16-bit true color panoramas.  initGraphics MUST be called
+	// before toolbar.init so the toolbar surfaces are created in the correct pixel format.
+	Graphics::PixelFormat screenFmt(2, 5, 6, 5, 0, 11, 5, 0, 0); // RGB565
+	initGraphics(640, 480, &screenFmt);
+	_omni3dMan.setPixelFormat(screenFmt);
+	_toolbar.init(&_sprites, &_inventory, this);
+	// The toolbar background is a single sprite: OBJETS0.SPR (599x82) with
+	// the thin golden line, 9 star-of-David slot ornaments, and decorative
+	// drops.  Centre the 599-wide sprite on the 640-wide toolbar by placing
+	// its left edge at x=20: addMenuSprite computes draw_x = tx - xoff, and
+	// the sprite carries xoff=-20, so tx=0 yields draw_x=20.  Inventory
+	// item icons are composited on top by the slot rendering path.
+	if (!_inventoryBarSprite.pixels.empty()) {
+		const SubjSprite &s = _inventoryBarSprite;
+		_toolbar.addMenuSprite(s.w, s.h, s.xoff, s.yoff, kSprTransp,
+		                       0, s.yoff, s.pixels.data(), s.blend.data());
+	}
+	setMousePos(Common::Point(320, 240));
+
+	syncSoundSettings();
+
+	_isPlaying = false;
+	_abortCommand = kAbortQuit;
+	_musicCurrentFile = nullptr;
+
+	int saveSlot = ConfMan.getInt("save_slot");
+
+	// Play Cryo logo and pre-intro cinematics before the main menu.
+	if (saveSlot < 0) {
+		playTransitionVideo("LOGO15N.HNM");
+		playTransitionVideo("PREINTRO.HNM");
+	}
+
+	loadPlayers();
+
+	bool stopGame = false;
+	while (!stopGame) {
+		bool exitLoop = false;
+		uint nextStep = 0;
+
+		if (saveSlot > -1) {
+			// Launched directly into a save from the ScummVM launcher: skip the
+			// player screen and take the player from the save slot's block.
+			_currentPlayer = saveSlot / (int)kPlayerSlotStride;
+			nextStep = 28;
+			_loadedSave = saveSlot + 1;
+			saveSlot = -1;
+		} else {
+			// Original-style player select / create / delete screen.
+			int chosen = displayPlayerScreen();
+			if (chosen < 0) {
+				stopGame = true;
+				break;
+			}
+			_currentPlayer = chosen;
+			// An existing player resumes their current episode (the latest
+			// per-chapter save); a brand-new player starts a new game.  Either
+			// way the New/Load/Quit startup menu (displayOptions) is bypassed.
+			uint resume = playerResumeSave((uint)chosen);
+			if (resume) {
+				_loadedSave = resume;
+				nextStep = 28;   // resume the player's current episode
+			} else {
+				nextStep = 27;   // new game
+			}
+		}
+
+		if (_sprites.getSpritesCount() > 0)
+			setCursor(0);
+		while (!exitLoop) {
+			_isPlaying = false;
+			if (!nextStep) {
+				nextStep = displayOptions();
+			}
+			if (nextStep == 40) {
+				exitLoop = true;
+				stopGame = true;
+			} else if (nextStep == 27 || nextStep == 28 || nextStep == 65) {
+				// Leaving the menu for the game: hide the menu cursor so the
+				// intro / transition cinematics play with no cursor visible;
+				// gameplay (handleWarp) shows its own cursor again.
+				showMouse(false);
+				if (nextStep == 27) {
+					// New game: CON arrival section at the starting place (vue=450) drives
+					// the intro cinematics and dialog — no hardcoded sequence here.
+					_abortCommand = kAbortNoAbort;
+					_isPlaying = true;
+					changeChapter(1);
+				} else if (nextStep == 28) {
+					// Load game
+					loadGame(_loadedSave);
+				} else if (nextStep == 65) {
+					// _currentChapter was set by executeTransition() when it detected
+					// a chapter-WAM sub-WAM (e.g. atlan2.wam).
+					changeChapter(_currentChapter);
+				}
+
+				_isPlaying = true;
+				nextStep = 0;
+				_abortCommand = kAbortNoAbort;
+
+				gameStep();
+
+				assert(_abortCommand != kAbortNoAbort);
+				switch (_abortCommand) {
+				case kAbortFinished:
+				case kAbortGameOver:
+					exitLoop = true;
+					break;
+				case kAbortQuit:
+					exitLoop = true;
+					stopGame = true;
+					break;
+				case kAbortNewGame:
+					nextStep = 27;
+					break;
+				case kAbortLoadGame:
+					nextStep = 28;
+					break;
+				case kAbortNextChapter:
+					nextStep = 65;
+					break;
+				default:
+					error("Invalid abortCommand: %d", _abortCommand);
+				}
+			}
+		}
+	}
+
+	SearchMan.remove("Atlantis_BigFile");
+	return Common::kNoError;
+}
+
+void CryOmni3DEngine_Atlantis::changeChapter(int chapter) {
+	_currentChapter = chapter;
+
+	_mixer->stopAll();
+	musicStop();   // a new chapter's CON re-selects its music via startmusik
+
+	if (chapter == 1) {
+		for (uint &v : _gameVariables)
+			v = 0;
+		_inventory.clear();
+		for (byte &b : _placeVisits)
+			b = 0;
+	}
+	_sujEnabled.clear();
+	_hiddenPersos.clear();
+	_npcPlaceBounds.clear();
+	_conScript.reset();
+	_gameVars.clear();
+
+	_nextPlaceId = uint(-1);
+	initNewChapter(chapter);
+}
+
+void CryOmni3DEngine_Atlantis::initNewChapter(int chapter) {
+	// setupChapterWAM calls loadConScript, which calls execConInitCommands.
+	// The INIT block may set _nextPlaceId via vue=N — honour that value.
+	setupChapterWAM(chapter);
+	initPlacesStates();
+	initChapterPlaceStates(chapter);
+
+	if (chapter < 1 || chapter > (int)ARRAYSIZE(kChapterInitialStates))
+		error("Invalid chapter %d", chapter);
+
+	const LevelInitialState &init = kChapterInitialStates[chapter - 1];
+	if (_nextPlaceId == uint(-1))
+		_nextPlaceId = init.placeId;  // fall back to hardcoded start if CON gave none
+	_omni3dMan.setAlpha(init.alpha);
+	_omni3dMan.setBeta(init.beta);
+
+	if (chapter == 1) {
+		// Seth begins chapter 1 carrying his companion's pass (item 257).
+		// No CON INIT command grants it; it's a starting item.
+		for (Object &o : _objects) {
+			if (o.valid() && o.idOBJ() == 257) {
+				if (!_inventory.inInventoryByNameID(257))
+					_inventory.add(&o);
+				break;
+			}
+		}
+	}
+}
+
+static const char *const kWAMNames[] = {
+	nullptr,
+	"ATLAN1.WAM",
+	"ATLAN2.WAM",
+	"ATLAN3.WAM",
+	"ATLAN4.WAM",
+	"ATLAN5.WAM",
+};
+
+void CryOmni3DEngine_Atlantis::setupChapterWAM(int chapter) {
+	if (chapter < 1 || chapter >= (int)ARRAYSIZE(kWAMNames) || !kWAMNames[chapter])
+		error("No WAM for chapter %d", chapter);
+
+	Common::ScopedPtr<Common::SeekableReadStream> s(
+	    openBigFileStream(kFileTypeWAM, kWAMNames[chapter]));
+	if (!s)
+		error("Cannot open WAM file for chapter %d (%s)", chapter, kWAMNames[chapter]);
+
+	_wam.loadStream(*s);
+	_currentWAMName = kWAMNames[chapter];
+	debugC(1, kDebugScript, "Loaded WAM for chapter %d: %u places", chapter, _wam.getPlaces().size());
+	loadSpritePlaceList();
+	loadSpfList();
+	if ((uint)chapter != _currentCONChapter) {
+		_currentCONChapter = (uint)chapter;
+		loadConScript(chapter);
+	}
+}
+
+void CryOmni3DEngine_Atlantis::setupWAMByName(const Common::String &wamName) {
+	Common::ScopedPtr<Common::SeekableReadStream> s(
+	    openBigFileStream(kFileTypeWAM, wamName));
+	if (!s) {
+		warning("Cannot open WAM file '%s'", wamName.c_str());
+		return;
+	}
+	_wam.loadStream(*s);
+	_currentWAMName = wamName;
+	debugC(1, kDebugScript, "Loaded WAM '%s': %u places", wamName.c_str(), _wam.getPlaces().size());
+	initPlacesStates();
+	// Each WAM references its own spwatlN.txt / spfatlN.txt — without
+	// reloading these here, sub-WAM hot-swaps (e.g. atlan1 → atlan4) keep
+	// the previous chapter's per-place sprite/transition data and NPCs in
+	// the new area (place 92 perso 602, place 93, ...) never composite.
+	loadSpritePlaceList();
+	loadSpfList();
+}
+
+void CryOmni3DEngine_Atlantis::initPlacesStates() {
+	_placeStates.resize(256);
+	for (PlaceState &ps : _placeStates)
+		ps = PlaceState();
+}
+
+void CryOmni3DEngine_Atlantis::initChapterPlaceStates(int chapter) {
+	// Wire place-specific filterEvent callbacks (implemented in logic.cpp).
+	// Guard logic at place 17 is handled by the CON script; no hardcoded filters needed.
+	(void)chapter;
+}
+
+void CryOmni3DEngine_Atlantis::playConDialog(int dialogId,
+                                              const Common::String &text,
+                                              const Common::String &bgVideoName) {
+	// Audio: WAV\ATA<dialogId4><track>.APC where dialogId is the CON section number.
+	const int kBarHeight = 80;
+	const int kScreenW   = 640;
+	const int kScreenH   = 480;
+
+	// Subtitles toggle: when the user has turned them off in the ScummVM
+	// options, draw nothing into the subtitle bar -- the audio still plays.
+	const Common::String &subText = showSubtitles() ? text : Common::String();
+
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	Graphics::ManagedSurface sub;
+	sub.create(kScreenW, kBarHeight, fmt);
+	sub.fillRect(Common::Rect(kScreenW, kBarHeight), 0);
+
+	const Graphics::Font *font = FontMan.getFontByUsage(Graphics::FontManager::kGUIFont);
+	if (font && !subText.empty()) {
+		uint32 white = fmt.RGBToColor(255, 255, 180);
+		int lineH = font->getFontHeight() + 2;
+		Common::Array<Common::String> lines;
+		font->wordWrapText(subText, kScreenW - 16, lines);
+		int y = (kBarHeight - (int)lines.size() * lineH) / 2;
+		for (uint i = 0; i < lines.size(); i++, y += lineH)
+			font->drawString(&sub, lines[i], 8, y, kScreenW - 16, white,
+			                 Graphics::kTextAlignCenter);
+	}
+
+	if (_warpLoaded)
+		_omni3dMan.updateCoords(0, 0, false);
+
+#ifdef USE_HNM
+	Video::HNMDecoder *bgDecoder = nullptr;
+	const Graphics::Surface *bgFrame = nullptr;
+
+	if (!bgVideoName.empty()) {
+		Common::String hnmName = bgVideoName;
+		const char *dot = strrchr(hnmName.c_str(), '.');
+		if (dot && !scumm_stricmp(dot, ".UBB"))
+			hnmName = Common::String(hnmName.c_str(), dot - hnmName.c_str()) + ".HNM";
+		Common::SeekableReadStream *bgStream = openBigFileStream(kFileTypeDialog, hnmName);
+		if (bgStream) {
+			bgDecoder = new Video::HNMDecoder(fmt, true);  // loop=true: seeks back on EOF
+			if (!bgDecoder->loadStream(bgStream)) {
+				delete bgDecoder;
+				bgDecoder = nullptr;
+			} else {
+				bgDecoder->start();
+			}
+		}
+	}
+#endif
+
+	auto drawFrame = [&]() {
+#ifdef USE_HNM
+		if (bgDecoder) {
+			if (bgDecoder->needsUpdate()) {
+				const Graphics::Surface *f = bgDecoder->decodeNextFrame();
+				if (f)
+					bgFrame = f;
+			}
+			if (bgFrame)
+				g_system->copyRectToScreen(bgFrame->getPixels(), bgFrame->pitch,
+				                           0, 0, bgFrame->w, bgFrame->h);
+		} else
+#endif
+		if (_warpLoaded) {
+			const Graphics::Surface *bg = _omni3dMan.getSurface();
+			if (bg)
+				g_system->copyRectToScreen(bg->getPixels(), bg->pitch, 0, 0, bg->w, bg->h);
+		}
+		g_system->copyRectToScreen(sub.getPixels(), sub.pitch,
+		                           0, kScreenH - kBarHeight, kScreenW, kBarHeight);
+		g_system->updateScreen();
+	};
+
+	// Play sequential APC tracks A, B, C, ...
+	for (char track = 'A'; track <= 'Z' && !shouldAbort(); track++) {
+		// One click skips only one track: drain a still-held skip input
+		// carried over from skipping the previous track.
+		while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+			pollEvents();
+			g_system->delayMillis(10);
+		}
+		clearKeys();
+		Common::String apcName = Common::String::format("ATA%04d%c.APC", dialogId, track);
+		Common::SeekableReadStream *apcFile = openBigFileStream(kFileTypeSound, apcName);
+		if (!apcFile) {
+			if (track == 'A')
+				debugC(1, kDebugScript, "playConDialog: no audio for dialogId=%d", dialogId);
+			break;
+		}
+
+		Audio::PacketizedAudioStream *apc = Audio::makeAPCStream(*apcFile);
+		if (apc) {
+			int64 remaining = apcFile->size() - apcFile->pos();
+			if (remaining > 0) {
+				byte *buf = new byte[remaining];
+				apcFile->read(buf, (uint32)remaining);
+				apc->queuePacket(new Common::MemoryReadStream(buf, remaining,
+				                                              DisposeAfterUse::YES));
+			}
+			apc->finish();
+			Audio::SoundHandle handle;
+			_mixer->playStream(Audio::Mixer::kSpeechSoundType, &handle, apc);
+			debugC(1, kDebugScript, "playConDialog: playing %s", apcName.c_str());
+
+			// Show panorama + subtitle while audio plays; allow click/key to skip.
+			while (!shouldAbort() && _mixer->isSoundHandleActive(handle)) {
+				drawFrame();
+				pollEvents();
+				if (checkKeysPressed(1, Common::KEYCODE_SPACE) || getCurrentMouseButton() != 0) {
+					_mixer->stopHandle(handle);
+					break;
+				}
+				g_system->delayMillis(10);
+			}
+			_mixer->stopHandle(handle);
+		}
+		delete apcFile;
+	}
+
+	// Leave subtitle visible for ~1s after all tracks (or if no audio).
+	if (!shouldAbort()) {
+		for (int ms = 0; ms < 1000 && !shouldAbort(); ms += 20) {
+			drawFrame();
+			pollEvents();
+			if (checkKeysPressed(1, Common::KEYCODE_SPACE) || getCurrentMouseButton() != 0)
+				break;
+			g_system->delayMillis(20);
+		}
+	}
+#ifdef USE_HNM
+	delete bgDecoder;
+#endif
+	sub.free();
+}
+
+void CryOmni3DEngine_Atlantis::gameStep() {
+	while (!_abortCommand) {
+		if (_nextPlaceId != uint(-1)) {
+			if (_nextPlaceId < _placeStates.size() && _placeStates[_nextPlaceId].initPlace)
+				(this->*_placeStates[_nextPlaceId].initPlace)();
+			// Music persists across places — only startmusik/stopmusik (run by
+			// the new place's arrival CON sections, if any) change it.
+			doPlaceChange();
+			musicUpdate();
+		}
+
+		// An arrival /sel section (e.g. vue=1 at the end of the intro) may have set
+		// _nextPlaceId during doPlaceChange().  Loop back to process the new destination
+		// instead of showing the current (transitional) panorama to the player.
+		if (_nextPlaceId != uint(-1))
+			continue;
+
+		uint actionId = handleWarp();
+		musicUpdate();
+		debugC(2, kDebugScript, "handleWarp returned %u", actionId);
+
+		// handleWarp returns 66666 when it leaves its loop without a place to
+		// navigate to.  If an abort is pending let run() process it; otherwise
+		// it bailed for a transient reason — re-enter the warp.  Handled here,
+		// before filterEvent(), so a place handler never sees the sentinel.
+		if (actionId == 66666) {
+			if (_abortCommand != kAbortNoAbort)
+				break;
+			debugC(1, kDebugScript, "gameStep: handleWarp bailed with no abort; resuming warp");
+			continue;
+		}
+
+		// Script-initiated transition: handleWarp returned a destination that
+		// was set by /set(Vue=N) inside an NPC dialog (it left _nextPlaceId
+		// equal to the returned actionId).  Skip the user-click pipeline —
+		// no zone /con scan, no departure /sel scan, no abortdepart gate —
+		// just transition.  /set(Vue=N) in the exe schedules the new place
+		// directly, independent of the lock-the-player /sel sections that
+		// fire on player navigation clicks.
+		if (actionId > 0 && _nextPlaceId == (uint)actionId) {
+			uint dest = _nextPlaceId;
+			_nextPlaceId = uint(-1);
+			executeTransition(dest);
+			continue;
+		}
+
+		_nextPlaceId = uint(-1);
+		bool doEvent = true;
+		if (_currentPlaceId < _placeStates.size() && _placeStates[_currentPlaceId].filterEvent)
+			doEvent = (this->*_placeStates[_currentPlaceId].filterEvent)(&actionId);
+
+		if (_abortCommand)
+			break;
+
+		if (actionId >= 1 && actionId < 10000) {
+			if (doEvent) {
+				// A zone action can be either a navigation destination (place ID)
+				// or a zone-click handler key (matched against CON section
+				// `clicZone` fields, e.g. `/con*(cliczone=499)` for an item-use
+				// hotspot).  CON authors put click handlers in a separate
+				// numeric range (typically 100+) from place IDs, but the data
+				// itself is what tells us which is which: if any CON section's
+				// clicZone matches this action, route the click through the
+				// zone-click path and never invoke executeTransition (place
+				// "499" doesn't exist anywhere).
+				bool isClicZone = false;
+				for (const ConSection &sec : _conScript.sections()) {
+					if (sec.clicZone == (int)actionId) {
+						isClicZone = true;
+						break;
+					}
+				}
+
+				if (isClicZone) {
+					runZoneConSections((int)actionId);
+					// The fired /con* section may have requested a place
+					// change via /set(vue=N) -- CHAPI012 section 14
+					// (`/con*(Cliczone=3260)&(ObjetEnMain=260)&(Flagtemp6=1)`
+					// -> /set(Cinema=31) + /set(Vue=415)) is the canonical
+					// case: clicking the lion-stone with object 260 plays
+					// the door-opening cinematic and then must transition
+					// to vue 415 (the cyclo showing the now-open door).
+					// Previously this branch unconditionally cleared
+					// _nextPlaceId, so the cinematic played but the cyclo
+					// stayed on the closed-door view.
+					if (!shouldAbort() && _nextPlaceId != uint(-1)) {
+						uint dest = _nextPlaceId;
+						_nextPlaceId = uint(-1);
+						executeTransition(dest);
+					}
+				} else if (_inventory.selectedObject() &&
+				           _inventory.selectedObject()->idOBJ() != uint(-1)) {
+					// Object in hand: a plain navigation zone is inert.  The
+					// original engine (atlantis.exe FUN_004212cc, the place-
+					// change block at ~0x424070) only navigates when
+					// objetenmain == 0 — it gates the whole move on
+					// `*(int *)(... + 0x611210) == 0`.  Clicking a destination
+					// while an item is selected does nothing; the player must
+					// put the object away first.  Using an item *on* a hotspot
+					// is a separate ClicZone /con path (handled above) and is
+					// unaffected.
+					_nextPlaceId = uint(-1);
+				} else {
+					// Place transition: first check zone-click /con* sections
+					// (which may redirect via /set(vue=…) or abort by clearing
+					// _nextPlaceId), then run departure /sel sections, then
+					// execute the resulting transition.
+					_nextPlaceId = actionId;       // tentative departure destination
+					runZoneConSections((int)actionId);
+
+					if (!shouldAbort() && _nextPlaceId == actionId)
+						runDepartureSelSections(actionId);
+
+					if (!shouldAbort() && _nextPlaceId != uint(-1)) {
+						uint dest = _nextPlaceId;
+						_nextPlaceId = uint(-1);    // executeTransition sets it at the end
+						executeTransition(dest);
+					} else {
+						_nextPlaceId = uint(-1);    // aborted or shouldAbort
+					}
+				}
+			}
+		} else if (actionId >= 10000 && actionId < 20000) {
+			// Speak/react action: player says something or an ambient reaction plays.
+			// Not observed in Atlantis WAM data; no-op for now.
+		} else if (actionId >= 40000 && actionId < 50000) {
+			// Close-up examination: not yet implemented (Atlantis uses CON vue= redirects).
+		}
+		// actionId == 66666 is handled above, before filterEvent().
+	}
+}
+
+// Dump the whole script-visible story state to the log.  The CON section
+// conditions are already printed by loadConScript(), so a stuck point can be
+// read off directly: compare a section's conditions against these values.
+void CryOmni3DEngine_Atlantis::debugDumpStoryState(const char *ctx) {
+	Common::String vars;
+	for (Common::HashMap<Common::String, int>::const_iterator it = _gameVars.begin();
+	     it != _gameVars.end(); ++it)
+		vars += Common::String::format("%s=%d ", it->_key.c_str(), it->_value);
+	debugC(1, kDebugScript, "STORY STATE [%s]: place=%u CONchapter=%u musicTrack=%d | %s",
+	      ctx, _currentPlaceId, _currentCONChapter, _musicTrackId, vars.c_str());
+}
+
+void CryOmni3DEngine_Atlantis::doPlaceChange() {
+	debugC(1, kDebugScript, "doPlaceChange: ENTER _currentPlaceId=%d _nextPlaceId=%d "
+	         "_currentPlace=%s _autosavePending=%d",
+	      (int)_currentPlaceId, (int)_nextPlaceId,
+	      _currentPlace ? "set" : "null", (int)_autosavePending);
+	// The place we are leaving — handed to runArrivalSelSections() as the
+	// "arrived from" value so /sel (arriveevue=N)&(vue=M) conditions resolve.
+	const uint fromPlaceId = _currentPlaceId;
+
+	const AtlantisPlace *nextPlace = _wam.findPlaceById((uint16)_nextPlaceId);
+	if (!nextPlace) {
+		// Place not in current WAM — check sub-WAMs keyed by destination.
+		for (const AtlantisSubWAM &sub : _wam.getSubWAMs()) {
+			if (sub.dstPlaceId == _nextPlaceId) {
+				// Copy wamName before setupWAMByName clears _subWAMs.
+				Common::String wamName = sub.wamName;
+				debugC(1, kDebugScript, "doPlaceChange: place %u not found, loading sub-WAM '%s'",
+				      _nextPlaceId, wamName.c_str());
+				setupWAMByName(wamName);
+				nextPlace = _wam.findPlaceById((uint16)_nextPlaceId);
+				break;
+			}
+		}
+		if (!nextPlace) {
+			warning("doPlaceChange: place %u not found in WAM or any sub-WAM", _nextPlaceId);
+			_nextPlaceId = uint(-1);
+			return;
+		}
+	}
+
+	_currentPlace = nextPlace;
+	_currentPlaceId = _nextPlaceId;
+	_nextPlaceId = uint(-1);
+
+	// A place change ends any dialog context: drop a pending "object received"
+	// icon so it can't leak onto the next scene.
+	_dialogGivenObjSprite = -1;
+
+	// Original-game autosave: when a CON `chapter=N` command advanced the
+	// chapter, persist the player's single save now that the new chapter's
+	// first place is set (state — inventory, vars, place — is consistent
+	// here, and the panorama has not been entered yet).
+	if (_autosavePending) {
+		debugC(1, kDebugScript, "doPlaceChange: running autosave for chapter %u", _currentCONChapter);
+		_autosavePending = false;
+		autosave();
+		debugC(1, kDebugScript, "doPlaceChange: autosave done");
+	}
+
+	// Load the panoramic cyclo HNM, then composite NPC sprites on top.
+	if (loadCycloHNM(nextPlace->cycloHnm)) {
+		compositeNPCSprites();
+		_omni3dMan.setSourceSurface(&_warpSurface);
+		setupPalette(_mainPalette, 0, 256);
+	}
+
+	// Full 360° horizontal rotation — no alpha clamp, wrapping is handled
+	// internally in updateCoords. Limit vertical tilt to ±45°.
+	_omni3dMan.setBetaMinConstraint(-M_PI / 4.);
+	_omni3dMan.setBetaMaxConstraint( M_PI / 4.);
+
+	setMousePos(Common::Point(320, 240));
+
+	debugC(1, kDebugScript, "doPlaceChange: at place %u (%s)", _currentPlaceId, nextPlace->cycloHnm.c_str());
+	debugDumpStoryState("place change");
+	for (const AtlantisZone &z : nextPlace->zones)
+		debugC(2, kDebugScript, "  zone: action=%d x=%d y=%d w=%d h=%d",
+		      z.action, z.x, z.y, z.w, z.h);
+
+	// Each place starts at the 75 degrees navigation FOV.  Clear any zoom
+	// left over from the place just left (atlantis.exe FUN_004212cc restores
+	// the FOV and zeroes var[zoom] when its warp loop ends) so this place's
+	// arrival /sel can request a fresh one.
+	_omni3dMan.setHFov(75.0 / 180.0 * M_PI);
+	_gameVars["zoom"] = 0;
+	_zoomLastMs = 0;
+
+	// Run /sel arrival sections: intro dialog, cinematics, story triggers.
+	runArrivalSelSections((int)_currentPlaceId, (int)fromPlaceId);
+
+	// Count this visit AFTER the arrival sections, so a place's first-visit
+	// /sel sections (nbvisite=0) fire exactly once (NbVisite).
+	if (_currentPlaceId < _placeVisits.size() && _placeVisits[_currentPlaceId] < 255)
+		_placeVisits[_currentPlaceId]++;
+}
+
+void CryOmni3DEngine_Atlantis::executeTransition(uint nextPlaceId) {
+	// _currentPlace can be null after /set(changewam=...) -- the script's
+	// next /set(vue=N) is the destination, and there is no transition video
+	// between the old and new WAMs anyway.  Skip the transition lookup and
+	// the cross-WAM hand-off (the new WAM is already loaded) and just hand
+	// the destination to gameStep's outer loop via _nextPlaceId so
+	// doPlaceChange runs.  Previously we early-returned which left
+	// _nextPlaceId at -1, so the destination silently dropped.
+	if (!_currentPlace) {
+		_nextPlaceId = nextPlaceId;
+		return;
+	}
+
+	const AtlantisTransition *trans = _currentPlace->findTransition((uint16)nextPlaceId);
+	if (trans) {
+		playTransitionVideo(trans->videoName, _currentPlaceId, nextPlaceId);
+		_omni3dMan.setAlpha(trans->dstAlpha);
+		_omni3dMan.setBeta(trans->dstBeta);
+	}
+
+	// Cross-WAM transition: sub-WAMs hot-swap the navigation map when a
+	// (src, dst) pair crosses into a different WAM.  Even chapter-named WAMs
+	// (atlan2/3/4/5.wam) are hot-swapped here without resetting chapter
+	// state — those WAMs serve as sub-areas of chapter 1.  Actual chapter
+	// progression is driven by CON `/set(chapter=N)` once gameplay in the
+	// new sub-area triggers it (e.g. arriving at vue=14 advances chapter 1
+	// to chapter 2 via CHAPI001.CON section 10).
+	for (const AtlantisSubWAM &sub : _wam.getSubWAMs()) {
+		if (sub.srcPlaceId == _currentPlaceId && sub.dstPlaceId == nextPlaceId) {
+			// Copy fields to locals BEFORE setupWAMByName: that call invokes
+			// _wam.clear() which destroys _subWAMs, making sub a dangling ref.
+			Common::String wamName = sub.wamName;
+			uint16 dstPlaceId     = sub.dstPlaceId;
+
+			debugC(1, kDebugScript, "Sub-WAM transition: place %u → WAM '%s' place %u",
+			      nextPlaceId, wamName.c_str(), dstPlaceId);
+			setupWAMByName(wamName);
+			// _wam._places was cleared; _currentPlace is now a dangling pointer.
+			_currentPlace   = nullptr;
+			_currentPlaceId = uint(-1);
+			_nextPlaceId    = dstPlaceId;
+			return;
+		}
+	}
+
+	_nextPlaceId = nextPlaceId;
+}
+
+bool CryOmni3DEngine_Atlantis::loadCycloHNM(const Common::String &name) {
+#ifdef USE_HNM
+	Common::SeekableReadStream *stream = openBigFileStream(kFileTypeCyclo, name);
+	if (!stream && !name.hasSuffix(".hnm") && !name.hasSuffix(".HNM")) {
+		// Some WAM entries use .tga extension but the archive only has .hnm
+		Common::String hnmName = name;
+		const char *dot = strrchr(hnmName.c_str(), '.');
+		if (dot) {
+			hnmName = Common::String(hnmName.c_str(), dot - hnmName.c_str()) + ".hnm";
+			stream = openBigFileStream(kFileTypeCyclo, hnmName);
+		}
+	}
+	if (!stream) {
+		warning("Cannot open cyclo HNM: %s", name.c_str());
+		return false;
+	}
+
+	// HNM6 panoramas are 16-bit true color; use the screen pixel format.
+	// HNMDecoder takes ownership of the stream when loadStream() is called.
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	Video::HNMDecoder *decoder = new Video::HNMDecoder(fmt);
+
+	// loadStream takes ownership of stream immediately (even on failure).
+	if (!decoder->loadStream(stream)) {
+		warning("Cannot load cyclo HNM: %s", name.c_str());
+		delete decoder;
+		return false;
+	}
+
+	decoder->start();
+
+	const Graphics::Surface *frame = nullptr;
+	while (!frame && !decoder->endOfVideo()) {
+		if (decoder->needsUpdate())
+			frame = decoder->decodeNextFrame();
+		else
+			decoder->decodeNextFrame();
+	}
+
+	if (!frame) {
+		warning("No frames in cyclo HNM: %s", name.c_str());
+		delete decoder;
+		return false;
+	}
+
+	_cycloSurface.free();
+	_cycloSurface.copyFrom(*frame);
+	_warpSurface.free();
+	_warpSurface.copyFrom(*frame);
+
+	if (decoder->hasDirtyPalette())
+		memcpy(_mainPalette, decoder->getPalette(), 3 * 256);
+
+	delete decoder;
+	_warpLoaded = true;
+	_propAnimFrames = 0;
+	_propAnimFrame  = 0;
+	_propAnimNextMs = 0;
+	debugC(1, kDebugScript, "loadCycloHNM: %s (%dx%d)", name.c_str(), _warpSurface.w, _warpSurface.h);
+	return true;
+#else
+	warning("HNM support not compiled in; cannot load cyclo %s", name.c_str());
+	return false;
+#endif
+}
+
+void CryOmni3DEngine_Atlantis::playTransitionVideo(const Common::String &videoName,
+                                                    uint fromPlace, uint toPlace) {
+#ifdef USE_HNM
+	// WAM records use .UBB extension but the BigFile stores them as .HNM.
+	Common::String hnmName = videoName;
+	{
+		const char *dot = strrchr(hnmName.c_str(), '.');
+		if (dot && !scumm_stricmp(dot, ".UBB"))
+			hnmName = Common::String(hnmName.c_str(), dot - hnmName.c_str()) + ".HNM";
+	}
+
+	Common::SeekableReadStream *stream = openBigFileStream(kFileTypeTransition, hnmName);
+	if (!stream) {
+		debugC(1, kDebugScript, "playTransitionVideo: '%s' not found", hnmName.c_str());
+		return;
+	}
+
+	// Open SPF transition-sprite streams that apply to this (from,to) pair.
+	// Matches the original engine's FUN_0041b81c: scan the SPF table for
+	// entries keyed by (current place, target place) and load each.  Streams
+	// stay open for the duration of the transition so per-frame decode is
+	// cheap; closed afterwards.  A no-op when either place ID is unknown
+	// (e.g. cinematic videos played via the legacy single-arg overload).
+	Common::Array<Common::SeekableReadStream *> spfStreams;
+	if (fromPlace != uint(-1) && toPlace != uint(-1)) {
+		for (const SpriteTransEntry &e : _spriteTransList) {
+			if (e.fromPlace != fromPlace || e.toPlace != toPlace) continue;
+			// Honour the hidden-perso list so /set(HidePerso=N) suppresses
+			// transition sprites for that NPC just like static sprites.
+			bool hidden = false;
+			for (int h : _hiddenPersos)
+				if (h == e.persoId) { hidden = true; break; }
+			if (hidden) continue;
+			Common::SeekableReadStream *spf =
+			    openBigFileStream(kFileTypeSpriteUbb, e.spfFile);
+			if (spf) {
+				spfStreams.push_back(spf);
+				debugC(2, kDebugScript, "playTransitionVideo: opened SPF '%s' (perso=%d)",
+				      e.spfFile.c_str(), e.persoId);
+			}
+		}
+	}
+
+	Graphics::PixelFormat screenFmt = g_system->getScreenFormat();
+	Graphics::PixelFormat fmt = (screenFmt.bytesPerPixel == 1)
+	    ? Graphics::PixelFormat::createFormatCLUT8()
+	    : screenFmt;
+	byte *savedPalette = nullptr;
+	if (screenFmt.bytesPerPixel == 1) {
+		savedPalette = new byte[3 * 256];
+		g_system->getPaletteManager()->grabPalette(savedPalette, 0, 256);
+	}
+
+	Video::HNMDecoder *decoder = new Video::HNMDecoder(fmt, false, savedPalette);
+	decoder->setSoundType(Audio::Mixer::kSFXSoundType);
+	// loadStream takes ownership immediately.
+	if (!decoder->loadStream(stream)) {
+		delete decoder;
+		return;
+	}
+
+	decoder->start();
+
+	// Play matching APC audio if present (e.g. WAV\CINEM020.APC for CINEM020.HNM).
+	// AT*.HNM place-to-place transitions are intentionally silent.
+	Audio::SoundHandle apcHandle;
+	{
+		const char *dot = strrchr(hnmName.c_str(), '.');
+		Common::String apcName = dot
+		    ? Common::String(hnmName.c_str(), dot - hnmName.c_str()) + ".APC"
+		    : hnmName + ".APC";
+		Common::SeekableReadStream *apcFile = openBigFileStream(kFileTypeSound, apcName);
+		if (apcFile) {
+			// makeAPCStream reads the file header; queue remaining bytes as one packet.
+			Audio::PacketizedAudioStream *apc = Audio::makeAPCStream(*apcFile);
+			if (apc) {
+				int64 remaining = apcFile->size() - apcFile->pos();
+				if (remaining > 0) {
+					byte *buf = new byte[remaining];
+					apcFile->read(buf, (uint32)remaining);
+					apc->queuePacket(new Common::MemoryReadStream(buf, remaining,
+					                                              DisposeAfterUse::YES));
+				}
+				apc->finish();
+				_mixer->playStream(Audio::Mixer::kSFXSoundType, &apcHandle, apc);
+			}
+			delete apcFile;
+		}
+	}
+
+	uint spfFrameIdx = 0;
+	Graphics::Surface composite;  // per-frame scratch when sprites are active
+	while (!shouldAbort() && !decoder->endOfVideo()) {
+		if (decoder->needsUpdate()) {
+			const Graphics::Surface *frame = decoder->decodeNextFrame();
+			if (frame) {
+				if (decoder->hasDirtyPalette())
+					setPalette(decoder->getPalette(), 0, 256);
+
+				const Graphics::Surface *toBlit = frame;
+				if (!spfStreams.empty() && fmt.bytesPerPixel >= 2) {
+					// Composite the SPF sprites for this frame into a
+					// throwaway copy of the video frame.  The SPF pixel
+					// stream is RGB565 (format=9), so we only do this
+					// when the target surface is at least 16bpp — at
+					// 8bpp the formats don't mix and we just show the
+					// raw video.
+					if (composite.w != frame->w || composite.h != frame->h
+					 || composite.format != fmt) {
+						composite.free();
+						composite.create(frame->w, frame->h, fmt);
+					}
+					const uint rowBytes = (uint)frame->w * fmt.bytesPerPixel;
+					for (int row = 0; row < frame->h; ++row)
+						memcpy(composite.getBasePtr(0, row),
+						       frame->getBasePtr(0, row), rowBytes);
+					for (Common::SeekableReadStream *spf : spfStreams)
+						compositeSpfFrame(spf, spfFrameIdx, composite);
+					toBlit = &composite;
+				}
+
+				g_system->copyRectToScreen(toBlit->getPixels(), toBlit->pitch,
+				                           0, 0, toBlit->w, toBlit->h);
+				g_system->updateScreen();
+				++spfFrameIdx;
+			}
+		}
+		pollEvents();
+		if (checkKeysPressed(1, Common::KEYCODE_SPACE))
+			break;
+		g_system->delayMillis(10);
+	}
+	_mixer->stopHandle(apcHandle);
+	delete decoder;
+	for (Common::SeekableReadStream *spf : spfStreams)
+		delete spf;
+	composite.free();
+#else
+	debugC(1, kDebugScript, "playTransitionVideo: %s (HNM not compiled)", videoName.c_str());
+#endif
+}
+
+// ---------------------------------------------------------------------------
+// QUIT GAME outro slideshow
+// ---------------------------------------------------------------------------
+//
+// Triggered by the in-game (Escape) menu's QUIT GAME entry.  Mirrors the
+// original game's credits sequence: CREDIT01..10.TGA in the left ~340 px
+// of the screen (the right ~300 px is a black region authored as a text
+// overlay area) and the FUN_00428... credits loop renders the matching
+// $NN section of SPRLIST\CREDITS.TXT into that black area.  We reproduce
+// both halves here.
+//
+// Asset notes (verified against BIGCD1.BIG):
+//   * END.TGA and 04GENERI.APC are NOT on disc 1 — they ship on a later CD.
+//     We skip END.TGA entirely and try 04GENERI.APC first (so multi-disc
+//     installs still work), falling back to 33INTRO.APC (track 20 in
+//     kMusicTrackNames; present on disc 1) for that "Cryo narration" feel.
+//   * CREDIT01..10.TGA are 640×480; profiling the pixels confirms the right
+//     half is uniformly black (intensity 0) starting around x=340.
+//   * SPRLIST\CREDITS.TXT is segmented by `$NN` markers (10 sections);
+//     within each section `<>TEXT` is a credit line and `<>\TEXT` is a
+//     section label (rendered the same way here — the leading `\` is
+//     stripped).  Section NN corresponds to CREDITNN.TGA.
+
+namespace {
+
+// One parsed line of credits text.
+struct CreditsLine {
+	Common::String text;
+	bool label;     // true if the original line started with `\`
+};
+
+// Split CREDITS.TXT into 10 sections keyed by `$NN`.  Lines that are not
+// `$NN` or `<>...` are ignored (the file contains blank padding lines).
+struct CreditsScript {
+	Common::Array<CreditsLine> sections[10];
+};
+
+static void parseCreditsScript(Common::ReadStream &stream, CreditsScript &out) {
+	Common::Array<byte> buf;
+	byte chunk[256];
+	while (!stream.eos()) {
+		uint32 got = stream.read(chunk, sizeof(chunk));
+		if (!got) break;
+		for (uint32 i = 0; i < got; i++)
+			buf.push_back(chunk[i]);
+	}
+	buf.push_back(0);
+
+	int section = -1;       // 0..9, set when we see `$NN`
+	const char *cur = (const char *)buf.data();
+	while (*cur) {
+		Common::String line;
+		while (*cur && *cur != '\n' && *cur != '\r') {
+			line += *cur;
+			++cur;
+		}
+		while (*cur == '\n' || *cur == '\r') ++cur;
+
+		if (line.empty())
+			continue;
+
+		// Section marker: `$NN` (one or two digits).
+		if (line[0] == '$' && line.size() >= 2) {
+			int n = 0;
+			for (uint i = 1; i < line.size(); i++) {
+				char c = line[i];
+				if (c < '0' || c > '9') break;
+				n = n * 10 + (c - '0');
+			}
+			if (n >= 1 && n <= 10)
+				section = n - 1;
+			continue;
+		}
+
+		// Body line: `<>TEXT` or `<>\TEXT`.
+		if (section >= 0 && line.size() >= 2 && line[0] == '<' && line[1] == '>') {
+			CreditsLine cl;
+			const char *p = line.c_str() + 2;
+			if (*p == '\\') {
+				cl.label = true;
+				++p;
+			} else {
+				cl.label = false;
+			}
+			cl.text = Common::String(p);
+			out.sections[section].push_back(cl);
+		}
+	}
+}
+
+} // anonymous
+
+void CryOmni3DEngine_Atlantis::playQuitOutro() {
+	static const char *const kSlides[10] = {
+		"CREDIT01.TGA", "CREDIT02.TGA", "CREDIT03.TGA", "CREDIT04.TGA",
+		"CREDIT05.TGA", "CREDIT06.TGA", "CREDIT07.TGA", "CREDIT08.TGA",
+		"CREDIT09.TGA", "CREDIT10.TGA",
+	};
+	static const uint32 kSlideDurationMs = 6000;
+	// 04GENERI.APC ("generique"=credits, music track 22 per the engine's
+	// kMusicTrackNames table) is the authentic credits music but only
+	// ships on a later CD — disc 1 just doesn't have it.  We try to load
+	// it for completeness on multi-disc installs; on disc 1 the slideshow
+	// runs in silence, which is exactly what the original game does there.
+	// We DO NOT substitute a different track: the user reported that the
+	// previous 33INTRO fallback fought with the still-running chapter
+	// music and produced an obviously wrong soundscape.
+	static const char *const kMusicApc = "04GENERI.APC";
+
+	// Silence the chapter music first, regardless of whether the credits
+	// APC loads — the original game's GereGameOver path stops sample
+	// playback (FUN_0042b290 → _AIL_stop_sample_4) before drawing the
+	// first credit slide.
+	musicStop();
+
+	// --- Music (credits track if present) ----------------------------
+	Audio::SoundHandle musicHandle;
+	bool musicPlaying = false;
+	{
+		Common::SeekableReadStream *apcFile =
+		    openBigFileStream(kFileTypeSound, kMusicApc);
+		if (apcFile) {
+			Audio::PacketizedAudioStream *apc = Audio::makeAPCStream(*apcFile);
+			if (apc) {
+				int64 remaining = apcFile->size() - apcFile->pos();
+				if (remaining > 0) {
+					byte *buf = new byte[remaining];
+					apcFile->read(buf, (uint32)remaining);
+					apc->queuePacket(new Common::MemoryReadStream(
+					    buf, remaining, DisposeAfterUse::YES));
+				}
+				apc->finish();
+				_mixer->playStream(Audio::Mixer::kMusicSoundType,
+				                   &musicHandle, apc);
+				musicPlaying = true;
+				debugC(1, kDebugScript, "playQuitOutro: %s playing", kMusicApc);
+			}
+			delete apcFile;
+		} else {
+			debugC(1, kDebugScript, "playQuitOutro: %s not on this disc (silent credits)",
+			      kMusicApc);
+		}
+	}
+
+	// --- Credits text -------------------------------------------------
+	CreditsScript credits;
+	{
+		Common::ScopedPtr<Common::SeekableReadStream> txt(
+		    openBigFileStream(kFileTypeSprite, "CREDITS.TXT"));
+		if (txt)
+			parseCreditsScript(*txt, credits);
+	}
+
+	// Centering matches FUN_0042073c (atlantis.exe @ 0x42073c):
+	//   x = (0x3c0 - text_pixel_width) / 2
+	// 0x3c0 = 960 is the original engine's text-area virtual width.  In
+	// practice the CRED font lines are short enough that this places them
+	// in the black band on the right of the slide art (artwork ends near
+	// x≈340 per the per-column-brightness profile of CREDIT01.TGA).
+	const int kCenterWidth = 0x3c0;
+
+	// Vertical layout: stack lines with a step that fits the per-section
+	// max line count (≈22 lines for the biggest sections) in 480 px, and
+	// centre the block vertically.  Char height is ~18 in the original
+	// SPR; 22 px step gives a comfortable readable gap.
+	const int kLineStep = 22;
+
+	showMouse(false);
+	clearKeys();
+
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+
+	bool skipped = false;
+	for (uint i = 0; i < ARRAYSIZE(kSlides) && !skipped && !shouldAbort();
+	     i++) {
+		Graphics::Surface *slide = loadTGA(kFileTypeImages, kSlides[i]);
+		if (!slide) {
+			warning("playQuitOutro: missing slide '%s'", kSlides[i]);
+			continue;
+		}
+
+		// Build the composite once: slide artwork + credit text overlay.
+		Graphics::ManagedSurface frame;
+		frame.create(slide->w, slide->h, fmt);
+		frame.blitFrom(*slide);
+
+		const Common::Array<CreditsLine> &lines = credits.sections[i];
+		if (!lines.empty() && !_creditBlanSprites.empty()) {
+			int totalH = (int)lines.size() * kLineStep;
+			int y = (480 - totalH) / 2 + kLineStep;   // baseline of first line
+			for (uint l = 0; l < lines.size(); l++) {
+				const CreditsLine &cl = lines[l];
+				int w = creditStringWidth(cl.text);
+				int x = (kCenterWidth - w) / 2;        // authentic formula
+				drawCreditText(frame, cl.text, x, y, cl.label);
+				y += kLineStep;
+				if (y > 478) break;
+			}
+		}
+
+		g_system->copyRectToScreen(frame.getPixels(), frame.pitch,
+		                            0, 0, frame.w, frame.h);
+		g_system->updateScreen();
+
+		slide->free();
+		delete slide;
+
+		// Per-slide wait, skippable.
+		const uint32 deadline = g_system->getMillis() + kSlideDurationMs;
+		while (g_system->getMillis() < deadline && !shouldAbort()) {
+			pollEvents();   // pump engine-level queues
+
+			// Direct event-manager poll for the skip signal.
+			Common::Event ev;
+			while (g_system->getEventManager()->pollEvent(ev)) {
+				if (ev.type == Common::EVENT_KEYDOWN
+				 || ev.type == Common::EVENT_LBUTTONDOWN
+				 || ev.type == Common::EVENT_RBUTTONDOWN) {
+					skipped = true;
+					break;
+				}
+			}
+			if (skipped)
+				break;
+
+			g_system->updateScreen();
+			g_system->delayMillis(10);
+		}
+	}
+
+	if (musicPlaying)
+		_mixer->stopHandle(musicHandle);
+	clearKeys();
+}
+
+// ---------------------------------------------------------------------------
+// Warp-view cursor helpers
+// ---------------------------------------------------------------------------
+
+// Key color (transparent) for warp cursors: pure blue in RGB565.
+// Not used in the warm Mediterranean/Atlantis palette.
+static const uint16 kWarpCursorKey = 0x001Fu;
+
+// Cursor group indices matching CURSEURS.SPR sprite groups.
+enum WarpCursorState {
+	kWarpCursorDefault  = 0,  // sprites 0–8   (20×20) — no interactive zone
+	kWarpCursorNavigate = 1,  // sprites 9–17  (24×24) — place transition
+	kWarpCursorObject   = 2,  // sprites 18–25 (32×32 crosshair) — object interaction
+	kWarpCursorTalk     = 3   // sprites 26–45 (32×32 rotating)  — NPC interaction
+};
+
+// Fallback bitmask cursors used when CURSEURS.SPR is unavailable.
+static void buildWarpCursorFallback(uint16 *out, const uint16 *rowMasks, uint16 color) {
+	for (int r = 0; r < 16; r++) {
+		uint16 mask = rowMasks[r];
+		for (int c = 0; c < 16; c++)
+			out[r * 16 + c] = (mask & (0x8000u >> c)) ? color : kWarpCursorKey;
+	}
+}
+static const uint16 kCursorDefaultMask[16] = {
+	0x8000, 0xC000, 0xE000, 0xF000, 0xF800, 0xFC00, 0xFE00, 0xFF00,
+	0xE000, 0xC800, 0x8400, 0x0200, 0x0000, 0x0000, 0x0000, 0x0000
+};
+static const uint16 kCursorNavigateMask[16] = {
+	0x0000, 0x0000, 0x0000, 0x0000, 0x0010, 0x0030, 0x0070, 0xFFF0,
+	0xFFF8, 0xFFF0, 0x0070, 0x0030, 0x0010, 0x0000, 0x0000, 0x0000
+};
+static const uint16 kCursorTalkMask[16] = {
+	0x0000, 0x1FF0, 0x2004, 0x2448, 0x2448, 0x2004, 0x2814, 0x27E4,
+	0x2004, 0x1FF0, 0x0080, 0x0100, 0x0200, 0x0000, 0x0000, 0x0000
+};
+
+// Convert one RGB565 sprite pixel to straight-alpha ARGB8888 for a hardware
+// cursor.  Opaque pixels become fully opaque; blend pixels carry a 5-bit
+// factor and a premultiplied colour (atlantis.exe stores src*factor/32), so the
+// colour is un-premultiplied and the factor becomes the alpha — ScummVM's
+// cursor compositor uses straight alpha.
+static uint32 spriteToArgb(uint16 p, uint8 factor, uint16 transpKey) {
+	if (p == transpKey)
+		return 0;  // fully transparent
+	uint r = (p >> 11) & 0x1f;
+	uint g = (p >>  5) & 0x3f;
+	uint b =  p        & 0x1f;
+	uint a = 0xff;
+	if (factor != kSprNoBlend) {
+		uint f = factor & 0x1f;
+		if (f == 0)
+			return 0;  // factor 0 == fully transparent edge pixel
+		r = MIN<uint>(0x1f, r * 32 / f);
+		g = MIN<uint>(0x3f, g * 32 / f);
+		b = MIN<uint>(0x1f, b * 32 / f);
+		a = f * 255 / 32;
+	}
+	uint r8 = (r << 3) | (r >> 2);
+	uint g8 = (g << 2) | (g >> 4);
+	uint b8 = (b << 3) | (b >> 2);
+	return (a << 24) | (r8 << 16) | (g8 << 8) | b8;
+}
+
+void CryOmni3DEngine_Atlantis::setBlendedCursor(uint16 w, uint16 h,
+        const uint16 *pixels, const uint8 *blend, int hotX, int hotY,
+        uint16 transpKey) {
+	const uint n = (uint)w * h;
+	if (g_system->hasFeature(OSystem::kFeatureCursorAlpha)) {
+		// ARGB8888 cursor: the backend alpha-composites it over the scene, so
+		// anti-aliased edges blend the way the original game does.
+		Graphics::PixelFormat fmt(4, 8, 8, 8, 8, 16, 8, 0, 24);
+		Common::Array<uint32> buf(n);
+		for (uint i = 0; i < n; i++)
+			buf[i] = spriteToArgb(pixels[i],
+			                      blend ? blend[i] : (uint8)kSprNoBlend, transpKey);
+		CursorMan.replaceCursor(buf.data(), w, h, hotX, hotY, 0, false, &fmt);
+	} else {
+		// No alpha-cursor support: fall back to a key-colour RGB565 cursor.
+		Graphics::PixelFormat fmt(2, 5, 6, 5, 0, 11, 5, 0, 0);
+		Common::Array<uint16> buf;
+		buf.assign(pixels, pixels + n);
+		for (uint16 &p : buf)
+			if (p == transpKey)
+				p = kWarpCursorKey;
+		CursorMan.replaceCursor(buf.data(), w, h, hotX, hotY, kWarpCursorKey,
+		                        false, &fmt);
+	}
+}
+
+void CryOmni3DEngine_Atlantis::setWarpCursor(int group) {
+	_warpCursorGroup = group;
+	_warpCursorFrame = -1;   // tickWarpCursor advances to 0 on first call
+	_warpCursorNextMs = 0;   // trigger immediate update
+	tickWarpCursor();
+}
+
+void CryOmni3DEngine_Atlantis::setItemCursor(const Object *obj, int overlayCursorFrame) {
+	if (!obj || _objects.empty() || _objSprites.empty()) return;
+	ptrdiff_t idx = obj - &_objects.front();
+	if (idx < 0 || (uint)idx >= _objSprites.size()) return;
+	const SubjSprite &spr = _objSprites[(uint)idx];
+	if (spr.pixels.empty()) return;
+
+	const bool overlay = overlayCursorFrame >= 0 &&
+	    (uint)overlayCursorFrame < _cursorSprites.size() &&
+	    !_cursorSprites[(uint)overlayCursorFrame].pixels.empty();
+
+	if (!overlay) {
+		// No action overlay: the object sprite alone is the cursor.
+		setBlendedCursor(spr.w, spr.h, spr.pixels.data(), spr.blend.data(),
+		                 spr.xoff, spr.yoff, kSprTransp);
+		return;
+	}
+
+	// Carrying an object with an action available: composite the object
+	// sprite with the action cursor drawn on top.  Both sub-sprites are
+	// anchored by their own hotspot to a shared hotspot, so the result
+	// behaves like the two cursors drawn at the same point.
+	const CursorSpr &act = _cursorSprites[(uint)overlayCursorFrame];
+	const int hx = MAX((int)spr.xoff, (int)act.xoff);
+	const int hy = MAX((int)spr.yoff, (int)act.yoff);
+	const int w  = hx + MAX((int)spr.w - spr.xoff, (int)act.w - act.xoff);
+	const int h  = hy + MAX((int)spr.h - spr.yoff, (int)act.h - act.yoff);
+
+	Common::Array<uint16> buf;
+	Common::Array<uint8>  blendBuf;
+	buf.resize((uint)(w * h), kSprTransp);
+	blendBuf.resize((uint)(w * h), kSprNoBlend);
+
+	const int ox = hx - spr.xoff, oy = hy - spr.yoff;   // object (base)
+	for (int y = 0; y < (int)spr.h; y++)
+		for (int x = 0; x < (int)spr.w; x++) {
+			uint si = y * spr.w + x;
+			if (spr.pixels[si] != kSprTransp) {
+				uint di = (oy + y) * w + (ox + x);
+				buf[di]      = spr.pixels[si];
+				blendBuf[di] = spr.blend[si];
+			}
+		}
+	const int ax = hx - act.xoff, ay = hy - act.yoff;   // action cursor (top)
+	for (int y = 0; y < (int)act.h; y++)
+		for (int x = 0; x < (int)act.w; x++) {
+			uint si = y * act.w + x;
+			if (act.pixels[si] != kWarpCursorKey) {
+				uint di = (ay + y) * w + (ax + x);
+				buf[di]      = act.pixels[si];
+				blendBuf[di] = act.blend[si];
+			}
+		}
+	setBlendedCursor((uint16)w, (uint16)h, buf.data(), blendBuf.data(),
+	                 hx, hy, kSprTransp);
+}
+
+// The plain Atlantis pointer: CURSEURS.SPR sprite 8, the last (fully formed)
+// frame of the default-cursor group.  This is the static arrow the original
+// uses for the toolbar and the option menus — distinct from the animated
+// navigation / interaction cursors.
+void CryOmni3DEngine_Atlantis::setArrowCursor() {
+	if (_cursorSprites.size() <= 8)
+		return;
+	const CursorSpr &spr = _cursorSprites[8];
+	if (spr.pixels.empty())
+		return;
+	setBlendedCursor(spr.w, spr.h, spr.pixels.data(), spr.blend.data(),
+	                 spr.xoff, spr.yoff, kWarpCursorKey);
+}
+
+void CryOmni3DEngine_Atlantis::tickWarpCursor() {
+	static const int kGroupFirst[] = {  0,  9, 18, 26 };
+	static const int kGroupCount[] = {  9,  9,  8, 20 };
+
+	if (!_cursorSprites.empty()) {
+		int grp = CLIP(_warpCursorGroup, 0, 3);
+
+		// The default cursor — shown when the view is over plain scenery,
+		// not a point of interest — is static in the original game; only the
+		// navigate / object / talk cursors animate.  Cycling group 0 made it
+		// visibly blink, so hold it on its first frame instead.
+		if (grp == kWarpCursorDefault) {
+			if (_warpCursorFrame == 0)
+				return;  // already on the static frame
+			_warpCursorFrame = 0;
+		} else {
+			uint32 now = g_system->getMillis();
+			if (now < _warpCursorNextMs) return;
+			_warpCursorNextMs = now + 80;  // ~12 fps
+			_warpCursorFrame = (_warpCursorFrame + 1) % kGroupCount[grp];
+		}
+
+		const CursorSpr &spr = _cursorSprites[kGroupFirst[grp] + _warpCursorFrame];
+		if (!spr.pixels.empty())
+			setBlendedCursor(spr.w, spr.h, spr.pixels.data(), spr.blend.data(),
+			                 spr.xoff, spr.yoff, kWarpCursorKey);
+		return;
+	}
+
+	// Fallback: hardcoded bitmask cursors when CURSEURS.SPR is not loaded.
+	if (_warpCursorFrame == 0) return;  // already set, avoid redundant update
+	_warpCursorFrame = 0;
+	// Stack-local scratch buffer (16×16 RGB565 = 512 bytes).  Was previously
+	// declared `static` for no good reason — that made the engine non-
+	// re-entrant per ScummVM's engine guidelines.
+	uint16 buf[16 * 16];
+	Graphics::PixelFormat fmt(2, 5, 6, 5, 0, 11, 5, 0, 0);
+	switch (_warpCursorGroup) {
+	case 1:
+		buildWarpCursorFallback(buf, kCursorNavigateMask, 0xFFE0u);
+		CursorMan.replaceCursor(buf, 16, 16, 0, 7, kWarpCursorKey, false, &fmt);
+		break;
+	case 2:
+		// Object interaction — no dedicated bitmask; use white default arrow
+		buildWarpCursorFallback(buf, kCursorDefaultMask, 0xFFFFu);
+		CursorMan.replaceCursor(buf, 16, 16, 0, 0, kWarpCursorKey, false, &fmt);
+		break;
+	case 3:
+		// NPC interaction — cyan face+bubble
+		buildWarpCursorFallback(buf, kCursorTalkMask, 0x07FFu);
+		CursorMan.replaceCursor(buf, 16, 16, 7, 4, kWarpCursorKey, false, &fmt);
+		break;
+	default:
+		buildWarpCursorFallback(buf, kCursorDefaultMask, 0xFFFFu);
+		CursorMan.replaceCursor(buf, 16, 16, 0, 0, kWarpCursorKey, false, &fmt);
+		break;
+	}
+}
+
+int CryOmni3DEngine_Atlantis::handleWarp() {
+	bool leftButtonPressed = false;
+	bool exit = false;
+	bool firstDraw = true;
+	bool moving = true;
+	uint actionId = 0;
+
+	showMouse(true);
+	_canLoadSave = true;
+
+	// FPS mode: center cursor so the first delta is zero.
+	setMousePos(Common::Point(320, 240));
+
+	WarpCursorState cursorState = kWarpCursorDefault;
+	const Object *cursorHeldObj = nullptr;   // object whose cursor is shown
+	int cursorOverlayFrame = 0;              // animated action-overlay frame
+	uint32 cursorOverlayNextMs = 0;
+	if (_inventory.selectedObject() == nullptr)
+		setWarpCursor(cursorState);
+
+	// Drain stale clicks from navigation or window-focus events.
+	// Ignore input for ~100ms after entering a place (5 × 20ms) to consume focus clicks.
+	for (int grace = 0; grace < 5 && !shouldAbort(); grace++) {
+		pollEvents();
+		g_system->delayMillis(20);
+	}
+	while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+		pollEvents();
+		g_system->delayMillis(10);
+	}
+	setMousePos(Common::Point(320, 240));
+
+	// Lock the cursor into SDL relative mode for the look.  warpMouse cannot
+	// re-centre the pointer on Wayland (WSL), so reading an offset-from-centre
+	// would make the camera scroll until the cursor crossed the centre.
+	// Relative mode delivers pure per-frame motion (event.relMouse) instead.
+	g_system->lockMouse(true);
+	takeMouseRelative();   // discard motion accumulated before entry
+
+	// FPS mouse-look sensitivity — atlantis.exe FUN_0041bfa0.  The exe runs a
+	// momentum integrator   speed += delta / K;  angle += speed;  speed *= 0.8
+	// with K = 3000 (yaw) and K = 4000 (pitch), in an uncapped render-bound
+	// loop.  On any modern-speed machine the 0.8 decay collapses within a
+	// frame, so there is no perceptible inertia — the net rotation of a
+	// gesture is just its total delta / (K * (1 - 0.8)).  Reproduce that as a
+	// direct mapping: 3000*0.2 = 600 px/rad yaw, 4000*0.2 = 800 px/rad pitch.
+	static const double kLookYawDiv    = 600.0;
+	static const double kLookPitchDiv  = 800.0;
+	static const double kWarpBetaLimit = M_PI / 4.0;  // matches doPlaceChange
+
+	while (!leftButtonPressed && !exit) {
+		pollEvents();
+
+		// FPS mouse-look: this frame's accumulated relative motion.
+		//
+		// SDL reports relative-mouse motion as right = positive on every
+		// standard backend — verified on the native Windows build, where
+		// relMouse.x came back positive for a rightward move.  WSLg's
+		// Wayland relative-pointer is the lone exception: it inverts the X
+		// axis (Y is consistent everywhere).  The Linux build runs solely
+		// under WSLg, so flip X there; the Windows build takes it as-is.
+		// xDelta must end up positive for a rightward look — the rotation
+		// below subtracts it from alpha.
+		Common::Point lookRel = takeMouseRelative();
+#if defined(WIN32)
+		int xDelta = lookRel.x;
+#else
+		int xDelta = -lookRel.x;   // compensate WSLg's inverted Wayland X
+#endif
+		int yDelta = -lookRel.y;
+
+		// Pin the crosshair to the exact screen centre.  Every action check
+		// (navigation zones, NPC dialog) is hit-tested at the centre, so the
+		// cursor must stay there; discard the motion the re-centre produces.
+		setMousePos(Common::Point(320, 240));
+		takeMouseRelative();
+
+		leftButtonPressed = (getCurrentMouseButton() == 1);
+
+		// Hit-test panorama at the screen centre — that is always where the
+		// crosshair/cursor sits in FPS mode.
+		actionId = 0;
+		Common::Point pan;
+		bool havePan = false;
+		if (_currentPlace && _warpLoaded) {
+			pan = _omni3dMan.mapMouseCoords(Common::Point(320, 240));
+			pan.y = 768 - pan.y; // flip Y to top-left origin
+			havePan = true;
+			int16 hit = _currentPlace->hitTest(pan.x, pan.y);
+			if (hit > 0)
+				actionId = (uint)hit;
+		}
+
+		// Update cursor shape based on what the centre is pointing at:
+		// an NPC (talk), an object hotspot (converging-arrows), a
+		// navigation zone (navigate), or nothing.
+		//
+		// A zone's action is an Object hotspot iff (a) some ConSection's
+		// clicZone explicitly matches it (e.g. `/con*(cliczone=499)`) OR
+		// (b) it isn't a real navigation destination at all -- neither a
+		// place in the current WAM nor a sub-WAM destination.  Case (b)
+		// catches puzzle-launcher sentinels like CHAPI012 vue 221's
+		// action=1000, where the /sel that fires is a generic
+		// `(vue=N)&(flagtemp6=0)` without a cliczone clause and the
+		// action value is just a hotspot trigger, not a real place ID --
+		// without case (b), the cursor would say "go there" over a
+		// hotspot that does NOT navigate.
+		{
+			WarpCursorState action = kWarpCursorDefault;
+			if (havePan) {
+				int dummy = 0;
+				if (npcPanoHitTest(pan, dummy)) {
+					action = kWarpCursorTalk;
+				} else if (actionId > 0) {
+					bool isClicZone = false;
+					for (const ConSection &sec : _conScript.sections()) {
+						if (sec.clicZone == (int)actionId) {
+							isClicZone = true;
+							break;
+						}
+					}
+					bool isNavTarget = (_wam.findPlaceById((uint16)actionId) != nullptr);
+					if (!isNavTarget) {
+						for (const AtlantisSubWAM &sub : _wam.getSubWAMs()) {
+							if (sub.dstPlaceId == (uint16)actionId) {
+								isNavTarget = true;
+								break;
+							}
+						}
+					}
+					action = (isClicZone || !isNavTarget)
+					         ? kWarpCursorObject : kWarpCursorNavigate;
+				}
+			}
+
+			// CURSEURS.SPR action-cursor group for the carried-object overlay:
+			// navigate is frames 9..17, object is 18..25, talk is 26..45.
+			// ovFirst < 0 = none.
+			int ovFirst = -1, ovCount = 0;
+			if (action == kWarpCursorTalk)          { ovFirst = 26; ovCount = 20; }
+			else if (action == kWarpCursorObject)   { ovFirst = 18; ovCount =  8; }
+			else if (action == kWarpCursorNavigate) { ovFirst =  9; ovCount =  9; }
+
+			const Object *heldObj = _inventory.selectedObject();
+			// Navigation is impossible while an object is in hand (see the
+			// gameStep nav gate), so don't overlay the navigate arrows on the
+			// held-item cursor -- show the plain item icon instead.  The
+			// talk/use overlays stay: using the item on an NPC or hotspot is
+			// still valid.
+			if (heldObj && action == kWarpCursorNavigate) {
+				ovFirst = -1;
+				ovCount = 0;
+			}
+			if (heldObj != cursorHeldObj || action != cursorState) {
+				// Held object or action changed: rebuild and restart the
+				// overlay animation.
+				cursorHeldObj = heldObj;
+				cursorState = action;
+				cursorOverlayFrame = 0;
+				cursorOverlayNextMs = g_system->getMillis() + 80;
+				if (heldObj)
+					setItemCursor(heldObj, ovFirst);
+				else
+					setWarpCursor(action);
+			} else if (heldObj && ovFirst >= 0 &&
+			           g_system->getMillis() >= cursorOverlayNextMs) {
+				// Animate the overlaid action cursor so it looks like the
+				// normal-navigation cursor, which tickWarpCursor() animates.
+				cursorOverlayFrame = (cursorOverlayFrame + 1) % ovCount;
+				cursorOverlayNextMs = g_system->getMillis() + 80;
+				setItemCursor(heldObj, ovFirst + cursorOverlayFrame);
+			}
+		}
+
+		// Log every left-click with the panorama hit-test result.
+		if (leftButtonPressed)
+			debugC(5, kDebugScript, "handleWarp: left-click pan=(%d,%d) havePan=%d hitActionId=%u",
+			      pan.x, pan.y, (int)havePan, actionId);
+
+		// Generic /con scan -- mirror of atlantis.exe FUN_00425cf4, which the
+		// original engine runs before perso / zone dispatch whenever the click
+		// action lands in the object id range.  Handles "use held object in
+		// the world at a specific state" scripts that lack ClicPerso /
+		// ClicZone gates (CHAPI013 sections 178 + /014 — "throw the pot on
+		// the priest aide"): when the player holds object 261 and the camera
+		// + animation frame land in the right window, a click anywhere fires
+		// the section and consumes the click.  evalSelSection's conditions
+		// are tight enough that this can't fire unintentionally.
+		if (leftButtonPressed && havePan) {
+			// Dump the live state the scan will see so a "throw missed"
+			// failure can be reconciled against the section conditions.
+			Object *heldObj = _inventory.selectedObject();
+			debugC(1, kDebugScript, "leftclick: vue=%u anglewarpx=%d anglewarpy=%d "
+			      "wsprframe=%d objetenmain=%d",
+			      _currentPlaceId,
+			      _gameVars["anglewarpx"],
+			      _gameVars["anglewarpy"],
+			      _gameVars["wsprframe"],
+			      (heldObj && heldObj->idOBJ() != uint(-1))
+			          ? (int)heldObj->idOBJ() : 0);
+			// Gate the generic scan: atlantis.exe FUN_004278a0 only runs
+			// FUN_00425cf4 when the click action lands in the object id
+			// range [256, 512) OR with a control flag that empirically
+			// tracks "an object is in hand".  Every generic /con section
+			// in the data carries (ObjetEnMain=N) anyway, so condition on
+			// "something is held" -- this prevents a stray click on the
+			// panorama from triggering an unintended section, and also
+			// keeps NPC clicks (action >= 512) going straight to
+			// interactNPC without the scan stealing them.
+			const bool scanEligible = (heldObj != nullptr);
+			if (scanEligible && runGenericConSections()) {
+				leftButtonPressed = false;
+				actionId = 0;
+				if (shouldAbort()) {
+					actionId = 66666;
+					exit = true;
+				} else if (_nextPlaceId != uint(-1)) {
+					// /set(Vue=N) fired inside the section -- hand the
+					// destination to gameStep just like the NPC-dialog path.
+					uint dest = _nextPlaceId;
+					_canLoadSave = false;
+					showMouse(false);
+					return (int)dest;
+				}
+				// Drain the click then continue the loop; cursor will resync
+				// on the next iteration via cursorHeldObj == nullptr below.
+				cursorHeldObj = nullptr;
+				while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+					pollEvents();
+					g_system->delayMillis(10);
+				}
+				continue;
+			}
+		}
+
+		// NPC sprite click takes priority over WAM zone navigation.
+		// A guard or NPC standing in front of a zone must remain clickable.
+		if (leftButtonPressed && havePan) {
+			int clickedPerso = 0;
+			if (npcPanoHitTest(pan, clickedPerso)) {
+				leftButtonPressed = false;
+				actionId = 0; // consume the action; suppress zone navigation below
+				// Object pickup branch (atlantis.exe FUN_0042785c lines
+				// 21720-21758): when the clicked sprite's "persoId" is
+				// actually an OBJECT id (< 0x200 = 512; real NPC ids
+				// start at 512), the engine adds the object to the
+				// inventory list, hides the sprite from the cyclo, and
+				// selects the object as held -- the canonical case is
+				// CHAPI013 vue 126's flower pot (action=261, object id
+				// 261, perso id 261 of the apotf126 sprite).
+				if (clickedPerso > 0 && clickedPerso < 0x200) {
+					Object *obj = nullptr;
+					for (Object &o : _objects)
+						if (o.valid() && o.idOBJ() == (uint)clickedPerso) {
+							obj = &o; break;
+						}
+					if (obj) {
+						// Replicate atlantis.exe FUN_0042785c (lines
+						// 21717-21758): every world-pickup with action id
+						// < 0x200 (= 512) is written to the inventory slot
+						// array at &DAT_006ce138 *and* selected as held.
+						// One unified path -- no per-object "transient"
+						// special-casing.  Items that are throw-and-forget
+						// (CHAPI013's pot 261) leave the inventory via the
+						// throw script's /set(invent261=0); items the
+						// player keeps (CHAPI014's knife 262) stay until
+						// used elsewhere.  Empirically pot 261 and knife
+						// 262 are both entries in the exe's inventory
+						// table at 0x004967b0, so neither is special at
+						// the engine level.
+						if (!_inventory.inInventoryByNameID((uint)clickedPerso))
+							_inventory.add(obj);
+						_inventory.setSelectedObject(obj);
+						// Deactivate every sprite entry for this perso AND
+						// add it to _hiddenPersos -- mirror the ShowPerso /
+						// HidePerso wiring exactly.  Without the entry.active
+						// flip, recompositeSpriteLayer keeps drawing the
+						// picked-up sprite until a place change or
+						// compositeNPCSprites runs again.
+						bool found = false;
+						for (int h : _hiddenPersos)
+							if (h == clickedPerso) { found = true; break; }
+						if (!found)
+							_hiddenPersos.push_back(clickedPerso);
+						for (SpritePlaceEntry &e : _spritePlaceList)
+							if (e.persoId == clickedPerso) e.active = false;
+						_spriteLayerDirty = true;
+						_npcBoundsDirty   = true;
+						cursorHeldObj = nullptr;   // force cursor re-sync
+						debugC(1, kDebugScript, "object pickup: picked up id=%d "
+						         "(added to inventory + selected)",
+						         clickedPerso);
+						// Drain the click then continue; no NPC dialog.
+						while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+							pollEvents();
+							g_system->delayMillis(10);
+						}
+						continue;
+					}
+					// Perso id < 512 but NOT a pickable inventory object --
+					// it's a "use on this thing" target (rope at vue 158
+					// perso 277, palace traps at 194/215, etc.).  Atlantis.exe
+					// FUN_004278a0 still dispatches the action through the
+					// generic /con scan path so /con(ClicPerso=N) sections
+					// like CHAPI015 `/203 /con*(ClicPerso=277)&(ObjetEnMain=
+					// 262)` (cut the rope with the knife) can fire.  Route
+					// through interactNPC -- it sets clicperso and walks the
+					// /con section list with the same condition gate the
+					// NPC-dialog path uses; sections without /suj fire
+					// directly with no menu, exactly the exe count==0 branch.
+					// Fall through to the standard interactNPC handler below.
+				}
+				// Dialog (and its subject menu) needs a normal free cursor.
+				g_system->lockMouse(false);
+				// Was an object being used on this NPC?  Capture before the
+				// /con section plays.  Only real NPCs (id >= 0x200) go through
+				// the exe's NPC handler; the perso<0x200 "use on a world thing"
+				// path (rope/traps) is handled by a different exe branch that
+				// does NOT auto-clear -- those sections manage the item.
+				const bool usedObjectOnNpc =
+				    clickedPerso >= 0x200 && _inventory.selectedObject() &&
+				    _inventory.selectedObject()->idOBJ() != uint(-1);
+				interactNPC(clickedPerso);
+				// atlantis.exe FUN_00425828: when an NPC is clicked with an
+				// object in hand, the handler runs the /con scan (use object on
+				// NPC) and then UNCONDITIONALLY clears the held slot
+				// (*(int *)(... + 0x611210) = 0), so the item returns to the
+				// inventory.  Mirror that.
+				if (usedObjectOnNpc) {
+					_inventory.setSelectedObject(nullptr);
+					_gameVars["objetenmain"] = 0;
+				}
+				// The dialog is over: stop showing any "object received" icon
+				// (the original clears DAT_0049619c when the dialog restores the
+				// navigation FOV).
+				_dialogGivenObjSprite = -1;
+				if (shouldAbort()) {
+					actionId = 66666;
+					exit = true;
+				} else if (_nextPlaceId != uint(-1)) {
+					// Dialog triggered a place transition (/set(Vue=N) inside
+					// playConSection).  Hand it off to gameStep, BUT leave
+					// _nextPlaceId set: gameStep distinguishes a script-set
+					// destination from a user click by `_nextPlaceId == actionId`
+					// and bypasses the /con and /sel departure scans in that
+					// case — those are gates on player-driven navigation, not on
+					// scripted scene changes.  Without this, CHAPI011 section 128's
+					// /set(Vue=50) (Creon dismissing Seth back to vue 50) is
+					// caught by section 10's throne-room lock /sel(departvue>0)&
+					// (vue>274)&(vue<300) and the abortdepart cancels the move.
+					uint dest = _nextPlaceId;
+					_canLoadSave = false;
+					showMouse(false);
+					return (int)dest;
+				} else {
+					// Dialog playback hides the cursor — restore it so the
+					// warp cursor is visible again over points of interest.
+					showMouse(true);
+					// Item may have been used/deselected; ensure cursor is updated.
+					if (_inventory.selectedObject() == nullptr) {
+						cursorState = kWarpCursorDefault;
+						setWarpCursor(cursorState);
+					}
+					cursorHeldObj = nullptr;   // force the cursor block to re-sync
+					// Drain button release, then re-arm relative look mode.
+					while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+						pollEvents();
+						g_system->delayMillis(10);
+					}
+					setMousePos(Common::Point(320, 240));
+					g_system->lockMouse(true);
+					takeMouseRelative();
+					firstDraw = true;
+				}
+			}
+		}
+
+		if (shouldAbort()) {
+			actionId = 66666;
+			exit = true;
+		}
+
+		// Drain one keypress per frame; route Space → toolbar, Escape →
+		// in-game menu.  All other keys are discarded by design (the
+		// underlying queue continues to fill from pollEvents()).
+		Common::KeyCode kc = getNextKey().keycode;
+		bool toolbarTrigger = (getCurrentMouseButton() == 2 ||
+		                       kc == Common::KEYCODE_SPACE);
+		bool menuTrigger = (kc == Common::KEYCODE_ESCAPE);
+
+		if (!exit && toolbarTrigger) {
+			if (_warpLoaded) {
+				const Graphics::Surface *bg = _omni3dMan.getSurface();
+				g_system->copyRectToScreen(bg->getPixels(), bg->pitch, 0, 0, bg->w, bg->h);
+			}
+			g_system->lockMouse(false);   // toolbar needs a normal cursor
+			// The toolbar uses the plain Atlantis arrow cursor — unless an
+			// object is being carried, in which case the cursor stays in
+			// "object" mode so you can see what you hold while the bar is
+			// open.  (The toolbar's own setCursor() calls are inert: Atlantis
+			// never populates the base _sprites collection.)
+			if (_inventory.selectedObject() != nullptr)
+				setItemCursor(_inventory.selectedObject());
+			else
+				setArrowCursor();
+			displayToolbar(_warpLoaded ? _omni3dMan.getSurface() : nullptr);
+			if (shouldAbort()) {
+				actionId = 66666;
+				exit = true;
+			}
+			// If item was deselected in toolbar, restore warp cursor.
+			if (_inventory.selectedObject() == nullptr) {
+				cursorState = kWarpCursorDefault;
+				setWarpCursor(cursorState);
+			}
+			cursorHeldObj = nullptr;   // force the cursor block to re-sync
+			// Re-arm relative look mode after the toolbar.
+			setMousePos(Common::Point(320, 240));
+			g_system->lockMouse(true);
+			takeMouseRelative();
+			firstDraw = true;
+		}
+
+		// Escape: open the in-game menu.  displayInGameMenu() runs its own
+		// non-blocking sub-loop (pollEvents + updateScreen + delayMillis(10)
+		// per iteration, shouldAbort tested every tick) so the host stays
+		// responsive.  Its return value uses the same codes as displayOptions
+		// so the engine's existing abort state machine routes the action.
+		if (!exit && menuTrigger) {
+			showMouse(true);
+			g_system->lockMouse(false);   // in-game menu needs a normal cursor
+			uint act = displayInGameMenu();
+			switch (act) {
+			case 28:  // Load game
+				actionId = 66666;
+				_abortCommand = kAbortLoadGame;
+				exit = true;
+				break;
+			case 27:  // New game
+				actionId = 66666;
+				_abortCommand = kAbortNewGame;
+				exit = true;
+				break;
+			case 40:  // Quit — clean GMM-friendly path.
+				actionId = 66666;
+				_abortCommand = kAbortQuit;
+				exit = true;
+				break;
+			default:  // Continue / save / cancelled — resume warp.
+				break;
+			}
+			// Re-arm relative look mode and force redraw so the menu
+			// snapshot is not blitted as the panorama next frame.
+			setMousePos(Common::Point(320, 240));
+			g_system->lockMouse(true);
+			takeMouseRelative();
+			firstDraw = true;
+		}
+
+		// zoom=1 (CON) — narrow the panorama FOV for a close-up.  The original
+		// (atlantis.exe FUN_004212cc) ramps the warp FOV by -3 degrees/frame
+		// via FUN_0045179a while var[zoom] is set; here it is time-based
+		// (~30 deg/s) and clamped, holding once the close-up FOV is reached.
+		// doPlaceChange() restores the 75 degrees FOV and clears the flag.
+		{
+			Common::HashMap<Common::String, int>::iterator zit = _gameVars.find("zoom");
+			if (_warpLoaded && zit != _gameVars.end() && zit->_value != 0) {
+				const double kZoomTargetFov = 40.0 / 180.0 * M_PI;
+				double hf = _omni3dMan.getHFov();
+				uint32 now = g_system->getMillis();
+				if (hf > kZoomTargetFov && _zoomLastMs != 0) {
+					double step = (30.0 / 180.0 * M_PI) * (now - _zoomLastMs) / 1000.0;
+					hf = (hf - step < kZoomTargetFov) ? kZoomTargetFov : hf - step;
+					_omni3dMan.setHFov(hf);
+					firstDraw = true;
+				}
+				_zoomLastMs = now;
+			} else {
+				_zoomLastMs = 0;
+			}
+		}
+
+		if (_warpLoaded && (firstDraw || xDelta || yDelta)) {
+			// Direct mouse-look (atlantis.exe FUN_0041bfa0).  The exe's
+			// delta is prevCentre - cursor = -xDelta; yaw uses 600 px/rad,
+			// pitch 800 px/rad (see note above the loop).
+			double alpha = _omni3dMan.getAlpha() - xDelta / kLookYawDiv;
+			// OMNI 3D "MODE 1" (options menu) inverts the vertical axis.
+			int pitch = omni3dInvertY() ? -yDelta : yDelta;
+			double beta = _omni3dMan.getBeta() + pitch / kLookPitchDiv;
+
+			while (alpha >= 2.0 * M_PI) alpha -= 2.0 * M_PI;
+			while (alpha < 0.0)         alpha += 2.0 * M_PI;
+			if (beta < -kWarpBetaLimit) beta = -kWarpBetaLimit;
+			if (beta >  kWarpBetaLimit) beta =  kWarpBetaLimit;
+
+			_omni3dMan.setAlpha(alpha);
+			_omni3dMan.setBeta(beta);
+			// Keep angle vars in sync for CON conditions (AngleWarpX<N).
+			_gameVars["anglewarpx"] = (int)(alpha * 180.0 / M_PI);
+			_gameVars["anglewarpy"] = (int)(beta  * 180.0 / M_PI);
+			const Graphics::Surface *result = _omni3dMan.getSurface();
+			if (result)
+				g_system->copyRectToScreen(result->getPixels(), result->pitch, 0, 0, result->w, result->h);
+			if (!exit)
+				g_system->updateScreen();
+			moving = true;
+			firstDraw = false;
+		} else if (moving) {
+			if (_warpLoaded) {
+				const Graphics::Surface *result = _omni3dMan.getSurface();
+				if (result)
+					g_system->copyRectToScreen(result->getPixels(), result->pitch, 0, 0, result->w, result->h);
+			}
+			if (!exit)
+				g_system->updateScreen();
+			moving = false;
+		} else {
+			if (!exit)
+				g_system->updateScreen();
+		}
+
+		if (_inventory.selectedObject() == nullptr)
+			tickWarpCursor();
+
+		// Advance animated prop sprite if the interval has elapsed.
+		// Mirror the new frame into _gameVars["wsprframe"] so script
+		// conditions like `/con(...)&(Wsprframe>7)&(Wsprframe<34)`
+		// (CHAPI013 line 92, the priest-aide bottle-use action at
+		// vue 126) see the live animation frame -- the script only
+		// fires the action when the perso's idle cycle is in the
+		// right pose window.  Mirrors the wspranim path's wsprframe
+		// hijack via atlantis.exe FUN_00425304 (the propAnim and
+		// wspranim share the same gate slot at runtime).
+		if (_propAnimFrames > 1 && g_system->getMillis() >= _propAnimNextMs) {
+			_propAnimFrame = (_propAnimFrame + 1) % (uint)_propAnimFrames;
+			_propAnimNextMs = g_system->getMillis() + kPropAnimIntervalMs;
+			_gameVars["wsprframe"] = (int)_propAnimFrame;
+			recompositeSpriteLayer();
+			_omni3dMan.setSourceSurface(&_warpSurface);
+			firstDraw = true;  // force Omni3D redraw with updated source
+		}
+
+		// Advance the active wspranim sprite, mirror its frame counter
+		// into the script's WSPRFRAME variable, and then re-evaluate /Tim2
+		// sections immediately — this is what makes `WSprFrame=31` (an
+		// exact equality on one frame out of 33) actually fire in CHAPI012.
+		//
+		// atlantis.exe FUN_00425304 (the per-frame sprite renderer) does
+		// two things on each render iteration: (1) hijacks the timer-2
+		// gate at 0x611210[1] by overwriting it with the active sprite's
+		// current frame counter (line 20086 in the decompile), and (2)
+		// advances the frame counter if more than 0xd ms (13 ms) have
+		// passed since the last advance.  The next iteration's main-loop
+		// call to FUN_0042be3c then scans every /Tim2 section with that
+		// hijacked value in scope — so conditions like `(WSprFrame=31)`
+		// resolve against the *current* sprite frame, not against the
+		// 1-Hz time2 counter.  Without re-running the /Tim2 scan on each
+		// wspranim frame change, the equality is essentially never caught:
+		// frame 31 only exists for ~30 ms, and a 1-Hz time2 tick is
+		// unlikely to land inside that window — the dialog only fires
+		// later when a place change runs the fallback
+		// /sel(departvue>0)&(Flagtemp3=1) on line 29 of CHAPI012.
+		//
+		// We use 30 ms here (~33 fps wspranim → ~1 s 33-frame walk) rather
+		// than the exe's 13 ms threshold: ScummVM's main loop iterates
+		// roughly every 15 ms, so a 13 ms threshold would advance nearly
+		// every iteration and the walk would finish in ~500 ms, faster
+		// than the original game appeared on period hardware.
+		if (_wsprAnimActiveIdx >= 0 && g_system->getMillis() >= _wsprAnimNextMs) {
+			_wsprAnimNextMs = g_system->getMillis() + kWsprAnimIntervalMs;
+			int seen = 0;
+			for (SpritePlaceEntry &e : _spritePlaceList) {
+				if (e.placeId != (uint16)_currentPlaceId) continue;
+				if (seen != _wsprAnimActiveIdx) { seen++; continue; }
+				e.frame++;
+				_gameVars["wsprframe"] = e.frame;
+				_spriteLayerDirty = true;
+				// Mirror FUN_0042be3c's per-frame /Tim2 scan with the
+				// just-advanced wsprframe value in scope.  Gated on
+				// testtime2 the same way the regular 1-Hz scan is (a
+				// section can opt out of polling by setting testtime2=0).
+				Common::HashMap<Common::String, int>::const_iterator t2 =
+				    _gameVars.find("testtime2");
+				if (t2 != _gameVars.end() && t2->_value != 0)
+					runTimerSections(2);
+				// Re-find the entry: runTimerSections may have changed
+				// chapter (e.g. /set(chapter=N) from a /go169 trigger),
+				// which calls loadConScript and rebuilds _spritePlaceList.
+				if (shouldAbort() || _nextPlaceId != uint(-1))
+					break;
+				// Wrap check happens AFTER the scan so the terminal frame
+				// value is observable to /Tim2 conditions one tick before
+				// the counter resets (matching the exe's ordering, where
+				// the gate is set from the pre-advance frame).
+				Common::SeekableReadStream *spw =
+				    openBigFileStream(kFileTypeSpriteCyclo, e.spwFile);
+				if (spw) {
+					spw->seek(0x04);
+					uint32 nFrames = spw->readUint32LE();
+					delete spw;
+					if (nFrames > 0 && (uint)e.frame >= nFrames) {
+						e.frame = 0;
+						// type=2 "play once then disable" — exe sets
+						// sprite.field+0x04 = 0 at the wrap.
+						if (e.type == 2) {
+							e.active = false;
+							_wsprAnimActiveIdx = -1;
+						}
+						_gameVars["wsprframe"] = 0;
+					}
+				}
+				break;
+			}
+		}
+
+		// A CON command changed the panorama sprite layer while it was off
+		// screen (e.g. mid-dialog).  Rebuild the NPC click-target list if a
+		// showperso/hideperso changed visibility, then recomposite and force
+		// a redraw — so the change shows without waiting for a place change.
+		if (_npcBoundsDirty) {
+			_npcBoundsDirty = false;
+			rebuildNpcPlaceBounds();
+		}
+		if (_spriteLayerDirty) {
+			_spriteLayerDirty = false;
+			recompositeSpriteLayer();
+			_omni3dMan.setSourceSurface(&_warpSurface);
+			firstDraw = true;
+		}
+
+		// Tick auto-incrementing timers and poll /tim* sections.
+		//
+		// time1 and time2 are free-running counters that increment on EVERY
+		// tick interval, regardless of testtime1/testtime2.  The script
+		// resets them with /set(timeN=0) before any /sel or /tim section
+		// that reads them, and conditions like `/Tim1(time1>10000)` or
+		// `/Sel(...&time2>25)` only make sense if the counter accumulates
+		// continuously (CHAPI011 section 158 sets time2=0 alone — without
+		// any testtime2=1 — yet section 159's /sel(...&time2<5) waiting
+		// lock is meant to lift after ~5 seconds, which only works if
+		// time2 ticks anyway).
+		//
+		// testtimeN gates ONLY /tim* section polling — i.e. whether the
+		// engine bothers to scan /timN sections each tick.  The /tim
+		// sections themselves carry their own (Vue=...), (FlagX=...)
+		// guards, so when the script switches testtimeN on, the relevant
+		// /tim section starts firing on every tick whose conditions hold.
+		uint32 nowMs = g_system->getMillis();
+		for (int t = 0; t < 2 && !shouldAbort() && _nextPlaceId == uint(-1) && !exit; t++) {
+			int timerNum = t + 1;
+			const char *testKey = (timerNum == 1) ? "testtime1" : "testtime2";
+			const char *timeKey = (timerNum == 1) ? "time1"     : "time2";
+			if (nowMs < _timerTickNextMs[t]) continue;
+			_timerTickNextMs[t] = nowMs + kTimerTickIntervalMs;
+			_gameVars[timeKey]++;
+			debugC(2, kDebugScript, "timer%d tick: %s=%d wsprframe=%d", timerNum, timeKey,
+			      _gameVars[timeKey], _gameVars.contains("wsprframe") ? _gameVars["wsprframe"] : 0);
+			Common::HashMap<Common::String, int>::const_iterator ti = _gameVars.find(testKey);
+			if (ti != _gameVars.end() && ti->_value != 0)
+				runTimerSections(timerNum);
+		}
+
+		g_system->delayMillis(10);
+	}
+
+	_canLoadSave = false;
+	g_system->lockMouse(false);
+	showMouse(false);
+	return (int)actionId;
+}
+
+// ---------------------------------------------------------------------------
+// CON script loading and subject state
+// ---------------------------------------------------------------------------
+
+// CON variables live in one global array (VARIAS.CON line order).  Only
+// indices 0-6 are persistent — Chapter, GardeCel, NewSound, FlagChp8,
+// BoucleCreon, CodeTroneVu, NbStatues; they are written to the save and
+// survive a chapter change.  Indices 7+ are transient: atlantis.exe's
+// FUN_00427634 zeroes them on every `chapter=` (for i=7; i<0x80; var[i]=0).
+bool CryOmni3DEngine_Atlantis::isPersistentGameVar(const Common::String &key) {
+	static const char *const kPersistent[] = {
+		"chapter", "gardecel", "newsound", "flagchp8",
+		"bouclecreon", "codetronevu", "nbstatues"
+	};
+	for (const char *p : kPersistent)
+		if (key.equalsIgnoreCase(p))
+			return true;
+	return false;
+}
+
+void CryOmni3DEngine_Atlantis::loadConScript(int chapter) {
+	// Stamp the wall-clock so the `chaptertime` condition (seconds since the
+	// active CHAPI*.CON loaded) can be evaluated dynamically.  CHAPI030
+	// section 65 (`/Con(ClicPerso=551)&(Flagtemp5=0)&(ChapterTime>120)`)
+	// and section 69 (`/sel(...)&(ChapterTime>20)`) read this -- before, both
+	// always failed because the var stayed at 0.  Reset on every chapter
+	// switch so the clock matches what the original engine sees.
+	_chapterStartMs = g_system->getMillis();
+	_gameVars["chaptertime"] = 0;
+
+	_conScript.reset();
+	_sujEnabled.clear();
+	// A chapter change keeps only the 7 persistent CON variables; the
+	// transient ones (broche30, parletemp*, flagtemp*, vue, ...) reset to 0.
+	{
+		Common::HashMap<Common::String, int> persist;
+		for (const auto &kv : _gameVars)
+			if (isPersistentGameVar(kv._key))
+				persist[kv._key] = kv._value;
+		_gameVars = persist;
+	}
+
+	// The hidden-perso list PERSISTS across chapter switches -- it is the
+	// exe's persistent list at 0x611010 (see execConSetCommand), distinct
+	// from the per-chapter CON variable array that FUN_00427634 zeroes.  A
+	// chapter's /INIT block carries only the DELTAS (the persos it newly
+	// shows/hides), not a complete re-statement: CHAPI001 hides ~42 persos,
+	// CHAPI002 re-lists only ~18 of them.  Clearing here made the ~24 left
+	// out of CHAPI002's INIT (279/280/281/524/531-538/565-582/587/591/595)
+	// pop back into view every time the script reloaded.  The concrete bug
+	// was perso 587 (Anaan): hidden by CHAPI001, never re-shown until
+	// CHAPI056, but visible+clickable at vue 110 in chapters 17-24 (its SPW
+	// entry has startActive=true), producing "interactNPC: no options found".
+	// Meljanz (617) -- the case the old clear was meant to fix -- is shown in
+	// CHAPI012 via /set(NewWsprAnim=2), which activates the sprite by index
+	// (bypassing _hiddenPersos), so persisting the hide does not hide him.
+	// A genuine new game still starts clean: changeChapter() clears the list
+	// before the first loadConScript, and loadGame restores the saved list.
+	// Guests are chapter-scoped: a follower from chapter N doesn't leak
+	// into chapter N+1 -- the new chapter's INIT block re-establishes
+	// who's around.  Clear before the script loads so /set(addguest=N)
+	// in the new /INIT lands in a clean list.
+	_guests.clear();
+	_spriteLayerDirty = true;
+	_npcBoundsDirty   = true;
+
+	Common::String name = Common::String::format("CHAPI%03d.CON", chapter);
+	Common::SeekableReadStream *s = openBigFileStream(kFileTypeScript, name);
+	if (!s) {
+		debugC(1, kDebugScript, "loadConScript: no CON file '%s'", name.c_str());
+		return;
+	}
+
+	uint32 sz = (uint32)s->size();
+	byte *buf = new byte[sz + 1];
+	s->read(buf, sz);
+	buf[sz] = '\0';
+	delete s;
+
+	_conScript.parse((const char *)buf, sz);
+	delete[] buf;
+
+	execConInitCommands();
+	debugC(1, kDebugScript, "loadConScript: '%s' → %u sections, %u suj-states",
+	      name.c_str(), _conScript.sections().size(), _sujEnabled.size());
+	for (const ConSection &sec : _conScript.sections()) {
+		debugC(2, kDebugScript, "  section %d: isCon=%d needsItem=%d clicPerso=%d clicZone=%d sujId=%d gotoId=%d items=%u",
+		      sec.id, sec.isCon, sec.needsItem, sec.clicPerso, sec.clicZone, sec.sujId, sec.gotoId, sec.items.size());
+		for (const ConCondition &cc : sec.conditions) {
+			const char sep = cc.nextSep ? cc.nextSep : ' ';
+			debugC(2, kDebugScript, "    cond: %s %c %d   [next=%c]", cc.key.c_str(), cc.op, cc.value, sep);
+		}
+	}
+}
+
+// Resolve a dialog line's speaker name to a perso ID.
+//
+// The original engine resolves speakers with a fixed table, not a heuristic:
+// the strncmp chain in atlantis.exe at VA 0x428f58 (which drives the
+// CLICPERSO game variable) tests the speaker name against a sequence of
+// fixed prefixes, each paired with a persoId.  The compare (sub_44a83f) is a
+// plain case-sensitive strncmp of the first N characters; the exe stores
+// both a capitalised and a lowercase spelling of every name to absorb case.
+// We transcribe the same table — in the same order, with the same per-entry
+// compare length — but match case-insensitively against the capitalised
+// spelling, which covers both exe variants in a single row.
+//
+// Order is significant: it is the exe's test order, so a shorter prefix that
+// is also a prefix of a later name takes precedence (e.g. "Rein" before
+// "Reinem").  The persoIds cross-check against INITDIAL.TXT (520 = agat1,
+// 521 = lasc, 522 = meljan1a, ...).
+//
+// The player character "Seth" is handled before the table: the exe maps
+// "seth" to disguise-specific hero meshes (513 herpret, 514 hegr), but for
+// dialog playback we always want the plain hero persoId that
+// loadDialInitData() detected from INITDIAL's s3d="hero" row.
+int CryOmni3DEngine_Atlantis::resolveSpeakerPersoId(const Common::String &speaker) const {
+	if (speaker.empty())
+		return 0;
+	if (_heroPersoId > 0 && scumm_strnicmp(speaker.c_str(), "seth", 4) == 0)
+		return _heroPersoId;
+
+	struct SpeakerEntry { const char *prefix; uint len; int persoId; };
+	static const SpeakerEntry kSpeakerTable[] = {
+		{ "Agat",      4, 520 }, { "Lasc",      4, 521 }, { "Melj",      4, 522 },
+		{ "Sorc",      4, 567 }, { "Gard",      4, 604 }, { "Sold",      4, 604 },
+		{ "Pech",      4, 524 }, { "Acty",      4, 524 }, { "Creo",      4, 525 },
+		{ "Chas",      4, 540 }, { "Passant9",  8, 602 }, { "Carv",      4, 602 },
+		{ "Passant6",  8, 601 }, { "Passante7", 9, 606 }, { "Hect",      4, 543 },
+		{ "Cuis",      4, 551 }, { "Rein",      4, 560 }, { "Reinem",    6, 561 },
+		{ "Reinep",    6, 562 }, { "Garc",      4, 526 }, { "Servan",    6, 609 },
+		{ "Servag",    6, 582 }, { "Chie",      4, 650 }, { "Anna",      4, 663 },
+		{ "Escl",      4, 597 }, { "Enne",      4, 667 }, { "Hona",      4, 682 },
+		{ "Sama",      4, 683 }, { "Naka",      4, 684 }, { "Lona",      4, 576 },
+		{ "JPil",      4, 571 }, { "Gimb",      4, 563 },
+	};
+	for (const SpeakerEntry &e : kSpeakerTable) {
+		if (scumm_strnicmp(speaker.c_str(), e.prefix, e.len) == 0)
+			return e.persoId;
+	}
+	return 0;
+}
+
+void CryOmni3DEngine_Atlantis::execConInitCommands() {
+	for (const Common::String &cmd : _conScript.initCmds())
+		execConSetCommand(cmd);
+}
+
+Common::Array<int> &CryOmni3DEngine_Atlantis::sujsForPerso(int persoId) {
+	for (SujState &ss : _sujEnabled)
+		if (ss.persoId == persoId) return ss.sujs;
+	SujState ns;
+	ns.persoId = persoId;
+	_sujEnabled.push_back(ns);
+	return _sujEnabled.back().sujs;
+}
+
+// True when subject `sujId` is in perso `persoId`'s enabled-subject list.
+// Mirrors the per-perso subject table atlantis.exe builds at 0x602f10 (225
+// bytes/perso: a count byte + up to 16 entries): enableSuj (FUN_00425f6c)
+// appends, disableSuj (FUN_0042606c) removes.  A perso with no record — or
+// one whose every subject was disabled — has no enabled subject, exactly
+// like a zero count byte.  interactNPC() only consults this for a perso
+// that *has* a non-empty record; a perso with none is not menu-driven.
+bool CryOmni3DEngine_Atlantis::isSujEnabled(int persoId, int sujId) const {
+	for (const SujState &ss : _sujEnabled) {
+		if (ss.persoId != persoId) continue;
+		for (int s : ss.sujs)
+			if (s == sujId) return true;
+		return false;
+	}
+	return false;
+}
+
+// gameover=N (CON) — the game-over screen, GereGameOver (atlantis.exe
+// FUN_00426590).  Displays the full-screen image IMAGES\GOVER<NN>.TGA (NN =
+// the GameOver variable, zero-padded to two digits — GOVER01..23 in the
+// BigFile), then plays the narrator's verdict over it: the first [Narratrice]
+// line that follows the /set(gameover=N) command, voiced by
+// WAV\ATA<section4d><track>.APC with its subtitle drawn on the image.  It
+// waits for the voice to finish — skippable on a click/key — or, when no APC
+// is found, for the original's ~5 s timeout (its 4999 ms cap).  Then it
+// returns to the caller, which reloads the chapter checkpoint (see
+// playConSection): a game-over is gated on a persistent CON variable, so
+// returning in place would only loop straight back into the same death.
+//
+// The narrator commentary build mirrors the original exactly: it always picks
+// the *first* [Narratrice] line of the run (GereGameOver's per-section repeat
+// counter at 0x6cccac is cleared on entry, so its variant-B branch is dead
+// code) and derives the APC track letter from that line's index in the
+// section (the '[' lines GereGameOver counts from the section header).
+void CryOmni3DEngine_Atlantis::showGameOver(int sectionId, int n,
+		const Common::String &narratorText, char narratorTrack) {
+	Common::String name = Common::String::format("GOVER%02d.TGA", n);
+	Graphics::Surface *raw = loadTGA(kFileTypeImages, name.c_str());
+	if (!raw) {
+		warning("showGameOver: cannot load IMAGES\\%s", name.c_str());
+		return;
+	}
+
+	const Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	Graphics::ManagedSurface img(640, 480, fmt);
+	img.fillRect(Common::Rect(640, 480), 0);
+	img.blitFrom(*raw);
+	raw->free();
+	delete raw;
+
+	// Narrator subtitle, bottom-anchored over the image — same metrics and
+	// drop-shadow scheme as playSingleConLine().  Honour the ScummVM subtitle
+	// toggle; the voice still plays when it is off.
+	if (showSubtitles() && !narratorText.empty()) {
+		const int leftMargin = 5;
+		int widthBudget = img.w - leftMargin - 5;
+		if (widthBudget < 32)
+			widthBudget = 32;
+
+		// Subtitles render in a proportional sans-serif font, matching the
+		// original engine which draws all dialog/narration text in Arial via
+		// GDI (atlantis.exe FUN_0041aee4: CreateFontA "Arial" + TextOutA, white
+		// over a black shadow, transparent background) -- NOT the gold FONTMAX
+		// sprite font, which the original uses only for menus.  kBigGUIFont is
+		// ScummVM's built-in proportional Helvetica (Arial-like), compiled in so
+		// it also works on the no-FreeType/no-theme Windows build.
+		const bool useFontMax = false;
+		const Graphics::Font *guiFont =
+		    FontMan.getFontByUsage(Graphics::FontManager::kBigGUIFont);
+		if (!guiFont)
+			guiFont = FontMan.getFontByUsage(Graphics::FontManager::kGUIFont);
+		Common::Array<Common::String> subLines;
+		int subLineH = 0;
+
+		if (useFontMax) {
+			int maxGlyphH = 0;
+			for (uint si = 0; si < _fontMaxSprites.size(); ++si)
+				if ((int)_fontMaxSprites[si].h > maxGlyphH)
+					maxGlyphH = _fontMaxSprites[si].h;
+			subLineH = (maxGlyphH > 0) ? maxGlyphH + 2 : 24;
+
+			// Greedy whitespace word-wrap using FONTMAX advance widths.
+			Common::String line, word;
+			for (uint i = 0; i <= narratorText.size(); ++i) {
+				char c = (i < narratorText.size()) ? narratorText[i] : ' ';
+				if (c == ' ' || c == '\r' || c == '\n') {
+					if (!word.empty()) {
+						Common::String cand =
+						    line.empty() ? word : line + " " + word;
+						if (fontMaxStringWidth(cand) > widthBudget &&
+						    !line.empty()) {
+							subLines.push_back(line);
+							line = word;
+						} else {
+							line = cand;
+						}
+						word.clear();
+					}
+				} else {
+					word += c;
+				}
+			}
+			if (!line.empty())
+				subLines.push_back(line);
+		} else if (guiFont) {
+			subLineH = guiFont->getFontHeight() + 2;
+			guiFont->wordWrapText(narratorText, widthBudget, subLines);
+		}
+
+		const uint32 subColor  = fmt.RGBToColor(255, 255, 255);
+		const uint32 subShadow = fmt.RGBToColor(0, 0, 0);
+		int subBaseY = img.h - (int)subLines.size() * subLineH - 6;
+		if (subBaseY < 0)
+			subBaseY = 0;
+		for (uint i = 0; i < subLines.size(); ++i) {
+			if (useFontMax) {
+				int by = subBaseY + (int)i * subLineH + subLineH - 4;
+				drawFontMaxText(img, subLines[i], leftMargin + 1, by + 1);
+				drawFontMaxText(img, subLines[i], leftMargin,     by);
+			} else if (guiFont) {
+				int by = subBaseY + (int)i * subLineH;
+				guiFont->drawString(&img, subLines[i], leftMargin + 1, by + 1,
+				                    widthBudget, subShadow,
+				                    Graphics::kTextAlignLeft);
+				guiFont->drawString(&img, subLines[i], leftMargin, by,
+				                    widthBudget, subColor,
+				                    Graphics::kTextAlignLeft);
+			}
+		}
+	}
+
+	g_system->copyRectToScreen(img.getPixels(), img.pitch, 0, 0, 640, 480);
+	g_system->updateScreen();
+
+	// The screen owns the player's attention now — keep the cursor hidden and
+	// drain the click/key that ended the triggering dialog so it is not read
+	// as an immediate skip.
+	showMouse(false);
+	while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+		pollEvents();
+		g_system->delayMillis(10);
+	}
+	clearKeys();
+
+	// Narrator voice: WAV\ATA<section4d><track>.APC.  Wait for it to finish;
+	// a click or key skips it (atlantis.exe GereGameOver's AIL_sample_status
+	// loop, broken by its skip flag).
+	Common::String apcName =
+	    Common::String::format("ATA%04d%c.APC", sectionId, narratorTrack);
+	Common::SeekableReadStream *apcFile =
+	    narratorText.empty() ? nullptr
+	                         : openBigFileStream(kFileTypeSound, apcName);
+	Audio::PacketizedAudioStream *apc =
+	    apcFile ? Audio::makeAPCStream(*apcFile) : nullptr;
+
+	if (apc) {
+		int64 remaining = apcFile->size() - apcFile->pos();
+		if (remaining > 0) {
+			byte *buf = new byte[remaining];
+			apcFile->read(buf, (uint32)remaining);
+			apc->queuePacket(new Common::MemoryReadStream(buf, remaining,
+			                                              DisposeAfterUse::YES));
+		}
+		apc->finish();
+		Audio::SoundHandle handle;
+		_mixer->playStream(Audio::Mixer::kSpeechSoundType, &handle, apc);
+		debugC(1, kDebugScript, "showGameOver: GOVER%02d.TGA + %s", n, apcName.c_str());
+
+		while (!shouldAbort() && _mixer->isSoundHandleActive(handle)) {
+			pollEvents();
+			if (checkKeysPressed(1, Common::KEYCODE_SPACE) || getCurrentMouseButton() != 0)
+				break;
+			g_system->delayMillis(10);
+		}
+		_mixer->stopHandle(handle);
+	} else {
+		// No narrator APC — hold the image for the original's ~5 s cap.
+		debugC(1, kDebugScript, "showGameOver: GOVER%02d.TGA (no narrator audio)", n);
+		uint32 deadline = g_system->getMillis() + 5000;
+		while (!shouldAbort() && g_system->getMillis() < deadline) {
+			pollEvents();
+			if (checkKeysPressed(1, Common::KEYCODE_SPACE) || getCurrentMouseButton() != 0)
+				break;
+			g_system->delayMillis(10);
+		}
+	}
+	delete apcFile;
+
+	// Drain the skip click so it does not leak into the resumed game.
+	while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+		pollEvents();
+		g_system->delayMillis(10);
+	}
+	clearKeys();
+}
+
+// Fade the on-screen image to black over ~0.3 s.  Used by /set(fadeout) just
+// before a gameover or a scene change; a plain multiplicative ramp of the
+// framebuffer, then a solid-black fill so the next screen draws over black.
+void CryOmni3DEngine_Atlantis::fadeScreenToBlack() {
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	for (int step = 0; step < 16 && !shouldAbort(); step++) {
+		Graphics::Surface *s = g_system->lockScreen();
+		if (s && fmt.bytesPerPixel == 2) {
+			for (int y = 0; y < s->h; y++) {
+				uint16 *row = (uint16 *)s->getBasePtr(0, y);
+				for (int x = 0; x < s->w; x++) {
+					uint8 r, g, b;
+					fmt.colorToRGB(row[x], r, g, b);
+					row[x] = (uint16)fmt.RGBToColor(r * 13 / 16, g * 13 / 16, b * 13 / 16);
+				}
+			}
+		}
+		g_system->unlockScreen();
+		g_system->updateScreen();
+		g_system->delayMillis(20);
+	}
+	Graphics::Surface *s = g_system->lockScreen();
+	if (s)
+		s->fillRect(Common::Rect(0, 0, s->w, s->h), 0);
+	g_system->unlockScreen();
+	g_system->updateScreen();
+}
+
+void CryOmni3DEngine_Atlantis::playPuzzle(int puzzleId) {
+	// Dispatch to the per-puzzle handler.  Puzzles not yet implemented
+	// fall back to the auto-win stub so their CHAPI script chains keep
+	// progressing (most of them gate further story content behind
+	// FinPuzzle=255, e.g. CHAPI012's /sel(FinPuzzle=255)&(Vue=N)&...).
+	int finPuzzle = 255;
+	switch (puzzleId) {
+	case 0: {
+		// Celestial alignment ("eclipse on Atlantis") at CHAPI012 vue 221.
+		EclipsePuzzle puz(this);
+		finPuzzle = puz.run();
+		break;
+	}
+	default:
+		debugC(1, kDebugScript, "playPuzzle: no handler for puzzle %d, auto-win", puzzleId);
+		break;
+	}
+	_gameVars["finpuzzle"] = finPuzzle;
+	// Puzzle launches are often gated behind a click on a sentinel zone
+	// (CHAPI012 vue 221 zone.action=1000 — "1000" is not a real place,
+	// just a hotspot trigger for /sel(vue=221)&(flagtemp6=0)).  The /sel
+	// itself doesn't /set(abortdepart=1), so the pending departure to
+	// place 1000 would still fire after the puzzle returns — emitting a
+	// "place 1000 not found" warning and stranding the player.  Cancel
+	// any pending departure here so the puzzle's caller stays put.
+	_nextPlaceId = uint(-1);
+
+	// Re-run the arrival /sel scan so /sel sections that gate on
+	// `FinPuzzle = 255` fire immediately on win.  CHAPI012 line 129
+	// (`/sel(FinPuzzle=255)&(Vue=221)&(Flagtemp6=0)` -> /set(cinema=30)
+	// + hide/show NPCs + Flagtemp6=1) is the canonical case: without
+	// this re-scan the cinematic only triggers on the next natural
+	// place transition.  The puzzle-launch /sel
+	// (`/sel(vue=221)&(flagtemp6=0)` -> /set(Startpuzzle=0)) sits
+	// in the same scan but the cinema gate fires first (earlier in
+	// the CON file), sets Flagtemp6=1, and the puzzle-launch /sel's
+	// `flagtemp6=0` cond then fails -- no recursive puzzle relaunch.
+	if (finPuzzle == 255 && _currentPlaceId != uint(-1))
+		runArrivalSelSections((int)_currentPlaceId, (int)_currentPlaceId);
+}
+
+void CryOmni3DEngine_Atlantis::execConSetCommand(const Common::String &cmd) {
+	const char *p = cmd.c_str();
+
+	// enableSuj,persoId=suj1,suj2,...
+	if (scumm_strnicmp(p, "enablesuj,", 10) == 0) {
+		p += 10;
+		int perso = atoi(p);
+		while (*p && *p != '=') p++;
+		if (*p == '=') {
+			p++;
+			Common::Array<int> &sujs = sujsForPerso(perso);
+			while (*p) {
+				int suj = atoi(p);
+				if (suj > 0) {
+					bool found = false;
+					for (int s : sujs) { if (s == suj) { found = true; break; } }
+					if (!found) sujs.push_back(suj);
+				}
+				while (*p && *p != ',' && *p != ')') p++;
+				if (*p == ',') p++; else break;
+			}
+		}
+		return;
+	}
+
+	// disablesuj,persoId=sujId[,sujId...]
+	// Supports a comma-separated list (e.g. `/Set(DisableSuj,560=1,5)` in
+	// CHAPI*.CON disables BOTH subjects 1 and 5 for perso 560).  The previous
+	// single-value parse silently dropped every id past the first, leaving
+	// stale subjects in `_sujEnabled` that re-appeared in the topic menu.
+	if (scumm_strnicmp(p, "disablesuj,", 11) == 0) {
+		p += 11;
+		int perso = atoi(p);
+		while (*p && *p != '=') p++;
+		if (*p == '=') {
+			p++;
+			Common::Array<int> &sujs = sujsForPerso(perso);
+			while (*p) {
+				int suj = atoi(p);
+				if (suj > 0) {
+					for (int i = (int)sujs.size() - 1; i >= 0; i--)
+						if (sujs[i] == suj) { sujs.remove_at(i); break; }
+				}
+				while (*p && *p != ',' && *p != ')') p++;
+				if (*p == ',') p++; else break;
+			}
+		}
+		return;
+	}
+
+	// hideperso=N / disableperso=N — deactivate every sprite entry for
+	// perso N across every place (atlantis.exe FUN_00427bd0: walks the
+	// 512-place sprite array, sets field+0x04=0 on records whose persoId
+	// matches, and adds N to the persistent hidden-perso list at +0x611010).
+	if (scumm_strnicmp(p, "hideperso=", 10) == 0 ||
+	        scumm_strnicmp(p, "disableperso=", 13) == 0) {
+		const char *eq = strchr(p, '=');
+		int perso = eq ? atoi(eq + 1) : 0;
+		if (perso > 0) {
+			bool found = false;
+			for (int h : _hiddenPersos) if (h == perso) { found = true; break; }
+			if (!found)
+				_hiddenPersos.push_back(perso);
+			for (SpritePlaceEntry &e : _spritePlaceList)
+				if (e.persoId == perso) e.active = false;
+			_spriteLayerDirty = true;
+			_npcBoundsDirty   = true;
+			debugC(1, kDebugScript, "execConSetCommand: hide perso %d", perso);
+		}
+		return;
+	}
+
+	// showperso=N — activate every sprite entry for perso N (exe's
+	// FUN_00427eb0: walks all places, sets field+0x04=1 on matching
+	// records, also restores the perso from the hidden list).
+	if (scumm_strnicmp(p, "showperso=", 10) == 0) {
+		int perso = atoi(p + 10);
+		for (int i = (int)_hiddenPersos.size() - 1; i >= 0; i--)
+			if (_hiddenPersos[i] == perso) _hiddenPersos.remove_at(i);
+		for (SpritePlaceEntry &e : _spritePlaceList)
+			if (e.persoId == perso) e.active = true;
+		_spriteLayerDirty = true;
+		_npcBoundsDirty   = true;
+		debugC(1, kDebugScript, "execConSetCommand: show perso %d", perso);
+		return;
+	}
+
+	// addguest=N -- NPC N starts following the hero.  Whatever the exe's
+	// internal record layout (it shares the 9-byte inventory-slot array at
+	// 0x6ce138 according to FUN_0042785c's pickup branch), the visible
+	// effect is: from now until /set(subguest=N), the guest is force-shown
+	// at every place they have a sprite, overriding any prior HidePerso.
+	// CHAPI032/038/056-58/64/66-68/78-79 use this for Servage (523), the
+	// queen's lady (530), Lascoyt (587/592), and friends.  Without it, the
+	// companion NPCs that should accompany Seth are simply absent from
+	// every place after the script switches them on.
+	if (scumm_strnicmp(p, "addguest=", 9) == 0) {
+		int perso = atoi(p + 9);
+		if (perso > 0) {
+			bool found = false;
+			for (int g : _guests) if (g == perso) { found = true; break; }
+			if (!found) _guests.push_back(perso);
+			// A guest is by definition shown -- pull them out of the
+			// hidden list and activate their sprites at every place.
+			for (int i = (int)_hiddenPersos.size() - 1; i >= 0; i--)
+				if (_hiddenPersos[i] == perso) _hiddenPersos.remove_at(i);
+			for (SpritePlaceEntry &e : _spritePlaceList)
+				if (e.persoId == perso) e.active = true;
+			_spriteLayerDirty = true;
+			_npcBoundsDirty   = true;
+			debugC(1, kDebugScript, "execConSetCommand: addguest %d", perso);
+		}
+		return;
+	}
+
+	// subguest=N -- NPC N stops following the hero.  Mirror of addguest:
+	// remove from the guest list AND deactivate their sprites so the
+	// companion vanishes from the current and future places.
+	if (scumm_strnicmp(p, "subguest=", 9) == 0) {
+		int perso = atoi(p + 9);
+		if (perso > 0) {
+			for (int i = (int)_guests.size() - 1; i >= 0; i--)
+				if (_guests[i] == perso) _guests.remove_at(i);
+			for (SpritePlaceEntry &e : _spritePlaceList)
+				if (e.persoId == perso) e.active = false;
+			_spriteLayerDirty = true;
+			_npcBoundsDirty   = true;
+			debugC(1, kDebugScript, "execConSetCommand: subguest %d", perso);
+		}
+		return;
+	}
+
+	// loadmusik=N,M,...  — preload one or more music tracks (ignore for now)
+	// loadmusik / delmusik — in the original these copy APC tracks between the
+	// CD and a hard-disk cache.  This port streams every track straight from
+	// the BigFile, so there is nothing to pre-load or evict; accept and ignore
+	// both.  startmusik / stopmusik do the actual playback control.
+	if (scumm_strnicmp(p, "loadmusik=", 10) == 0 ||
+	        scumm_strnicmp(p, "delmusik=", 9) == 0) {
+		return;
+	}
+
+	// vue=N — transition to panoramic place N
+	if (scumm_strnicmp(p, "vue=", 4) == 0) {
+		_nextPlaceId = (uint)atoi(p + 4);
+		return;
+	}
+
+	// startmusik=N
+	if (scumm_strnicmp(p, "startmusik=", 11) == 0) {
+		musicPlayTrack(atoi(p + 11));
+		return;
+	}
+
+	// stopmusik=N
+	if (scumm_strnicmp(p, "stopmusik=", 10) == 0) {
+		musicStop();
+		return;
+	}
+
+	// exit=N -- end-of-game trigger.  Only one use in the data
+	// (CHAPI085 line 42 after the final narrator line + cinema 210), so the
+	// concrete behaviour is "the game has reached the credits, stop the
+	// regular game loop".  Set the gameVar so any /sel(exit=N) condition can
+	// pick it up, then route through the existing main-menu abort path
+	// (kAbortNewGame is the closest match: brings the player back to the
+	// title menu rather than auto-quitting).
+	if (scumm_strnicmp(p, "exit=", 5) == 0) {
+		int n = atoi(p + 5);
+		_gameVars["exit"] = n;
+		debugC(1, kDebugScript, "execConSetCommand: exit=%d -> returning to main menu", n);
+		_abortCommand = kAbortNewGame;
+		return;
+	}
+
+	// cinema=N — play transition video CINEM<N>.HNM
+	if (scumm_strnicmp(p, "cinema=", 7) == 0) {
+		int cinId = atoi(p + 7);
+		Common::String hnm = Common::String::format("CINEM%03d.HNM", cinId);
+		debugC(1, kDebugScript, "execConSetCommand: cinema=%d -> %s", cinId, hnm.c_str());
+		playTransitionVideo(hnm);
+		return;
+	}
+
+	// abortdepart=1 — cancel pending place departure
+	if (scumm_strnicmp(p, "abortdepart=", 12) == 0) {
+		_nextPlaceId = uint(-1);
+		return;
+	}
+
+	// changewam=name.wam
+	// setupWAMByName invokes _wam.clear() which destroys every AtlantisPlace
+	// the old WAM owned -- including the one _currentPlace points at.  Null
+	// the pointer here (matching the sub-WAM hand-off at line 1728) so the
+	// next executeTransition / handleWarp doesn't dereference freed memory.
+	// CHAPI015 section 203 reproduces the crash: the Meljanz escape runs
+	// /set(Changewam=atlan4.wam) followed by /set(vue=81), and the
+	// subsequent place-change in gameStep crashed on _currentPlace inside
+	// executeTransition.
+	if (scumm_strnicmp(p, "changewam=", 10) == 0) {
+		setupWAMByName(p + 10);
+		_currentPlace   = nullptr;
+		_currentPlaceId = uint(-1);
+		return;
+	}
+
+	// inventN=1 — add object N to inventory; inventN=0 — remove it.
+	if (scumm_strnicmp(p, "invent", 6) == 0 && Common::isDigit(p[6])) {
+		const char *eqPos = strchr(p + 6, '=');
+		if (eqPos) {
+			uint objId = (uint)atoi(p + 6);
+			int val = atoi(eqPos + 1);
+			if (val) {
+				// findObjectByNameID calls error() on failure; check first.
+				Object *obj = nullptr;
+				for (Object &o : _objects)
+					if (o.valid() && o.idOBJ() == objId) { obj = &o; break; }
+				if (obj) {
+					if (!_inventory.inInventoryByNameID(objId)) {
+						_inventory.add(obj);
+						debugC(1, kDebugScript, "execConSetCommand: added object %u to inventory", objId);
+					}
+					// Remember the given object so it shows centre-bottom for
+					// the rest of the dialog (atlantis.exe DAT_0049619c, set by
+					// the INVENT add in FUN_0042b328 and drawn each dialog frame
+					// until the dialog ends).  The sprite index is the object's
+					// position in _objects (parallel to _objSprites).
+					if (!_objects.empty())
+						_dialogGivenObjSprite = (int)(obj - &_objects.front());
+				} else {
+					debugC(1, kDebugScript, "execConSetCommand: invent%u=1 — object not defined", objId);
+				}
+			} else {
+				_inventory.removeByNameID(objId);
+				// removeByNameID only deselects if the object is in the
+				// persistent inventory list.  World pickups (CHAPI013
+				// vue 126's flower pot) bypass the list and live only
+				// as selectedObject(), so the deselect would miss them
+				// -- match by id and clear the selection explicitly.
+				Object *sel = _inventory.selectedObject();
+				if (sel && sel->idOBJ() == objId)
+					_inventory.deselectObject();
+				debugC(1, kDebugScript, "execConSetCommand: removed object %u from inventory", objId);
+			}
+			return;
+		}
+	}
+
+	// chapter=N — switch active CON script to chapter N (independent of WAM chapter).
+	if (scumm_strnicmp(p, "chapter=", 8) == 0) {
+		int newChapter = atoi(p + 8);
+		_gameVars["chapter"] = newChapter;
+		if ((uint)newChapter != _currentCONChapter) {
+			debugC(1, kDebugScript, "execConSetCommand: switching CON script to chapter %d", newChapter);
+			_currentCONChapter = (uint)newChapter;
+			_sujEnabled.clear();
+			loadConScript(newChapter);
+			execConInitCommands();
+			// Original-game autosave point: a real chapter advance rewrites
+			// the player's single save.  Defer the write to doPlaceChange()
+			// so it captures the new chapter's first place (atlantis.exe
+			// FUN_00427634 saves as it enters that place).
+			_autosavePending = true;
+			// Fire the new chapter's intro /sel sections -- canonical example
+			// is CHAPI014.CON section 10 (`/sel(initflag=0) /set(Cinema=36)`),
+			// the throw-success cinematic that plays right after CHAPI013's
+			// /014 fires /set(chapter=14).  Without this scan the chapter
+			// switches silently and the player just lands at the same vue with
+			// no cinematic.  Same path arrival uses _currentPlaceId on both
+			// sides so (arriveevue>0) still holds.
+			runArrivalSelSections((int)_currentPlaceId, (int)_currentPlaceId);
+			debugC(1, kDebugScript, "execConSetCommand: chapter=%d switch DONE (back from arrival /sel)",
+			      newChapter);
+		}
+		return;
+	}
+
+	// AngleWarpX=N — snap camera horizontal angle to N degrees.
+	if (scumm_strnicmp(p, "anglewarpx=", 11) == 0) {
+		int deg = atoi(p + 11);
+		_omni3dMan.setAlpha(deg * M_PI / 180.0);
+		_gameVars["anglewarpx"] = deg;
+		return;
+	}
+
+	// AngleWarpY=N — snap camera vertical angle to N degrees.
+	if (scumm_strnicmp(p, "anglewarpy=", 11) == 0) {
+		int deg = atoi(p + 11);
+		_omni3dMan.setBeta(deg * M_PI / 180.0);
+		_gameVars["anglewarpy"] = deg;
+		return;
+	}
+
+	// gameover=N — store the variable only.  The game-over screen itself is
+	// driven by playConSection(): the original engine's section player
+	// (atlantis.exe FUN_0042844c) checks the GameOver variable after every
+	// command and, when it is non-zero, breaks out of the section and calls
+	// GereGameOver with the lines that follow.  Showing it from here would
+	// run it *before* those narrator lines instead of feeding them to it.
+	if (scumm_strnicmp(p, "gameover=", 9) == 0) {
+		int n = atoi(p + 9);
+		_gameVars["gameover"] = n;
+		return;
+	}
+
+	// objetenmain=N — force object N into the player's hand (N=0 clears selection).
+	if (scumm_strnicmp(p, "objetenmain=", 12) == 0) {
+		int objId = atoi(p + 12);
+		if (objId == 0) {
+			_inventory.setSelectedObject(nullptr);
+		} else {
+			for (Object &o : _objects) {
+				if (o.valid() && (int)o.idOBJ() == objId) {
+					_inventory.setSelectedObject(&o);
+					break;
+				}
+			}
+		}
+		_gameVars["objetenmain"] = objId;
+		return;
+	}
+
+	// newsound=N — play the ambient/SFX track identified by APC table index N
+	// (table extracted from atlantis.exe by loadAtlantisExeTables).  Always
+	// stops any active newsound before starting a new one, so blocked-zone
+	// feedback (e.g. CHAPI001 `/set(newsound=14)` at zones 150/168) doesn't
+	// pile up.  Played as one-shot SFX on the SFX channel — long enough that
+	// the player hears the cue; looping would need an APC-aware loop adapter.
+	if (scumm_strnicmp(p, "newsound=", 9) == 0) {
+		int soundId = atoi(p + 9);
+		_gameVars["newsound"] = soundId;
+
+		if (_mixer->isSoundHandleActive(_newSoundHandle))
+			_mixer->stopHandle(_newSoundHandle);
+
+		// soundId is a 0-based index into the APC table extracted from
+		// atlantis.exe: empirically, CON `newsound=14` plays the 15th file in
+		// our enumeration (Toctoc.apc), so do NOT subtract 1 here.
+		if (soundId < 0 || (uint)soundId >= _newSoundApcNames.size()) {
+			if (!_newSoundApcNames.empty())
+				debugC(1, kDebugScript, "execConSetCommand: newsound=%d out of table range (0..%u)",
+				      soundId, _newSoundApcNames.size() - 1);
+			return;
+		}
+
+		const Common::String &apcName = _newSoundApcNames[soundId];
+		Common::SeekableReadStream *apcFile =
+		    openBigFileStream(kFileTypeSound, apcName);
+		if (!apcFile) {
+			debugC(1, kDebugScript, "execConSetCommand: newsound=%d '%s' not in BigFile",
+			      soundId, apcName.c_str());
+			return;
+		}
+
+		Audio::PacketizedAudioStream *apc = Audio::makeAPCStream(*apcFile);
+		if (apc) {
+			int64 remaining = apcFile->size() - apcFile->pos();
+			if (remaining > 0) {
+				byte *buf = new byte[remaining];
+				apcFile->read(buf, (uint32)remaining);
+				apc->queuePacket(new Common::MemoryReadStream(buf, remaining,
+				                                              DisposeAfterUse::YES));
+			}
+			apc->finish();
+			_mixer->playStream(Audio::Mixer::kSFXSoundType, &_newSoundHandle, apc);
+			debugC(1, kDebugScript, "execConSetCommand: newsound=%d playing '%s'",
+			      soundId, apcName.c_str());
+		}
+		delete apcFile;
+		return;
+	}
+
+	// stopsound=N — stop the currently playing newsound.  N is ignored: the
+	// original engine only tracks one ambient channel and any stopsound
+	// silences it.
+	if (scumm_strnicmp(p, "stopsound=", 10) == 0) {
+		_gameVars["newsound"] = 0;
+		if (_mixer->isSoundHandleActive(_newSoundHandle))
+			_mixer->stopHandle(_newSoundHandle);
+		return;
+	}
+
+	// newwspranim=N — activate sprite[N-1] at the current place.
+	//
+	// N is a 1-based index into the place's sprite array (in spwpal1.txt
+	// order), NOT a sprite "type".  Per atlantis.exe disassembly at
+	// 0x428376:
+	//   sprite[N-1].field+0x04 = 1   ; mark active
+	//   place_base[+0x04] = N-1      ; remember "current wspranim sprite"
+	//   sprite[N-1].field+0x26 = 0   ; reset frame counter
+	//   vars[NEWWSPRANIM]    = 0     ; consume the command
+	// Example (CHAPI012 vue 180): NewWsprAnim=2 activates the 2nd sprite
+	// at vue 180 (a183h180.spw, static guard); the alarm fires
+	// NewWsprAnim=3 which swaps in the 3rd (a183g180.spw, 33-frame guard
+	// walking animation).  The frame counter on the active sprite is what
+	// the script reads as WSPRFRAME.
+	if (scumm_strnicmp(p, "newwspranim=", 12) == 0) {
+		int n = atoi(p + 12);
+		if (n >= 1) {
+			int seen = 0;
+			for (SpritePlaceEntry &e : _spritePlaceList) {
+				if (e.placeId != (uint16)_currentPlaceId) continue;
+				if (seen == n - 1) {
+					e.active = true;
+					e.frame  = 0;
+					_wsprAnimActiveIdx = n - 1;
+					_gameVars["wsprframe"] = 0;
+					_spriteLayerDirty = true;
+					break;
+				}
+				seen++;
+			}
+		}
+		return;
+	}
+
+	// stopwspranim=N — deactivate sprite[N-1] at the current place; reset
+	// its frame counter and the script's WSPRFRAME variable.  (Same VA
+	// 0x428450 disassembly path as NewWsprAnim above.)
+	if (scumm_strnicmp(p, "stopwspranim=", 13) == 0) {
+		int n = atoi(p + 13);
+		if (n >= 1) {
+			int seen = 0;
+			for (SpritePlaceEntry &e : _spritePlaceList) {
+				if (e.placeId != (uint16)_currentPlaceId) continue;
+				if (seen == n - 1) {
+					e.active = false;
+					e.frame  = 0;
+					if (_wsprAnimActiveIdx == n - 1)
+						_wsprAnimActiveIdx = -1;
+					_gameVars["wsprframe"] = 0;
+					_spriteLayerDirty = true;
+					break;
+				}
+				seen++;
+			}
+		}
+		return;
+	}
+
+	// disable=N — bump place N's visit count so its first-visit /sel sections
+	// (nbvisite=0) stop firing (atlantis.exe /set DISABLE branch).
+	if (scumm_strnicmp(p, "disable=", 8) == 0) {
+		uint placeId = (uint)atoi(p + 8);
+		if (placeId < _placeVisits.size() && _placeVisits[placeId] < 255)
+			_placeVisits[placeId]++;
+		debugC(1, kDebugScript, "execConSetCommand: disable place %u", placeId);
+		return;
+	}
+
+	// fadeout=N — fade the screen to black before a dramatic transition
+	// (a gameover or a scene change).  fadein is unused by any chapter.
+	if (scumm_strnicmp(p, "fadeout=", 8) == 0) {
+		fadeScreenToBlack();
+		return;
+	}
+
+	// startpuzzle=N — launch minigame N.  N is an enum of ~15 distinct
+	// puzzles (eclipse, sliding tile, hexa, serpent, crab, lion, throne,
+	// meta, ...) referenced across chapters 12-79.  On completion the
+	// puzzle writes back FinPuzzle (255 = win; smaller values denote
+	// loss patterns, e.g. CHAPI018's chess puzzle uses 1/2 for "poor
+	// queen" / "poor hero" voice-line variants).
+	//
+	// Framework only: actual puzzle UIs are not yet implemented.  Each
+	// /set(StartPuzzle=N) immediately resolves to FinPuzzle=255 so the
+	// CHAPI012 (and other) script chains continue past the puzzle gate
+	// instead of stalling.  Subsequent commits will replace the auto-
+	// win in playPuzzle() with the per-puzzle UIs.
+	if (scumm_strnicmp(p, "startpuzzle=", 12) == 0) {
+		int puzzleId = atoi(p + 12);
+		playPuzzle(puzzleId);
+		return;
+	}
+
+	// Generic assignment: varname=N — store in _gameVars for condition evaluation.
+	const char *eqPos = strchr(p, '=');
+	if (eqPos && eqPos > p) {
+		Common::String key(p, (uint32)(eqPos - p));
+		key.toLowercase();
+		int val = atoi(eqPos + 1);
+		_gameVars[key] = val;
+		// Several VARIAS.CON names are commands, not plain variables.  The
+		// ones execConSetCommand does not act on still get stored here (so
+		// flag conditions keep working), but their *action* is lost — make
+		// that visible as a stub line rather than a silent gamevar write.
+		static const char *const kStubCommands[] = {
+			"startpuzzle", "finpuzzle", "ouvrirporte", "tirfleche",
+			"addguest", "subguest", "hideguest", "showguest", "incperso",
+			"fadein", "waitclic"
+		};
+		bool isStub = false;
+		for (const char *s : kStubCommands)
+			if (key == s) { isStub = true; break; }
+		if (isStub)
+			debugC(1, kDebugScript, "execConSetCommand: '%s=%d' — command not implemented (stub)",
+			      key.c_str(), val);
+		else
+			debugC(2, kDebugScript, "execConSetCommand: gamevar %s=%d", key.c_str(), val);
+		return;
+	}
+	debugC(2, kDebugScript, "execConSetCommand: unhandled '%s'", cmd.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// NPC hit testing
+// ---------------------------------------------------------------------------
+
+bool CryOmni3DEngine_Atlantis::npcPanoHitTest(const Common::Point &pan, int &outPersoId) const {
+	for (const NPCBound &nb : _npcPlaceBounds) {
+		debugC(5, kDebugScript, "npcPanoHitTest: pan=(%d,%d) vs perso=%d bounds [%d,%d]-[%d,%d]",
+		      pan.x, pan.y, nb.persoId,
+		      nb.panoBounds.left, nb.panoBounds.top,
+		      nb.panoBounds.right, nb.panoBounds.bottom);
+		if (nb.panoBounds.contains(pan)) {
+			outPersoId = nb.persoId;
+			return true;
+		}
+	}
+	return false;
+}
+
+// ---------------------------------------------------------------------------
+// /sel condition evaluation and automatic section runners
+// ---------------------------------------------------------------------------
+
+bool CryOmni3DEngine_Atlantis::evalSelSection(const ConSection &sec,
+                                               int departZone, int currentVue) const {
+	// Roll a fresh random byte once per section evaluation so multiple
+	// `random` clauses inside the same conjunction (e.g. `(random>64)&
+	// (random<128)`) see a consistent value, while *different* sections
+	// see independent rolls.  Matches the original engine's per-section
+	// probabilistic gating used for ambient dialog variety.
+	const int rolledRandom = (int)_conRng.getRandomNumber(255);
+
+	// Left-to-right short-circuit eval, mirroring atlantis.exe FUN_004298ac:
+	//   nextSep '&' + fail -> EXIT FAIL ; pass -> continue
+	//   nextSep '|' + pass -> EXIT SUCCESS ; fail -> continue
+	//   end of list: last cond's result IS the overall result.
+	// So `A & B | C & D` reads as `A AND (B OR (C AND D))` — neither standard
+	// nor OR-tighter precedence; just a left-to-right chain.  This is the
+	// only reading that makes every multi-clause /sel in the game data
+	// behave as authored (e.g. /sel(parletemp3=3)&(departvue=38)|(56)|(22)
+	// gates the OR-list on the leading parletemp3=3 guard the way the exe
+	// evaluates it — without it, every navigation to 38/56/22 would silently
+	// abort regardless of parletemp3).
+	if (sec.conditions.empty()) return true;
+	for (const ConCondition &cc : sec.conditions) {
+		int lhs;
+		if (cc.key == "departvue") {
+			lhs = departZone;
+		} else if (cc.key == "vue") {
+			lhs = currentVue;
+		} else if (cc.key == "arriveevue") {
+			// When evalSelSection is called from runArrivalSelSections, the caller
+			// sets _gameVars["arriveevue"] to the arrived place ID.  Fall through to
+			// generic path so the condition is evaluated against that stored value.
+			Common::HashMap<Common::String, int>::const_iterator it = _gameVars.find(cc.key);
+			lhs = (it != _gameVars.end()) ? it->_value : 0;
+		} else if (cc.key == "objetenmain") {
+			Object *sel = _inventory.selectedObject();
+			lhs = (sel && sel->idOBJ() != uint(-1)) ? (int)sel->idOBJ() : 0;
+		} else if (cc.key.hasPrefix("invent") && cc.key.size() > 6
+		           && Common::isDigit(cc.key[6])) {
+			// invent<N> — 1 when object N is in the inventory, else 0.  The
+			// original (atlantis.exe FUN_00429e54) tests the live inventory
+			// here; it is not a stored game variable.
+			uint objId = (uint)atoi(cc.key.c_str() + 6);
+			lhs = _inventory.inInventoryByNameID(objId) ? 1 : 0;
+		} else if (cc.key == "chaptertime") {
+			// Live wall-clock seconds since the active CHAPI*.CON loaded.
+			// CHAPI030 uses (ChapterTime>120) and (ChapterTime>20) to gate
+			// dialog on real time elapsed -- the storage path through
+			// _gameVars would never tick this up, so it's computed here
+			// from the loadConScript stamp.
+			lhs = _chapterStartMs
+			      ? (int)((g_system->getMillis() - _chapterStartMs) / 1000)
+			      : 0;
+		} else if (cc.key == "nbvisite") {
+			// Per-place visit count of the place being evaluated.
+			lhs = (currentVue >= 0 && (uint)currentVue < _placeVisits.size())
+			      ? (int)_placeVisits[currentVue] : 0;
+		} else if (cc.key == "random") {
+			lhs = rolledRandom;
+		} else {
+			Common::HashMap<Common::String, int>::const_iterator it = _gameVars.find(cc.key);
+			lhs = (it != _gameVars.end()) ? it->_value : 0;
+		}
+
+		bool ok;
+		switch (cc.op) {
+		case '=': ok = (lhs == cc.value); break;
+		case '<': ok = (lhs <  cc.value); break;
+		case '>': ok = (lhs >  cc.value); break;
+		case '!': ok = (lhs != cc.value); break;
+		default:  ok = false;             break;
+		}
+
+		if (cc.nextSep == '&') {
+			if (!ok) return false;
+		} else if (cc.nextSep == '|') {
+			if (ok) return true;
+		} else {
+			// End of condition list — this cond's pass/fail is the answer.
+			return ok;
+		}
+	}
+	// Trailing separator with no closing condition (malformed input) — treat
+	// as the last group's success carrying through.
+	return true;
+}
+
+void CryOmni3DEngine_Atlantis::runZoneConSections(int zoneId) {
+	// Temporarily expose the clicked zone as a game variable so evalSelSection
+	// can evaluate (cliczone=N) conditions through the generic path.
+	_gameVars["cliczone"] = zoneId;
+
+	// A fired section may /set(chapter=N), reparsing _conScript and
+	// invalidating this range-for's iterators; stop if the chapter changes.
+	const uint entryChapter = _currentCONChapter;
+
+	for (ConSection &sec : _conScript.sections()) {
+		if (!sec.isCon || sec.clicZone != zoneId) continue;
+		// Don't gate on the /con* asterisk for zone clicks: sections that
+		// actually require an item-in-hand spell it out as an
+		// (ObjetEnMain=N) condition (handled by evalSelSection).  The
+		// asterisk on a cliczone section just marks it as a zone-click
+		// handler — empirically, CHAPI001.CON section 14 uses
+		// `/con*(cliczone=499)` with no ObjetEnMain and is expected to
+		// fire on a plain click (plays Toctoc.apc for the locked door).
+		if (!evalSelSection(sec, 0, (int)_currentPlaceId)) continue;
+
+		debugC(1, kDebugScript, "runZoneConSections: zone=%d firing section %d", zoneId, sec.id);
+		playConSection(sec);
+
+		if (shouldAbort() || _nextPlaceId == uint(-1) ||
+		    _currentCONChapter != entryChapter)
+			break;
+	}
+
+	_gameVars["cliczone"] = 0;
+}
+
+void CryOmni3DEngine_Atlantis::runDepartureSelSections(int departZone) {
+	// Faithful port of the exe's single /sel scanner (FUN_004280f8): walk
+	// every non-/con section in file order and fire the FIRST whose condition
+	// evaluates true.  Arrival vs departure are not categorised in the
+	// original — arriveevue stays 0 during a departure scan, so arrival-only
+	// sections (those gated on (arriveevue>0) / (initflag=0)) self-exclude;
+	// departure-only sections gate on (departvue>0) or (departvue=N).  Only
+	// the *operator* on departvue varies — the catch-all place-lock pattern
+	// is /sel(departvue>0)&(vue>A)&(vue<B) (e.g. CHAPI011 section 10 that
+	// locks the player into the throne-room cluster while Creon's cinema
+	// flow is active), so no pre-filter by operator/value; evalSelSection
+	// decides.  Single-fire also sidesteps dangling iterators if
+	// playConSection ends up doing /set(chapter=N).
+	for (ConSection &sec : _conScript.sections()) {
+		if (sec.isCon) continue;
+		// /tim* sections fire only on timer ticks — exclude them from the
+		// /sel scan, same reasoning as runArrivalSelSections.
+		if (sec.isTimer) continue;
+
+		if (!evalSelSection(sec, departZone, (int)_currentPlaceId)) continue;
+
+		debugC(1, kDebugScript, "runDepartureSelSections: zone=%d firing section %d", departZone, sec.id);
+		playConSection(sec);
+		break;
+	}
+}
+
+void CryOmni3DEngine_Atlantis::runArrivalSelSections(int arrivedVue, int fromVue) {
+	// arriveevue = the place we arrived FROM, so /sel conditions resolve both
+	// the plain marker form (arriveevue>0)&(vue=N) and the specific form
+	// (arriveevue=FROM)&(vue=TO).  On the very first transition there is no
+	// prior place; fall back to the arrived place so (arriveevue>0) still holds.
+	_gameVars["arriveevue"] = (fromVue > 0) ? fromVue : arrivedVue;
+
+	// Faithful port of the original /sel scanner — atlantis.exe FUN_004280f8,
+	// reached on every place arrival via FUN_00423ad8 -> FUN_00427814 ->
+	// FUN_004277c8.  The exe keeps a SINGLE /sel pool with no arrival/
+	// departure/init categorisation: it walks the CON script top to bottom and
+	// fires the FIRST /sel section whose condition expression evaluates true,
+	// then returns immediately (the `goto` out of FUN_004280f8 — exactly one
+	// section per scan).  arriveevue, departvue, vue, initflag, ... are just
+	// entries in the variable array at 0x611210, all compared generically by
+	// FUN_004298ac; there is no key filter.
+	//
+	// So every /sel (isCon==0) section is eligible, evaluated in file order.
+	// Two consequences fall out for free, both matching the exe:
+	//   - The chapter intro fires: every CHAPI*.CON opens (right after
+	//     /FININIT) with /sel(initflag=0), so it is the first section the scan
+	//     reaches, and initflag is 0 right after loadConScript clears the
+	//     transient variables.  Its first body item /set(initflag=1) then makes
+	//     the condition false (CHAPI011 section 125 — the throne-room cinema).
+	//   - Pure-conditional /sel sections (e.g. CHAPI011 167/168/162) become
+	//     reachable instead of dead.
+	// /con (clic-perso / clic-zone) sections are a separate scanner in the exe
+	// (FUN_004281f8); they are skipped here via sec.isCon.
+	for (ConSection &sec : _conScript.sections()) {
+		// /con sections belong to the separate FUN_004281f8 scanner.
+		if (sec.isCon) continue;
+		// /tim* sections fire only on timer ticks (runTimerSections), not on
+		// the arrival /sel scan.  Without this exclusion an arrival at vue 182
+		// in palais2 (CHAPI012 line 76-79 — a /tim2 with cond Vue=182 &
+		// flagtemp3=0) would run on entry and set flagtemp3=1 immediately,
+		// stranding the player on the first departure: line 29's death gate
+		// /sel(departvue>0)&(Flagtemp3=1) then fires on the next move.
+		if (sec.isTimer) continue;
+
+		// One-shot guard.  The exe has no per-/sel played flag — re-fire is
+		// prevented purely by the section mutating its own gate variable (e.g.
+		// /set(initflag=1)).  sec.played is kept as a safety net for sections
+		// that do not self-guard; it only ever suppresses a *repeat* firing,
+		// never one the exe's first-match scan would have produced.
+		if (sec.played) continue;
+
+		// departZone=0: on an arrival scan departvue resolves to 0, so any
+		// (departvue=N) clause fails on its own — departure /sel sections
+		// self-exclude with no key filter, just as in the exe (where the
+		// departvue variable simply holds 0 at this point).  currentVue=
+		// arrivedVue so (vue=N) checks the place just entered.
+		if (!evalSelSection(sec, 0, arrivedVue)) continue;
+
+		debugC(1, kDebugScript, "runArrivalSelSections: vue=%d firing section %d", arrivedVue, sec.id);
+		sec.played = true;
+		playConSection(sec);
+
+		// Single-fire: FUN_004280f8 returns the instant a section matches, so
+		// exactly one /sel runs per scan.  Breaking now also sidesteps the
+		// range-for iterator — playConSection() may /set(chapter=N) and reparse
+		// _conScript, which would leave `sec` and the iterator dangling.
+		break;
+	}
+
+	_gameVars["arriveevue"] = 0;
+}
+
+bool CryOmni3DEngine_Atlantis::runGenericConSections() {
+	// Generic /con scan -- mirror of atlantis.exe FUN_00425cf4.  The original
+	// engine triggers this whenever the click action lands in the object id
+	// range [256, 512): it walks every /Con or /con section (skipping /Suj-
+	// prefixed topic gates) and fires the FIRST whose conditions evaluate
+	// true.  Used for "use held object in the world at a specific state"
+	// scripts that don't gate on ClicPerso/ClicZone -- canonical case is
+	// CHAPI013 section 178 + /014 fallbacks ("throw the pot on the priest").
+	//
+	// We skip sections with a clicperso / cliczone clause (those belong to
+	// the NPC-dialog and zone-click paths respectively) and sections with a
+	// /suj subject gate (NPC topic menu entries).  Sections marked played
+	// are also skipped to match the one-shot semantics enforced by
+	// interactNPC().  A fired section may /set(chapter=N) which reparses
+	// _conScript, so break the moment that happens.
+	const uint entryChapter = _currentCONChapter;
+
+	for (ConSection &sec : _conScript.sections()) {
+		if (!sec.isCon) continue;
+		if (sec.played) continue;
+		if (sec.sujId > 0) continue;
+		bool gated = false;
+		for (const ConCondition &cc : sec.conditions) {
+			if (cc.key == "clicperso" || cc.key == "cliczone") {
+				gated = true;
+				break;
+			}
+		}
+		if (gated) continue;
+
+		// /con* (needsItem) auto sections require an object in hand --
+		// match the same guard interactNPC uses for sujId==0 sections.
+		if (sec.needsItem && !_inventory.selectedObject()) continue;
+
+		if (!evalSelSection(sec, 0, (int)_currentPlaceId)) continue;
+
+		// Several /con sections often share an id (CHAPI013 has four /014 success
+		// sections + one /014 miss catch-all, all id 14).  Log the section's
+		// gotoId and first /set command so success vs catch-all is unambiguous.
+		Common::String firstSet;
+		for (const ConSectionItem &it : sec.items) {
+			if (it.isSet) { firstSet = it.setCmd; break; }
+		}
+		debugC(1, kDebugScript, "runGenericConSections: firing section %d gotoId=%d firstSet=%s",
+		      sec.id, sec.gotoId, firstSet.c_str());
+		sec.played = true;
+		playConSection(sec);
+
+		// Whether or not the chapter changed, the section was fired and the
+		// click is consumed.  Returning true tells handleWarp to skip the
+		// pickup / NPC-dialog / zone-navigation fall-through.
+		(void)entryChapter;
+		return true;
+	}
+	return false;
+}
+
+void CryOmni3DEngine_Atlantis::runTimerSections(int timerNum) {
+	// Single-fire per scan, matching atlantis.exe FUN_0042bef4 (/tim1 scanner)
+	// and FUN_0042bfa4 (/tim2 scanner).  Both walk the script in file order
+	// for the first "/tim1" / "/tim2" directive whose condition evaluates true
+	// via FUN_004298ac, then return the section offset to the caller -- the
+	// caller fires exactly one section per tick.  Previously this loop would
+	// run every matching /tim section in turn, which could stack cinematics
+	// and /set commands on the same tick (e.g. two queued GameOvers from
+	// overlapping safety nets).  The first-match break also sidesteps
+	// iterator invalidation if playConSection /set(chapter=N) reparses
+	// _conScript.
+	for (ConSection &sec : _conScript.sections()) {
+		if (!sec.isTimer || sec.timerNum != timerNum) continue;
+		if (!evalSelSection(sec, 0, (int)_currentPlaceId)) continue;
+
+		debugC(1, kDebugScript, "runTimerSections: timer=%d firing section %d", timerNum, sec.id);
+		playConSection(sec);
+		break;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// NPC interaction
+// ---------------------------------------------------------------------------
+
+void CryOmni3DEngine_Atlantis::interactNPC(int persoId) {
+	debugC(1, kDebugScript, "interactNPC: persoId=%d", persoId);
+	debugDumpStoryState("interactNPC");
+	// Expose clicperso as a game variable so evalSelSection can check it
+	// against (clicperso=N) conditions on /con sections.
+	_gameVars["clicperso"] = persoId;
+	// New conversation: forget the last cam so the first line is free to pick
+	// any 2..5.  Mirrors the original engine, where `DAT_00772908` (prev cam)
+	// is consulted within a dialog but starts cleared at session entry.
+	_lastDialCam = 0;
+	// Capture the camera direction at the moment of the click; every default
+	// per-line angle in this session is computed relative to this so the
+	// hero's reverse-shot flip doesn't leak into the next NPC line.
+	_dialBaseAlpha = _omni3dMan.getAlpha();
+	_dialBaseAlphaValid = true;
+
+	// atlantis.exe's click-on-perso handler (FUN_00425828) branches on the
+	// perso's enabled-subject count (byte at 0x602f10 + (persoId-512)*0xE1):
+	//   count > 0  -> open the topic-selection menu of enabled subjects;
+	//   count == 0 -> no menu at all: just play the first /con(clicperso=N)
+	//                 section whose conditions pass (the jbe 0x425abe path).
+	// enableSuj/disableSuj are the ONLY things that ever change that count
+	// (verified: those are the sole callers of the inc/dec at 0x602f10), so
+	// "has a non-empty record in _sujEnabled" is exactly the exe's count>0.
+	// Chapters 1-3 list every talkable perso in their /INIT enableSuj
+	// commands; CHAPI004.CON has none — each chapter-4 NPC owns a single
+	// /con(clicperso=N)/suj1 section and is meant to play directly on click.
+	bool persoHasMenu = false;
+	for (const SujState &ss : _sujEnabled)
+		if (ss.persoId == persoId && !ss.sujs.empty()) { persoHasMenu = true; break; }
+
+	// atlantis.exe's FUN_00425828 plays exactly ONE /con section per click and
+	// returns: both of its FUN_0042844c (section player) call sites jump
+	// straight to the function's exit label.  It never re-scans the section
+	// list, so a /set in the line just played (e.g. broche30=1) cannot satisfy
+	// and chain into a second section.  interactNPC() mirrors that: it collects
+	// the candidate section(s), plays at most one, and returns — the topic menu
+	// reappears only on the next click, exactly as in the original.  The
+	// do/while(false) is a single pass whose early-out breaks share the cleanup.
+	do {
+		if (shouldAbort())
+			break;
+
+		// For each enabled subject, collect the first unplayed matching section.
+		Common::Array<ConSection *> options;
+		Common::Array<int> seenSujs;
+
+		for (ConSection &sec : _conScript.sections()) {
+			if (!sec.isCon) continue;
+			// A /con section belongs to this NPC if any of its clicperso
+			// conditions names it.  Test the conditions, not the single
+			// sec.clicPerso field, so a `(clicperso=A)|(clicperso=B)` section
+			// is offered for BOTH A and B — the field records only the last.
+			// Sections with NO clicperso condition (e.g. CHAPI013 section
+			// 92: `/con(vue=126)&(ObjetEnMain=261)&(angle...)&(wsprframe...)`
+			// -- "use bottle on the priest aide at the right pose") are
+			// allowed for any click, gated solely on their other conds.
+			bool hasClicPerso = false;
+			bool forThisPerso = false;
+			// Also skip sections whose ONLY click constraint is a ClicZone
+			// (those belong to runZoneConSections, not the per-NPC scan).
+			bool hasClicZone = false;
+			for (const ConCondition &cc : sec.conditions) {
+				if (cc.key == "clicperso") {
+					hasClicPerso = true;
+					if (cc.value == persoId) forThisPerso = true;
+				} else if (cc.key == "cliczone") {
+					hasClicZone = true;
+				}
+			}
+			if (hasClicPerso && !forThisPerso) continue;
+			if (!hasClicPerso && hasClicZone) continue;
+			debugC(2, kDebugScript, "interactNPC: checking section %d clicPerso=%d played=%d needsItem=%d sujId=%d",
+			      sec.id, persoId, sec.played, sec.needsItem, sec.sujId);
+			if (sec.played) { debugC(2, kDebugScript, "  -> skip: already played"); continue; }
+			// `/con*` is NOT "needs item in hand" -- atlantis.exe
+			// FUN_004281f8 (line 22141) treats the `*` as a depth-gate
+			// override that makes the section always reachable, never a
+			// hard "object required" prerequisite.  Sections that really
+			// need a held item spell it out: every CHAPI*.CON `/con*`
+			// that requires the inventory either carries an explicit
+			// `(ObjetEnMain=N)` clause (CHAPI015 sections 196 / 197 /
+			// 203-cut-rope, CHAPI013 section 178) or an `(invent<N>=...)`
+			// clause (CHAPI015 sections 193 / 195).  Sections like
+			// CHAPI015 `/203 /con*(ClicPerso=537)&(flagtemp2=1)` (the
+			// Meljanz escape) deliberately fire with NO item held: the
+			// player has just used /set(ObjetEnMain=0) when cutting the
+			// rope.  The old auto-skip stranded the player at the inn
+			// balcony unless they manually re-equipped the knife from
+			// the toolbar (which wrongly opened the door anyway because
+			// evalSelSection reads ObjetEnMain from selectedObject, not
+			// the gameVar).  Drop the filter; let evalSelSection's
+			// condition evaluation be the only gate.
+
+			// Evaluate all /con conditions (objetenmain, game vars, etc.).
+			if (!evalSelSection(sec, 0, (int)_currentPlaceId)) { debugC(2, kDebugScript, "  -> skip: conditions failed"); continue; }
+
+			// A perso with no enabled subject is not menu-driven: the first
+			// condition-passing /con(clicperso=N) section just plays — the
+			// exe's count==0 branch.  A sujId-0 section (a scripted greeting
+			// or give-object trigger) always plays directly the same way.
+			//
+			// An automatic section preempts the subject menu entirely: drop
+			// any topic options already collected so it plays on its own.
+			// Otherwise a sujId-0 section found *after* some sujId>0 topics
+			// (e.g. perso 523's give-brooch section 78, which follows topic
+			// section 75 in CHAPI005.CON) would be appended to the topic list
+			// and handed to showSubjectMenu(), which has no icon for sujId 0
+			// and renders that cell as a blank/duplicated border.
+			if (sec.sujId == 0 || !persoHasMenu) {
+				options.clear();
+				options.push_back(&sec);
+				break;
+			}
+
+			// Multi-sujid sections (`/suj1,2`): the section is available
+			// when ANY listed subject is enabled.  The menu uses the
+			// FIRST id as the icon and "already-seen" key; subsequent
+			// ids are just additional fire conditions.  CHAPI005
+			// section 113 (the game-over branch after GardePech1's
+			// warning) depends on this -- a /suj1,2 stays available
+			// when the player has disabled only one of the two.
+			bool alreadySeen = false;
+			for (int s : seenSujs) { if (s == sec.sujId) { alreadySeen = true; break; } }
+			if (alreadySeen) { debugC(2, kDebugScript, "  -> skip: sujId=%d already seen", sec.sujId); continue; }
+
+			bool anyEnabled = false;
+			for (int s : sec.sujIds) {
+				if (isSujEnabled(persoId, s)) { anyEnabled = true; break; }
+			}
+			if (!anyEnabled && sec.sujIds.empty() &&
+			    isSujEnabled(persoId, sec.sujId)) {
+				anyEnabled = true;   // legacy fallback if sujIds list empty
+			}
+			if (!anyEnabled) {
+				debugC(2, kDebugScript, "  -> skip: none of sujIds enabled for perso %d", persoId);
+				continue;
+			}
+
+			options.push_back(&sec);
+			seenSujs.push_back(sec.sujId);
+		}
+
+		if (options.empty()) {
+			debugC(1, kDebugScript, "interactNPC: persoId=%d no options found", persoId);
+			break;
+		}
+
+		int choice;
+		if (options.size() == 1 && (options[0]->sujId == 0 || !persoHasMenu)) {
+			// A single automatic (sujId 0) section — a scripted greeting or
+			// reaction — or any section of a perso with no enabled subject,
+			// plays directly with no subject menu (exe FUN_00425828 count==0).
+			choice = 0;
+		} else {
+			// One or more player-selectable subjects (sujId > 0): show the
+			// subject menu, even for a single subject — the original always
+			// lets the player choose the topic (or right-click to leave).
+			choice = showSubjectMenu(options);
+		}
+
+		if (choice < 0 || shouldAbort()) break;
+
+		ConSection *sec = options[(uint)choice];
+		sec->played = true;
+		playConSection(*sec);
+	} while (false);
+
+	_gameVars["clicperso"] = 0;
+	_dialBaseAlphaValid = false;
+}
+
+void CryOmni3DEngine_Atlantis::decodeSprite(Common::SeekableReadStream &stream,
+        SubjSprite &spr, const uint16 *colorTable) {
+	// Per-row offset table: h x uint32, relative to the pixel-data base.
+	Common::Array<uint32> rowOff(spr.h);
+	for (uint16 r = 0; r < spr.h; r++)
+		rowOff[r] = stream.readUint32LE();
+	const int64 pixBase = stream.pos();
+
+	spr.pixels.resize((uint)spr.w * spr.h);
+	spr.blend.resize((uint)spr.w * spr.h);
+	for (uint i = 0; i < spr.pixels.size(); i++) {
+		spr.pixels[i] = kSprTransp;
+		spr.blend[i]  = kSprNoBlend;
+	}
+
+	for (uint16 ry = 0; ry < spr.h; ry++) {
+		stream.seek(pixBase + rowOff[ry]);
+		int rx = 0;
+		while (rx < spr.w && !stream.eos()) {
+			byte b = stream.readByte();
+			int btype = (b >> 6) & 0x3;
+			int cnt   = b & 0x3F;
+			if (btype == 0) {
+				rx += cnt;  // transparent run
+			} else if (btype == 1) {
+				// Opaque run: cnt colour-index bytes.
+				for (int i = 0; i < cnt && rx < spr.w; i++, rx++) {
+					uint16 col = colorTable[stream.readByte()];
+					if (col == kSprTransp) col = 0x0000;
+					spr.pixels[ry * spr.w + rx] = col;
+				}
+			} else {
+				// Blend run: cnt (factor, index) pairs.  The colour-table
+				// entry is already premultiplied by factor/32 in the data
+				// (atlantis.exe FUN_0041047f); keep the factor so drawing
+				// can add the framebuffer's (32-factor)/32 share.
+				for (int i = 0; i < cnt && rx < spr.w; i++, rx++) {
+					byte factor = stream.readByte() & 0x1f;
+					uint16 col  = colorTable[stream.readByte()];
+					if (col == kSprTransp) col = 0x0000;
+					spr.pixels[ry * spr.w + rx] = col;
+					spr.blend[ry * spr.w + rx]  = factor;
+				}
+			}
+		}
+	}
+}
+
+void CryOmni3DEngine_Atlantis::loadSubjectSprites() {
+	Common::ScopedPtr<Common::SeekableReadStream> stream(
+	    openBigFileStream(kFileTypeSprite2D, "SUJETS.SPR"));
+	if (!stream) {
+		warning("Cannot open SPRITE\\2D\\SUJETS.SPR");
+		return;
+	}
+
+	// flags word: bit 2 = has 256-entry color table stored as RGB555
+	uint16 flags = stream->readUint16LE();
+
+	uint16 colorTable[256];
+	if (flags & 0x4) {
+		// Color table is stored in RGB555 format; convert to RGB565.
+		// Cannot use g_system->getScreenFormat() here — called before initGraphics().
+		// Green is 5 bits in RGB555 but 6 bits in RGB565: shift g left 6 (= g*2) so it
+		// fills bits [10:6] rather than [9:5], giving ~double the brightness.
+		for (int i = 0; i < 256; i++) {
+			uint16 rgb555 = stream->readUint16LE();
+			uint16 r = (rgb555 >> 10) & 0x1f;
+			uint16 g = (rgb555 >> 5)  & 0x1f;
+			uint16 b =  rgb555        & 0x1f;
+			colorTable[i] = (r << 11) | (g << 6) | b;
+		}
+	} else {
+		memset(colorTable, 0, sizeof(colorTable));
+	}
+	if (flags & 0x8) {
+		// 512-entry table: skip the extra 256 entries (already read 256 above)
+		stream->skip(256 * 2);
+	}
+
+	uint16 count = stream->readUint16LE();
+	if (count == 0 || count > 256) {
+		warning("loadSubjectSprites: unexpected count %u", count);
+		return;
+	}
+
+	// Sprite data section starts here (after flags + color table + count).
+	// Offsets in the sprite table are relative to this position.
+	const int64 sprDataBase = stream->pos();  // = 516 bytes in
+
+	Common::Array<uint32> offsets(count);
+	for (uint16 i = 0; i < count; i++)
+		offsets[i] = stream->readUint32LE();
+
+	_subjSprites.resize(count);
+
+	for (uint16 si = 0; si < count; si++) {
+		if (stream->seek(sprDataBase + offsets[si]) == false) {
+			warning("loadSubjectSprites: seek failed for sprite %u", si);
+			continue;
+		}
+
+		SubjSprite &spr = _subjSprites[si];
+		spr.w    = stream->readUint16LE();
+		spr.h    = stream->readUint16LE();
+		spr.xoff = stream->readSint16LE();
+		spr.yoff = stream->readSint16LE();
+
+		if (spr.w == 0 || spr.h == 0 || spr.w > 640 || spr.h > 480)
+			continue;
+
+		decodeSprite(*stream, spr, colorTable);
+	}
+
+	debugC(1, kDebugScript, "loadSubjectSprites: loaded %u sprites from SUJETS.SPR", count);
+}
+
+void CryOmni3DEngine_Atlantis::loadCursorSprites() {
+	Common::ScopedPtr<Common::SeekableReadStream> stream(
+	    openBigFileStream(kFileTypeSprite2D, "CURSEURS.SPR"));
+	if (!stream) {
+		warning("loadCursorSprites: cannot open SPRITE\\2D\\CURSEURS.SPR — using fallback cursors");
+		return;
+	}
+
+	uint16 flags = stream->readUint16LE();
+
+	uint16 colorTable[256];
+	memset(colorTable, 0, sizeof(colorTable));
+	if (flags & 0x4) {
+		for (int i = 0; i < 256; i++) {
+			uint16 rgb555 = stream->readUint16LE();
+			uint16 r = (rgb555 >> 10) & 0x1f;
+			uint16 g = (rgb555 >> 5)  & 0x1f;
+			uint16 b =  rgb555        & 0x1f;
+			uint16 rgb565 = (uint16)((r << 11) | (g << 6) | b);
+			// Remap the transparency sentinel to near-black to avoid false keying.
+			colorTable[i] = (rgb565 == kWarpCursorKey) ? 0x0000u : rgb565;
+		}
+	}
+	if (flags & 0x8)
+		stream->skip(512);
+
+	uint16 count = stream->readUint16LE();
+	if (count == 0 || count > 256) {
+		warning("loadCursorSprites: unexpected sprite count %u", count);
+		return;
+	}
+
+	const int64 sprDataBase = stream->pos();
+	Common::Array<uint32> offsets(count);
+	for (uint16 i = 0; i < count; i++)
+		offsets[i] = stream->readUint32LE();
+
+	_cursorSprites.resize(count);
+
+	for (uint16 si = 0; si < count; si++) {
+		if (!stream->seek(sprDataBase + offsets[si])) {
+			warning("loadCursorSprites: seek failed for sprite %u", si);
+			continue;
+		}
+		CursorSpr &spr = _cursorSprites[si];
+		spr.w    = stream->readUint16LE();
+		spr.h    = stream->readUint16LE();
+		spr.xoff = stream->readSint16LE();
+		spr.yoff = stream->readSint16LE();
+
+		if (spr.w == 0 || spr.h == 0 || spr.w > 64 || spr.h > 64)
+			continue;
+
+		Common::Array<uint32> rowOff(spr.h);
+		for (uint16 r = 0; r < spr.h; r++)
+			rowOff[r] = stream->readUint32LE();
+		const int64 pixBase = stream->pos();
+
+		spr.pixels.resize(spr.w * spr.h, kWarpCursorKey);
+		spr.blend.resize(spr.w * spr.h, kSprNoBlend);
+
+		for (uint16 ry = 0; ry < spr.h; ry++) {
+			stream->seek(pixBase + rowOff[ry]);
+			int rx = 0;
+			while (rx < (int)spr.w && !stream->eos()) {
+				byte b = stream->readByte();
+				int btype = (b >> 6) & 0x3;
+				int cnt   = b & 0x3F;
+				if (btype == 0) {
+					rx += cnt;
+				} else if (btype == 1) {
+					for (int i = 0; i < cnt && rx < (int)spr.w; i++, rx++) {
+						byte idx = stream->readByte();
+						spr.pixels[ry * spr.w + rx] = colorTable[idx];
+					}
+				} else {
+					for (int i = 0; i < cnt && rx < (int)spr.w; i++, rx++) {
+						byte factor = stream->readByte() & 0x1f;
+						byte idx = stream->readByte();
+						spr.pixels[ry * spr.w + rx] = colorTable[idx];
+						spr.blend[ry * spr.w + rx]  = factor;
+					}
+				}
+			}
+		}
+	}
+
+	debugC(1, kDebugScript, "loadCursorSprites: loaded %u sprites from CURSEURS.SPR", count);
+}
+
+void CryOmni3DEngine_Atlantis::loadObjectSprites() {
+	Common::ScopedPtr<Common::SeekableReadStream> stream(
+	    openBigFileStream(kFileTypeSprite2D, "OBJETS1.SPR"));
+	if (!stream) {
+		warning("loadObjectSprites: cannot open SPRITE\\2D\\OBJETS1.SPR");
+		return;
+	}
+
+	uint16 flags = stream->readUint16LE();
+
+	uint16 colorTable[256];
+	memset(colorTable, 0, sizeof(colorTable));
+	if (flags & 0x4) {
+		for (int i = 0; i < 256; i++) {
+			uint16 rgb555 = stream->readUint16LE();
+			uint16 r = (rgb555 >> 10) & 0x1f;
+			uint16 g = (rgb555 >> 5)  & 0x1f;
+			uint16 b =  rgb555        & 0x1f;
+			colorTable[i] = (r << 11) | (g << 6) | b;
+		}
+	}
+	if (flags & 0x8)
+		stream->skip(256 * 2);
+
+	uint16 count = stream->readUint16LE();
+	if (count == 0 || count > 256) {
+		warning("loadObjectSprites: unexpected count %u", count);
+		return;
+	}
+
+	const int64 sprDataBase = stream->pos();
+
+	Common::Array<uint32> offsets(count);
+	for (uint16 i = 0; i < count; i++)
+		offsets[i] = stream->readUint32LE();
+
+	_objSprites.resize(count);
+
+	for (uint16 si = 0; si < count; si++) {
+		if (!stream->seek(sprDataBase + offsets[si])) {
+			warning("loadObjectSprites: seek failed for sprite %u", si);
+			continue;
+		}
+
+		SubjSprite &spr = _objSprites[si];
+		spr.w    = stream->readUint16LE();
+		spr.h    = stream->readUint16LE();
+		spr.xoff = stream->readSint16LE();
+		spr.yoff = stream->readSint16LE();
+
+		if (spr.w == 0 || spr.h == 0 || spr.w > 640 || spr.h > 480)
+			continue;
+
+		decodeSprite(*stream, spr, colorTable);
+	}
+
+	debugC(1, kDebugScript, "loadObjectSprites: loaded %u sprites from OBJETS1.SPR", count);
+}
+
+void CryOmni3DEngine_Atlantis::loadInventoryBarSprite() {
+	// OBJETS0.SPR holds the single 599x82 inventory-bar background sprite.
+	// File format is identical to OBJETS1.SPR / SPRMENU.SPR: same SPR header,
+	// 256 RGB555 color-table entries, optional skipped extra table, then a
+	// sprite count (always 1 here) and the offset table.  We decode exactly
+	// the same RLE rows as loadObjectSprites().
+	_inventoryBarSprite = SubjSprite();
+	Common::ScopedPtr<Common::SeekableReadStream> stream(
+	    openBigFileStream(kFileTypeSprite2D, "OBJETS0.SPR"));
+	if (!stream) {
+		warning("loadInventoryBarSprite: cannot open SPRITE\\2D\\OBJETS0.SPR");
+		return;
+	}
+
+	uint16 flags = stream->readUint16LE();
+
+	uint16 colorTable[256];
+	memset(colorTable, 0, sizeof(colorTable));
+	if (flags & 0x4) {
+		for (int i = 0; i < 256; i++) {
+			uint16 rgb555 = stream->readUint16LE();
+			uint16 r = (rgb555 >> 10) & 0x1f;
+			uint16 g = (rgb555 >> 5)  & 0x1f;
+			uint16 b =  rgb555        & 0x1f;
+			colorTable[i] = (r << 11) | (g << 6) | b;
+		}
+	}
+	if (flags & 0x8)
+		stream->skip(256 * 2);
+
+	uint16 count = stream->readUint16LE();
+	if (count != 1) {
+		warning("loadInventoryBarSprite: expected 1 sprite, got %u", count);
+		return;
+	}
+
+	const int64 sprDataBase = stream->pos();
+	uint32 spr0Off = stream->readUint32LE();
+
+	if (!stream->seek(sprDataBase + spr0Off)) {
+		warning("loadInventoryBarSprite: seek failed");
+		return;
+	}
+
+	SubjSprite &spr = _inventoryBarSprite;
+	spr.w    = stream->readUint16LE();
+	spr.h    = stream->readUint16LE();
+	spr.xoff = stream->readSint16LE();
+	spr.yoff = stream->readSint16LE();
+	if (spr.w == 0 || spr.h == 0 || spr.w > 1024 || spr.h > 256) {
+		warning("loadInventoryBarSprite: bad dims %ux%u", spr.w, spr.h);
+		spr = SubjSprite();
+		return;
+	}
+
+	decodeSprite(*stream, spr, colorTable);
+
+	debugC(1, kDebugScript, "loadInventoryBarSprite: loaded %ux%u sprite from OBJETS0.SPR (hotspot %d,%d)",
+	      spr.w, spr.h, spr.xoff, spr.yoff);
+}
+
+Graphics::Surface *CryOmni3DEngine_Atlantis::loadTGA(FileType ft, const char *name) {
+	Common::ScopedPtr<Common::SeekableReadStream> stream(openBigFileStream(ft, name));
+	if (!stream) {
+		warning("loadTGA: cannot open %s", name);
+		return nullptr;
+	}
+
+	// TGA header (18 bytes): all game TGAs are type 2 (uncompressed true-color), 640x480, depth=15
+	byte  idLen    = stream->readByte();
+	/* cmType = */ stream->readByte();
+	byte  imgType  = stream->readByte();
+	stream->skip(9); // color-map spec (5) + x/y origin (4)
+	uint16 w       = stream->readUint16LE();
+	uint16 h       = stream->readUint16LE();
+	byte   depth   = stream->readByte();
+	stream->readByte(); // image descriptor
+	stream->skip(idLen); // optional ID field
+
+	if (imgType != 2 || depth != 15 || w == 0 || h == 0) {
+		warning("loadTGA: unexpected format in %s (type=%u depth=%u %ux%u)", name, imgType, depth, w, h);
+		return nullptr;
+	}
+
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	Graphics::Surface *surf = new Graphics::Surface();
+	surf->create(w, h, fmt);
+
+	for (uint16 y = 0; y < h; y++) {
+		// TGA origin is bottom-left by default (image_descriptor bit5 = 0)
+		uint16 *row = (uint16 *)surf->getBasePtr(0, h - 1 - y);
+		for (uint16 x = 0; x < w; x++) {
+			uint16 px = stream->readUint16LE();
+			uint8 r = ((px >> 10) & 0x1f) << 3;
+			uint8 g = ((px >>  5) & 0x1f) << 3;
+			uint8 b = ( px        & 0x1f) << 3;
+			row[x] = (uint16)fmt.RGBToColor(r, g, b);
+		}
+	}
+
+	return surf;
+}
+
+void CryOmni3DEngine_Atlantis::blitMenuSprite(Graphics::ManagedSurface &dst, uint idx, int hx, int hy) const {
+	if (idx >= _menuSprites.size() || _menuSprites[idx].pixels.empty())
+		return;
+	const SubjSprite &s = _menuSprites[idx];
+	int baseX = hx - s.xoff;
+	int baseY = hy - s.yoff;
+	for (int sy = 0; sy < (int)s.h; sy++) {
+		int dy = baseY + sy;
+		if (dy < 0 || dy >= dst.h)
+			continue;
+		for (int sx = 0; sx < (int)s.w; sx++) {
+			int dx = baseX + sx;
+			if (dx < 0 || dx >= dst.w)
+				continue;
+			uint sidx = sy * s.w + sx;
+			uint16 pix = s.pixels[sidx];
+			if (pix == kSprTransp)
+				continue;
+			uint16 *dp = (uint16 *)dst.getBasePtr(dx, dy);
+			if (s.blend[sidx] != kSprNoBlend)
+				pix = blendSprPixel565(pix, *dp, s.blend[sidx]);
+			*dp = pix;
+		}
+	}
+}
+
+void CryOmni3DEngine_Atlantis::loadMenuSprites() {
+	Common::ScopedPtr<Common::SeekableReadStream> stream(
+	    openBigFileStream(kFileTypeSprite2D, "SPRMENU.SPR"));
+	if (!stream) {
+		warning("loadMenuSprites: cannot open SPRITE\\2D\\SPRMENU.SPR");
+		return;
+	}
+
+	uint16 flags = stream->readUint16LE();
+
+	uint16 colorTable[256];
+	memset(colorTable, 0, sizeof(colorTable));
+	if (flags & 0x4) {
+		for (int i = 0; i < 256; i++) {
+			uint16 rgb555 = stream->readUint16LE();
+			uint16 r = (rgb555 >> 10) & 0x1f;
+			uint16 g = (rgb555 >> 5)  & 0x1f;
+			uint16 b =  rgb555        & 0x1f;
+			colorTable[i] = (r << 11) | (g << 6) | b;
+		}
+	}
+	if (flags & 0x8)
+		stream->skip(256 * 2);
+
+	uint16 count = stream->readUint16LE();
+	if (count == 0 || count > 256) {
+		warning("loadMenuSprites: unexpected count %u", count);
+		return;
+	}
+
+	const int64 sprDataBase = stream->pos();
+
+	Common::Array<uint32> offsets(count);
+	for (uint16 i = 0; i < count; i++)
+		offsets[i] = stream->readUint32LE();
+
+	_menuSprites.resize(count);
+
+	for (uint16 si = 0; si < count; si++) {
+		if (!stream->seek(sprDataBase + offsets[si])) {
+			warning("loadMenuSprites: seek failed for sprite %u", si);
+			continue;
+		}
+
+		SubjSprite &spr = _menuSprites[si];
+		spr.w    = stream->readUint16LE();
+		spr.h    = stream->readUint16LE();
+		spr.xoff = stream->readSint16LE();
+		spr.yoff = stream->readSint16LE();
+
+		if (spr.w == 0 || spr.h == 0 || spr.w > 640 || spr.h > 480)
+			continue;
+
+		decodeSprite(*stream, spr, colorTable);
+	}
+
+}
+
+void CryOmni3DEngine_Atlantis::loadFontMaxSprites() {
+	// Default and hover glyph sets share the same SPR format.  FONTMAX/FONTMAX2
+	// are the gold menu font; FONTMIN/FONTMIN2 the smaller red player-name font.
+	loadFontSpriteSet("FONTMAX.SPR",  _fontMaxSprites);
+	loadFontSpriteSet("FONTMAX2.SPR", _fontMaxHoverSprites);
+	loadFontSpriteSet("FONTMIN.SPR",  _fontMinSprites);
+	loadFontSpriteSet("FONTMIN2.SPR", _fontMin2Sprites);
+}
+
+void CryOmni3DEngine_Atlantis::loadCreditFontSprites() {
+	// Two glyph banks for the credits roll.  Same SPR format as FONTMAX.
+	loadFontSpriteSet("CREDBLAN.SPR", _creditBlanSprites);
+	loadFontSpriteSet("CREDBLEU.SPR", _creditBleuSprites);
+}
+
+void CryOmni3DEngine_Atlantis::loadFontSpriteSet(const char *sprName,
+        Common::Array<SubjSprite> &out) {
+	out.clear();
+	Common::ScopedPtr<Common::SeekableReadStream> stream(
+	    openBigFileStream(kFileTypeSprite2D, sprName));
+	if (!stream) {
+		warning("loadFontSpriteSet: cannot open SPRITE\\2D\\%s", sprName);
+		return;
+	}
+
+	uint16 flags = stream->readUint16LE();
+
+	uint16 colorTable[256];
+	memset(colorTable, 0, sizeof(colorTable));
+	if (flags & 0x4) {
+		for (int i = 0; i < 256; i++) {
+			uint16 rgb555 = stream->readUint16LE();
+			uint16 r = (rgb555 >> 10) & 0x1f;
+			uint16 g = (rgb555 >> 5)  & 0x1f;
+			uint16 b =  rgb555        & 0x1f;
+			colorTable[i] = (r << 11) | (g << 6) | b;
+		}
+	}
+	if (flags & 0x8)
+		stream->skip(256 * 2);
+
+	uint16 count = stream->readUint16LE();
+	if (count == 0 || count > 256) {
+		warning("loadFontSpriteSet(%s): unexpected count %u", sprName, count);
+		return;
+	}
+
+	const int64 sprDataBase = stream->pos();
+
+	Common::Array<uint32> offsets(count);
+	for (uint16 i = 0; i < count; i++)
+		offsets[i] = stream->readUint32LE();
+
+	out.resize(count);
+
+	for (uint16 si = 0; si < count; si++) {
+		if (!stream->seek(sprDataBase + offsets[si])) {
+			warning("loadFontSpriteSet(%s): seek failed for sprite %u", sprName, si);
+			continue;
+		}
+
+		SubjSprite &spr = out[si];
+		spr.w    = stream->readUint16LE();
+		spr.h    = stream->readUint16LE();
+		spr.xoff = stream->readSint16LE();
+		spr.yoff = stream->readSint16LE();
+
+		if (spr.w == 0 || spr.h == 0 || spr.w > 640 || spr.h > 480)
+			continue;
+
+		decodeSprite(*stream, spr, colorTable);
+	}
+}
+
+void CryOmni3DEngine_Atlantis::drawInventoryIcon(Graphics::ManagedSurface &dst,
+        const Object *obj, const Common::Rect &r) {
+	if (_objSprites.empty() || obj == nullptr)
+		return;
+
+	// Find this object's index in _objects via pointer arithmetic.
+	if (_objects.empty())
+		return;
+	ptrdiff_t idx = obj - &_objects.front();
+	if (idx < 0 || (uint)idx >= _objSprites.size())
+		return;
+
+	const SubjSprite &spr = _objSprites[(uint)idx];
+	if (spr.pixels.empty())
+		return;
+
+	// Center sprite within the slot rect.
+	int cx = (r.left + r.right)  / 2;
+	int cy = (r.top  + r.bottom) / 2;
+	// xoff/yoff = hotspot (center of sprite); compute top-left corner.
+	int dx = cx - spr.xoff;
+	int dy = cy - spr.yoff;
+
+	// Clip ONLY to the destination surface, never to the slot rect.  The slot
+	// is 50x40 but OBJETS1.SPR icons run up to 60x60 (e.g. sprites 33/44), so
+	// clipping to the slot would trim the top/bottom of most items.  The
+	// original engine's icon blit (atlantis.exe FUN_0041047f) clips against the
+	// global render-target window, not a per-slot box: the icon draws full size
+	// centred on the slot, overflowing into the bar's vertical margin (the 70px
+	// column spacing — slot centres 70px apart — leaves room horizontally for
+	// the ≤60px-wide icons).  `r` here is used only to centre the icon.
+	for (int y = 0; y < (int)spr.h; y++) {
+		int sy = dy + y;
+		if (sy < 0 || sy >= (int)dst.h) continue;
+		for (int x = 0; x < (int)spr.w; x++) {
+			int sx = dx + x;
+			if (sx < 0 || sx >= (int)dst.w) continue;
+			uint sidx = y * spr.w + x;
+			uint16 pix = spr.pixels[sidx];
+			if (pix == kSprTransp) continue;
+			uint16 *dp = (uint16 *)dst.getBasePtr(sx, sy);
+			if (spr.blend[sidx] != kSprNoBlend)
+				pix = blendSprPixel565(pix, *dp, spr.blend[sidx]);
+			*dp = pix;
+		}
+	}
+}
+
+void CryOmni3DEngine_Atlantis::drawGivenObject(Graphics::Surface &dst) const {
+	if (_dialogGivenObjSprite < 0 || (uint)_dialogGivenObjSprite >= _objSprites.size())
+		return;
+	const SubjSprite &spr = _objSprites[(uint)_dialogGivenObjSprite];
+	if (spr.pixels.empty())
+		return;
+	// Centre horizontally; sit near the bottom, above the subtitle strip.
+	// (The original draws the given object's icon centre-bottom on every
+	// dialog frame via DAT_0049619c; the exact Y is not recoverable from the
+	// decompiler, so anchor the icon's bottom a fixed gap above the screen
+	// edge.)
+	const int cx = dst.w / 2;
+	const int objBottom = dst.h - 56;          // leave room for subtitles below
+	const int cy = objBottom - ((int)spr.h - spr.yoff);  // hotspot Y for that bottom
+	const int dx = cx - spr.xoff;
+	const int dy = cy - spr.yoff;
+	for (int y = 0; y < (int)spr.h; y++) {
+		int sy = dy + y;
+		if (sy < 0 || sy >= dst.h) continue;
+		for (int x = 0; x < (int)spr.w; x++) {
+			int sx = dx + x;
+			if (sx < 0 || sx >= dst.w) continue;
+			uint sidx = y * spr.w + x;
+			uint16 pix = spr.pixels[sidx];
+			if (pix == kSprTransp) continue;
+			uint16 *dp = (uint16 *)dst.getBasePtr(sx, sy);
+			if (spr.blend[sidx] != kSprNoBlend)
+				pix = blendSprPixel565(pix, *dp, spr.blend[sidx]);
+			*dp = pix;
+		}
+	}
+}
+
+void CryOmni3DEngine_Atlantis::drawSubjectSprite(Graphics::Surface &dst,
+        uint sprIdx, int cx, int cy) const {
+	if (sprIdx >= _subjSprites.size())
+		return;
+	const SubjSprite &spr = _subjSprites[sprIdx];
+	if (spr.pixels.empty())
+		return;
+
+	// cx,cy = center point; xoff,yoff = hotspot offset from top-left
+	int dx = cx - spr.xoff;
+	int dy = cy - spr.yoff;
+
+	for (int y = 0; y < (int)spr.h; y++) {
+		int sy = dy + y;
+		if (sy < 0 || sy >= dst.h) continue;
+		for (int x = 0; x < (int)spr.w; x++) {
+			int sx = dx + x;
+			if (sx < 0 || sx >= dst.w) continue;
+			uint sidx = y * spr.w + x;
+			uint16 pix = spr.pixels[sidx];
+			if (pix == kSprTransp) continue;
+			uint16 *dp = (uint16 *)dst.getBasePtr(sx, sy);
+			if (spr.blend[sidx] != kSprNoBlend)
+				pix = blendSprPixel565(pix, *dp, spr.blend[sidx]);
+			*dp = pix;
+		}
+	}
+}
+
+// Subject-choice menu, reproduced from atlantis.exe's subject grid (draw at
+// FUN_004261a0, hit-test at FUN_004211f0 — both confirmed against the
+// decompilation and a dynamic CreateFileA/blit trace of the original):
+//
+//  - Each subject is two sprites: the border (SUJETS.SPR sprite 0) drawn at
+//    the cell's top-left, then the icon (sprite = sujId) at the cell centre,
+//    i.e. icon anchor = border anchor + (25, 25).
+//  - Cells are 50x50; 4 rows per column; columns step 50 px in X from X=450.
+//  - For <=4 subjects the single column is bottom-anchored
+//    (startY = 330 - 50*N); for >=5 the grid starts at Y=180.
+//  - The original draws the icons statically: there is NO hover highlight and
+//    NO on-screen "exit" affordance — a right-click cancels.
+//
+// Returns the chosen option index, or -1 on cancel.
+int CryOmni3DEngine_Atlantis::showSubjectMenu(const Common::Array<ConSection *> &options) {
+	const int kScreenW = 640, kScreenH = 480;
+	const uint nOpts = options.size();
+	if (nOpts == 0)
+		return -1;
+
+	const int kBorderX  = 450;  // exe 0x1c2 — column-0 cell origin X
+	const int kColStepX = 50;
+	const int kRowStepY = 50;
+	const int kCell     = 50;   // exe FUN_004211f0 hit-test cell (0x32)
+	const int kIconDX   = 25;   // icon anchor = border (cell top-left) + (25,25)
+	const int kIconDY   = 25;
+	const int kPerCol   = 4;
+
+	// Column start Y: a single bottom-anchored column for <=4 subjects, a
+	// fixed grid from Y=180 once a second column is needed.
+	const int startY = (nOpts < 5) ? (int)(330 - 50 * nOpts) : 180;
+
+	// Border-sprite anchor (= cell top-left) for each subject.
+	struct IconLayout { int bx, by; uint optIdx; };
+	Common::Array<IconLayout> layout;
+	for (uint i = 0; i < nOpts; i++) {
+		int col = (int)i / kPerCol;
+		int row = (int)i % kPerCol;
+		layout.push_back({kBorderX + col * kColStepX, startY + row * kRowStepY, i});
+	}
+
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	Graphics::ManagedSurface frame(kScreenW, kScreenH, fmt);
+
+	showMouse(true);
+	setArrowCursor();
+
+	// Drain the button press that opened the menu (the player just clicked the
+	// NPC) so it is not consumed as an immediate — and missing — selection,
+	// which would close the menu the instant it appeared.
+	while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+		pollEvents();
+		g_system->delayMillis(10);
+	}
+
+	int result = -1;
+	bool done = false;
+	while (!done && !shouldAbort()) {
+		pollEvents();
+
+		// Panoramic background → frame buffer.
+		if (_warpLoaded) {
+			const Graphics::Surface *bg = _omni3dMan.getSurface();
+			if (bg)
+				frame.blitFrom(*bg);
+			else
+				frame.fillRect(Common::Rect(kScreenW, kScreenH), 0);
+		} else {
+			frame.fillRect(Common::Rect(kScreenW, kScreenH), 0);
+		}
+
+		Graphics::Surface *rawPtr = frame.surfacePtr();
+
+		// Each subject: border (sprite 0) first, then the icon on top — the
+		// original draws every icon identically, with no hover highlight.
+		for (const IconLayout &il : layout) {
+			drawSubjectSprite(*rawPtr, 0, il.bx, il.by);
+			int sujId = options[il.optIdx]->sujId;
+			uint sprIdx = (sujId > 0 && (uint)sujId < _subjSprites.size())
+			              ? (uint)sujId : 0;
+			drawSubjectSprite(*rawPtr, sprIdx, il.bx + kIconDX, il.by + kIconDY);
+		}
+
+		g_system->copyRectToScreen(frame.getPixels(), frame.pitch, 0, 0, kScreenW, kScreenH);
+		g_system->updateScreen();
+
+		if (getCurrentMouseButton() == 1) {
+			Common::Point click = getMousePos();
+			while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+				pollEvents();
+				g_system->delayMillis(10);
+			}
+			// 50x50 hit cell anchored at each subject's border (top-left).
+			for (const IconLayout &il : layout) {
+				if (click.x >= il.bx && click.x < il.bx + kCell &&
+				    click.y >= il.by && click.y < il.by + kCell) {
+					result = (int)il.optIdx;
+					break;
+				}
+			}
+			done = true;
+		} else if (getCurrentMouseButton() == 2) {
+			done = true;   // right-click cancels
+		}
+
+		g_system->delayMillis(10);
+	}
+
+	showMouse(false);
+	return result;
+}
+
+// Build the HNM filename for a dialog line's background video.
+// speaker + params="camN" → "<SPEAKER_UPPER>N.HNM"; params="off"/empty → no video.
+void CryOmni3DEngine_Atlantis::loadDialInitData() {
+	Common::ScopedPtr<Common::SeekableReadStream> s(
+	    openBigFileStream(kFileTypeDialog, "INITDIAL.TXT"));
+	if (!s) {
+		warning("loadDialInitData: cannot open DIALOG\\INITDIAL.TXT");
+		return;
+	}
+
+	uint32 sz = (uint32)s->size();
+	Common::Array<char> buf(sz + 1);
+	s->read(buf.data(), sz);
+	buf[sz] = '\0';
+
+	const char *p = buf.data();
+	while (*p) {
+		while (*p && (*p == '\r' || *p == '\n' || *p == ' ' || *p == '\t')) p++;
+		if (!*p) break;
+
+		Common::Array<Common::String> tok;
+		while (*p && *p != '\r' && *p != '\n') {
+			while (*p && (*p == ' ' || *p == '\t')) p++;
+			if (!*p || *p == '\r' || *p == '\n') break;
+			const char *te = p;
+			while (*te && *te != ' ' && *te != '\t' && *te != '\r' && *te != '\n') te++;
+			tok.push_back(Common::String(p, (uint32)(te - p)));
+			p = te;
+		}
+
+		if (tok.empty() || tok[0].equalsIgnoreCase("FIN")) break;
+		// Format: persoId unk anim3DC anim3DA animM s3d cam2 cam3 cam4 cam5 [spf2..spf5]
+		if (tok.size() < 10) continue;
+
+		int persoId = atoi(tok[0].c_str());
+		if (persoId <= 0) continue;
+
+		// Detect the player character (hero) by the s3d field being "hero".
+		if (tok[5].equalsIgnoreCase("hero"))
+			_heroPersoId = persoId;
+
+		DialInitEntry entry;
+		for (int i = 0; i < 4; i++)
+			entry.camUBB[i] = tok[6 + i];  // cam2..cam5 basenames
+
+		// Column 4 (0-indexed) is the animM basename — the per-character
+		// mouth vertex-animation file at DIALOG\PERSO\<base>.3DA.  The
+		// trailing "m" in the basename is a Cryo convention (e.g.
+		// "heroan1m" → HEROAN1M.3DA).  "none" is used as a sentinel for
+		// characters that don't ship a mouth file.
+		if (!tok[4].equalsIgnoreCase("none"))
+			entry.animMBase = tok[4];
+
+		// Column 5 (0-indexed) is the s3d basename — the per-character
+		// scene-graph mesh at DIALOG\PERSO\<base>.S3D.  Multiple persoIds
+		// share a mesh (every "Garde" persoId points at "garde"), so the
+		// 20 .S3D files on disc cover the ~67 INITDIAL entries.  Used by
+		// F3dcMesh to load the triangle topology that maps vertices in
+		// the animM pool into drawable triangles.
+		if (!tok[5].equalsIgnoreCase("none"))
+			entry.s3dBase = tok[5];
+
+		// Column 2 (0-indexed) is the anim3DC basename — the per-character
+		// body file at DIALOG\PERSO\<base>.3DC.  Despite the name it also
+		// carries the dialog mouth MESH: an "fvi" scene-graph node with the
+		// bind-pose vertices and the triangle topology, decoded by
+		// F3dcMouthMesh.
+		if (!tok[2].equalsIgnoreCase("none"))
+			entry.anim3DCBase = tok[2];
+
+		// Columns 10..13 (when present) carry the per-cam SPF overlay basenames.
+		// Rows lacking these columns leave the SPF slots empty; "none" tokens
+		// also map to empty per the original sentinel convention used for camUBB.
+		// Examples:
+		//   persoId 567 (Sorciere):    none vispf1c3 vispf1c4 vispf1c5
+		//   persoId 667 (EnnemiPilot): none bapan1k3 bapan1k4 bapan1k5
+		for (int i = 0; i < 4; i++) {
+			if (10 + i < (int)tok.size() && !tok[10 + i].equalsIgnoreCase("none"))
+				entry.camSPF[i] = tok[10 + i];
+		}
+
+		_dialInitData[persoId] = entry;
+	}
+
+	debugC(1, kDebugScript, "loadDialInitData: %u entries from INITDIAL.TXT, heroPersoId=%d",
+	      _dialInitData.size(), _heroPersoId);
+}
+
+// Per-line camera picker.  Re-implements the random-cam loop from
+// atlantis.exe.c FUN_0042844c, lines 22460-22470:
+//
+//   while (cam == prevCam || INITDIAL[persoId].camUBB[cam-2] is "none") {
+//       cam = (rand() & 3) + 2;        // 2..5
+//   }
+//
+// When the CON directive supplies an explicit `camN` (`explicitCam` != 0),
+// the original honours it directly; we do the same but still validate
+// against `_dialInitData`, falling through to the first available cam if
+// the requested one is unavailable.  Returns 2..5.  `_lastDialCam` is
+// updated by the caller after the line plays so a fallback failure
+// (e.g. no valid cams at all) doesn't poison the next pick.
+int CryOmni3DEngine_Atlantis::pickDialCam(int persoId, int explicitCam) {
+	// Look up which cam variants exist for this speaker.  Treat "none" /
+	// empty as unavailable.
+	bool avail[4] = { false, false, false, false };
+	int availCount = 0;
+	Common::HashMap<int, DialInitEntry>::const_iterator it =
+	    _dialInitData.find(persoId);
+	if (it != _dialInitData.end()) {
+		for (int i = 0; i < 4; i++) {
+			const Common::String &s = it->_value.camUBB[i];
+			if (!s.empty() && !s.equalsIgnoreCase("none")) {
+				avail[i] = true;
+				availCount++;
+			}
+		}
+	}
+
+	// Explicit cam from `[Speaker, X, Y, camN]`: honour it if valid+available,
+	// otherwise fall through to the random pick below.
+	if (explicitCam >= 2 && explicitCam <= 5) {
+		if (availCount == 0 || avail[explicitCam - 2])
+			return explicitCam;
+	}
+
+	// No INITDIAL data at all → keep deterministic cam2 close-up.
+	if (availCount == 0)
+		return 2;
+
+	// Random pick — same `(rand & 3) + 2` shape as the original, rejecting
+	// previous-cam and unavailable cams.  If the only available cam is the
+	// previous one (avoid impossible), we still return it.
+	int cam = 2;
+	for (int tries = 0; tries < 16; tries++) {
+		cam = (int)_dialRng.getRandomNumber(3) + 2;  // 2..5
+		if (cam == _lastDialCam && availCount > 1)
+			continue;
+		if (avail[cam - 2])
+			return cam;
+	}
+	// Fallback: first available cam (favouring something other than last).
+	for (int c = 2; c <= 5; c++)
+		if (avail[c - 2] && c != _lastDialCam)
+			return c;
+	for (int c = 2; c <= 5; c++)
+		if (avail[c - 2])
+			return c;
+	return 2;
+}
+
+void CryOmni3DEngine_Atlantis::playConSection(ConSection &sec) {
+	// The cursor is hidden for the duration of dialog playback; remember its
+	// prior visibility so it is restored to exactly that when the section ends.
+	bool cursorWasVisible = showMouse(false);
+
+	// Drain the input gesture that triggered us before any line starts.
+	// Departure /sel sections (e.g. zone 146 → Seth's "off" line) fire while
+	// the player still holds down the click that initiated the navigation;
+	// the per-line wait loop reads that held button as "skip this line" and
+	// aborts immediately, swallowing the subtitle and audio.  Consume the
+	// held button + any buffered keypresses here so the skip gesture only
+	// counts when the player clicks/presses *during* playback.
+	while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+		pollEvents();
+		g_system->delayMillis(10);
+	}
+	clearKeys();
+
+	// Execute items in source order so cinematics and music play at the right moment
+	// relative to dialog lines (CON files freely interleave /set commands with dialog).
+	int lineIdx = 0;
+	// GereGameOver hand-off: a /set(gameover=N) command (N != 0) ends the
+	// section immediately (atlantis.exe FUN_0042844c breaks its line loop the
+	// moment the GameOver variable becomes non-zero) and the lines that follow
+	// are handed to the game-over screen instead of being played as ordinary
+	// dialog.  Captured here, run after the loop.
+	int            pendingGameOver = 0;
+	Common::String gameOverText;
+	char           gameOverTrack   = 'A';
+	// A /set(chapter=N) item reloads _conScript, freeing `sec` and every
+	// section the caller is iterating.  Remember the chapter on entry so the
+	// item loop can stop the instant that happens (see the check below).
+	const uint entryChapter = _currentCONChapter;
+	for (uint itemIdx = 0; itemIdx < sec.items.size(); ++itemIdx) {
+		const ConSectionItem &item = sec.items[itemIdx];
+		if (shouldAbort()) break;
+		if (item.isSet) {
+			// /set(gameover=N): N != 0 triggers the game-over screen.
+			if (scumm_strnicmp(item.setCmd.c_str(), "gameover=", 9) == 0 &&
+			    atoi(item.setCmd.c_str() + 9) != 0) {
+				execConSetCommand(item.setCmd);
+				pendingGameOver = atoi(item.setCmd.c_str() + 9);
+				// The narrator commentary is the first dialog line after the
+				// command; its APC track letter is its line index within the
+				// section (atlantis.exe GereGameOver counts '[' lines from the
+				// section header to the first [Narratrice] line).
+				for (uint j = itemIdx + 1; j < sec.items.size(); ++j) {
+					if (!sec.items[j].isSet) {
+						gameOverText  = sec.items[j].line.text;
+						gameOverTrack = (char)('A' + lineIdx);
+						break;
+					}
+				}
+				break;
+			}
+			const uint placeBeforeSet = _nextPlaceId;
+			execConSetCommand(item.setCmd);
+			// A /set(chapter=N) command reloaded _conScript: `sec`, `item`
+			// and the section list are now freed memory.  Stop at once —
+			// re-reading sec.items below would touch the dangling buffer.
+			// The new chapter's init /set commands have already run inside
+			// loadConScript(); any trailing items of this section are
+			// abandoned, exactly as the original engine drops the rest of a
+			// section once its chapter advance fires.
+			if (_currentCONChapter != entryChapter)
+				break;
+			// A /set(vue=N) inside a dialog section moves the conversation
+			// to a new place.  vue= is normally deferred to the game loop's
+			// doPlaceChange(), but a dialog section can place vue= *before*
+			// its closing lines (e.g. CHAPI005 section 78 — the talk follows
+			// the fisherman from place 139 to vue=145 before its last line).
+			// Those trailing lines must composite over the destination
+			// cyclo, not the one the dialog opened on, so swap the clean
+			// cyclo now.  _nextPlaceId stays set: the real place change —
+			// transition video, arrival /sel sections — still runs through
+			// the normal path once the section ends.
+			if (_nextPlaceId != uint(-1) && _nextPlaceId != placeBeforeSet) {
+				bool laterLine = false;
+				for (uint j = itemIdx + 1; j < sec.items.size(); ++j)
+					if (!sec.items[j].isSet) { laterLine = true; break; }
+				const AtlantisPlace *destPlace = laterLine
+				    ? _wam.findPlaceById((uint16)_nextPlaceId) : nullptr;
+				if (destPlace && loadCycloHNM(destPlace->cycloHnm))
+					debugC(1, kDebugScript, "playConSection: vue=%u mid-section — clean "
+					         "cyclo swapped for trailing dialog lines",
+					      _nextPlaceId);
+			}
+		} else {
+			Common::String vid;
+			// Resolve the on-screen character from the line's speaker name
+			// via the exe's speaker → persoId table.  sec.clicPerso (the NPC
+			// the player clicked) is deliberately not used: a dialog freely
+			// interleaves lines from several characters, so only the speaker
+			// name identifies who is actually talking on this line.
+			int persoId = resolveSpeakerPersoId(item.line.speaker);
+			// Pick the camera shot.  When the CON directive has an explicit
+			// `camN` we honour it; otherwise pickDialCam() randomises in 2..5
+			// the way the original engine does (avoiding the previous cam
+			// and any cam whose UBB resource is missing).  Both the FOV
+			// (zoom) and the UBB filename are keyed off the chosen cam.
+			int explicitCam = 0;
+			{
+				const char *camTag = strstr(item.line.params.c_str(), "cam");
+				if (camTag) sscanf(camTag, "cam%d", &explicitCam);
+				if (explicitCam < 2 || explicitCam > 5) explicitCam = 0;
+			}
+			int camNum = pickDialCam(persoId, explicitCam);
+			Common::String spfBase;
+			Common::String animMBase;
+			Common::String s3dBase;
+			Common::String anim3DCBase;
+			// Skip per-perso UBB / SPF lookup for any off-camera spelling
+			// (`off`, `off0`, `off1`) -- the line plays as voiceover with no
+			// head shot, so the resource basenames are irrelevant.
+			const bool _offForLookup = item.line.params.equalsIgnoreCase("off")
+			                       || item.line.params.equalsIgnoreCase("off0")
+			                       || item.line.params.equalsIgnoreCase("off1");
+			if (persoId > 0 && !_offForLookup) {
+				Common::HashMap<int, DialInitEntry>::const_iterator it =
+				    _dialInitData.find(persoId);
+				if (it != _dialInitData.end()) {
+					Common::String fn = it->_value.camUBB[camNum - 2];
+					if (!fn.empty() && !fn.equalsIgnoreCase("none")) {
+						fn.toUppercase();
+						vid = Common::String("PERSO\\") + fn + ".UBB";
+					}
+					// Per-cam SPF overlay (INITDIAL columns 10..13).  Parser
+					// already strips "none" to empty, so a non-empty basename
+					// here means we have an overlay to composite.
+					spfBase = it->_value.camSPF[camNum - 2];
+					// Per-character mouth vertex animation (INITDIAL column 5).
+					// Single basename across all cams — the mouth mesh moves
+					// in 3D and the camera projects whichever cam is chosen.
+					animMBase = it->_value.animMBase;
+					// Per-character mesh topology (INITDIAL column 6).  Holds
+					// the triangle indices the future rasteriser will use to
+					// turn the animM vertex pool into solid polygons.
+					s3dBase = it->_value.s3dBase;
+					// Per-character body file (INITDIAL column 2) — carries
+					// the dialog mouth mesh (verts + triangle topology) in
+					// its "fvi" node, decoded by F3dcMouthMesh.
+					anim3DCBase = it->_value.anim3DCBase;
+				}
+			}
+			// Remember for the next line so consecutive lines don't repeat.
+			_lastDialCam = camNum;
+			// Effective per-line angle, matching the original engine
+			// (atlantis.exe.c FUN_0042844c lines 22497–22541):
+			//
+			//   • Explicit `[Speaker, X, Y, camN]` (hasAngle):
+			//       alpha = X°, beta = Y°   (line 22543)
+			//   • `[Speaker, off]` (off-camera narrator):
+			//       alpha = current + FOV°, beta = 0  (line 22516–22522)
+			//   • Bare / camN-only lines:
+			//       alpha = current,        beta = 0  (line 22536)
+			//
+			// Common to all three: beta is always normalised — either set
+			// explicitly or snapped to 0 (horizon).  That's the only
+			// automatic motion the original applies for un-annotated
+			// lines.  There is *no* "rotate-to-face-the-speaker" fallback
+			// in the original; the natural per-character motion comes
+			// from authored X,Y on the lead line of each dialog branch
+			// (~24% of lines), with FPS-mode aiming doing the rest (the
+			// player is already pointing at the NPC by the time the
+			// click registers, so preserving alpha lands on-target).
+			bool effHasAngle = item.line.hasAngle;
+			int  effAngleX   = item.line.angleX;
+			int  effAngleY   = item.line.angleY;
+			// Off-camera marker: the dialog directive tail token can be `off`,
+			// `off0`, or `off1`.  atlantis.exe FUN_0042844c (lines 22418-22431)
+			// sets three distinct flag globals (DAT_004960b4/b8/bc) for the
+			// three spellings, but every consumer downstream treats "any flag
+			// non-zero" the same way -- suppress the UBB head, skip the per-cam
+			// FOV change, leave the panorama where the player was facing.  So
+			// from the renderer's view, off / off0 / off1 are interchangeable.
+			// Match all three here (the old code only matched the bare "off",
+			// silently treating `[Narratrice,off0]` lines as on-camera and
+			// flipping the cyclo for a head that wasn't going to render).
+			const bool isOffCam = item.line.params.equalsIgnoreCase("off")
+			                   || item.line.params.equalsIgnoreCase("off0")
+			                   || item.line.params.equalsIgnoreCase("off1");
+			const bool isHero  = (persoId == _heroPersoId && _heroPersoId > 0);
+			const char *defaultSource = "";
+			if (!effHasAngle && _warpLoaded && !isOffCam) {
+				// Faithful default: preserve alpha, zero beta.
+				//   - Hero speakers (reverse-shot of the player character):
+				//     rotate 180° so the cyclo behind Seth's talking head is
+				//     the half of the panorama opposite the NPC, mimicking an
+				//     over-the-shoulder cut.  The NPC's own lines keep alpha
+				//     unchanged so the player sees the NPC framed directly.
+				//   - "off" speakers (voiceover / self-talk, e.g. Seth's
+				//     departure-zone lines): the original game does NOT
+				//     rotate the camera — the panorama stays exactly where
+				//     the player was facing.  Handled by the !isOffCam guard
+				//     above so we skip default-angle injection entirely; the
+				//     line plays with no view change.
+				//
+				// The "current" alpha here is the player's click-time facing,
+				// captured into _dialBaseAlpha at interactNPC entry — *not*
+				// _omni3dMan.getAlpha(), which already reflects the previous
+				// line's reverse-shot flip and would leak into the next NPC
+				// line.  For non-NPC entry points (e.g. /sel-triggered
+				// dialog), fall back to the live alpha.
+				const double baseAlpha = _dialBaseAlphaValid
+				                       ? _dialBaseAlpha
+				                       : _omni3dMan.getAlpha();
+				const double curAlphaDeg = baseAlpha * 180.0 / M_PI;
+				double effDegX = curAlphaDeg;
+				if (isHero) {
+					effDegX = curAlphaDeg + 180.0;
+				}
+				double dx = effDegX - 360.0 * floor(effDegX / 360.0);
+				effHasAngle = true;
+				effAngleX   = (int)(dx + 0.5);
+				effAngleY   = 0;
+				defaultSource = isHero ? " [default: hero reverse-shot 180°]"
+				                       : " [default: beta=0, alpha preserved]";
+			}
+
+			// Suppress the per-cam FOV change for off-camera variants
+			// (`off` / `off0` / `off1`).  The original engine gates the
+			// FUN_0045179a(camFovDeg) call at FUN_0042844c:22497 on the
+			// off-flags all being zero — for self-talk/voiceover lines the
+			// panorama stays at the navigation default 75.137° FOV.
+			// Passing camNum=0 lands outside playSingleConLine's `2..5`
+			// range check, so the FOV change is skipped while the UBB
+			// dialog video (if any) still plays.
+			const int effCamNum = isOffCam ? 0 : camNum;
+			// Off-cam lines display no head, so they also get no SPF, no
+			// mouth animation, and no mesh load — drop any basenames the
+			// INITDIAL lookup found.
+			const Common::String effSpfBase   = isOffCam ? Common::String() : spfBase;
+			const Common::String effAnimMBase = isOffCam ? Common::String() : animMBase;
+			const Common::String effS3dBase   = isOffCam ? Common::String() : s3dBase;
+			const Common::String effAnim3DCBase = isOffCam ? Common::String() : anim3DCBase;
+			debugC(2, kDebugScript, "playConSection: speaker='%s' params='%s' persoId=%d "
+			         "cam=%d vid='%s' spf='%s' mouth='%s' s3d='%s' 3dc='%s' angle=(%d,%d)%s%s",
+			      item.line.speaker.c_str(), item.line.params.c_str(), persoId,
+			      effCamNum, vid.c_str(), effSpfBase.c_str(),
+			      effAnimMBase.c_str(), effS3dBase.c_str(), effAnim3DCBase.c_str(),
+			      effAngleX, effAngleY,
+			      effHasAngle ? "" : " (none)",
+			      defaultSource);
+			playSingleConLine(sec.id, (char)('A' + lineIdx++),
+			                  item.line.text, vid,
+			                  effHasAngle, effAngleX, effAngleY,
+			                  effCamNum, effSpfBase, effAnimMBase, effS3dBase,
+			                  effAnim3DCBase,
+			                  /*interactiveDialog=*/sec.isCon);
+		}
+	}
+
+	// Game-over screen (GereGameOver): show the image + narrator commentary,
+	// then reload the chapter checkpoint.  Run after the loop so the click/key
+	// that ended the last ordinary dialog line has already been drained.
+	if (pendingGameOver != 0) {
+		showGameOver(sec.id, pendingGameOver, gameOverText, gameOverTrack);
+		// The original restores GameOver to its pre-section value on section
+		// exit (atlantis.exe FUN_0042844c, LAB_00428c92) — 0 in every chapter.
+		_gameVars["gameover"] = 0;
+
+		// A game-over is not a spot the player can recover from in place: it
+		// is gated on a *persistent* CON variable (VARIAS.CON indices 0-6 —
+		// here FlagChp8), and the section that kills the player stays
+		// reachable while that variable keeps its fatal value.  The dialog
+		// chain that leads here is also marked played, so simply returning
+		// would strand the NPC with no options at all (the reported bug).
+		//
+		// The exe offers no in-place escape: a chapter change (FUN_00427634)
+		// zeroes only the transient vars 7+, and GereGameOver (FUN_00426590)
+		// just resets a few loop flags.  The one thing that rolls a
+		// persistent variable back is loading a save — and the game
+		// autosaves exactly once per chapter, on entry (FUN_00427634 ->
+		// FUN_0042d6b8).  So the original's game-over necessarily reloads the
+		// current chapter's checkpoint; mirror that here by routing through
+		// the engine's existing load-game abort path.
+		int  ckSlot = (_currentPlayer >= 0)
+		            ? episodeSaveSlot((uint)_currentPlayer, _currentCONChapter)
+		            : -1;
+		uint reload = (ckSlot >= 0 && saveSlotExists(ckSlot))
+		            ? (uint)ckSlot + 1
+		            : (_currentPlayer >= 0
+		               ? playerResumeSave((uint)_currentPlayer) : 0);
+		if (reload != 0) {
+			debugC(1, kDebugScript, "showGameOver: reloading chapter checkpoint (slot %u)", reload);
+			_loadedSave   = reload;
+			_abortCommand = kAbortLoadGame;
+		} else {
+			// No checkpoint exists yet (a game-over before the first
+			// autosave): the only state-clearing fallback is a fresh start.
+			warning("showGameOver: no checkpoint to reload; restarting game");
+			_abortCommand = kAbortNewGame;
+		}
+	}
+
+	// Restore the cursor to whatever it was before the dialog.
+	showMouse(cursorWasVisible);
+
+	// /go N — section chain: after this section's body finishes, play
+	// section N in continuation.  Sections like CHAPI012 /169 have BOTH a
+	// dialog body ([Garde185] "Hey, you! Companion!") AND a trailing
+	// /go170 — the body MUST play before /go fires the next section,
+	// otherwise the "Hey, you" voice-over is skipped and the game jumps
+	// straight to the game-over screen.  Skip the chain if the body's
+	// /set(chapter=N) just reparsed _conScript (the gotoId would now name
+	// the wrong section in the new chapter's pool) or if a game-over
+	// reload is pending (loadGame will replay the chapter from scratch).
+	if (sec.gotoId > 0 && !shouldAbort() && _currentCONChapter == entryChapter &&
+	    pendingGameOver == 0 && _abortCommand == kAbortNoAbort) {
+		for (ConSection &target : _conScript.sections()) {
+			if (target.id == sec.gotoId) {
+				target.played = true;
+				playConSection(target);
+				break;
+			}
+		}
+	}
+
+	// Final-line skip drain.  playSingleConLine treats a click/key during
+	// audio or the trailing subtitle as "advance the line"; on the LAST
+	// line of a section the click is therefore still held when we return
+	// to handleWarp.  handleWarp's warp loop reads getCurrentMouseButton()
+	// as the press signal (it's a level test, not an edge test), so the
+	// held button fires a phantom click at the camera's new angle -- the
+	// directive `[Lascoyt,190,0,cam5]` snaps alpha to face Lascoyt, and
+	// the centre-screen hit-test then dispatches whatever zone happens to
+	// sit at that angle.  CHAPI015 reproduces this every time: the
+	// timer-fired Lascoyt welcome ends, the held skip-button hits zone
+	// 152 (the dining room exit), and section 190's
+	// /sel(departVue>151)&(departvue<168)&(FlagTemp1=0) -- "Grab him!" --
+	// fires immediately as game-over.  Drain the button here so the next
+	// outer click really is a fresh press.
+	while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+		pollEvents();
+		g_system->delayMillis(10);
+	}
+	clearKeys();
+}
+
+// Single dialog line: stream a UBB talking-head video over the warp panorama,
+// play the matching APC speech track, overlay the subtitle text.
+//
+// All geometry is derived from the data: the UBB header (dimensions, frame
+// count, frame delay) drives the composite, the screen pixel format drives
+// the CLUT8→RGB conversion, and the FONTMAX glyph table drives subtitle
+// metrics.  Nothing is hardcoded to 640×480 or RGB565.
+//
+// The animated dialog mouth mesh is rasterised by F3dcMouthRenderer
+// (f3dc_renderer.cpp).
+//
+// Layout mirrors the original (atlantis.exe FUN_0042ee88 + FUN_00430178):
+//   • UBB frame is decoded into a CLUT8 buffer by HNMDecoder.
+//   • Each pixel is colour-keyed (palette idx 0 = transparent) and converted
+//     to the screen pixel format.  Where transparent, the warp panorama
+//     shows through (ScummVM enhancement; the original simply opaquely
+//     overwrites the backbuffer).
+//   • The subtitle is drawn directly over the composite at the bottom-left,
+//     with a 1-pixel drop shadow for legibility.  The original draws white
+//     text at (5, 472) with no opaque backing — same anchor, derived from
+//     composite height.
+void CryOmni3DEngine_Atlantis::playSingleConLine(int sectionId, char track,
+                                                  const Common::String &text,
+                                                  const Common::String &videoName,
+                                                  bool hasAngle,
+                                                  int angleX, int angleY,
+                                                  int camNum,
+                                                  const Common::String &spfBaseName,
+                                                  const Common::String &animMBase,
+                                                  const Common::String &s3dBase,
+                                                  const Common::String &anim3DCBase,
+                                                  bool interactiveDialog) {
+	const Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	const int screenW = (int)g_system->getWidth();
+	const int screenH = (int)g_system->getHeight();
+
+	// Per-cam FOV (zoom).  Source: atlantis.exe DGROUP, VA 0x00496080,
+	// referenced at code 22514/22535 as `*(float *)(s_4_apc_00496078 +
+	// cam*4)` and passed to FUN_0045179a as the horizontal FOV in degrees.
+	// Indexing: cam2..cam5 → table[0..3].  cam2 = tight close-up,
+	// cam3 = medium, cam4/5 = wide.
+	//
+	// Save the current FOV so the panorama view restores to its
+	// navigation default after the line finishes.  This matches the
+	// original engine's FUN_0045179a(view, 75.137, 50.0) calls at
+	// lines 22550 / 22601 that restore the default FOV after a dialog.
+	static const float kCamFovDeg[4] = {20.68f, 30.0f, 48.0f, 48.26f};
+	const double savedHFov = _omni3dMan.getHFov();
+	bool fovChanged = false;
+	if (_warpLoaded && camNum >= 2 && camNum <= 5) {
+		const double camFov = (double)kCamFovDeg[camNum - 2] * M_PI / 180.0;
+		_omni3dMan.setHFov(camFov);
+		fovChanged = true;
+		debugC(2, kDebugScript, "playSingleConLine: cam%d FOV=%.2f° applied",
+		      camNum, (double)kCamFovDeg[camNum - 2]);
+	}
+
+	// Swap the panorama source to the *clean* cyclo (no NPC sprite overlay)
+	// whenever this line should hide the scene standing behind it.
+	// _warpSurface carries the NPC sprites composited onto the cyclo (via
+	// compositeNPCSprites + recompositeSpriteLayer); two cases must hide them:
+	//
+	//   • interactiveDialog — a /con dialog the player clicked into: the
+	//     original keeps the scene clean for the whole conversation,
+	//     including its off-camera reply lines, so the sprites don't flicker
+	//     in and out between shots.
+	//   • any line that renders a talking-head shot (a UBB is present): the
+	//     close-up head sits right over the speaker, so the speaker's own
+	//     standing sprite would otherwise show *behind his own head*.  This
+	//     is exactly the Creon throne-room arrival — CHAPI011 /sel section
+	//     125 fires CONAN1C2.UBB, and although it is a /sel (not /con) it
+	//     still needs the sprites hidden.
+	//
+	// The remaining case keeps _warpSurface: a /sel-triggered voiceover with
+	// NO head shot (`[Seth,off]`/`[Lascoyt,off]`, CHAPI011 sections 159/160 —
+	// the passing-by remark before chapter 12) must leave the scene's standing
+	// NPCs visible.  Restore the warped source on exit either way.
+	const bool hasHeadShot = !videoName.empty();
+	const Graphics::Surface *cleanSource =
+	    ((interactiveDialog || hasHeadShot) &&
+	     _warpLoaded && _cycloSurface.getPixels())
+	    ? &_cycloSurface : nullptr;
+	bool sourceSwapped = false;
+	if (cleanSource) {
+		_omni3dMan.setSourceSurface(cleanSource);
+		sourceSwapped = true;
+		debugC(2, kDebugScript, "playSingleConLine: source swapped to clean cyclo");
+	}
+
+	// Per-line panorama angle (data-driven).
+	//
+	// The original engine's CON dialog directive `[Speaker, X, Y, camN]`
+	// supplies two optional numeric tokens that the engine writes directly
+	// into the cyclo view's alpha/beta — see atlantis.exe.c lines 22381
+	// (X/Y → angle conversion) and 22543 (FUN_00451915 alpha/beta store).
+	//
+	// X and Y are authored in **degrees** — the same unit used by the
+	// `/set(anglewarpx=N)` CON command (line ~1707).  Empirically, sampling
+	// CHAPI001/003/011/054 yields X values clustered in the 0–360 range
+	// (e.g. 120, 180, 210, 269, 292, 350) which only makes sense as
+	// degrees, not panorama-pixel coordinates (which would span 0–2048).
+	// Y is small (typically 0–4) — vertical tilt in degrees.
+	//
+	// When the directive carries no numeric tokens the view is left exactly
+	// where the player aimed it (matching original behaviour for
+	// `[Speaker, camN]` and `[Speaker]` lines).
+	if (_warpLoaded && hasAngle) {
+		const double alpha = ((double)angleX) * M_PI / 180.0;
+		const double beta  = ((double)angleY) * M_PI / 180.0;
+		_omni3dMan.setAlpha(alpha);
+		_omni3dMan.setBeta(beta);
+		_gameVars["anglewarpx"] = (int)(_omni3dMan.getAlpha() * 180.0 / M_PI);
+		_gameVars["anglewarpy"] = (int)(_omni3dMan.getBeta()  * 180.0 / M_PI);
+		debugC(2, kDebugScript, "playSingleConLine: angle applied X=%d° Y=%d° "
+		         "→ alpha=%.3f rad beta=%.3f rad", angleX, angleY, alpha, beta);
+	}
+
+#ifdef USE_HNM
+	Video::HNMDecoder *bgDecoder = nullptr;
+	Graphics::Surface ubbConvFrame;
+	// Cleared per line so a leftover palette from a previous video can't
+	// leak through if the new stream starts mid-stream without a 'PL' chunk.
+	byte ubbPal[256 * 3];
+	memset(ubbPal, 0, sizeof(ubbPal));
+
+	// Engine-faithful UBB compositor (no SKIP/RUN distinction available).
+	// The original engine seeds the dialog buffer with a cyclo perspective
+	// warp each frame and the IV codec's opcode stream tells it which
+	// pixel runs to leave (SKIP -> cyclo) and which to write (RUN ->
+	// palette[idx]).  ScummVM's Video::HNMDecoder collapses the opcode
+	// stream into a flat CLUT8 buffer, and HNM5 motion compensation reads
+	// from the previous-frame buffer for *most* opcodes — not just opcode
+	// 0x20 — so a sentinel-init trick can't recover the SKIP/RUN
+	// distinction without poisoning every motion-compensated block (see
+	// project_ubb_compositor memory, offline-render verification at
+	// /tmp/seq_strip_*.png).  Until we add an opt-in tracking mask to the
+	// shared HNMDecoder (option B), we paint every idx as palette[idx]:
+	// idx 0 resolves to palette[0]=black, matching the artist's authored
+	// hair colour and the un-enhanced original look.
+
+
+	// Optional per-cam SPF overlay — the dialog mouth animation that the
+	// original engine composites on top of the talking head every UBB frame.
+	// The UBB stream has the mouth region painted as palette index 0 (the
+	// canonical Cryo chroma key); the SPF fills it in.  Files live alongside
+	// the UBB at `DIALOG\PERSO\<base>.SPF` (24 of them on the shipped CD),
+	// NOT under `SPRITE\UBB\` (that prefix holds the 205 transition-video
+	// SPFs used by playTransitionVideo for navigation walk-ons).  Only ~24
+	// dialog cams have a mouth SPF — for the rest, the mouth is baked into
+	// the UBB itself, so a missing file is normal and not a warning.
+	Common::SeekableReadStream *spfStream = nullptr;
+	uint spfFrameCount = 0;
+	// SPF screen bbox — the rectangle the scarf/veil actually paints
+	// into on screen.  The dialog SPF frame headers we sampled
+	// (BAPAN1K3.SPF, GRDAN1C5.SPF) have ZEROED (x1, y_bot, x2, y_top)
+	// fields, unlike navigation SPFs.  They position themselves
+	// entirely via ROW_SEP opcodes in the flat-buffer pixel stream, so
+	// the bbox only emerges from rendering.  Probe by compositing
+	// frame[0] onto a scratch surface seeded with a sentinel colour
+	// the SPF can never emit, then scan for non-sentinel pixels.
+	int spfBboxX1 = -1, spfBboxY1 = -1, spfBboxX2 = -1, spfBboxY2 = -1;
+	if (!spfBaseName.empty()) {
+		Common::String spfFile = spfBaseName;
+		spfFile.toUppercase();
+		Common::String spfPath = Common::String("PERSO\\") + spfFile + ".SPF";
+		spfStream = openBigFileStream(kFileTypeDialog, spfPath);
+		if (spfStream) {
+			if (spfStream->seek(4))
+				spfFrameCount = spfStream->readUint32LE();
+			// Composite frame[0] onto a scratch RGB565 surface seeded
+			// with 0xFFFE.  SPF palettes emit RGB565 colours through
+			// rgb565ToSurfaceColor (sprite_renderer.cpp:327); 0xFFFE is
+			// reserved (the kSprTransp transparent marker is 0x0001 and
+			// pure white is 0xFFFF), so any pixel left at 0xFFFE was
+			// untouched and any other value was painted by the SPF.
+			Graphics::PixelFormat probeFmt(2, 5, 6, 5, 0, 11, 5, 0, 0);
+			Graphics::Surface probe;
+			probe.create(640, 480, probeFmt);
+			const uint16 sentinel = 0xFFFE;
+			uint16 *probePix = (uint16 *)probe.getPixels();
+			for (int i = 0; i < 640 * 480; i++) probePix[i] = sentinel;
+			compositeSpfFrame(spfStream, 0, probe);
+			for (int py = 0; py < 480; py++) {
+				const uint16 *row = (const uint16 *)probe.getBasePtr(0, py);
+				for (int px = 0; px < 640; px++) {
+					if (row[px] != sentinel) {
+						if (spfBboxX1 < 0 || px < spfBboxX1) spfBboxX1 = px;
+						if (spfBboxX2 < 0 || px > spfBboxX2) spfBboxX2 = px;
+						if (spfBboxY1 < 0 || py < spfBboxY1) spfBboxY1 = py;
+						if (spfBboxY2 < 0 || py > spfBboxY2) spfBboxY2 = py;
+					}
+				}
+			}
+			probe.free();
+			spfStream->seek(0);
+		}
+		debugC(1, kDebugScript, "playSingleConLine: SPF overlay '%s' %s "
+		         "(%u frames, screen bbox [%d,%d]-[%d,%d])",
+		      spfPath.c_str(),
+		      spfStream ? "loaded" : "absent (mouth baked in UBB)",
+		      spfFrameCount,
+		      spfBboxX1, spfBboxY1, spfBboxX2, spfBboxY2);
+	}
+
+	// Per-character mouth vertex animation (.3DA M, F3DC subfmt 2) — the
+	// per-frame lip-sync visemes the original engine morphs into the mouth
+	// mesh.  F3dcMouthRenderer drives the rendered geometry from these.
+	F3dcMouthAnim mouthAnim;
+	int32 mouthMinX = 0, mouthMinY = 0, mouthMaxX = 0, mouthMaxY = 0;
+	int32 mouthMinZ = 0, mouthMaxZ = 0;
+	if (!animMBase.empty()) {
+		Common::String mFile = animMBase;
+		mFile.toUppercase();
+		Common::String mPath = Common::String("PERSO\\") + mFile + ".3DA";
+		Common::ScopedPtr<Common::SeekableReadStream> ms(
+		    openBigFileStream(kFileTypeDialog, mPath));
+		if (ms && mouthAnim.loadFromStream(*ms)) {
+			mouthAnim.getBounds(mouthMinX, mouthMinY, mouthMinZ,
+			                    mouthMaxX, mouthMaxY, mouthMaxZ);
+			debugC(1, kDebugScript, "playSingleConLine: mouth anim '%s' loaded "
+			         "(%u frames, %u verts, X[%d..%d] Y[%d..%d] Z[%d..%d])",
+			      mPath.c_str(),
+			      mouthAnim.frameCount(), mouthAnim.verticesPerFrame(),
+			      mouthMinX, mouthMaxX, mouthMinY, mouthMaxY,
+			      mouthMinZ, mouthMaxZ);
+		} else {
+			debugC(1, kDebugScript, "playSingleConLine: mouth anim '%s' unavailable",
+			      mPath.c_str());
+		}
+	}
+
+	// Per-character head-sway / skeleton animation (.3DA A, F3DC subfmt 4).
+	// Same basename as the mouth anim but with the trailing "M" replaced by
+	// "A" (e.g. BADPAN1M.3DA → BADPAN1A.3DA).  Prototype: feeds a per-K1
+	// model-space translation into F3dcMouthRenderer to roughly track the
+	// head's motion in the UBB video.  See project_f3dc_head_sway memory.
+	F3dcSmallAnim smallAnim;
+	if (!animMBase.empty()) {
+		Common::String aFile = animMBase;
+		aFile.toUppercase();
+		const uint sz = aFile.size();
+		if (sz >= 2 && aFile[sz - 1] == 'M') {
+			aFile.setChar('A', sz - 1);
+			Common::String aPath = Common::String("PERSO\\") + aFile + ".3DA";
+			Common::ScopedPtr<Common::SeekableReadStream> as(
+			    openBigFileStream(kFileTypeDialog, aPath));
+			if (as && smallAnim.loadFromStream(*as)) {
+				debugC(1, kDebugScript, "playSingleConLine: head-sway anim '%s' loaded "
+				         "(%u bones)", aPath.c_str(), smallAnim.boneCount());
+			} else {
+				debugC(1, kDebugScript, "playSingleConLine: head-sway anim '%s' unavailable",
+				      aPath.c_str());
+			}
+		}
+	}
+
+	// Per-character scene-graph mesh file (DIALOG\PERSO\<base>.S3D).  Its
+	// tail holds the per-camera look-at transforms F3dcMouthRenderer uses
+	// to project the mouth mesh onto the talking-head video.
+	F3dcMesh mesh;
+	if (!s3dBase.empty()) {
+		Common::String sFile = s3dBase;
+		sFile.toUppercase();
+		Common::String sPath = Common::String("PERSO\\") + sFile + ".S3D";
+		Common::ScopedPtr<Common::SeekableReadStream> ss(
+		    openBigFileStream(kFileTypeDialog, sPath));
+		if (ss && mesh.loadFromStream(*ss)) {
+			uint32 roots[4];
+			mesh.getRootFileOffsets(roots);
+			debugC(1, kDebugScript, "playSingleConLine: mesh '%s' loaded "
+			         "(countA=%u, roots 0x%x 0x%x 0x%x 0x%x)",
+			      sPath.c_str(), mesh.headerCountA(),
+			      roots[0], roots[1], roots[2], roots[3]);
+		} else {
+			debugC(1, kDebugScript, "playSingleConLine: mesh '%s' unavailable", sPath.c_str());
+		}
+	}
+
+	// Per-character dialog mouth MESH (verts + triangle topology) from the
+	// .3DC body file's "fvi" node.  This is the real geometry that fills
+	// the UBB chroma-key mouth hole.
+	F3dcMouthMesh mouthMesh;
+	if (!anim3DCBase.empty()) {
+		Common::String cFile = anim3DCBase;
+		cFile.toUppercase();
+		Common::String cPath = Common::String("PERSO\\") + cFile + ".3DC";
+		Common::ScopedPtr<Common::SeekableReadStream> cs(
+		    openBigFileStream(kFileTypeDialog, cPath));
+		if (cs && mouthMesh.loadFromStream(*cs)) {
+			debugC(1, kDebugScript, "playSingleConLine: mouth mesh '%s' loaded "
+			         "(%u verts, %u triangles)",
+			      cPath.c_str(), mouthMesh.vertexCount(),
+			      mouthMesh.triangleCount());
+		} else {
+			debugC(1, kDebugScript, "playSingleConLine: mouth mesh '%s' unavailable",
+			      cPath.c_str());
+		}
+	}
+
+	// Per-character face texture (DIALOG\MAPS\<base>.3DM).  The dialog mouth
+	// mesh is texture-mapped with this 256x256 image; its basename is
+	// embedded in the .3DC header, exposed as candidate strings.
+	F3dcTextureMap mouthTex;
+	if (mouthMesh.isLoaded()) {
+		const Common::Array<Common::String> &cands =
+		    mouthMesh.textureMapCandidates();
+		for (uint ci = 0; ci < cands.size() && !mouthTex.isLoaded(); ci++) {
+			Common::String tFile = cands[ci];
+			tFile.toUppercase();
+			Common::String tPath = Common::String("MAPS\\") + tFile + ".3DM";
+			Common::ScopedPtr<Common::SeekableReadStream> ts(
+			    openBigFileStream(kFileTypeDialog, tPath));
+			if (ts && mouthTex.loadFromStream(*ts))
+				debugC(1, kDebugScript, "playSingleConLine: face texture '%s' loaded",
+				      tPath.c_str());
+		}
+		if (!mouthTex.isLoaded())
+			debugC(1, kDebugScript, "playSingleConLine: no .3DM face texture "
+			         "(%u candidates) — mouth flat-shaded", cands.size());
+	}
+
+	// Animated dialog mouth-mesh renderer — projects the per-character .3DC
+	// mesh through the .S3D look-at camera and rasterises the lip-sync
+	// .3DA-M visemes, texture-mapped, into the UBB chroma-key mouth hole.
+	F3dcMouthRenderer mouthRenderer;
+	mouthRenderer.init(mouthMesh, mesh, mouthAnim,
+	                   mouthTex.isLoaded() ? &mouthTex : nullptr, camNum,
+	                   smallAnim.isLoaded() ? &smallAnim : nullptr);
+
+	if (!videoName.empty()) {
+		debugC(1, kDebugScript, "playSingleConLine: trying DIALOG\\%s", videoName.c_str());
+		Common::SeekableReadStream *vs = openBigFileStream(kFileTypeDialog, videoName);
+		if (!vs) {
+			debugC(1, kDebugScript, "playSingleConLine: file not found in BigFile");
+		} else {
+			// UBB2 is 8-bit paletted; HNMDecoder rejects CLUT8 streams when
+			// initialised with an RGB target, so we decode into CLUT8 and
+			// convert per-pixel below.  This also lets us colour-key idx 0.
+			Graphics::PixelFormat clut8 = Graphics::PixelFormat::createFormatCLUT8();
+			bgDecoder = new Video::HNMDecoder(clut8, true);  // loop=true
+			if (!bgDecoder->loadStream(vs)) {
+				debugC(1, kDebugScript, "playSingleConLine: HNMDecoder::loadStream failed");
+				delete bgDecoder;
+				bgDecoder = nullptr;
+			} else {
+				// Composite surface tracks the decoder's intrinsic resolution.
+				ubbConvFrame.create(bgDecoder->getWidth(), bgDecoder->getHeight(), fmt);
+				debugC(1, kDebugScript, "playSingleConLine: video loaded OK (%ux%u)",
+				      bgDecoder->getWidth(), bgDecoder->getHeight());
+				// Atlantis dialog UBBs ship a FUN_00450b08 opcode stream
+				// in the IA chunks alongside the IV (CLUT8) chunks; the
+				// opcode stream carries the SKIP/RUN distinction that
+				// drives the cyclo bleed-through.  Opt in so the decoder
+				// stops discarding IA as audio.  See project_ubb_compositor.
+				bgDecoder->setCaptureOpcodeStream(true);
+				bgDecoder->start();
+			}
+		}
+	}
+#endif
+
+	// Subtitle pre-wrap.  Width budget is the composite width less symmetric
+	// margins (5 px on either side, matching the original's x=5 origin).
+	const int subLeftMargin  = 5;
+	const int subRightMargin = 5;
+	int subWidthBudget = screenW - subLeftMargin - subRightMargin;
+#ifdef USE_HNM
+	if (ubbConvFrame.getPixels())
+		subWidthBudget = ubbConvFrame.w - subLeftMargin - subRightMargin;
+#endif
+	if (subWidthBudget < 32) subWidthBudget = 32;
+
+	// Subtitles render in a proportional sans-serif font, matching the original
+	// (Arial via GDI TextOutA, atlantis.exe FUN_0041aee4) -- NOT the gold
+	// FONTMAX sprite font, which is the menu font.  kBigGUIFont is ScummVM's
+	// built-in proportional Helvetica (Arial-like), compiled in so it works on
+	// the no-FreeType/no-theme Windows build too.
+	const Graphics::Font *guiFont =
+	    FontMan.getFontByUsage(Graphics::FontManager::kBigGUIFont);
+	if (!guiFont)
+		guiFont = FontMan.getFontByUsage(Graphics::FontManager::kGUIFont);
+	Common::Array<Common::String> subLines;
+	int subLineH = 0;
+	const bool useFontMax = false;
+	// Subtitle toggle: when disabled in ScummVM options, leave subLines
+	// empty so nothing is rendered.  Voice playback further down is not
+	// affected -- it runs through Audio::Mixer::kSpeechSoundType and obeys
+	// the standard speech volume / speech-mute settings via the mixer.
+	const bool drawSubs = showSubtitles();
+	if (drawSubs && !text.empty()) {
+		if (useFontMax) {
+			// Greedy whitespace word-wrap using FONTMAX advance widths.
+			subLineH = 24;  // FONTMAX glyph height upper bound (data-driven below)
+			int maxGlyphH = 0;
+			for (uint si = 0; si < _fontMaxSprites.size(); ++si)
+				if ((int)_fontMaxSprites[si].h > maxGlyphH)
+					maxGlyphH = _fontMaxSprites[si].h;
+			if (maxGlyphH > 0) subLineH = maxGlyphH + 2;
+
+			Common::String line, word;
+			for (uint i = 0; i <= text.size(); ++i) {
+				char c = (i < text.size()) ? text[i] : ' ';
+				if (c == ' ' || c == '\r' || c == '\n') {
+					if (!word.empty()) {
+						Common::String cand = line.empty() ? word : line + " " + word;
+						if (fontMaxStringWidth(cand) > subWidthBudget && !line.empty()) {
+							subLines.push_back(line);
+							line = word;
+						} else {
+							line = cand;
+						}
+						word.clear();
+					}
+					if (c == '\r' || c == '\n') {
+						if (!line.empty()) { subLines.push_back(line); line.clear(); }
+					}
+				} else {
+					word += c;
+				}
+			}
+			if (!line.empty()) subLines.push_back(line);
+		} else if (guiFont) {
+			subLineH = guiFont->getFontHeight() + 2;
+			guiFont->wordWrapText(text, subWidthBudget, subLines);
+		}
+	}
+
+	// Render-on-screen color for subtitles: pure white, mirroring the
+	// original (0xffff in RGB565 is white).  Shadow is opaque black.
+	const uint32 subColor    = fmt.RGBToColor(255, 255, 255);
+	const uint32 subShadow   = fmt.RGBToColor(0,   0,   0);
+
+	// Tracks whether the no-video / no-panorama fallback has already cleared
+	// the backbuffer on this call.  Function-local (not `static`) so the
+	// engine remains re-entrant — each line restarts from "not cleared".
+	bool emptyBackbufferCleared = false;
+
+	// SPF overlay frame index: advances once per *fresh* UBB frame so the
+	// i-th SPF frame composites on top of the i-th UBB frame, mirroring the
+	// original engine's shared frame counter at FUN_0042f9e8 + 0x358.  When
+	// the SPF runs short, compositeSpfFrame() clamps to its last frame.
+	uint spfFrameIdx = 0;
+
+	auto drawFrame = [&]() {
+		// 1. Underlay: warp panorama (if loaded) or cleared backbuffer.
+		const Graphics::Surface *warpView =
+		    _warpLoaded ? _omni3dMan.getSurface() : nullptr;
+
+#ifdef USE_HNM
+		if (bgDecoder && ubbConvFrame.getPixels()) {
+			// Drive frame timing from the decoder's natural rate (HNM
+			// regularFrameDelayMs ≈ 50 ms = 20 FPS for UBB2 dialog).
+			const Graphics::Surface *f = nullptr;
+			if (bgDecoder->needsUpdate())
+				f = bgDecoder->decodeNextFrame();
+
+			if (f) {
+				if (bgDecoder->hasDirtyPalette())
+					memcpy(ubbPal, bgDecoder->getPalette(), 256 * 3);
+
+				// Seed ubbConvFrame with the cyclo panorama (mirrors
+				// FUN_00451d8b in atlantis.exe).  The SKIP opcodes in
+				// the IA stream leave dst untouched, so this seed shows
+				// through wherever the artist wanted transparency
+				// (cinematic letterbox).  Falls back to black if the
+				// warp panorama is absent or mismatched.
+				if (warpView && warpView->w == ubbConvFrame.w &&
+				                warpView->h == ubbConvFrame.h &&
+				                warpView->format == fmt) {
+					const uint copyRowBytes = ubbConvFrame.w * fmt.bytesPerPixel;
+					for (int row = 0; row < ubbConvFrame.h; row++)
+						memcpy(ubbConvFrame.getBasePtr(0, row),
+						       warpView->getBasePtr(0, row), copyRowBytes);
+				} else {
+					ubbConvFrame.fillRect(
+					    Common::Rect(ubbConvFrame.w, ubbConvFrame.h), 0);
+				}
+
+				// Per-pixel composite via FUN_00450b08 port.  The IA
+				// chunk's opcode stream drives the SKIP/RUN decision
+				// per pixel run; ScummVM's HNM5-decoded CLUT8 buffer
+				// supplies palette indices for the RUN positions.
+				// Format-only support for the original's shade blend
+				// (shade<0xff): we always paint at full intensity for
+				// simplicity — visual impact is a slight loss of
+				// darkening on dimly-lit edges, not a correctness bug.
+				const int fw = f->w, fh = f->h;
+				const byte *srcBase = (const byte *)f->getBasePtr(0, 0);
+				uint32 opSize = 0;
+				const byte *opcodes = bgDecoder->getOpcodeStream(opSize);
+
+				// Build a 16-bit RGB565 palette LUT from the CLUT8
+				// palette for O(1) per-RUN-pixel lookup.
+				uint16 palLUT[256];
+				for (int i = 0; i < 256; i++)
+					palLUT[i] = (uint16)fmt.RGBToColor(ubbPal[i*3+0],
+					                                  ubbPal[i*3+1],
+					                                  ubbPal[i*3+2]);
+
+				if (opcodes && opSize >= 4 &&
+				    fmt.bytesPerPixel == 2) {
+					// Walk the FUN_00450b08 opcode stream.
+					const byte *op = opcodes;
+					const byte *opEnd = opcodes + opSize;
+					uint32 pos = 0;                            // pixel offset into frame
+					const uint32 frameN = (uint32)fw * (uint32)fh;
+					uint16 *dst16 = (uint16 *)ubbConvFrame.getPixels();
+					while (op + 2 <= opEnd && pos < frameN) {
+						const byte type = op[0];
+						const byte runHi = op[1];
+						if (type == 0) {
+							// SKIP: 4-byte op, runlen in high 24 bits.
+							if (op + 4 > opEnd) break;
+							const uint32 runlen = ((uint32)op[1]) |
+							                      ((uint32)op[2] << 8) |
+							                      ((uint32)op[3] << 16);
+							if (runlen == 0) break;            // terminator
+							pos += runlen;
+							op += 4;
+						} else if (type == 1) {
+							// RUN with a single shade byte (op[2]).
+							// shade>>3 == 0x1f -> full intensity (solid
+							// palette colour); a lower shade is an edge
+							// pixel the original alpha-blends against the
+							// background (the cyclo seed in dst), so the
+							// head edge is anti-aliased instead of leaving
+							// a hard outline.  Mirrors FUN_00450b08.
+							if (op + 3 > opEnd) break;
+							const uint32 runlen = runHi;
+							const byte *src = srcBase + pos;
+							const uint shade = (uint)(op[2] >> 3);
+							if (shade >= 0x1f) {
+								for (uint32 i = 0; i < runlen && pos + i < frameN; i++)
+									dst16[pos + i] = palLUT[src[i]];
+							} else {
+								for (uint32 i = 0; i < runlen && pos + i < frameN; i++)
+									dst16[pos + i] = blendUbbPixel565(
+									    palLUT[src[i]], dst16[pos + i], shade);
+							}
+							pos += runlen;
+							op += 3;
+						} else if (type == 2) {
+							// RUN with per-pixel shade: runHi pixels, then
+							// runHi shade bytes.  Each pixel uses its own
+							// shade; 0x1f is solid, lower values blend with
+							// the background (FUN_00450b08 type-2 path).
+							if (op + 2 + runHi > opEnd) break;
+							const uint32 runlen = runHi;
+							const byte *src = srcBase + pos;
+							const byte *shadeBytes = op + 2;
+							for (uint32 i = 0; i < runlen && pos + i < frameN; i++) {
+								const uint shade = (uint)(shadeBytes[i] >> 3);
+								dst16[pos + i] = (shade >= 0x1f)
+								    ? palLUT[src[i]]
+								    : blendUbbPixel565(palLUT[src[i]],
+								                       dst16[pos + i], shade);
+							}
+							pos += runlen;
+							op += 2 + runlen;
+						} else {
+							warning("playSingleConLine: unknown UBB opcode 0x%02x at +%u",
+							        type, (uint)(op - opcodes));
+							break;
+						}
+					}
+				} else {
+					// No opcode stream available (or unsupported pixel
+					// format) — fall back to the flat composite so the
+					// head is at least visible.
+					const uint bpp = fmt.bytesPerPixel;
+					const int fp = f->pitch;
+					for (int fy = 0; fy < fh; fy++) {
+						const byte *src = srcBase + fy * fp;
+						byte *dst = (byte *)ubbConvFrame.getBasePtr(0, fy);
+						for (int fx = 0; fx < fw; fx++, dst += bpp) {
+							const uint32 c = palLUT[src[fx]];
+							if (bpp == 2)       *(uint16 *)dst = (uint16)c;
+							else if (bpp == 4)  *(uint32 *)dst = c;
+							else                memcpy(dst, &c, bpp);
+						}
+					}
+				}
+
+				// 1d. Dialog mouth-mesh render — drawn AFTER the UBB so
+				//     the mesh overpaints whatever the UBB drew in the
+				//     mouth area.  The remaining "green border" artefact
+				//     at the mesh silhouette is still under investigation
+				//     (see project_f3dc_renderer memory) — the original
+				//     engine somehow filters it but neither bit-0/bit-1
+				//     triangle type, backface culling, nor BFS-classified
+				//     chroma compositing reproduces that filter.  For now,
+				//     keep the working render until further dynamic trace.
+				if (mouthRenderer.isReady())
+					mouthRenderer.renderFrame(ubbConvFrame, spfFrameIdx, 0);
+
+				// 1e. Per-cam SPF overlay (INITDIAL columns 10..13).  The
+				//     original engine composites the matching SPF frame on
+				//     top of every UBB frame in the dialog playback loop at
+				//     FUN_0042f9e8 (atlantis.exe.c:26609-26734), sharing the
+				//     UBB's frame counter.  We mirror that exactly, plus a
+				//     modulo so the SPF LOOPS when the UBB outlives it —
+				//     compositeSpfFrame clamps to the last frame on its own,
+				//     which freezes the scarf/veil while the head keeps
+				//     talking (visible bug on EnnemiPilot whose UBB runs
+				//     30+ frames against a much shorter SPF).
+				//     Drawn last, on top of the UBB head, so extra body
+				//     parts (e.g. the Ennemi Pilot's scarf) overlay it.
+				if (spfStream) {
+					const uint sfi = (spfFrameCount > 0)
+					    ? (spfFrameIdx % spfFrameCount)
+					    : spfFrameIdx;
+					compositeSpfFrame(spfStream, sfi, ubbConvFrame);
+				}
+
+				// 1f. "Object just received" icon: an NPC that gave Seth an
+				//     item this dialog shows its icon centre-bottom over the
+				//     head, on top of everything (the original DAT_0049619c
+				//     overlay).  Cleared when the dialog ends.
+				if (fmt.bytesPerPixel == 2)
+					drawGivenObject(ubbConvFrame);
+
+				// Advance the shared SPF / mouth-anim frame counter once
+				// per fresh UBB frame.  Same one-to-one mapping the
+				// original engine uses (atlantis.exe.c FUN_0042f9e8:26710).
+				++spfFrameIdx;
+			}
+		} else
+#endif
+		if (warpView) {
+			// No video — keep the panorama on-screen behind the subtitle.  If
+			// an NPC gave Seth an item this dialog, overlay its icon
+			// centre-bottom on a copy of the panorama first (the DAT_0049619c
+			// overlay still shows on off-camera/voiceover lines).
+			if (_dialogGivenObjSprite >= 0 && fmt.bytesPerPixel == 2) {
+				Graphics::Surface tmp;
+				tmp.create(warpView->w, warpView->h, fmt);
+				tmp.copyFrom(*warpView);
+				drawGivenObject(tmp);
+				g_system->copyRectToScreen(tmp.getPixels(), tmp.pitch,
+				                           0, 0, tmp.w, tmp.h);
+				tmp.free();
+			} else {
+				g_system->copyRectToScreen(warpView->getPixels(), warpView->pitch,
+				                           0, 0, warpView->w, warpView->h);
+			}
+		} else {
+			// No video and no panorama — clear once per playSingleConLine call.
+			if (!emptyBackbufferCleared) {
+				Graphics::ManagedSurface clr(screenW, screenH, fmt);
+				clr.fillRect(Common::Rect(screenW, screenH), 0);
+				g_system->copyRectToScreen(clr.getPixels(), clr.pitch,
+				                           0, 0, screenW, screenH);
+				emptyBackbufferCleared = true;
+			}
+		}
+
+		// 2. Subtitle overlay, drawn directly onto the composite (no opaque
+		//    backing bar — matching the original).  Anchored to the bottom
+		//    of the *composite* surface so videos with non-480 height work.
+#ifdef USE_HNM
+		Graphics::ManagedSurface compose;
+		bool composeOwnsPixels = false;
+		int blitX = 0, blitY = 0, blitW = 0, blitH = 0;
+
+		if (bgDecoder && ubbConvFrame.getPixels()) {
+			// Snapshot the conv frame into a ManagedSurface so FONTMAX /
+			// GUI font helpers can blit through the standard interface.
+			compose.create(ubbConvFrame.w, ubbConvFrame.h, fmt);
+			composeOwnsPixels = true;
+			const uint rowBytes = ubbConvFrame.w * fmt.bytesPerPixel;
+			for (int row = 0; row < ubbConvFrame.h; row++)
+				memcpy(compose.getBasePtr(0, row),
+				       ubbConvFrame.getBasePtr(0, row), rowBytes);
+			blitW = ubbConvFrame.w;
+			blitH = ubbConvFrame.h;
+			// Centre the composite if it's smaller than the screen.
+			blitX = (screenW - blitW) / 2;
+			blitY = (screenH - blitH) / 2;
+			if (blitX < 0) blitX = 0;
+			if (blitY < 0) blitY = 0;
+		}
+#endif
+
+		// Bottom-anchored subtitle, 6 px gap from bottom edge.
+		int subAreaH = subLines.size() * subLineH;
+		int subBaseY = 0;
+#ifdef USE_HNM
+		int subSurfH = composeOwnsPixels ? compose.h : screenH;
+#else
+		int subSurfH = screenH;
+#endif
+		subBaseY = subSurfH - subAreaH - 6;
+		if (subBaseY < 0) subBaseY = 0;
+
+#ifdef USE_HNM
+		if (composeOwnsPixels) {
+			if (useFontMax) {
+				for (uint i = 0; i < subLines.size(); ++i) {
+					int by = subBaseY + (int)i * subLineH + subLineH - 4;
+					// 1-px black drop shadow for legibility against the head.
+					drawFontMaxText(compose, subLines[i],
+					                subLeftMargin + 1, by + 1);
+					drawFontMaxText(compose, subLines[i],
+					                subLeftMargin,     by);
+				}
+			} else if (guiFont) {
+				for (uint i = 0; i < subLines.size(); ++i) {
+					int by = subBaseY + (int)i * subLineH;
+					guiFont->drawString(&compose, subLines[i],
+					    subLeftMargin + 1, by + 1, subWidthBudget, subShadow,
+					    Graphics::kTextAlignLeft);
+					guiFont->drawString(&compose, subLines[i],
+					    subLeftMargin, by, subWidthBudget, subColor,
+					    Graphics::kTextAlignLeft);
+				}
+			}
+			g_system->copyRectToScreen(compose.getPixels(), compose.pitch,
+			                           blitX, blitY, blitW, blitH);
+			compose.free();
+		} else
+#endif
+		{
+			// No composite surface (no video) — text on the warp/cleared
+			// backbuffer via a small overlay surface, same shadow scheme.
+			if (!subLines.empty() && subLineH > 0) {
+				Graphics::ManagedSurface overlay(screenW, subAreaH + 4, fmt);
+				if (warpView) {
+					// Pull the matching strip from the panorama so the text
+					// keeps the original backdrop pixels (no opaque bar).
+					int srcY = screenH - subAreaH - 6;
+					if (srcY < 0) srcY = 0;
+					int rowsAvail = warpView->h - srcY;
+					if (rowsAvail > overlay.h) rowsAvail = overlay.h;
+					const uint rowBytes = warpView->w * fmt.bytesPerPixel;
+					for (int row = 0; row < rowsAvail; row++)
+						memcpy(overlay.getBasePtr(0, row),
+						       warpView->getBasePtr(0, srcY + row), rowBytes);
+				} else {
+					overlay.fillRect(Common::Rect(overlay.w, overlay.h), 0);
+				}
+				if (useFontMax) {
+					for (uint i = 0; i < subLines.size(); ++i) {
+						int by = (int)i * subLineH + subLineH - 4;
+						drawFontMaxText(overlay, subLines[i],
+						                subLeftMargin + 1, by + 1);
+						drawFontMaxText(overlay, subLines[i],
+						                subLeftMargin,     by);
+					}
+				} else if (guiFont) {
+					for (uint i = 0; i < subLines.size(); ++i) {
+						int by = (int)i * subLineH;
+						guiFont->drawString(&overlay, subLines[i],
+						    subLeftMargin + 1, by + 1, subWidthBudget, subShadow,
+						    Graphics::kTextAlignLeft);
+						guiFont->drawString(&overlay, subLines[i],
+						    subLeftMargin, by, subWidthBudget, subColor,
+						    Graphics::kTextAlignLeft);
+					}
+				}
+				int dy = screenH - subAreaH - 6;
+				if (dy < 0) dy = 0;
+				g_system->copyRectToScreen(overlay.getPixels(), overlay.pitch,
+				                           0, dy, overlay.w, overlay.h);
+				overlay.free();
+			}
+		}
+		g_system->updateScreen();
+	};
+
+	// Linger: scale with subtitle length (visible time ≈ 80 ms/char,
+	// minimum 1.5 s) so longer lines aren't cut short when no audio exists.
+	int lingerMs = 1500;
+	if (!text.empty())
+		lingerMs = MAX(1500, (int)text.size() * 80);
+
+	// One click (or key) skips only one line: drain a still-held skip input
+	// carried over from skipping the previous line, so this line's playback
+	// watches for a fresh press instead of consuming the old one.
+	while (getCurrentMouseButton() != 0 && !shouldAbort()) {
+		pollEvents();
+		g_system->delayMillis(10);
+	}
+	clearKeys();
+
+	Common::String apcName = Common::String::format("ATA%04d%c.APC", sectionId, track);
+	Common::SeekableReadStream *apcFile = openBigFileStream(kFileTypeSound, apcName);
+
+	if (!apcFile) {
+		for (int ms = 0; ms < lingerMs && !shouldAbort(); ms += 20) {
+			drawFrame();
+			pollEvents();
+			if (checkKeysPressed(1, Common::KEYCODE_SPACE) || getCurrentMouseButton() != 0) break;
+			g_system->delayMillis(20);
+		}
+#ifdef USE_HNM
+		delete bgDecoder;
+		delete spfStream;
+		ubbConvFrame.free();
+#endif
+		if (fovChanged) _omni3dMan.setHFov(savedHFov);
+		if (sourceSwapped) _omni3dMan.setSourceSurface(&_warpSurface);
+		return;
+	}
+
+	Audio::PacketizedAudioStream *apc = Audio::makeAPCStream(*apcFile);
+	if (apc) {
+		int64 remaining = apcFile->size() - apcFile->pos();
+		if (remaining > 0) {
+			byte *buf = new byte[remaining];
+			apcFile->read(buf, (uint32)remaining);
+			apc->queuePacket(new Common::MemoryReadStream(buf, remaining,
+			                                              DisposeAfterUse::YES));
+		}
+		apc->finish();
+		Audio::SoundHandle handle;
+		_mixer->playStream(Audio::Mixer::kSpeechSoundType, &handle, apc);
+		debugC(1, kDebugScript, "playSingleConLine: %s", apcName.c_str());
+
+		while (!shouldAbort() && _mixer->isSoundHandleActive(handle)) {
+			drawFrame();
+			pollEvents();
+			if (checkKeysPressed(1, Common::KEYCODE_SPACE) || getCurrentMouseButton() != 0) {
+				_mixer->stopHandle(handle);
+				break;
+			}
+			g_system->delayMillis(10);
+		}
+		_mixer->stopHandle(handle);
+	}
+	delete apcFile;
+
+	// Subtitle linger after audio ends — fixed 500 ms tail matches the
+	// original game's "fade-out grace" before the next line starts.
+	for (int ms = 0; ms < 500 && !shouldAbort(); ms += 20) {
+		drawFrame();
+		pollEvents();
+		if (checkKeysPressed(1, Common::KEYCODE_SPACE) || getCurrentMouseButton() != 0) break;
+		g_system->delayMillis(20);
+	}
+#ifdef USE_HNM
+	delete bgDecoder;
+	delete spfStream;
+	ubbConvFrame.free();
+#endif
+	if (fovChanged) _omni3dMan.setHFov(savedHFov);
+	if (sourceSwapped) _omni3dMan.setSourceSurface(&_warpSurface);
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/engine.h
+++ b/engines/cryomni3d/atlantis/engine.h
@@ -1,0 +1,897 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CRYOMNI3D_ATLANTIS_ENGINE_H
+#define CRYOMNI3D_ATLANTIS_ENGINE_H
+
+#include "common/array.h"
+#include "common/hashmap.h"
+#include "common/hash-str.h"
+#include "common/random.h"
+#include "common/rect.h"
+#include "common/str.h"
+#include "common/stream.h"
+
+#include "cryomni3d/cryomni3d.h"
+#include "cryomni3d/omni3d.h"
+
+#include "graphics/surface.h"
+
+#include "cryomni3d/atlantis/bigfile.h"
+#include "cryomni3d/atlantis/con_script.h"
+#include "cryomni3d/atlantis/dialogs_manager.h"
+#include "cryomni3d/atlantis/menu_layout.h"
+#include "cryomni3d/atlantis/sprite_blend.h"
+#include "cryomni3d/atlantis/toolbar.h"
+#include "cryomni3d/atlantis/wam_parser.h"
+
+namespace CryOmni3D {
+struct FixedImageConfiguration;
+class ZonFixedImage;
+}
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+enum AbortCommand {
+	kAbortNoAbort   = 0,
+	kAbortQuit      = 1,
+	kAbortLoadGame  = 2,
+	kAbortNewGame   = 3,
+	kAbortNextChapter = 5,
+	kAbortFinished  = 6,
+	kAbortGameOver  = 7
+};
+
+// File type enum mapping Atlantis's BigFile directory layout.
+// All files are read from the BigFile archive; these constants describe
+// which subdirectory prefix to prepend.
+enum FileType {
+	kFileTypeCyclo,        // CYCLO\        — panoramic HNM videos
+	kFileTypeTransition,   // UBB_VUE\      — place-to-place transition HNM videos
+	kFileTypeDialog,       // DIALOG\       — dialog UBB audio + font + init files
+	kFileTypeSync,         // SYC\          — lip-sync timing data
+	kFileTypeFont,         // FONTS\        (or game root) — font files
+	kFileTypeSprite,       // SPRLIST\      — sprite list text files
+	kFileTypeWAM,          // WAM\          — navigation map files
+	kFileTypeObject,       // OBJETS\       — object images
+	kFileTypeMenu,         // MENU\         — menu/UI images
+	kFileTypeScript,       // SCENAR\       — chapter scenario scripts (.CON files)
+	kFileTypeSound,        // WAV\          — APC audio files (music, ambient, dialog)
+	kFileTypeSpriteCyclo,  // SPRITE\CYCLO\ — pre-rendered NPC/prop sprites (SPW files)
+	kFileTypeSpriteUbb,    // SPRITE\UBB\   — per-transition NPC animations (SPF files)
+	kFileTypeSprite2D,     // SPRITE\2D\    — 2D subject/cursor icon sprites (SPR files)
+	kFileTypeImages,       // IMAGES\       — full-screen TGA background images
+	kFileTypePuzzles       // PUZZLES\      — per-minigame sprites + TGAs (eclipse, chess, …)
+};
+
+struct PlaceState {
+	typedef void (CryOmni3DEngine_Atlantis::*InitFunc)();
+	typedef bool (CryOmni3DEngine_Atlantis::*FilterEventFunc)(uint *event);
+
+	PlaceState() : initPlace(nullptr), filterEvent(nullptr), state(0) {}
+	PlaceState(InitFunc init, FilterEventFunc filter) :
+		initPlace(init), filterEvent(filter), state(0) {}
+
+	InitFunc initPlace;
+	FilterEventFunc filterEvent;
+	uint state;
+};
+
+struct LevelInitialState {
+	uint placeId;
+	float alpha;
+	float beta;
+};
+
+// One entry from the WAM's SPF transition-sprite list (e.g. SPFATL1.TXT).
+// Format per line: `fromPlace toPlace persoId spfFile`.  During a transition
+// from fromPlace to toPlace the engine composites the matching SPF's frames
+// onto the HNM transition video so NPCs remain visible as the camera moves.
+// SPF on-disk format is identical to SPW (same header, frame table, RLE
+// pixel stream), just authored against the 640×480 video frame instead of
+// the 2048-wide cyclo panorama.
+struct SpriteTransEntry {
+	uint16 fromPlace;
+	uint16 toPlace;
+	int    persoId;
+	Common::String spfFile;
+};
+
+// One entry from the WAM's SPW sprite list (e.g. SPWATL1.TXT).
+// NPC entries have type==0 and persoId>0; animated props (torches) have type!=0.
+struct SpritePlaceEntry {
+	uint16 placeId;
+	int type;     // 0 = NPC, non-zero = animated prop (torch, etc.)
+	int frames;   // animation frame count (0 for static NPC)
+	int persoId;  // character ID (0 for props)
+	float angle;  // camera look angle for NPC orientation
+	Common::String spwFile;
+	// True when this entry marks the NPC's "home" place — the only place
+	// where the player can interact (talk) with them.  In the SPW list this
+	// is encoded as a leading minus sign on the angle field (e.g. `-00`
+	// vs. plain `00`); from every other listed place the NPC sprite is
+	// visible at a distance but not clickable.
+	bool interactive;
+	// Initial "active" state encoded by trailing '-' on the placeId token.
+	// "180" (no dash) -> startActive=true ; "180-" (dash) -> startActive=false.
+	// startActive entries (torches, ambient props) render on place load.
+	// Dashed entries (NPCs, alternate wspranim poses) require an explicit
+	// /set(NewWsprAnim=N) — 1-based index into the place's sprite array —
+	// or a /set(ShowPerso=N) to flip `active` true before they render.
+	// Mirrors atlantis.exe sprite-record field +0x04 (rendered iff non-zero).
+	bool startActive;
+	// Runtime active flag.  Reset to startActive on place load; flipped by
+	// ShowPerso/HidePerso/NewWsprAnim/StopWsprAnim.
+	mutable bool active;
+	// Current animation frame for this sprite.  Type-2 wspranim sprites use
+	// their own per-sprite frame counter; the script's WSPRFRAME variable
+	// reflects the active sprite's frame each tick.
+	mutable int frame;
+};
+
+class CryOmni3DEngine_Atlantis : public CryOmni3DEngine {
+	friend class Atlantis_DialogsManager;
+	friend class Atlantis_Toolbar;
+
+protected:
+	Common::Error run() override;
+
+public:
+	CryOmni3DEngine_Atlantis(OSystem *syst, const CryOmni3DGameDescription *gamedesc);
+	~CryOmni3DEngine_Atlantis() override;
+
+	bool hasFeature(EngineFeature f) const override;
+	Common::Error loadGameState(int slot) override;
+	Common::Error saveGameState(int slot, const Common::String &desc, bool isAutosave = false) override;
+	Common::String getSaveStateName(int slot) const override;
+	// Atlantis autosaves on chapter transitions (see autosave()), never on a
+	// timer — disable ScummVM's periodic autosave so it cannot write a slot.
+	int getAutosaveSlot() const override { return -1; }
+
+	// Whether dialog text should be drawn on screen.  Reads ScummVM's
+	// "subtitles" config key, which is wired to the standard ScummVM GUI
+	// toggle and to the F-key shortcut.  Engine advertises
+	// kSupportsSubtitleOptions via the cryomni3d base class so the option
+	// is exposed in the launcher and in-game GMM.
+	bool showSubtitles() const;
+
+	// Build a path for a named file of the given type (for files outside the BigFile).
+	Common::Path getFilePath(FileType fileType, const Common::String &baseName) const;
+
+	// Open a file from the BigFile archive and return a new stream (caller owns it).
+	// Returns nullptr if not found.
+	Common::SeekableReadStream *openBigFileStream(FileType fileType,
+	                                               const Common::String &baseName) const;
+
+	void setupPalette(const byte *colors, uint start, uint num) override;
+	void makeTranslucent(Graphics::Surface &dst, const Graphics::Surface &src) const override;
+
+	bool displayToolbar(const Graphics::Surface *original) override { return _toolbar.displayToolbar(original); }
+	bool hasPlaceDocumentation() override { return false; }
+	bool displayPlaceDocumentation() override { return false; }
+	uint displayOptions() override;
+	bool shouldAbort() override;
+	void drawInventoryIcon(Graphics::ManagedSurface &dst, const Object *obj,
+	                       const Common::Rect &r) override;
+
+	// Draw the "object just received" icon centred horizontally near the
+	// bottom of `dst` while a give is pending (_dialogGivenObjSprite >= 0).
+	// Mirrors the original's DAT_0049619c per-dialog-frame draw.
+	void drawGivenObject(Graphics::Surface &dst) const;
+
+private:
+	void setupFonts();
+	void setupObjects();
+	void loadStaticData();
+
+	// Wire up place-specific initPlace/filterEvent callbacks for a chapter.
+	void initChapterPlaceStates(int chapter);
+
+	void syncSoundSettings() override;
+	void calculateTransparentMapping();
+
+	// Load the panoramic HNM for a place and set it as the Omni3D source.
+	// Returns true if successful.
+	bool loadCycloHNM(const Common::String &name);
+
+	void changeChapter(int chapter);
+	void initNewChapter(int chapter);
+	void setupChapterWAM(int chapter);
+	void setupWAMByName(const Common::String &wamName);
+	void initPlacesStates();
+
+	void gameStep();
+	void doPlaceChange();
+	void executeTransition(uint nextPlaceId);
+
+	int handleWarp();
+
+	void drawMenuTitle(Graphics::ManagedSurface *surface, byte color);
+	uint displayFilePicker(const Graphics::Surface *bgFrame, bool saveMode,
+	                       Common::String &saveName);
+
+	bool loadGame(uint saveNum);
+	void saveGame(uint saveNum, const Common::String &saveName);
+
+	// Parse one of the original SPRLIST\*MENU.TXT files (relative basename
+	// only, e.g. "MAINMENU.TXT") into the supplied MenuLayout.  Returns
+	// false only on missing file / unreadable stream — an empty layout is
+	// reported as success.
+	bool loadMenuLayout(const char *baseName, MenuLayout &out) const;
+
+	// Render every item of `layout` onto `dst` and fill `hitRectsOut` with
+	// the bounding box of each text item (in the same order as
+	// `layout.items`).  Sprite items get a Rect() (empty).
+	void renderMenuLayout(Graphics::ManagedSurface &dst, const MenuLayout &layout,
+	                      int hoveredTextIdx,
+	                      Common::Array<Common::Rect> &hitRectsOut) const;
+
+	// In-game (Escape) menu.  Returns:
+	//   0  — continue (resume warp)
+	//   28 — load game (caller must consume _loadedSave)
+	//   27 — new game
+	//   40 — quit
+	uint displayInGameMenu();
+
+	// Quit confirmation dialog.  Composites SPRLIST\SUREMENU.TXT (the
+	// "ARE YOU SURE ?" prompt with its OK / Cancel buttons and ornament
+	// sprites) over `bg`.  All text and positions come from that file, so
+	// localized discs work unchanged.  Returns true when the player
+	// confirms, false on cancel or Escape.
+	bool confirmQuit(const Graphics::ManagedSurface &bg);
+
+	// Options menu (SPRLIST\OPTMENU.TXT): the SUBTITLES and OMNI 3D toggles
+	// plus a SOUND OPTIONS sub-menu button.  Modal; returns when OK is
+	// clicked or Escape is pressed.
+	void displayOptionsMenu(const Graphics::ManagedSurface &bg);
+
+	// Sound-options sub-menu (SPRLIST\SONMENU.TXT): four volume sliders.
+	// OK commits the volumes to the ScummVM config, Cancel discards them.
+	void displaySoundMenu(const Graphics::ManagedSurface &bg);
+
+	// Play WAV\<apcName> once with a stereo balance (-127 = full left ...
+	// +127 = full right) — the sound menu's Left/Right speaker test.
+	void playPannedSound(const char *apcName, int8 balance);
+
+	// True when the player selected OMNI 3D "MODE 1" — that mode inverts
+	// the vertical (up/down) panorama look control in handleWarp().
+	bool omni3dInvertY() const;
+
+	// --- Player profiles (original-game player management) ----------------
+	// Up to kMaxPlayers named players, each owning the absolute save-slot
+	// block [id*kPlayerSlotStride, id*kPlayerSlotStride + kPlayerSlotStride).
+	// The id is the fixed array index, so a player's saves stay associated
+	// when other players are created or deleted.  Within a block the local
+	// slot index IS the chapter number: a player keeps one named save per
+	// episode (see autosave()), so chapter N's save lives at local slot N.
+	static const uint kMaxPlayers       = 5;
+	static const uint kPlayerSlotStride = 100;
+	static const uint kPlayerNameLen    = 16;
+
+	Common::String _players[kMaxPlayers];  // empty string = unused slot
+	int            _currentPlayer;
+	// Per-player resume pointer: the chapter the player is currently in, so a
+	// resume reloads that episode's save instead of guessing.  0 = no save.
+	// Persisted in atlantis-players.dat (format version 2).
+	int            _playerChapter[kMaxPlayers];
+
+	void loadPlayers();
+	void savePlayers();
+	void deletePlayerSaves(uint player);
+	// Select / create / delete screen.  Returns the chosen player id, or -1.
+	int  displayPlayerScreen();
+
+	// Native save-slot picker laid out from SPRLIST\SELEMENU.TXT.  Lists
+	// every kept per-episode save of the current player by its EPI.TXT
+	// checkpoint name.  Returns the absolute slot number (1-based), or 0 on
+	// cancel.
+	uint displaySavePicker(bool saveMode, Common::String &outSaveName);
+
+	// --- Per-episode saves (original-game behaviour) -----------------------
+	// Atlantis has no manual save: the game keeps one named save per episode
+	// and rewrites it whenever that episode is (re-)entered.  A CON
+	// `chapter=N` transition autosaves into the new chapter's slot, named
+	// from SPRLIST\EPI.TXT (mirrors atlantis.exe FUN_00427634 -> FUN_0042d6b8).
+	// Absolute (0-based) save slot a chapter occupies in a player's block.
+	int  episodeSaveSlot(uint player, uint chapter) const {
+		return (int)(player * kPlayerSlotStride + chapter);
+	}
+	// True if an episode save file exists at the given absolute slot.
+	bool saveSlotExists(int absSlot) const;
+	// True if `player` has any episode save to resume.
+	bool playerHasSave(uint player) const;
+	// The save `player` should resume into — their tracked current chapter's
+	// slot.  Returns the absolute (1-based) save number, or 0 when none.
+	uint playerResumeSave(uint player) const;
+	void autosave();
+	// Set when a CON `chapter=N` command advances the chapter; consumed by
+	// doPlaceChange() so the autosave is written as the new chapter's first
+	// place is entered (mirrors atlantis.exe FUN_00427634 -> FUN_0042d6b8).
+	bool _autosavePending;
+
+	// Checkpoint name for `chapter` — EPI.TXT line (chapter - 1).
+	Common::String episodeName(uint chapter) const;
+	// Episode checkpoint names parsed once from SPRLIST\EPI.TXT at startup.
+	// Index i is the name shown for a save made on entering chapter i + 1.
+	void loadEpisodeNames();
+	Common::Array<Common::String> _episodeNames;
+
+	// Play the transition HNM video.  When fromPlace and toPlace are both
+	// supplied (non-uint(-1)), the renderer composites SPF transition
+	// sprites onto each video frame so NPCs remain visible as the camera
+	// moves between the two places.
+	void playTransitionVideo(const Common::String &videoName,
+	                         uint fromPlace = uint(-1),
+	                         uint toPlace   = uint(-1));
+
+	// QUIT GAME outro: the original game's end-card slideshow.  Shows
+	// IMAGES\END.TGA followed by IMAGES\CREDIT01..10.TGA with
+	// WAV\04GENERI.APC playing throughout.  Skippable on any key or
+	// mouse click.  Invoked from displayInGameMenu()'s kQuit branch
+	// before returning the kAbortQuit code to handleWarp().
+	void playQuitOutro();
+
+	// gameover=N (CON command) — the game-over screen (GereGameOver,
+	// atlantis.exe FUN_00426590).  Shows the full-screen image
+	// IMAGES\GOVER<NN>.TGA, plays the narrator's commentary over it
+	// (WAV\ATA<section4d><track>.APC, the first [Narratrice] line that
+	// follows the /set(gameover=N) command in the section) with its
+	// subtitle, waits for the voice to finish (skippable; ~5 s cap when no
+	// audio), then returns.  showGameOver() itself only presents the screen;
+	// playConSection() then reloads the chapter checkpoint (a game-over is
+	// gated on a persistent CON variable, so the only escape is a reload).
+	//   sectionId/narratorTrack — together name the ATA APC file.
+	//   narratorText            — the narrator subtitle (empty = none).
+	void showGameOver(int sectionId, int n, const Common::String &narratorText,
+	                  char narratorTrack);
+
+	// Parse the WAM's SPW sprite list (e.g. SPWATL1.TXT) into _spritePlaceList.
+	void loadSpritePlaceList();
+	// Parse the WAM's SPF transition-sprite list (e.g. SPFATL1.TXT) into
+	// _spriteTransList.  Run once per chapter alongside loadSpritePlaceList.
+	void loadSpfList();
+	// Composite NPC/prop sprites for the current place onto _warpSurface.
+	// Also populates _npcPlaceBounds for hit testing.
+	void compositeNPCSprites();
+	// Rebuild only the NPC click-target list (_npcPlaceBounds) for the
+	// current place, honouring _hiddenPersos.  Safe to call mid-place after
+	// a showperso/hideperso change — unlike compositeNPCSprites() it leaves
+	// prop-/wspr-animation state untouched.
+	void rebuildNpcPlaceBounds();
+
+	// Load and parse the chapter CON script (CHAPI<N>.CON) into _conScript.
+	// Processes /INIT commands into _sujEnabled.
+	void loadConScript(int chapter);
+	// True for the 7 VARIAS.CON variables (indices 0-6) that persist across a
+	// chapter change and are written to the save; all others are transient.
+	static bool isPersistentGameVar(const Common::String &key);
+
+	// Process all INIT-section /set(...) commands (enableSuj, hidePerso, etc.).
+	void execConInitCommands();
+
+	// Execute a single /set(...) command string (content inside the parentheses).
+	void execConSetCommand(const Common::String &cmd);
+
+	// Fade the screen to black over a few frames (the /set(fadeout) command).
+	void fadeScreenToBlack();
+
+	// Launch the minigame indexed by puzzleId (the /set(StartPuzzle=N)
+	// command).  On exit writes back _gameVars["finpuzzle"] — 255 on
+	// success, other codes per-puzzle (e.g. CHAPI018's chess uses 1/2
+	// for distinct loss-line variants).  Phase-1 stub: every call
+	// immediately resolves to FinPuzzle=255 so script chains continue;
+	// per-puzzle UIs land in follow-up commits.
+	void playPuzzle(int puzzleId);
+
+	// NPC interaction: present enabled dialog subjects for persoId, play chosen sections.
+	void interactNPC(int persoId);
+
+	// Show the subject-selection menu for the given options (one ConSection* per choice).
+	// Returns the chosen index, or -1 to exit conversation.
+	int showSubjectMenu(const Common::Array<ConSection *> &options);
+
+	// Play all dialog lines of a section (audio + subtitles), then execute its /set commands.
+	void playConSection(ConSection &sec);
+
+	// Play one APC audio track for a section, displaying the given subtitle text.
+	// If videoName is non-empty, that HNM from DIALOG\ is looped as background video.
+	//
+	// `hasAngle`/`angleX`/`angleY` come from the CON dialog directive's optional
+	// numeric tokens (`[Speaker, X, Y, camN]` — see ConLine).  When supplied,
+	// the renderer rotates the panorama view to (X, Y) in panorama-pixel space
+	// before starting the line, so the cyclo background under the talking head
+	// faces the authored direction.  Conversion to radians uses the live
+	// panorama dimensions (`_warpSurface.w/h`); no hardcoded scale.
+	//
+	// `camNum` (2..5) selects the per-cam zoom level — the renderer narrows
+	// the panorama FOV using the table extracted from atlantis.exe at VA
+	// 0x00496080.  This is what visibly changes the view between dialog
+	// subjects in the original game.  The caller (playConSection) picks the
+	// cam via pickDialCam() so callers should always pass a valid 2..5.
+	// `spfBaseName` (basename only, no extension) selects the per-cam SPF overlay
+	// composited frame-by-frame onto the UBB talking head — INITDIAL columns 10..13
+	// per persoId, resolved by playConSection() from `_dialInitData[persoId].camSPF`.
+	// Empty string disables the overlay (matches the original "none" sentinel).
+	// `animMBase` (basename only) selects the per-character mouth vertex animation
+	// at DIALOG\PERSO\<base>.3DA (INITDIAL column 5).  When loaded, the parsed F3DC
+	// frame vertices are projected and splatted into the UBB's chroma-key mouth
+	// hole each tick as a debug point cloud — placeholder for the future scene-
+	// graph triangle rasteriser.  Empty disables the cloud.
+	// `s3dBase` (basename only) selects the per-character scene-graph mesh at
+	// DIALOG\PERSO\<base>.S3D (INITDIAL column 6).  Currently only the header is
+	// parsed for verification; triangle extraction is the next implementation pass.
+	void playSingleConLine(int sectionId, char track, const Common::String &text,
+	                       const Common::String &videoName = "",
+	                       bool hasAngle = false, int angleX = 0, int angleY = 0,
+	                       int camNum = 2,
+	                       const Common::String &spfBaseName = "",
+	                       const Common::String &animMBase = "",
+	                       const Common::String &s3dBase = "",
+	                       const Common::String &anim3DCBase = "",
+	                       bool interactiveDialog = true);
+
+	// Returns true if subject sujId is in the enabled list for persoId.
+	bool isSujEnabled(int persoId, int sujId) const;
+
+	// Return (creating if absent) the enabled-subjects list for persoId.
+	Common::Array<int> &sujsForPerso(int persoId);
+
+	// Evaluate all conditions of a /sel section.
+	// departZone: WAM zone the player is trying to leave via (0 for arrival checks).
+	// currentVue: the place ID currently active.
+	bool evalSelSection(const ConSection &sec, int departZone, int currentVue) const;
+
+	// Run /sel sections whose departvue condition matches departZone.
+	// Sets _nextPlaceId = uint(-1) if abortdepart=1 fires; may redirect via vue=N.
+	void runDepartureSelSections(int departZone);
+
+	// Run /con* sections whose cliczone condition matches zoneId (item-use on a zone).
+	// Temporarily sets _gameVars["cliczone"] so evalSelSection can check it.
+	void runZoneConSections(int zoneId);
+
+	// Run /sel sections whose arriveevue condition matches (ArriveeVue>0)&(vue=arrivedVue).
+	// Marks each fired section as played to prevent re-triggering.
+	void runArrivalSelSections(int arrivedVue, int fromVue);
+
+	// Generic /con scan -- mirror of atlantis.exe FUN_00425cf4.  The original
+	// engine runs this on every left-click whose dispatched action falls in
+	// the object id range [256, 512): it iterates every /Con or /con section
+	// (skipping /Suj-prefixed topic gates) and fires the FIRST whose
+	// conditions evaluate true via the generic eval path -- exactly the way
+	// /sel sections are dispatched on arrival/departure, just keyed off
+	// general game state instead of (arriveevue, departvue).
+	//
+	// Used for "use held object in the world at a specific state" scripts
+	// that have no ClicPerso / ClicZone gate.  Canonical case: CHAPI013
+	// section 178 + the three /014 fallbacks ("throw the flower pot on the
+	// priest aide") -- the player holds object 261, aims the camera within a
+	// narrow (AngleWarpX, AngleWarpY) window, and clicks while wsprframe is
+	// in the right pose window.  Returns true if a section fired so the
+	// caller can consume the click (no NPC dialog / pickup / zone navigation
+	// after a hit).
+	bool runGenericConSections();
+	// Debug: log the full story state (place, CON chapter, music track and
+	// every game variable) so a progression problem can be diagnosed from
+	// the log against the CON section conditions.
+	void debugDumpStoryState(const char *ctx);
+
+	// Run all /tim<timerNum> sections whose conditions currently match.
+	// Timer sections are not marked played — they re-evaluate on every tick.
+	void runTimerSections(int timerNum);
+
+	// Hit-test panoramic point against cached NPC bounding boxes.
+	// If a match is found, sets outPersoId and returns true.
+	bool npcPanoHitTest(const Common::Point &pan, int &outPersoId) const;
+
+	// Place-specific filterEvent callbacks (logic.cpp).
+	// Each returns true if the event should proceed, false to block it.
+	// *event may be modified to redirect the action.
+	// (currently none — guard logic at place 17 is CON-script driven)
+
+	// Play a CON-script dialog: display subtitle text while playing
+	// sequential APC tracks (ATA<dialogId4>A.APC, B.APC, ...).
+	// dialogId is the CON section number, which doubles as the 4-digit audio ID.
+	// If bgVideoName is non-empty, that HNM is looped as background video during playback.
+	void playConDialog(int dialogId, const Common::String &text,
+	                   const Common::String &bgVideoName = "");
+
+	// Music is fully CON-driven: startmusik selects a looping track, stopmusik
+	// clears it.  musicUpdate() keeps the mixer in sync with that selection
+	// every frame, including across the mute state.
+	void musicUpdate();
+	void musicStop();
+	// Select and (re)play a numbered music track (1-based, matching the
+	// startmusik CON command IDs).  The track loops until changed.
+	void musicPlayTrack(int trackId);
+	// Stop mixer playback and free the decoded buffer without clearing the
+	// selected track — used for the mute state and before a track switch.
+	void musicHaltPlayback();
+
+	static const LevelInitialState kChapterInitialStates[];
+
+	Atlantis_Toolbar _toolbar;
+	Atlantis_DialogsManager _dialogsMan;
+
+	BigFileArchive _bigFile;
+	AtlantisWAMParser _wam;
+
+	Omni3DManager _omni3dMan;
+	ZonFixedImage *_fixedImage;
+
+	byte *_mainPalette;
+	byte *_transparentPaletteMap;
+	uint _transparentSrcStart;
+	uint _transparentSrcStop;
+	uint _transparentDstStart;
+	uint _transparentDstStop;
+	uint _transparentNewStart;
+	uint _transparentNewStop;
+
+	bool _isPlaying;
+	AbortCommand _abortCommand;
+	uint _loadedSave;
+
+	uint _currentChapter;
+	uint _currentPlaceId;
+	uint _nextPlaceId;
+	const AtlantisPlace *_currentPlace;
+
+	// Decoded panorama for the current place (owned by this object).
+	// _cycloSurface holds the clean cyclo pixels; _warpSurface is the composited display copy.
+	Graphics::Surface _cycloSurface;
+	Graphics::Surface _warpSurface;
+	bool _warpLoaded;
+
+	// Animated prop sprite state for the current place (torches etc, type=1).
+	int   _propAnimFrames;  // total frame count (0 = no animated prop at current place)
+	uint  _propAnimFrame;   // current animation frame index
+	uint32 _propAnimNextMs; // g_system->getMillis() threshold for next frame advance
+	static const uint32 kPropAnimIntervalMs = 80;  // ~12.5 fps
+
+	// Active wspranim sprite index for the CURRENT place.  /set(NewWsprAnim=N)
+	// sets this to N-1 (1-based index in the place's sprite array) and
+	// activates that sprite; /set(StopWsprAnim=N) clears the active sprite.
+	// Driven from handleWarp's main loop, NOT from time1/time2 — wsprframe
+	// is an animation-frame counter, not a one-per-second tick.  Each
+	// frame advance re-runs the /Tim2 scan with the new wsprframe in
+	// scope, mirroring atlantis.exe FUN_00425304's timer-2 gate hijack
+	// (line 20086 in the decompile) that lets `/Tim2(WSprFrame=N)`
+	// conditions match against the live sprite frame.
+	int    _wsprAnimActiveIdx;     // place-local sprite index; -1 = none active
+	uint32 _wsprAnimNextMs;        // next allowed frame-advance timestamp
+	// Per-frame interval.  Exe uses a 13-ms threshold (~75 fps wspranim
+	// gated by the render loop's actual rate); 30 ms gives ~33 fps
+	// wspranim, so CHAPI012's 33-frame guard walk finishes in ~1 s —
+	// matching how the original played on period hardware where the
+	// main loop itself, not the threshold, was the cadence bottleneck.
+	static const uint32 kWsprAnimIntervalMs = 30;
+
+	// Deferred-refresh flags for CON commands that change the panorama sprite
+	// layer while it is not on screen (e.g. mid-dialog).  handleWarp()
+	// consumes them on its next frame so the change shows without a place
+	// change.  _spriteLayerDirty triggers a recomposite + redraw (set by
+	// showperso/hideperso and newwspranim/stopwspranim); _npcBoundsDirty
+	// additionally rebuilds the NPC click-target list (set only by
+	// showperso/hideperso, the only commands that alter it).
+	bool _spriteLayerDirty;
+	bool _npcBoundsDirty;
+
+	// Re-composite all sprites for the current place onto _warpSurface from _cycloSurface.
+	// Called both at place entry and during animation ticks.
+	void recompositeSpriteLayer();
+
+	Common::Array<uint> _gameVariables;
+	Common::Array<PlaceState> _placeStates;
+	// Per-place visit counter (NbVisite), indexed by place id; survives
+	// chapter changes.  /set(disable=N) bumps entry N to suppress place N's
+	// first-visit /sel sections.  Mirrors atlantis.exe's 0x6cc6cc array.
+	Common::Array<byte> _placeVisits;
+
+	// Named game variables: set by /set(key=val) and evaluated in /sel conditions.
+	Common::HashMap<Common::String, int> _gameVars;
+
+	// Per-character dialog resource table parsed from DIALOG\INITDIAL.TXT.
+	// camUBB[0..3] = UBB video basenames for camera angles 2..5 ("none" or empty = unavailable).
+	// camSPF[0..3] = optional per-cam decorative SPF overlay basenames composited each frame
+	//               onto the talking-head UBB, sourced from INITDIAL columns 10..13.
+	//               These are the Sprite-Per-Frame files the original engine pulls from
+	//               SPRITE\UBB\<base>.SPF (FUN_0042f9e8 in atlantis.exe.c:26543-26615
+	//               opens them via FUN_00434814 and composites them inside the UBB
+	//               playback loop on the same frame counter as the host video).
+	//               "none" or missing in the source row → empty here; skip compositing.
+	// animMBase  = INITDIAL column 5 (e.g. "heroan1m" for Seth) — basename of the
+	//               per-character mouth vertex-animation file at DIALOG\PERSO\<base>.3DA.
+	//               This is what fills the mouth-shaped chroma-key hole in the UBB; loaded
+	//               by F3dcMouthAnim in playSingleConLine.  Empty when the parser was unable
+	//               to find a per-character mouth.
+	// s3dBase    = INITDIAL column 6 (e.g. "hero" for Seth, "garde" for the Gardes) —
+	//               basename of the per-character mesh topology at DIALOG\PERSO\<base>.S3D.
+	//               This is the scene-graph file that holds the triangle indices into the
+	//               .3DA vertex pool; loaded by F3dcMesh in playSingleConLine.  Currently
+	//               only the header is parsed — full scene-graph walking is TBD.
+	struct DialInitEntry {
+		Common::String camUBB[4];
+		Common::String camSPF[4];
+		Common::String animMBase;
+		Common::String s3dBase;
+		Common::String anim3DCBase;
+	};
+	void loadDialInitData();
+	Common::HashMap<int, DialInitEntry> _dialInitData;
+
+	// Random camera selection per dialog line.  Mirrors atlantis.exe.c
+	// FUN_0042844c lines 22460-22470: when a CON directive has no explicit
+	// `camN`, the original engine picks a random cam in 2..5, rejecting the
+	// previous line's choice (so consecutive lines never use the same shot)
+	// and any cam whose UBB resource is missing for the speaker.
+	Common::RandomSource _dialRng;
+	int _lastDialCam;  // 0 = no previous line in this dialog session
+	int pickDialCam(int persoId, int explicitCam);
+
+	// Index into _objSprites (== _objects) of an object an NPC just gave Seth
+	// during the current dialog, or -1 when none.  Set by /set(inventN=1) and
+	// drawn centre-bottom on every dialog frame (the original's DAT_0049619c),
+	// cleared when the dialog ends (interactNPC return / place change).
+	int _dialogGivenObjSprite;
+
+	// RNG for CON `random` conditions.  Each evalSelSection call queries this
+	// once and stores the byte (0..255) as the LHS of any `random` comparison
+	// — letting CON authors gate dialog branches probabilistically (e.g.
+	// `/con(...)&(random<128) /suj5`).  Mutable so the const-marked
+	// evalSelSection can advance the stream.
+	mutable Common::RandomSource _conRng;
+
+	// Panorama alpha captured at the start of an NPC interaction (the
+	// direction the player was facing when they clicked the NPC).  This is
+	// the baseline for the default per-line angle: NPC lines preserve it,
+	// hero lines flip 180° from it.  Without anchoring on the click angle,
+	// the previous line's reverse-shot would leak into the next NPC line.
+	// Set true only between interactNPC entry and exit.
+	double _dialBaseAlpha;
+	bool   _dialBaseAlphaValid;
+
+	// Resolve a dialog line's speaker name to a perso ID.  Transcribes the
+	// speaker-name → persoId strncmp chain from atlantis.exe (VA 0x428f58):
+	// a fixed table keyed by a case-insensitive prefix of the speaker name.
+	// The player character ("Seth") always resolves to _heroPersoId.
+	int resolveSpeakerPersoId(const Common::String &speaker) const;
+	int _heroPersoId;  // persoId of the player character (detected from INITDIAL "hero" entry)
+
+	Common::String _currentWAMName;
+	Common::Array<SpritePlaceEntry> _spritePlaceList;
+
+	// Parsed SPF transition-sprite list (e.g. SPFATL1.TXT).
+	Common::Array<SpriteTransEntry> _spriteTransList;
+
+	// Decode a single frame of an SPF transition sprite stream and composite
+	// it onto `dst`.  The SPF format is identical to SPW (same header / RLE
+	// pixel stream), so the same flat-buffer decoder is reused — but here
+	// the surface width matches the transition video (640) rather than the
+	// 2048-wide cyclo panorama.  Implemented in sprite_renderer.cpp.
+	void compositeSpfFrame(Common::SeekableReadStream *spf, uint frameIdx,
+	                       Graphics::Surface &dst);
+
+	// Per-NPC subject enable state (keyed by persoId).
+	struct SujState {
+		int persoId;
+		Common::Array<int> sujs;
+	};
+	Common::Array<SujState> _sujEnabled;
+
+	// Panoramic bounding boxes for NPCs in the current place (for mouse hit testing).
+	struct NPCBound {
+		int persoId;
+		Common::Rect panoBounds;  // in panoramic coords (Y=0 at top, exclusive right/bottom)
+	};
+	Common::Array<NPCBound> _npcPlaceBounds;
+
+	// Set of persoIds hidden by /set(hideperso=N) or /set(disableperso=N).
+	// Cleared on chapter change; showperso=N removes from the set.
+	Common::Array<int> _hiddenPersos;
+
+	// Set of persoIds currently following the hero (companion NPCs).
+	// Added via /set(addguest=N), removed via /set(subguest=N).  At
+	// compositeNPCSprites time every guest's sprite at the current place
+	// (if one exists) is force-shown -- this overrides _hiddenPersos for
+	// that perso while they're a guest, so a script that hid an NPC at
+	// chapter init can still let them appear later as a follower without
+	// an explicit /set(showperso=N).  Persists across place changes
+	// within a chapter; cleared on chapter switch like _hiddenPersos.
+	Common::Array<int> _guests;
+
+	// Parsed CON script for the current chapter.
+	ConScript _conScript;
+
+	uint _currentCONChapter;  // which CHAPI00N.CON is currently loaded (0 = none)
+
+	// Wall-clock at which the active CHAPI*.CON was loaded.  Used to compute
+	// the `chaptertime` CON condition (seconds elapsed since chapter switch).
+	// Reset by loadConScript on every chapter advance; read live by
+	// evalSelSection so dialog gates like CHAPI030's
+	// `/Con(...)&(ChapterTime>120)` fire when the time actually elapses.
+	uint32 _chapterStartMs;
+
+	// Per-timer tick timestamps: _timerTickNextMs[i] is the g_system->getMillis() threshold
+	// for the next tick of timer i+1.  Timer sections increment timeN each tick when
+	// testTimeN=1 is set.  Currently supports timers 1 and 2 (indices 0 and 1).
+	uint32 _timerTickNextMs[2];
+	static const uint32 kTimerTickIntervalMs = 1000;  // 1 tick per second
+
+	// zoom=1 (CON) — close-up FOV ramp.  _zoomLastMs is the getMillis() of the
+	// previous ramp frame (0 = not ramping); see the gameStep warp loop.
+	uint32 _zoomLastMs;
+
+	const char *_musicCurrentFile;
+	Audio::SoundHandle _musicHandle;
+	byte *_musicRawData;
+	uint32 _musicRawSize;
+	int _musicTrackId;   // selected startmusik track id (0 = stopped / none)
+
+	// Ambient SFX playback driven by CON `/set(newsound=N)`.  The id-to-APC
+	// mapping lives in atlantis.exe at VA 0x004961e0: a pointer table that
+	// starts with 17 WAM names then continues with APC filenames.  newsound
+	// IDs are 0-based into the APC portion, so id N maps directly to
+	// _newSoundApcNames[N] (== file-table index N+17).  Verified empirically:
+	// CON `newsound=14` at CHAPI001/zone 168 plays Toctoc.apc, which is the
+	// 15th APC entry in the table (array index 14).  Loaded once at engine
+	// start by loadAtlantisExeTables().
+	Common::Array<Common::String> _newSoundApcNames;
+	Audio::SoundHandle _newSoundHandle;
+
+	// World-object-id table extracted from atlantis.exe at VA 0x004967b0:
+	// a zero-terminated int32 array (~39 entries) where index i is the sprite
+	// slot in SPRITE\2D\OBJETS1.SPR and the value is the world object id that
+	// uses that sprite as its inventory icon.  setupObjects() builds _objects
+	// from this so drawInventoryIcon() (which indexes _objSprites by
+	// (obj - &_objects.front())) lands on the matching icon by construction.
+	Common::Array<uint> _inventoryObjectIds;
+
+	void loadAtlantisExeTables();
+
+	static const FixedImageConfiguration kFixedImageConfiguration;
+
+	// Subject icon sprites decoded from SPRITE\2D\SUJETS.SPR.
+	struct SubjSprite {
+		uint16 w, h;
+		int16  xoff, yoff;
+		Common::Array<uint16> pixels;  // RGB565; kSprTransp marks transparent pixels
+		Common::Array<uint8>  blend;   // per-pixel blend factor; kSprNoBlend = opaque
+	};
+	static const uint16 kSprTransp = 0x0001;  // sentinel: not a real game color
+
+	// Decode one sprite's RLE rows (atlantis.exe FUN_0041047f) into spr.pixels
+	// and spr.blend.  spr.w/h must already be set; the stream must be positioned
+	// at the per-row offset table.  Shared by every SPR loader.
+	void decodeSprite(Common::SeekableReadStream &stream, SubjSprite &spr,
+	                  const uint16 *colorTable);
+
+	void loadSubjectSprites();
+	void drawSubjectSprite(Graphics::Surface &dst, uint sprIdx, int cx, int cy) const;
+
+	Common::Array<SubjSprite> _subjSprites;
+
+	// Inventory item icon sprites decoded from SPRITE\2D\OBJETS1.SPR.
+	// Indexed by position in _objects (sprite[i] is the icon for _objects[i]).
+	void loadObjectSprites();
+	Common::Array<SubjSprite> _objSprites;
+
+	// The single 599x82 inventory-bar background sprite from
+	// SPRITE\2D\OBJETS0.SPR -- thin golden filigree line at top, then 8
+	// star-of-David slot ornaments and decorative drops.  This IS the
+	// inventory bar in the original game; SPRMENU.SPR is used only for the
+	// menu-screen frames and dialog borders, not the toolbar.  Loaded by
+	// loadInventoryBarSprite().
+	void loadInventoryBarSprite();
+	SubjSprite _inventoryBarSprite;
+
+	// Toolbar/menu UI sprites decoded from SPRITE\2D\SPRMENU.SPR.
+	// Sprite 0 is the full-width toolbar background bar.
+	void loadMenuSprites();
+	Common::Array<SubjSprite> _menuSprites;
+
+	// Menu font sprites.  Two glyph sets are loaded from SPRITE\2D\:
+	//   FONTMAX.SPR  → default menu label colour (gold).
+	//   FONTMAX2.SPR → hover/highlight glyphs (brighter yellow).
+	// Both share the same indexing convention (sprite_index = char_code - 0x20)
+	// and the same space advance kFontMaxSpaceAdvance (22 px).  Selecting the
+	// hover set is what produces the original game's "yellow tint" on the
+	// currently-highlighted menu entry — there is no per-pixel modulation.
+	void loadFontMaxSprites();
+	void loadFontSpriteSet(const char *spr, Common::Array<SubjSprite> &out);
+	Common::Array<SubjSprite> _fontMaxSprites;
+	Common::Array<SubjSprite> _fontMaxHoverSprites;
+	// FONTMIN.SPR / FONTMIN2.SPR — the smaller, red-tinted font the original
+	// uses for player names on the player-management screen.
+	Common::Array<SubjSprite> _fontMinSprites;
+	Common::Array<SubjSprite> _fontMin2Sprites;
+
+	int  fontMaxCharAdvance(unsigned char c) const;
+	int  fontMaxStringWidth(const Common::String &text) const;
+	void drawFontMaxText(Graphics::ManagedSurface &dst, const Common::String &text,
+	                     int anchorX, int anchorY, bool hover = false) const;
+	void drawFontMinText(Graphics::ManagedSurface &dst, const Common::String &text,
+	                     int anchorX, int anchorY, bool hover = false) const;
+	void drawPlayerText(Graphics::ManagedSurface &dst, const Common::String &text,
+	                    int anchorX, int anchorY, bool hover = false) const;
+	void drawSprFontText(Graphics::ManagedSurface &dst, const Common::String &text,
+	                     int anchorX, int anchorY,
+	                     const Common::Array<SubjSprite> &drawGlyphs,
+	                     const Common::Array<SubjSprite> &layoutGlyphs,
+	                     int spaceAdvance) const;
+
+	// Credits font sprites — sprite atlases used by the original GereGameOver
+	// path for the quit-game / completion credit roll.  Two banks:
+	//   CREDBLAN.SPR → "blanc" (white) glyphs for regular credit lines.
+	//   CREDBLEU.SPR → "bleu" (blue) glyphs used after `\` markers in
+	//                   CREDITS.TXT (e.g. "\Directed by").
+	// Both share the original engine's 256-byte per-char advance table
+	// (atlantis.exe @ VA 0x004966fc), loaded into _creditCharWidths by
+	// loadAtlantisExeTables() so the engine's existing per-glyph SPR data
+	// drives the visuals while the table drives proportional spacing —
+	// the same split FUN_0042073c uses for centering.
+	void loadCreditFontSprites();
+	Common::Array<SubjSprite> _creditBlanSprites;
+	Common::Array<SubjSprite> _creditBleuSprites;
+	byte _creditCharWidths[256];  // populated by loadAtlantisExeTables
+
+	int  creditCharAdvance(unsigned char c) const;
+	int  creditStringWidth(const Common::String &text) const;
+	void drawCreditText(Graphics::ManagedSurface &dst, const Common::String &text,
+	                    int anchorX, int anchorY, bool blue) const;
+
+	Graphics::Surface *loadTGA(FileType ft, const char *name);
+
+	// Blit a SPRMENU.SPR sprite onto dst with its hotspot at screen position (hx, hy).
+	void blitMenuSprite(Graphics::ManagedSurface &dst, uint idx, int hx, int hy) const;
+
+	// Animated warp-view cursors decoded from SPRITE\2D\CURSEURS.SPR.
+	// Three groups map to WarpCursorState: default(0-8), navigate(9-17), talk(18-25).
+	struct CursorSpr {
+		uint16 w, h;
+		int16  xoff, yoff;
+		Common::Array<uint16> pixels;  // RGB565; kWarpCursorKey = transparent
+		Common::Array<uint8>  blend;   // per-pixel blend factor; kSprNoBlend = opaque
+	};
+
+	void loadCursorSprites();
+	// Install an alpha-blended hardware cursor from sprite pixels + blend factors.
+	void setBlendedCursor(uint16 w, uint16 h, const uint16 *pixels,
+	                      const uint8 *blend, int hotX, int hotY, uint16 transpKey);
+	void setWarpCursor(int group);   // set cursor group and reset animation
+	void tickWarpCursor();            // advance animation frame (call in game loop)
+	// Set the carried-item cursor.  When overlayCursorFrame >= 0 that
+	// _cursorSprites frame (an action cursor) is composited on top.
+	void setItemCursor(const Object *obj, int overlayCursorFrame = -1);
+public:
+	void setArrowCursor();   // plain Atlantis arrow cursor (CURSEURS.SPR sprite 8)
+private:
+
+	Common::Array<CursorSpr> _cursorSprites;
+	int    _warpCursorGroup;    // 0=default 1=navigate 2=talk
+	int    _warpCursorFrame;    // current frame index within group
+	uint32 _warpCursorNextMs;   // g_system->getMillis() threshold for next frame
+};
+
+} // namespace Atlantis
+} // namespace CryOmni3D
+
+#endif // CRYOMNI3D_ATLANTIS_ENGINE_H

--- a/engines/cryomni3d/atlantis/f3dc_parser.cpp
+++ b/engines/cryomni3d/atlantis/f3dc_parser.cpp
@@ -1,0 +1,1172 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/debug.h"
+#include "common/scummsys.h"
+#include "common/textconsole.h"
+
+#include "cryomni3d/cryomni3d.h"
+#include "cryomni3d/atlantis/f3dc_parser.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// "F3DC" read as big-endian gives 0x46334443 — the bytes on disk are
+// 0x46 0x33 0x44 0x43, so the first byte ('F' = 0x46) is the most
+// significant byte of the BE u32.
+static const uint32 kF3dcMagic = MKTAG('F', '3', 'D', 'C');
+
+// Fixed-size on-disk header that precedes the per-frame data table.
+//   0x00..0x07 = magic + class id
+//   0x08..0x1F = subformat + zeros + frame count
+//   0x20..     = uint32[frameCount] offset table
+static const uint32 kHeaderBytesFixed = 32;
+
+F3dcMouthAnim::F3dcMouthAnim() : _frameCount(0), _vertsPerFrame(0) {}
+
+void F3dcMouthAnim::reset() {
+	_frameCount    = 0;
+	_vertsPerFrame = 0;
+	_data.clear();
+}
+
+bool F3dcMouthAnim::loadFromStream(Common::SeekableReadStream &s) {
+	reset();
+
+	const int64 fileSize = s.size();
+	if (fileSize < (int64)kHeaderBytesFixed) {
+		warning("F3dcMouthAnim: file too small (%d bytes, need at least %d)",
+		        (int)fileSize, (int)kHeaderBytesFixed);
+		return false;
+	}
+
+	s.seek(0);
+	if (s.readUint32BE() != kF3dcMagic) {
+		warning("F3dcMouthAnim: bad F3DC magic");
+		return false;
+	}
+
+	s.seek(0x10);
+	const uint32 subfmt = s.readUint32LE();
+	if (subfmt != (uint32)kF3dcSubfmtMouthAnim) {
+		warning("F3dcMouthAnim: unsupported subformat %u (need %u)",
+		        subfmt, (uint32)kF3dcSubfmtMouthAnim);
+		return false;
+	}
+
+	s.seek(0x1C);
+	const uint32 cnt = s.readUint32LE();
+	// Empirically every shipped M file has 11..14 frames; cap at 1024
+	// to flag corruption while leaving generous headroom.
+	if (cnt == 0 || cnt > 1024) {
+		warning("F3dcMouthAnim: implausible frame count %u", cnt);
+		return false;
+	}
+
+	// Frame offset table — each entry i is a delta:
+	//   frame_file_offset[i] = 28 + table[i]
+	// Verified for HEROAN1M.3DA in the reverse-engineering pass.
+	Common::Array<uint32> table;
+	table.resize(cnt);
+	s.seek(0x20);
+	for (uint i = 0; i < cnt; i++)
+		table[i] = s.readUint32LE();
+	if (s.err()) {
+		warning("F3dcMouthAnim: short read in offset table");
+		reset();
+		return false;
+	}
+
+	// Payload = file size minus fixed header minus table.  All shipped
+	// mouth files split it into `cnt` equal frames of bytesPerFrame
+	// bytes each, with bytesPerFrame a multiple of 12 (3 × int32 LE per
+	// vertex).  Verified across all 19 mouth files in BIGCD1.BIG.
+	const uint32 headerBytes  = kHeaderBytesFixed + 4 * cnt;
+	if ((uint32)fileSize <= headerBytes) {
+		warning("F3dcMouthAnim: no payload (%d bytes file, %u header)",
+		        (int)fileSize, headerBytes);
+		return false;
+	}
+	const uint32 payloadBytes = (uint32)fileSize - headerBytes;
+	if (payloadBytes % cnt != 0) {
+		warning("F3dcMouthAnim: payload %u not divisible by frame count %u",
+		        payloadBytes, cnt);
+		return false;
+	}
+	const uint32 bytesPerFrame = payloadBytes / cnt;
+	if (bytesPerFrame % 12 != 0) {
+		warning("F3dcMouthAnim: bytes/frame %u not a multiple of 12",
+		        bytesPerFrame);
+		return false;
+	}
+
+	_frameCount    = cnt;
+	_vertsPerFrame = bytesPerFrame / 12;
+	_data.resize((uint)_frameCount * _vertsPerFrame * 3);
+
+	int32 *dst = _data.begin();
+	for (uint fi = 0; fi < _frameCount; fi++) {
+		const uint32 frameOff = 28 + table[fi];
+		if (frameOff + bytesPerFrame > (uint32)fileSize) {
+			warning("F3dcMouthAnim: frame[%u] OOB (off=0x%x size=%u)",
+			        fi, frameOff, bytesPerFrame);
+			reset();
+			return false;
+		}
+		s.seek(frameOff);
+		for (uint vi = 0; vi < _vertsPerFrame; vi++) {
+			*dst++ = (int32)s.readUint32LE();
+			*dst++ = (int32)s.readUint32LE();
+			*dst++ = (int32)s.readUint32LE();
+		}
+	}
+	if (s.err()) {
+		warning("F3dcMouthAnim: short read in frame bodies");
+		reset();
+		return false;
+	}
+
+	debugC(1, kDebugMesh, "F3dcMouthAnim: loaded %u frames × %u verts (bind pose at frame 0)",
+	      _frameCount, _vertsPerFrame);
+	return true;
+}
+
+bool F3dcMouthAnim::getVertex(uint fi, uint vi, int32 &x, int32 &y, int32 &z) const {
+	if (fi >= _frameCount || vi >= _vertsPerFrame) {
+		x = y = z = 0;
+		return false;
+	}
+	const int32 *src = _data.begin() + (fi * _vertsPerFrame + vi) * 3;
+	x = src[0];
+	y = src[1];
+	z = src[2];
+	return true;
+}
+
+const int32 *F3dcMouthAnim::frameVertices(uint fi) const {
+	if (fi >= _frameCount)
+		return nullptr;
+	return _data.begin() + fi * _vertsPerFrame * 3;
+}
+
+void F3dcMouthAnim::getBounds(int32 &minX, int32 &minY, int32 &minZ,
+                              int32 &maxX, int32 &maxY, int32 &maxZ) const {
+	if (_data.empty()) {
+		minX = minY = minZ = maxX = maxY = maxZ = 0;
+		return;
+	}
+	minX = minY = minZ =  0x7FFFFFFF;
+	maxX = maxY = maxZ = -0x7FFFFFFF;
+	for (uint i = 0; i < _data.size(); i += 3) {
+		const int32 x = _data[i];
+		const int32 y = _data[i + 1];
+		const int32 z = _data[i + 2];
+		if (x < minX) minX = x;
+		if (x > maxX) maxX = x;
+		if (y < minY) minY = y;
+		if (y > maxY) maxY = y;
+		if (z < minZ) minZ = z;
+		if (z > maxZ) maxZ = z;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// F3dcSmallAnim — `.3DA A` per-bone skeletal animation (subfmt 4).
+// ---------------------------------------------------------------------------
+//
+// See class-level comment in f3dc_parser.h and the project_f3dc_head_sway
+// memory for the architecture overview.  The parser only decodes the
+// file layout; it does NOT interpret the field semantics inside each
+// keyframe (the time-axis convention is still uncertain pending dynamic
+// capture).
+
+F3dcSmallAnim::F3dcSmallAnim() : _boneCount(0) {}
+
+void F3dcSmallAnim::reset() {
+	_boneCount = 0;
+	_curveA.clear();
+	_curveB.clear();
+}
+
+bool F3dcSmallAnim::loadFromStream(Common::SeekableReadStream &s) {
+	reset();
+
+	const int64 fileSize = s.size();
+	if (fileSize < 0x40) {
+		warning("F3dcSmallAnim: file too small (%d bytes)", (int)fileSize);
+		return false;
+	}
+
+	s.seek(0);
+	if (s.readUint32BE() != kF3dcMagic) {
+		warning("F3dcSmallAnim: bad F3DC magic");
+		return false;
+	}
+
+	s.seek(0x10);
+	const uint32 subfmt = s.readUint32LE();
+	if (subfmt != (uint32)kF3dcSubfmtSmallAnim) {
+		warning("F3dcSmallAnim: unsupported subformat %u (need %u)",
+		        subfmt, (uint32)kF3dcSubfmtSmallAnim);
+		return false;
+	}
+
+	s.seek(0x1C);
+	const uint32 nRaw = s.readUint32LE();
+	if (nRaw == 0 || nRaw > 64) {
+		warning("F3dcSmallAnim: implausible bone count %u", nRaw);
+		return false;
+	}
+
+	// Offset table at +0x24.  The last entry is a sentinel (value
+	// 0x1e in every file we've inspected); real bones are 0..nRaw-2.
+	Common::Array<uint32> table;
+	table.resize(nRaw);
+	s.seek(0x24);
+	for (uint i = 0; i < nRaw; i++)
+		table[i] = s.readUint32LE();
+	if (s.err()) {
+		warning("F3dcSmallAnim: short read in offset table");
+		reset();
+		return false;
+	}
+
+	const uint nBones = nRaw - 1;
+	_curveA.resize(nBones);
+	_curveB.resize(nBones);
+
+	for (uint bi = 0; bi < nBones; bi++) {
+		const uint32 hdrOff = 28 + table[bi];
+		if (hdrOff + 20 > (uint32)fileSize) {
+			warning("F3dcSmallAnim: bone[%u] header OOB (off=0x%x)",
+			        bi, hdrOff);
+			reset();
+			return false;
+		}
+		s.seek(hdrOff);
+		(void)s.readUint32LE();                      // +0x00 unused
+		const uint32 countA = s.readUint32LE();       // +0x04
+		const uint32 countB = s.readUint32LE();       // +0x08
+		// +0x0c and +0x10 are ptr_A / ptr_B in file form (= file_off
+		// minus 0x1c).  But x32dbg traces 2026-05-27 confirmed the
+		// TRUE curve_A starts at bone_hdr + 0x14 in BOTH the file and
+		// the runtime image (the engine doesn't transform the layout,
+		// it just relocates the ptr values).  So we read the curves
+		// directly off bone_hdr + 0x14 rather than chasing ptr_A.
+		(void)s.readUint32LE();                      // +0x0c (file ptr_A, ignored)
+		(void)s.readUint32LE();                      // +0x10 (file ptr_B, ignored)
+
+		if (countA == 0 || countA > 256 || countB == 0 || countB > 256) {
+			warning("F3dcSmallAnim: bone[%u] implausible counts A=%u B=%u",
+			        bi, countA, countB);
+			reset();
+			return false;
+		}
+		const uint32 curveAOff = hdrOff + 0x14;
+		const uint32 curveBOff = curveAOff + countA * 20;
+		if (curveAOff + countA * 20 > (uint32)fileSize ||
+		    curveBOff + countB * 16 > (uint32)fileSize) {
+			warning("F3dcSmallAnim: bone[%u] curve OOB "
+			        "(A_off=0x%x A*20=0x%x B_off=0x%x B*16=0x%x file=0x%x)",
+			        bi, curveAOff, countA * 20, curveBOff, countB * 16,
+			        (uint32)fileSize);
+			reset();
+			return false;
+		}
+
+		// curve_A keyframes: each is 20 bytes = (frame_idx, qx, qy, qz, qw)
+		// at offsets (0, 4, 8, 0xc, 0x10).  Q15 quaternion in fields
+		// +4..+0x13.  The engine reads the quaternion starting at +4
+		// (skipping frame_idx) and applies via FUN_0045d128.
+		_curveA[bi].resize(countA * 5);
+		s.seek(curveAOff);
+		for (uint i = 0; i < countA; i++) {
+			_curveA[bi][i*5 + 0] = (int32)s.readUint32LE(); // frame_idx
+			_curveA[bi][i*5 + 1] = (int32)s.readUint32LE(); // qx
+			_curveA[bi][i*5 + 2] = (int32)s.readUint32LE(); // qy
+			_curveA[bi][i*5 + 3] = (int32)s.readUint32LE(); // qz
+			_curveA[bi][i*5 + 4] = (int32)s.readUint32LE(); // qw
+		}
+
+		// curve_B keyframes: each is 16 bytes = (frame_idx, tx, ty, tz).
+		_curveB[bi].resize(countB * 4);
+		s.seek(curveBOff);
+		for (uint i = 0; i < countB; i++) {
+			_curveB[bi][i*4 + 0] = (int32)s.readUint32LE(); // frame_idx
+			_curveB[bi][i*4 + 1] = (int32)s.readUint32LE(); // tx
+			_curveB[bi][i*4 + 2] = (int32)s.readUint32LE(); // ty
+			_curveB[bi][i*4 + 3] = (int32)s.readUint32LE(); // tz
+		}
+	}
+	if (s.err()) {
+		warning("F3dcSmallAnim: short read in bone bodies");
+		reset();
+		return false;
+	}
+
+	_boneCount = nBones;
+	debugC(1, kDebugMesh, "F3dcSmallAnim: loaded %u bones (raw count %u in file)",
+	      _boneCount, nRaw);
+	return true;
+}
+
+uint F3dcSmallAnim::curveACount(uint bi) const {
+	if (bi >= _boneCount)
+		return 0;
+	return _curveA[bi].size() / 5;
+}
+
+uint F3dcSmallAnim::curveBCount(uint bi) const {
+	if (bi >= _boneCount)
+		return 0;
+	return _curveB[bi].size() / 4;
+}
+
+bool F3dcSmallAnim::getCurveA(uint bi, uint i, int32 out[5]) const {
+	if (bi >= _boneCount || i >= curveACount(bi)) {
+		for (uint k = 0; k < 5; k++) out[k] = 0;
+		return false;
+	}
+	const int32 *p = &_curveA[bi][i * 5];
+	for (uint k = 0; k < 5; k++) out[k] = p[k];
+	return true;
+}
+
+bool F3dcSmallAnim::getCurveB(uint bi, uint i, int32 out[4]) const {
+	if (bi >= _boneCount || i >= curveBCount(bi)) {
+		for (uint k = 0; k < 4; k++) out[k] = 0;
+		return false;
+	}
+	const int32 *p = &_curveB[bi][i * 4];
+	for (uint k = 0; k < 4; k++) out[k] = p[k];
+	return true;
+}
+
+// ---------------------------------------------------------------------------
+// F3dcTextureMap — `.3DM` per-character face texture.
+// ---------------------------------------------------------------------------
+
+F3dcTextureMap::F3dcTextureMap() : _loaded(false) {}
+
+void F3dcTextureMap::reset() {
+	_loaded = false;
+	_tex.clear();
+	_shade.clear();
+}
+
+bool F3dcTextureMap::loadFromStream(Common::SeekableReadStream &s) {
+	reset();
+
+	const int64 fileSize = s.size();
+	const uint32 texBytes   = kSize * kSize;             // 0x10000
+	const uint32 shadeCount = kShadeLevels * 256;        // 8192 entries
+	// magic(8) + header(0x14) + shade table(8192*4) + texture(0x10000).
+	const int64 minSize = 8 + 0x14 + (int64)shadeCount * 4 + texBytes;
+	if (fileSize < minSize || fileSize > 0x4000000) {
+		warning("F3dcTextureMap: implausible file size %d", (int)fileSize);
+		return false;
+	}
+
+	s.seek(0);
+	if (s.readUint32BE() != kF3dcMagic) {
+		warning("F3dcTextureMap: bad F3DC magic");
+		return false;
+	}
+
+	// Shade table at file 0x1C: 32*256 records of `00 00 <RGB555 u16>`.
+	_shade.resize(shadeCount);
+	s.seek(0x1C);
+	for (uint32 i = 0; i < shadeCount; i++) {
+		s.readUint16LE();             // the two leading zero bytes
+		_shade[i] = s.readUint16LE();
+	}
+	if (s.err()) {
+		warning("F3dcTextureMap: short read on shade table");
+		reset();
+		return false;
+	}
+
+	// The 256x256 face texture is the trailing 0x10000 bytes.
+	_tex.resize(texBytes);
+	s.seek(fileSize - (int64)texBytes);
+	if (s.read(_tex.begin(), texBytes) != texBytes) {
+		warning("F3dcTextureMap: short read on texture block");
+		reset();
+		return false;
+	}
+
+	_loaded = true;
+	debugC(1, kDebugMesh, "F3dcTextureMap: loaded %ux%u texture + %u-level shade table",
+	      kSize, kSize, kShadeLevels);
+	return true;
+}
+
+void F3dcTextureMap::shadeRGB(byte index, uint shade,
+                              byte &r, byte &g, byte &b) const {
+	// The .3DM shade-table u16 is R5G6B5 — bit 15 (= high R bit) doubles
+	// as the chroma flag; opaque (bit 15 = 0) entries therefore cap R at
+	// 4 bits of saturation.  Verified empirically against the original
+	// engine 2026-05-24 by patching BAD10000.3DM with known colours and
+	// observing the displayed result (see memory `f3dc-colour-format`).
+	const uint16 c  = _shade[(shade % kShadeLevels) * 256 + index];
+	const byte   r5 = (c >> 11) & 31;       // R: 5 bits (high bit is the chroma flag)
+	const byte   g6 = (c >>  5) & 63;       // G: 6 bits
+	const byte   b5 =  c        & 31;       // B: 5 bits
+	// Bit-fan to 8 bpc.
+	r = (byte)((r5 << 3) | (r5 >> 2));
+	g = (byte)((g6 << 2) | (g6 >> 4));
+	b = (byte)((b5 << 3) | (b5 >> 2));
+}
+
+// ---------------------------------------------------------------------------
+// F3dcMesh — FILE_S3D scene-graph mesh (foundation only, triangle-pool
+// walker TBD).
+// ---------------------------------------------------------------------------
+
+// "FILE_S3D" first 4 bytes (BE): 'F','I','L','E' = 0x46494C45.
+static const uint32 kS3dMagicHi = MKTAG('F', 'I', 'L', 'E');
+// Second 4 bytes: '_','S','3','D' = 0x5F533344.
+static const uint32 kS3dMagicLo = MKTAG('_', 'S', '3', 'D');
+
+F3dcMesh::F3dcMesh() : _loaded(false), _countA(0) {
+	for (uint i = 0; i < 4; i++) _rootOff[i] = 0;
+	for (uint i = 0; i < 4; i++) {
+		_camPresent[i] = false;
+		for (uint j = 0; j < 8; j++) _camTransform[i][j] = 0.0;
+	}
+}
+
+void F3dcMesh::reset() {
+	_loaded = false;
+	_countA = 0;
+	for (uint i = 0; i < 4; i++) _rootOff[i] = 0;
+	for (uint i = 0; i < 4; i++) {
+		_camPresent[i] = false;
+		for (uint j = 0; j < 8; j++) _camTransform[i][j] = 0.0;
+	}
+}
+
+bool F3dcMesh::getCamTransform(int camNum, double out[8]) const {
+	if (camNum < 2 || camNum > 5)
+		return false;
+	const int idx = camNum - 2;
+	if (!_camPresent[idx]) {
+		for (uint i = 0; i < 8; i++) out[i] = 0.0;
+		return false;
+	}
+	for (uint i = 0; i < 8; i++) out[i] = _camTransform[idx][i];
+	return true;
+}
+
+bool F3dcMesh::loadFromStream(Common::SeekableReadStream &s) {
+	reset();
+	const int64 fileSize = s.size();
+	// Header (48 bytes) + at minimum some character-specific body.
+	if (fileSize < 0x180) {
+		warning("F3dcMesh: file too small (%d bytes)", (int)fileSize);
+		return false;
+	}
+
+	s.seek(0);
+	if (s.readUint32BE() != kS3dMagicHi || s.readUint32BE() != kS3dMagicLo) {
+		warning("F3dcMesh: bad FILE_S3D magic");
+		return false;
+	}
+
+	s.seek(0x10);
+	const uint32 subfmt = s.readUint32LE();
+	if (subfmt != (uint32)kF3dcSubfmtMesh) {
+		warning("F3dcMesh: unsupported subformat %u (need %u)",
+		        subfmt, (uint32)kF3dcSubfmtMesh);
+		return false;
+	}
+
+	s.seek(0x14);
+	_countA = s.readUint32LE();
+	// All shipped meshes have countA = 14.  Cap at 256 to flag corruption.
+	if (_countA == 0 || _countA > 256) {
+		warning("F3dcMesh: implausible countA %u", _countA);
+		reset();
+		return false;
+	}
+
+	s.seek(0x1C);
+	const uint32 relocCount = s.readUint32LE();
+	if (relocCount != 4) {
+		warning("F3dcMesh: unexpected reloc count %u (need 4)", relocCount);
+		reset();
+		return false;
+	}
+
+	// File-offset form of each root: (28 + raw_delta).  In-memory, the
+	// runtime relocates by adding the loaded buffer base; for our
+	// disk-driven parser we just store the file offsets so callers can
+	// seek directly to the sub-structures.
+	s.seek(0x20);
+	for (uint i = 0; i < 4; i++) {
+		const uint32 delta = s.readUint32LE();
+		_rootOff[i] = 28 + delta;
+	}
+	if (s.err()) {
+		warning("F3dcMesh: short read in reloc table");
+		reset();
+		return false;
+	}
+
+	// Scan the file tail for the four CAMn records.  Each tag ("CAM2"
+	// through "CAM5") sits at variable file offsets (not 8-aligned, not
+	// at a fixed stride — the layout has 2-byte alignment quirks
+	// between records).  For each tag found, read the 64 bytes
+	// IMMEDIATELY BEFORE the tag as 8 little-endian doubles, which the
+	// original engine treats as the projection transform for that cam.
+	// Reads directly from the input stream; no buffering or auxiliary
+	// allocation needed (.S3D files are tiny — <2 KB).
+	{
+		const int64 fileBytes = s.size();
+		for (int64 i = 64; i + 4 <= fileBytes; i++) {
+			if (!s.seek(i)) break;
+			byte tag[4];
+			if (s.read(tag, 4) != 4) break;
+			if (tag[0] != 'C' || tag[1] != 'A' || tag[2] != 'M')
+				continue;
+			if (tag[3] < '2' || tag[3] > '5')
+				continue;
+			const uint idx = (uint)(tag[3] - '2');
+			if (!s.seek(i - 64))
+				continue;
+			for (uint j = 0; j < 8; j++)
+				_camTransform[idx][j] = s.readDoubleLE();
+			if (s.err()) {
+				s.clearErr();
+				continue;
+			}
+			_camPresent[idx] = true;
+			// Skip past the tag so we don't re-match its bytes.
+			i += 3;
+		}
+		s.clearErr();
+	}
+
+	_loaded = true;
+	debugC(1, kDebugMesh, "F3dcMesh: loaded (countA=%u, roots: 0x%x 0x%x 0x%x 0x%x; "
+	      "cams: %d %d %d %d)",
+	      _countA, _rootOff[0], _rootOff[1], _rootOff[2], _rootOff[3],
+	      _camPresent[0] ? 1 : 0, _camPresent[1] ? 1 : 0,
+	      _camPresent[2] ? 1 : 0, _camPresent[3] ? 1 : 0);
+	return true;
+}
+
+void F3dcMesh::getRootFileOffsets(uint32 out[4]) const {
+	for (uint i = 0; i < 4; i++)
+		out[i] = _rootOff[i];
+}
+
+// ---------------------------------------------------------------------------
+// F3dcMouthMesh — dialog mouth mesh (verts + triangle topology) from a .3DC.
+// ---------------------------------------------------------------------------
+
+// Cam-offset chain-walk mode.  Default is `compose` -- ALWAYS compose
+// the chain-node rotations into the offset, regardless of fvi+0x28's
+// value.  This was confirmed by side-by-side testing 2026-05-27:
+// `compose` produces visually-correct meshes for Passant cam3/4/5 +
+// BadPan/Garde/Hero/Seth on chapter 1.  The previous `compose-iff-fvi-
+// near-identity` classifier flipped to `sum` per-frame when the .3DA-A
+// overwrote Passant's fvi+0x28 with a 90 deg quaternion, causing a
+// visible mesh jump.
+//
+// (Passant cam2 still misrenders -- different bug, see project memory.)
+
+// Walk the .3DC scene-graph chain from the fvi mouth node up to the skeleton
+// root and compose the node transforms to obtain the fvi node's world
+// position.  The dialog camera offset is O = -(that world position).
+//
+// Each scene-graph node has, relative to its 4..N-byte ASCII name:
+//   +0x10  uint32  parent link   (parent node = link + bodySize)
+//   +0x1C  int32x3 local position
+//   +0x28  int32x9 local rotation, row-major, fixed-point /32768
+// The root node has link == 0.  `bodySize` is a per-file constant; it is
+// auto-detected as the value that yields a valid terminating node chain.
+static bool f3dcComputeCamOffset(const byte *d, uint32 sz, uint32 fvi,
+                                 double out[3], double rotOut[9]) {
+	#define RDS(off) ((int32)((uint32)d[(off)] | ((uint32)d[(off)+1] << 8) | \
+	                  ((uint32)d[(off)+2] << 16) | ((uint32)d[(off)+3] << 24)))
+	for (uint32 bs = 0x60; bs <= 0x200; bs++) {
+		uint32 chain[16];
+		uint32 nNodes = 0;
+		uint32 node = fvi;
+		bool ok = false;
+		for (uint32 hop = 0; hop < 16; hop++) {
+			if (node + 0x4C > sz)
+				break;
+			const byte c0 = d[node];
+			if (!((c0 >= 'A' && c0 <= 'Z') || (c0 >= 'a' && c0 <= 'z')))
+				break;
+			chain[nNodes++] = node;
+			const uint32 link = (uint32)RDS(node + 0x10);
+			if (link == 0) { ok = true; break; }
+			node = link + bs;
+		}
+		// The root must sit near the file start (right after the header).
+		if (!ok || nNodes < 2 || chain[nNodes - 1] >= 0x1000)
+			continue;
+		// Compose root -> fvi.  The chain-node rotations are always folded
+		// into the offset (see the design note above); this `compose` path
+		// is the exe-faithful one, confirmed by side-by-side testing.
+		double wpos[3] = { 0.0, 0.0, 0.0 };
+		double wrot[9] = { 1, 0, 0, 0, 1, 0, 0, 0, 1 };
+		for (int i = (int)nNodes - 1; i >= 0; i--) {
+			const uint32 n = chain[i];
+			const double lp[3] = { (double)RDS(n + 0x1C),
+			                       (double)RDS(n + 0x20),
+			                       (double)RDS(n + 0x24) };
+			double lr[9];
+			for (int k = 0; k < 9; k++)
+				lr[k] = (double)RDS(n + 0x28 + k * 4) / 32768.0;
+			// worldPos += worldRot * localPos
+			for (int r = 0; r < 3; r++)
+				wpos[r] += wrot[r*3+0]*lp[0] +
+				           wrot[r*3+1]*lp[1] +
+				           wrot[r*3+2]*lp[2];
+			// worldRot = worldRot * transpose(localRot)
+			double nr[9];
+			for (int r = 0; r < 3; r++)
+				for (int c = 0; c < 3; c++)
+					nr[r*3+c] = wrot[r*3+0]*lr[c*3+0] +
+					            wrot[r*3+1]*lr[c*3+1] +
+					            wrot[r*3+2]*lr[c*3+2];
+			for (int k = 0; k < 9; k++)
+				wrot[k] = nr[k];
+		}
+		out[0] = -wpos[0]; out[1] = -wpos[1]; out[2] = -wpos[2];
+		for (int k = 0; k < 9; k++)
+			rotOut[k] = wrot[k];
+		return true;
+	}
+	#undef RDS
+	return false;
+}
+
+static void f3dcIdentity9(double m[9]) {
+	m[0]=1; m[1]=0; m[2]=0; m[3]=0; m[4]=1; m[5]=0; m[6]=0; m[7]=0; m[8]=1;
+}
+
+F3dcMouthMesh::F3dcMouthMesh() : _loaded(false), _hasOffset(false),
+	_hasUV(false) {
+	_offsetO[0] = _offsetO[1] = _offsetO[2] = 0.0;
+	f3dcIdentity9(_chainRot);
+}
+
+void F3dcMouthMesh::reset() {
+	_loaded = false;
+	_hasOffset = false;
+	_hasUV = false;
+	_offsetO[0] = _offsetO[1] = _offsetO[2] = 0.0;
+	f3dcIdentity9(_chainRot);
+	_verts.clear();
+	_tris.clear();
+	_uvs.clear();
+	_texMapCandidates.clear();
+	_boneNodeOff.clear();
+	_bytes.clear();
+	_fviOff = 0;
+}
+
+bool F3dcMouthMesh::loadFromStream(Common::SeekableReadStream &s) {
+	reset();
+
+	const int64 fileSize = s.size();
+	if (fileSize < 0x100 || fileSize > 0x4000000) {
+		warning("F3dcMouthMesh: implausible file size %d", (int)fileSize);
+		return false;
+	}
+
+	// Slurp the whole file — the format needs random access and these
+	// body files are small (under 256 KB).  Kept as a member so
+	// computeCamOffsetForFrame can re-walk the scene-graph chain with
+	// mutated bone transforms each UBB frame.
+	_bytes.resize((uint)fileSize);
+	s.seek(0);
+	if (s.read(_bytes.begin(), (uint32)fileSize) != (uint32)fileSize) {
+		warning("F3dcMouthMesh: short read");
+		return false;
+	}
+	const byte *d = _bytes.begin();
+	const uint32 sz = (uint32)fileSize;
+
+	// Little-endian readers with bounds checks.
+	#define RD_U32(off) ((uint32)d[(off)] | ((uint32)d[(off)+1] << 8) | \
+	                     ((uint32)d[(off)+2] << 16) | ((uint32)d[(off)+3] << 24))
+
+	// 1. Locate the "fvi\0" scene-graph node.
+	uint32 fvi = 0;
+	bool fviFound = false;
+	for (uint32 i = 0; i + 4 <= sz; i++) {
+		if (d[i] == 'f' && d[i+1] == 'v' && d[i+2] == 'i' && d[i+3] == 0) {
+			fvi = i;
+			fviFound = true;
+			break;
+		}
+	}
+	if (!fviFound || fvi + 0xD4 > sz) {
+		warning("F3dcMouthMesh: no fvi node");
+		return false;
+	}
+	_fviOff = fvi;
+
+	// Read the reloc table at +0x20.  x32dbg traces 2026-05-27 confirmed
+	// the engine iterates ALL reloc roots (Bass, Abdo, ..., fvi) and
+	// pairs each with a .3DA-A bone via curve_B rec[0] translation
+	// match (the .3DA-A bone whose first-frame translation equals the
+	// scene-graph node's rest position drives that node).
+	{
+		const uint32 relocCount = RD_U32(0x1C);
+		if (relocCount > 0 && relocCount < 32 &&
+		    0x20 + (uint64)relocCount * 4 <= sz) {
+			for (uint32 i = 0; i < relocCount; i++) {
+				const uint32 delta = RD_U32(0x20 + i * 4);
+				const uint32 off = 28 + delta;
+				if (off + 0x4C > sz) {
+					_boneNodeOff.clear();
+					warning("F3dcMouthMesh: reloc root[%u] OOB (off=0x%x)",
+					        i, off);
+					break;
+				}
+				// Sanity-check that the offset points to a named node
+				// (first byte must be a letter).
+				const byte c0 = d[off];
+				if (!((c0 >= 'A' && c0 <= 'Z') || (c0 >= 'a' && c0 <= 'z'))) {
+					_boneNodeOff.clear();
+					warning("F3dcMouthMesh: reloc root[%u] doesn't start "
+					        "with a letter (got 0x%02x)", i, c0);
+					break;
+				}
+				_boneNodeOff.push_back(off);
+			}
+			debugC(1, kDebugMesh, "F3dcMouthMesh: %u scene-graph root nodes",
+			      _boneNodeOff.size());
+		}
+	}
+
+	// Per-character dialog camera offset O + chain rotation, from the
+	// scene-graph chain.
+	_hasOffset = f3dcComputeCamOffset(d, sz, fvi, _offsetO, _chainRot);
+	if (_hasOffset)
+		debugC(1, kDebugMesh, "F3dcMouthMesh: cam offset O = (%.0f, %.0f, %.0f)",
+		      _offsetO[0], _offsetO[1], _offsetO[2]);
+	else
+		warning("F3dcMouthMesh: scene-graph chain not decoded");
+
+	// 2. Vertex pool — 40-byte records at fvi+0xD4, count at fvi+0x7C.
+	const uint32 vcount = RD_U32(fvi + 0x7C);
+	const uint32 p1ref  = RD_U32(fvi + 0x80);   // vertex-index base ref
+	const uint32 vbase  = fvi + 0xD4;
+	if (vcount == 0 || vcount > 4096 ||
+	    vbase + (uint64)vcount * 40 > sz) {
+		warning("F3dcMouthMesh: bad vertex pool (count=%u)", vcount);
+		return false;
+	}
+	_verts.resize(vcount * 3);
+	for (uint32 i = 0; i < vcount; i++) {
+		// XYZ is at the very start of each 40-byte record (the runtime
+		// form has a 4-byte link word ahead of XYZ; the on-disk form
+		// does not).
+		const uint32 o = vbase + i * 40;
+		_verts[i*3+0] = (int32)RD_U32(o);
+		_verts[i*3+1] = (int32)RD_U32(o + 4);
+		_verts[i*3+2] = (int32)RD_U32(o + 8);
+	}
+
+	// 3. Triangle count — pool-3 (face-normal) count at fvi+0x94.
+	const uint32 tcount = RD_U32(fvi + 0x94);
+	if (tcount == 0 || tcount > 8192) {
+		warning("F3dcMouthMesh: bad triangle count %u", tcount);
+		reset();
+		return false;
+	}
+
+	// 4. Locate the 64-byte triangle-struct array: the first file offset
+	//    where `tcount` consecutive 64-byte structs all decode to valid
+	//    vertex indices via (ref - p1ref) / 40.  Spot-check the first 40
+	//    structs to find the start, then accept.
+	const uint32 stride = 64;
+	const uint64 span = (uint64)tcount * stride;
+	if (span > sz) {
+		warning("F3dcMouthMesh: triangle span exceeds file");
+		reset();
+		return false;
+	}
+	// A struct decodes cleanly when each of its three vertex references
+	// (+0x08, +0x14, +0x20) maps to an in-range vertex index.
+	// The check is a macro-free lambda-style helper inlined below.
+	uint32 arr = 0;
+	bool arrFound = false;
+	const uint32 lastStart = sz - (uint32)span;
+	for (uint32 start = 0; start <= lastStart; start += 4) {
+		bool ok = true;
+		const uint32 probe = (tcount < 40) ? tcount : 40;
+		for (uint32 k = 0; k < probe && ok; k++) {
+			const uint32 o = start + k * stride;
+			for (uint f = 0; f < 3; f++) {
+				static const uint kFieldOff[3] = { 0x08, 0x14, 0x20 };
+				const uint32 ref = RD_U32(o + kFieldOff[f]);
+				if (ref < p1ref) { ok = false; break; }
+				const uint32 delta = ref - p1ref;
+				if ((delta % 40) != 0 || (delta / 40) >= vcount) {
+					ok = false;
+					break;
+				}
+			}
+		}
+		if (ok) {
+			arr = start;
+			arrFound = true;
+			break;
+		}
+	}
+	if (!arrFound) {
+		warning("F3dcMouthMesh: triangle struct array not found");
+		reset();
+		return false;
+	}
+
+	// 5. Extract triangle vertex indices, skipping chroma-key triangles.
+	//
+	//    The 64-byte triangle struct's first byte is a render-type flags
+	//    field consumed by atlantis.exe FUN_00456d88 (the triangle setup
+	//    that builds edge records for the deferred span rasteriser):
+	//
+	//        if ((*tri & 1) == 0) {            // bit 0 set  -> skip entirely
+	//            if ((*tri & 2) == 0) {        // bit 1 set  -> partial only,
+	//                ... full setup ...        //               no edge build
+	//            }
+	//        }
+	//
+	//    Triangles with bit 0 or bit 1 set never reach the rasteriser in
+	//    the original engine, even though they have valid vertex/UV refs.
+	//    Empirically these are the chroma-key triangles — the mesh covers
+	//    the entire facial silhouette but only the bare-skin triangles are
+	//    drawn; everything else (the head outline, eyes, hair, …) is left
+	//    transparent so the UBB shows through.  Including them in our
+	//    render produced the "green patches" artifact (e.g. BadPan eye
+	//    region) and the seemingly-saturated edges.  Verified dynamically
+	//    against atlantis.exe (x32dbg, 2026-05-23).
+	Common::Array<bool> triKeep;
+	triKeep.resize(tcount);
+	uint32 keptCount = 0;
+	for (uint32 k = 0; k < tcount; k++) {
+		const byte flags = d[arr + k * stride];
+		triKeep[k] = ((flags & 3) == 0);
+		if (triKeep[k])
+			keptCount++;
+	}
+	_tris.resize(keptCount * 3);
+	uint32 dstIdx = 0;
+	for (uint32 k = 0; k < tcount; k++) {
+		if (!triKeep[k])
+			continue;
+		const uint32 o = arr + k * stride;
+		static const uint kFieldOff[3] = { 0x08, 0x14, 0x20 };
+		for (uint f = 0; f < 3; f++) {
+			const uint32 idx = (RD_U32(o + kFieldOff[f]) - p1ref) / 40;
+			_tris[dstIdx*3+f] = (uint16)idx;
+		}
+		dstIdx++;
+	}
+	debugC(1, kDebugMesh, "F3dcMouthMesh: %u/%u triangles kept (%u chroma-key skipped)",
+	      keptCount, tcount, tcount - keptCount);
+
+	// 6. Scrape candidate `.3DM` texture-map basenames from the .3DC header
+	//    (a short word string after the `pA<material>` entries — e.g.
+	//    "bad10000", "gard", "facer").  The caller resolves them against
+	//    DIALOG\MAPS\<name>.3DM.
+	{
+		const uint32 scanEnd = (sz < 0x200) ? sz : 0x200;
+		Common::String cur;
+		for (uint32 i = 0x20; i <= scanEnd; i++) {
+			const byte c = (i < scanEnd) ? d[i] : 0;
+			const bool word = (c >= 'A' && c <= 'Z') ||
+			                  (c >= 'a' && c <= 'z') ||
+			                  (c >= '0' && c <= '9') || c == '_';
+			if (word) {
+				cur += (char)c;
+			} else {
+				if (cur.size() >= 3 && cur.size() <= 12 &&
+				    !cur.equalsIgnoreCase("DEFAULT") &&
+				    !cur.equalsIgnoreCase("WIRE") &&
+				    !((cur[0] == 'p' || cur[0] == 'P') &&
+				      (cur[1] == 'A' || cur[1] == 'a')))
+					_texMapCandidates.push_back(cur);
+				cur.clear();
+			}
+		}
+	}
+
+	// 7. Per-triangle texture coordinates.  The UV pool sits immediately
+	//    after the vertex pool — vertex records are 40 bytes starting at
+	//    fvi+0xD0, so the UVs begin at fvi+0xD0+vcount*40.  Each UV record
+	//    is 8 bytes = (int32 U, int32 V) in 16.16 fixed-point texel coords.
+	//    The triangle struct's +0x34/+0x38/+0x3C fields are UV references
+	//    parallel to the +0x08/+0x14/+0x20 vertex refs; the UV index is
+	//    (ref - poolhead2) / 8 with poolhead2 read from fvi+0x88.
+	{
+		const uint32 poolhead2 = RD_U32(fvi + 0x88);
+		const uint32 uvbase    = fvi + 0xD0 + vcount * 40;
+		static const uint kUvFieldOff[3] = { 0x34, 0x38, 0x3C };
+		// UVs follow the kept-triangle order so _uvs[i] aligns with _tris[i].
+		_uvs.resize(keptCount * 3 * 2);
+		const int32 kLim = 256 << 16;
+		uint32 nValid = 0;
+		bool ok = (uvbase < sz);
+		uint32 uvDst = 0;
+		for (uint32 k = 0; k < tcount && ok; k++) {
+			if (!triKeep[k])
+				continue;
+			const uint32 o = arr + k * stride;
+			for (uint f = 0; f < 3; f++) {
+				const uint32 ref = RD_U32(o + kUvFieldOff[f]);
+				int32 u = 0, v = 0;
+				if (ref >= poolhead2 && ((ref - poolhead2) % 8) == 0) {
+					const uint32 uo = uvbase + (ref - poolhead2);
+					if (uo + 8 <= sz) {
+						u = (int32)RD_U32(uo);
+						v = (int32)RD_U32(uo + 4);
+						if (u >= 0 && u < kLim && v >= 0 && v < kLim)
+							nValid++;
+					}
+				}
+				_uvs[(uvDst*3+f)*2+0] = u;
+				_uvs[(uvDst*3+f)*2+1] = v;
+			}
+			uvDst++;
+		}
+		// Accept the UV set only when nearly every coordinate landed inside
+		// the texture — a wrong pool base scrambles them out of range.
+		_hasUV = ok && keptCount > 0 &&
+		         nValid >= (keptCount * 3) * 99 / 100;
+		if (!_hasUV)
+			_uvs.clear();
+		debugC(1, kDebugMesh, "F3dcMouthMesh: UV pool @ 0x%x, %u/%u in range -> %s",
+		      uvbase, nValid, keptCount * 3, _hasUV ? "textured" : "no UVs");
+	}
+
+	#undef RD_U32
+
+	_loaded = true;
+	debugC(1, kDebugMesh, "F3dcMouthMesh: loaded %u verts, %u/%u triangles drawable "
+	      "(fvi @ 0x%x, tris @ 0x%x)",
+	      vcount, keptCount, tcount, fvi, arr);
+	return true;
+}
+
+// Standard quaternion (qx, qy, qz, qw) -> 3x3 rotation matrix, with all
+// inputs and outputs in Q15 fixed-point (0x8000 = 1.0).  Mirrors the
+// original engine's FUN_0045d128 (atlantis.exe.c:54979) bit-for-bit.
+static void f3dcQuatToMat3Q15(int32 qx, int32 qy, int32 qz, int32 qw,
+                              int32 m[9]) {
+	const int32 xx = qx * qx;
+	const int32 yy = qy * qy;
+	const int32 zz = qz * qz;
+	m[0] = 0x8000 - ((yy + zz) >> 14);
+	m[4] = 0x8000 - ((xx + zz) >> 14);
+	m[8] = 0x8000 - ((xx + yy) >> 14);
+	const int32 xy = qx * qy;
+	const int32 wz = qw * qz;
+	m[1] = (xy - wz) >> 14;
+	m[3] = (xy + wz) >> 14;
+	const int32 xz = qx * qz;
+	const int32 wy = qw * qy;
+	m[2] = (xz + wy) >> 14;
+	m[6] = (xz - wy) >> 14;
+	const int32 yz = qy * qz;
+	const int32 wx = qw * qx;
+	m[5] = (yz - wx) >> 14;
+	m[7] = (yz + wx) >> 14;
+}
+
+// Little-endian 32-bit store.
+static void f3dcWriteI32LE(byte *p, int32 v) {
+	p[0] = (byte) (v        & 0xFF);
+	p[1] = (byte)((v >>  8) & 0xFF);
+	p[2] = (byte)((v >> 16) & 0xFF);
+	p[3] = (byte)((v >> 24) & 0xFF);
+}
+
+// Little-endian 32-bit signed load.
+static int32 f3dcReadI32LE(const byte *p) {
+	return (int32)((uint32)p[0] | ((uint32)p[1] << 8) |
+	               ((uint32)p[2] << 16) | ((uint32)p[3] << 24));
+}
+
+bool F3dcMouthMesh::computeCamOffsetForFrame(uint frame,
+                                             const F3dcSmallAnim &anim,
+                                             double O[3], double rot[9]) const {
+	if (!_loaded || _bytes.empty() || !anim.isLoaded() || _fviOff == 0)
+		return false;
+
+	// Copy the .3DC bytes so we can mutate without disturbing _bytes.
+	Common::Array<byte> tmp;
+	tmp.resize(_bytes.size());
+	memcpy(tmp.begin(), _bytes.begin(), _bytes.size());
+
+	// Engine-faithful model (verified 2026-05-27 via x32dbg).
+	//
+	// The engine iterates ALL 8 scene-graph roots and pairs each with
+	// a .3DA-A bone via the "curve_B rec[0] translation matches the
+	// scene-graph node's rest position" rule.  For each (scene_root,
+	// bone) pair, the engine writes:
+	//   - bone+0x28..0x4F: 3x3 matrix derived from curve_A[N].quat
+	//                       (where N = cur_frame_idx mod count_A).
+	//   - bone+0x1C..0x27: 3 ints from curve_B[N].(tx,ty,tz).
+	// The matrix is the raw quat-to-matrix conversion (no delta-from-
+	// rec[0], no conjugation): the engine uses curve_A's stored
+	// quaternion ABSOLUTELY -- it IS the bone's local-to-parent
+	// rotation at frame N.
+	//
+	// Build the bone-to-scene-graph mapping by translation match.
+	// For each .3DA-A bone bi, find the scene-graph root whose rest
+	// position equals curve_B rec[0] (tx, ty, tz).  Tolerance is set
+	// to 0 since these are exact int32 matches per x32dbg.
+
+	const uint nBones = anim.boneCount();
+	const uint nNodes = boneNodeCount();
+
+	// boneToNode[bi] = scene-graph node index, or (uint)-1 if no match.
+	Common::Array<uint> boneToNode;
+	boneToNode.resize(nBones);
+	for (uint bi = 0; bi < nBones; bi++)
+		boneToNode[bi] = (uint)-1;
+
+	for (uint bi = 0; bi < nBones; bi++) {
+		if (anim.curveBCount(bi) < 1)
+			continue;
+		int32 kf0[4];
+		if (!anim.getCurveB(bi, 0, kf0))
+			continue;
+		const int32 tx = kf0[1], ty = kf0[2], tz = kf0[3];
+		for (uint ni = 0; ni < nNodes; ni++) {
+			const uint32 nodeOff = _boneNodeOff[ni];
+			if (nodeOff + 0x28 > tmp.size())
+				continue;
+			const int32 rx = f3dcReadI32LE(tmp.begin() + nodeOff + 0x1C);
+			const int32 ry = f3dcReadI32LE(tmp.begin() + nodeOff + 0x20);
+			const int32 rz = f3dcReadI32LE(tmp.begin() + nodeOff + 0x24);
+			if (rx == tx && ry == ty && rz == tz) {
+				boneToNode[bi] = ni;
+				break;
+			}
+		}
+	}
+
+	// Apply each animated bone's pose at frame N to its scene-graph node.
+	// curve_A keyframe layout (file = runtime, 20 bytes):
+	//   +0x00 (idx 0): frame_idx (unused by the engine; just a counter)
+	//   +0x04 (idx 1): qx (Q15)
+	//   +0x08 (idx 2): qy
+	//   +0x0C (idx 3): qz
+	//   +0x10 (idx 4): qw
+	// curve_B keyframe layout (16 bytes):
+	//   +0x00 (idx 0): frame_idx
+	//   +0x04 (idx 1): tx
+	//   +0x08 (idx 2): ty
+	//   +0x0C (idx 3): tz
+	// The engine indexes by cur_frame_idx directly (0..count-1).
+	for (uint bi = 0; bi < nBones; bi++) {
+		const uint ni = boneToNode[bi];
+		if (ni == (uint)-1)
+			continue;
+		const uint32 nodeOff = _boneNodeOff[ni];
+		if (nodeOff + 0x4C > tmp.size())
+			continue;
+
+		// --- Curve A: write rotation matrix from quaternion at frame N ---
+		// Note: our chain walker (f3dcComputeCamOffset) uses
+		// `wrot * transpose(localRot)`, so the effective rotation
+		// applied to the chain is the inverse of what we store.  To
+		// make the chain apply matrix(quat) (the engine's intent), we
+		// store matrix(conj(quat)) = transpose(matrix(quat)).
+		const uint cA = anim.curveACount(bi);
+		if (cA > 0) {
+			const uint kIdx = frame % cA;
+			int32 kf[5];
+			anim.getCurveA(bi, kIdx, kf);
+			const int32 qx = kf[1];
+			const int32 qy = kf[2];
+			const int32 qz = kf[3];
+			const int32 qw = kf[4];
+			int32 mat[9];
+			f3dcQuatToMat3Q15(-qx, -qy, -qz, qw, mat);
+			for (int j = 0; j < 9; j++)
+				f3dcWriteI32LE(tmp.begin() + nodeOff + 0x28 + j * 4, mat[j]);
+		}
+
+		// --- Curve B: write translation at frame N ---
+		const uint cB = anim.curveBCount(bi);
+		if (cB > 0) {
+			const uint kIdx = frame % cB;
+			int32 kf[4];
+			anim.getCurveB(bi, kIdx, kf);
+			f3dcWriteI32LE(tmp.begin() + nodeOff + 0x1C, kf[1]);
+			f3dcWriteI32LE(tmp.begin() + nodeOff + 0x20, kf[2]);
+			f3dcWriteI32LE(tmp.begin() + nodeOff + 0x24, kf[3]);
+		}
+	}
+
+	// Re-run the standard chain walk with the mutated bone transforms.
+	return f3dcComputeCamOffset(tmp.begin(), (uint32)tmp.size(),
+	                            _fviOff, O, rot);
+}
+
+
+bool F3dcMouthMesh::getVertex(uint vi, int32 &x, int32 &y, int32 &z) const {
+	if (vi * 3 + 2 >= _verts.size()) {
+		x = y = z = 0;
+		return false;
+	}
+	x = _verts[vi*3+0];
+	y = _verts[vi*3+1];
+	z = _verts[vi*3+2];
+	return true;
+}
+
+bool F3dcMouthMesh::getTriangle(uint ti, uint &v0, uint &v1, uint &v2) const {
+	if (ti * 3 + 2 >= _tris.size()) {
+		v0 = v1 = v2 = 0;
+		return false;
+	}
+	v0 = _tris[ti*3+0];
+	v1 = _tris[ti*3+1];
+	v2 = _tris[ti*3+2];
+	return true;
+}
+
+bool F3dcMouthMesh::getTriangleUV(uint ti, uint corner,
+                                  int32 &u, int32 &v) const {
+	if (!_hasUV || corner > 2 || (ti * 3 + corner) * 2 + 1 >= _uvs.size()) {
+		u = v = 0;
+		return false;
+	}
+	u = _uvs[(ti*3+corner)*2+0];
+	v = _uvs[(ti*3+corner)*2+1];
+	return true;
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/f3dc_parser.h
+++ b/engines/cryomni3d/atlantis/f3dc_parser.h
@@ -1,0 +1,439 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CRYOMNI3D_ATLANTIS_F3DC_PARSER_H
+#define CRYOMNI3D_ATLANTIS_F3DC_PARSER_H
+
+#include "common/array.h"
+#include "common/stream.h"
+#include "common/str.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// Subformat tag at on-disk file offset 0x10 (= buffer offset 8 after
+// the loader strips the 8-byte magic + class id prefix).  Dispatched by
+// the original engine's FUN_0044b77c at atlantis.exe.c:44723.
+enum F3dcSubFormat {
+	kF3dcSubfmtMesh      = 1,  // .S3D mesh topology, .3DC body anim — scene graph
+	kF3dcSubfmtMouthAnim = 2,  // .3DA "M" — per-frame full-mesh vertex animation
+	kF3dcSubfmtSmallAnim = 4   // .3DA "A" — small / skeleton animation
+};
+
+// Loads a Cryo `.S3D` mesh topology file (DIALOG\PERSO\<name>.S3D) and
+// exposes its 4 fixed-position relocation roots.  These point into the
+// per-character body of the file:
+//
+//   root[0] (~file 0x180) → scene-graph node table — pairs of uint32
+//                            (value, code), terminated by (-1, -1).
+//                            Tentatively interpreted as a tree of
+//                            triangle pools (see project_f3dc_format).
+//   root[1] (~file 0x408) → bone/joint index array (uint32[N]),
+//                            followed by float64 bind-pose transforms.
+//   root[2] (~file 0x40C) → root[1] + 4 bytes (overlapping slice of
+//                            the same bone array, skipping the first).
+//   root[3] (~file 0x01C) → sentinel pointing back into the header.
+//
+// This minimal class only handles the FILE_S3D header and the 4-entry
+// relocation table; the triangle-pool walker is the next implementation
+// pass.  It serves as a foundation for that work and lets callers query
+// "is this mesh known to be supported by the parser" before bothering
+// to load it.
+class F3dcMesh {
+public:
+	F3dcMesh();
+
+	// Parse `stream` (caller-owned).  Returns true on success.
+	bool loadFromStream(Common::SeekableReadStream &stream);
+
+	void reset();
+
+	bool isLoaded() const { return _loaded; }
+
+	// Field at file 0x14, present in every .S3D shipped so far.  Always
+	// equals the matching `.3DA` mouth frame count (14 for the standard
+	// characters), so this is probably the per-mesh max frame index.
+	uint headerCountA() const { return _countA; }
+
+	// 4-entry relocation table from file 0x20..0x2F (post-strip of the
+	// 8-byte magic these stay at the same file offsets).  Returned as
+	// FILE offsets, not in-memory pointers — useful for follow-up reads.
+	void getRootFileOffsets(uint32 out[4]) const;
+
+	// Camera projection transforms (CAM2..CAM5) extracted from the tail
+	// of the .S3D file.  Each cam record contains 8 float64 LE values
+	// followed by a 4-byte ASCII tag "CAMn" and trailing zero padding;
+	// the doubles are the transform components the original engine uses
+	// to project per-frame .3DA M vertices to screen space.
+	//
+	// Exact interpretation of the 8 doubles is TBD — candidates (tested
+	// in playSingleConLine) include 6-DOF + FOV pair, quaternion +
+	// translation + FOV, and 2D affine projection.  Returns false when
+	// camNum is out of [2..5] or the cam's record wasn't found.
+	bool getCamTransform(int camNum, double out[8]) const;
+
+private:
+	bool   _loaded;
+	uint32 _countA;
+	uint32 _rootOff[4];
+
+	// Cam transforms, indexed by camNum-2 (so [0] = CAM2, [3] = CAM5).
+	bool   _camPresent[4];
+	double _camTransform[4][8];
+};
+
+// Loads a Cryo F3DC ".3DA M" mouth vertex animation file
+// (DIALOG\PERSO\<base>M.3DA).  After loadFromStream() the per-frame
+// vertex positions are accessible via getVertex() / frameVertices().
+//
+// On-disk format (verified across all 19 mouth files in BIGCD1.BIG —
+// see project_f3dc_format memory entry for full derivation):
+//
+//   offset   bytes  field
+//   0x00     4      magic "F3DC"
+//   0x04     4      class id 0x000001C2
+//   0x08     8      zeros
+//   0x10     4      subformat (must be 2 for this parser)
+//   0x14     8      zeros
+//   0x1C     4      N = frame count (typ. 14, ANNAAN1M=11, FELIAN1M=13)
+//   0x20     4*N    frame offset table; frame i body lives at
+//                   file offset (28 + table[i])
+//   ...      ...    N frame bodies, each (verts/frame) × (3 × int32 LE)
+//
+// Frame 0 is the bind / rest pose, always physically first in the file at
+// offset 0x58.  Frames 1..N-1 are animation poses stored in REVERSE order
+// after the bind pose (N-1 first, then N-2, ..., 1 last).
+//
+// Vertex coordinates are signed integers in the Cryo authoring space:
+// X is bilaterally symmetric around 0 (face left-right axis), Y is the
+// up-down axis, Z is the forward-back axis.  Units are sub-pixel
+// fixed-point — the exact divisor is determined at rasterise time by
+// the camera projection.
+class F3dcMouthAnim {
+public:
+	F3dcMouthAnim();
+
+	// Parse `stream` (caller-owned).  Returns true on success.  On any
+	// validation failure the object is left in a reset state and the
+	// getters return zero.
+	bool loadFromStream(Common::SeekableReadStream &stream);
+
+	// Discard all parsed data; the object becomes equivalent to a
+	// freshly-constructed instance.
+	void reset();
+
+	bool isLoaded()           const { return _frameCount > 0; }
+	uint frameCount()         const { return _frameCount; }
+	uint verticesPerFrame()   const { return _vertsPerFrame; }
+
+	// Get a single (x, y, z) for vertex `vi` in frame `fi`.  Returns
+	// false when either index is out of range and sets all outputs to 0.
+	bool getVertex(uint fi, uint vi, int32 &x, int32 &y, int32 &z) const;
+
+	// Returns a pointer to a flat int32 array of length
+	// verticesPerFrame() * 3 for the requested frame, laid out as
+	// (x0, y0, z0, x1, y1, z1, ...).  Returns nullptr if fi is out of
+	// range.  Pointer is valid until reset() or destruction.
+	const int32 *frameVertices(uint fi) const;
+
+	// Get the bounding box across every vertex of every frame.
+	// When the parser is unloaded all outputs are 0.
+	void getBounds(int32 &minX, int32 &minY, int32 &minZ,
+	               int32 &maxX, int32 &maxY, int32 &maxZ) const;
+
+private:
+	uint _frameCount;
+	uint _vertsPerFrame;
+	// Flat vertex pool: index = (frame * _vertsPerFrame + vertex) * 3 + axis.
+	Common::Array<int32> _data;
+};
+
+// Loads a Cryo F3DC ".3DA A" per-bone skeletal animation file
+// (DIALOG\PERSO\<base>A.3DA, subformat 4).  See project_f3dc_head_sway
+// memory for the architecture: this file drives per-UBB-frame head
+// rotation + translation; the original engine consumes it via
+// FUN_00468990(0xff, animA + cur_frame_idx, 0) -> FUN_0046853c -> the
+// quat-to-matrix routine FUN_0045d128 (atlantis.exe.c:54979).
+//
+// On-disk format (verified against BADPAN1A.3DA, 7960 bytes):
+//
+//   0x00..0x03  "F3DC"
+//   0x04..0x07  class id 0x000001C2
+//   0x10..0x13  subformat = 4
+//   0x1C..0x1F  N_raw = bone count (last entry is a sentinel, so real
+//               bones = N_raw - 1)
+//   0x24..      uint32[N_raw] offset table; bone i header at file
+//               offset (28 + table[i])
+//
+// Per-bone header (at 28 + table[i]):
+//
+//   +0x00  unused (the prior parser called this "count1"; its value
+//          collides with the previous bone's trailing data)
+//   +0x04  count_A  (e.g. 31 for BadPan) -- number of curve-A entries
+//   +0x08  count_B  (e.g. 30 for BadPan) -- number of curve-B entries
+//   +0x0c  ptr_A    file offset to curve-A array; at runtime this is
+//                   relocated by FUN_0044b3ec to an absolute pointer
+//   +0x10  ptr_B    file offset to curve-B array
+//
+// Curve A entry (stride 0x14 = 20 bytes, count_A entries from ptr_A):
+//   5 int32 fields.  Field interpretation is not fully settled:
+//   - From decompile static analysis: looks like a "time" key plus
+//     a quaternion (qx, qy, qz, qw).
+//   - From file-data dump (BADPAN1A bone[0]): the field at +0x08
+//     monotonically counts 1, 2, 3, ..., count_A-2 across the body
+//     of the array (with the first 2 entries holding header-overlay
+//     garbage).  The other fields trace smooth sinusoidal curves.
+//   Until we have dynamic capture to settle the semantics, the parser
+//   exposes all 5 fields as raw int32 and lets callers interpret.
+//
+// Curve B entry (stride 0x10 = 16 bytes, count_B entries from ptr_B):
+//   4 int32 fields.  Similar story -- looks like a "time" key plus a
+//   3-component translation (tx, ty, tz), but rec[0]/rec[1] in each
+//   bone overlap the header and produce garbage.  Real keyframes
+//   start at index 2 of each array.
+//
+// Layout note: ptr_A typically equals (bone_header_offset - 8), so
+// the bone header overlaps the first 8 bytes of curve-A's first
+// entry.  The header's count_A / count_B / ptr_A / ptr_B u32s sit
+// inside what would be rec[1]'s last 16 bytes.  This is intentional
+// in the file format -- the original engine seems to either skip the
+// first 2 entries or rely on their "time" values being outside the
+// queried range.
+class F3dcSmallAnim {
+public:
+	F3dcSmallAnim();
+
+	// Parse `stream` (caller-owned).  Returns true on success.
+	bool loadFromStream(Common::SeekableReadStream &stream);
+
+	void reset();
+
+	bool isLoaded()  const { return _boneCount > 0; }
+	uint boneCount() const { return _boneCount; }
+
+	// Number of curve-A / curve-B entries for bone bi (raw — includes
+	// the two header-overlap entries at index 0 and 1).
+	uint curveACount(uint bi) const;
+	uint curveBCount(uint bi) const;
+
+	// Fetch one curve-A entry (5 int32) or curve-B entry (4 int32).
+	// Returns false if out of range; outputs are then zero.  The
+	// fields are returned as raw int32; field interpretation is the
+	// caller's responsibility (see class-level comment).
+	bool getCurveA(uint bi, uint i, int32 out[5]) const;
+	bool getCurveB(uint bi, uint i, int32 out[4]) const;
+
+private:
+	uint _boneCount;
+	// Per-bone curve A: flat int32 array of size curveACount(bi) * 5.
+	Common::Array<Common::Array<int32> > _curveA;
+	// Per-bone curve B: flat int32 array of size curveBCount(bi) * 4.
+	Common::Array<Common::Array<int32> > _curveB;
+};
+
+// Loads a Cryo `.3DM` texture-map file (DIALOG\MAPS\<base>.3DM).  The dialog
+// mouth mesh is texture-mapped: the original engine samples a per-character
+// 256x256 face texture whose bytes are *colour indices*, then resolves each
+// (colour index, light level) pair through a shade table to a final R5G6B5
+// colour — so the `.3DM` is fully self-contained, no external palette.
+//
+// On-disk format (verified across the 19 shipped .3DM files, all 98332 bytes):
+//   0x0000  8        "F3DC" + class id 0x1C2  (stripped by the engine loader)
+//   0x0008  0x14     header
+//   0x001C  0x8000   shade table: 32 light levels x 256 colours, each a
+//                    4-byte record `00 00 <R5G6B5 u16>`.  Bit 15 is the
+//                    high R bit, NOT a chroma flag — confirmed by
+//                    matching the .3DM lvl-15 row against RHEA.BMP's
+//                    palette (119 bit-15-set entries are all legitimate
+//                    face colours, deltas ≤ ±16 RGB).
+//   0x801C  0x10000  the 256x256 face texture (one colour index per texel)
+class F3dcTextureMap {
+public:
+	static const uint kSize        = 256;   // texture is 256 x 256
+	static const uint kShadeLevels = 32;    // shade-table light levels
+
+	F3dcTextureMap();
+
+	// Parse `stream` (caller-owned).  Returns true on success.
+	bool loadFromStream(Common::SeekableReadStream &stream);
+
+	void reset();
+
+	bool isLoaded() const { return _loaded; }
+
+	// Colour index of the texel at (u, v); u and v are wrapped to [0, 255].
+	byte texel(int u, int v) const {
+		return _tex[((uint)v & 255) * kSize + ((uint)u & 255)];
+	}
+
+	// Resolve a texel colour index at light level `shade` (0..31) to RGB
+	// through the `.3DM` shade table.
+	void shadeRGB(byte index, uint shade, byte &r, byte &g, byte &b) const;
+
+private:
+	bool _loaded;
+	Common::Array<byte>   _tex;     // kSize*kSize colour indices
+	Common::Array<uint16> _shade;   // kShadeLevels*256 R5G6B5 entries
+};
+
+// Extracts the dialog mouth MESH (bind-pose vertices + triangle topology)
+// from a Cryo `.3DC` body file (DIALOG\PERSO\<base>.3DC).
+//
+// The format was reverse-engineered by a hardware-breakpoint trace of the
+// running engine (see the project memory notes).  The `.3DC` contains an
+// "fvi" scene-graph node whose pools hold the mouth mesh:
+//
+//   fvi node      : 4-byte ASCII magic "fvi\0"
+//     +0x7C  uint32  vertex count
+//     +0x80  uint32  vertex-index base reference (used to decode tris)
+//     +0x94  uint32  triangle count
+//     +0xD4  ...     vertex pool — 40-byte records, XYZ int32 LE at +4
+//
+//   triangle struct array : 64-byte records, located by scanning for a
+//     run of `triangleCount` structs that decode cleanly.  Per struct:
+//     +0x08 / +0x14 / +0x20  uint32  vertex references.
+//       vertexIndex = (reference - vertexBaseRef) / 40
+//
+// Verified against BADPAN1A, GARDAN1A, HEROAN1A, GROAN1A, ANNAAN1A —
+// every file yields a closed mesh with zero degenerate triangles.
+class F3dcMouthMesh {
+public:
+	F3dcMouthMesh();
+
+	// Parse `stream` (caller-owned).  Returns true on success.
+	bool loadFromStream(Common::SeekableReadStream &stream);
+
+	void reset();
+
+	bool isLoaded()        const { return _loaded; }
+	uint vertexCount()     const { return _verts.size() / 3; }
+	uint triangleCount()   const { return _tris.size() / 3; }
+
+	// Vertex `vi` as (x, y, z).  Returns false if out of range.
+	bool getVertex(uint vi, int32 &x, int32 &y, int32 &z) const;
+
+	// Triangle `ti` as three vertex indices.  Returns false if out of
+	// range; the indices are guaranteed < vertexCount() on success.
+	bool getTriangle(uint ti, uint &v0, uint &v1, uint &v2) const;
+
+	// Per-character dialog camera offset O.  The engine places the mouth
+	// mesh at  P = d[6]*camAnchor + O, where O = -(the fvi node's world
+	// position).  That world position is obtained by walking the .3DC
+	// scene-graph chain from the fvi mouth node up to the skeleton root,
+	// composing each node's local position + rotation:
+	//     worldPos += worldRot * localPos
+	//     worldRot  = worldRot * transpose(localRot)
+	// Verified exact against the guard (GARDAN1A).  Valid only when
+	// hasCamOffset() is true.
+	bool hasCamOffset() const { return _hasOffset; }
+	void getCamOffset(double out[3]) const {
+		out[0] = _offsetO[0]; out[1] = _offsetO[1]; out[2] = _offsetO[2];
+	}
+
+	// The composed scene-graph chain rotation R_world (row-major).  The
+	// full dialog transform is  camera = R_view * (R_world*model - P);
+	// the engine bakes this chain rotation into the mouth mesh.  It is
+	// identity for most characters but a small rotation for some (e.g.
+	// the hero), where it must be applied to keep the mesh aligned.
+	void getChainRot(double out[9]) const {
+		for (int i = 0; i < 9; i++) out[i] = _chainRot[i];
+	}
+
+	// True when per-triangle texture coordinates were decoded (the mesh can
+	// be texture-mapped).  When false the caller should fall back to shading.
+	bool hasUV() const { return _hasUV; }
+
+	// Texture coordinates for triangle `ti`, corner 0..2.  Returned as
+	// 16.16 fixed-point texel coordinates into the 256x256 .3DM texture
+	// (corner i pairs with the vertex i of getTriangle()).  Returns false
+	// when ti / corner is out of range or no UVs were decoded.
+	bool getTriangleUV(uint ti, uint corner, int32 &u, int32 &v) const;
+
+	// Candidate basenames for the per-character `.3DM` texture map, scraped
+	// from the `.3DC` header (e.g. "bad10000", "gard", "facer").  The caller
+	// resolves these against DIALOG\MAPS\<name>.3DM and uses the first hit.
+	const Common::Array<Common::String> &textureMapCandidates() const {
+		return _texMapCandidates;
+	}
+
+	// Number of animated bones in the .3DC scene graph.  The .3DA-A
+	// skeletal track maps bone[bi] -> .3DC reloc root[bi + 1], i.e.
+	// root[0] (the character's world "Bass" root) is NOT driven by
+	// .3DA-A.  All subsequent reloc roots are animated, including the
+	// trailing `fvi` mouth anchor.  Verified across BadPan/Garde:
+	// each .3DA-A bone[bi]'s rec[2] (frame 1) translation EXACTLY
+	// matches .3DC reloc root[bi + 1]'s rest position.
+	uint boneNodeCount() const { return _boneNodeOff.size(); }
+
+	// File offset of the animated scene-graph node corresponding to
+	// .3DA-A bone[bi] (i.e. .3DC reloc root[bi + 1]).  The node header
+	// starts here: name at +0x00, parent ptr at +0x10, local position
+	// at +0x1C, local rotation matrix at +0x28.  Returns 0 when bi is
+	// out of range.
+	uint32 getBoneNodeOffset(uint bi) const {
+		return (bi < _boneNodeOff.size()) ? _boneNodeOff[bi] : 0;
+	}
+
+	// Per-UBB-frame cam offset O and chain rotation R_world, with the
+	// .3DA-A skeletal animation applied.  Conceptually: take the .3DC
+	// rest-pose, OVERWRITE each animated bone's local rotation matrix
+	// (+0x28) and local position (+0x1C) with the values interpolated
+	// from `anim` at UBB frame `frame`, then re-run the standard chain
+	// walk from fvi to root.  The result drifts the mouth-mesh anchor
+	// to match the head's per-frame motion in the UBB video.
+	//
+	// `frame` is the UBB frame counter; the routine maps it to the
+	// keyframe index modulo the animation length.  Returns false when
+	// the mesh wasn't loaded with bytes retained, or when `anim` has
+	// no usable data.  On false, O and rot are unchanged.
+	bool computeCamOffsetForFrame(uint frame, const F3dcSmallAnim &anim,
+	                              double O[3], double rot[9]) const;
+
+private:
+	bool _loaded;
+	bool _hasOffset;
+	bool _hasUV;
+	double _offsetO[3];
+	double _chainRot[9];
+	// Flat vertex pool: index = vertex*3 + axis.
+	Common::Array<int32>  _verts;
+	// Flat triangle list: index = triangle*3 + corner.
+	Common::Array<uint16> _tris;
+	// Per-triangle UVs: index = (triangle*3 + corner)*2 + (0=u, 1=v),
+	// 16.16 fixed-point.  Empty when _hasUV is false.
+	Common::Array<int32>  _uvs;
+	// `.3DM` texture-map basename candidates from the .3DC header.
+	Common::Array<Common::String> _texMapCandidates;
+	// File offsets of body-part scene-graph nodes (reloc roots 0..N-2;
+	// the final root is the fvi mouth anchor and is excluded).
+	Common::Array<uint32> _boneNodeOff;
+	// Retained copy of the .3DC file bytes (kept post-load so
+	// computeCamOffsetForFrame can re-walk the chain with mutated bone
+	// transforms).  Empty if !_loaded.
+	Common::Array<byte> _bytes;
+	// File offset of the fvi scene-graph node (the mouth anchor).
+	uint32 _fviOff;
+};
+
+} // namespace Atlantis
+} // namespace CryOmni3D
+
+#endif // CRYOMNI3D_ATLANTIS_F3DC_PARSER_H

--- a/engines/cryomni3d/atlantis/f3dc_renderer.cpp
+++ b/engines/cryomni3d/atlantis/f3dc_renderer.cpp
@@ -1,0 +1,746 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/array.h"
+#include "common/debug.h"
+#include "common/scummsys.h"
+#include "common/system.h"
+
+#include "graphics/surface.h"
+
+#include "cryomni3d/cryomni3d.h"
+#include "cryomni3d/atlantis/f3dc_parser.h"
+#include "cryomni3d/atlantis/f3dc_renderer.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// ---------------------------------------------------------------------------
+// Software rasteriser helpers (moved verbatim from engine.cpp).
+// ---------------------------------------------------------------------------
+
+// Z-buffered edge-function triangle rasteriser.  A pixel is inside the
+// triangle iff all three barycentric weights share a sign (accepts both
+// windings).  Depth is interpolated per pixel from the vertex Z values;
+// the pixel paints only when nearer than the z-buffer's current value.
+// Cryo Z points OUT of the screen, so larger Z = nearer the camera.
+static void fillTriangleZ(Graphics::Surface &surf, int32 *zbuf,
+                          int x0, int y0, int z0,
+                          int x1, int y1, int z1,
+                          int x2, int y2, int z2,
+                          uint32 color) {
+	const int W = surf.w;
+	const int H = surf.h;
+	const int bpp = surf.format.bytesPerPixel;
+	int minX = MIN(MIN(x0, x1), x2);
+	int maxX = MAX(MAX(x0, x1), x2);
+	int minY = MIN(MIN(y0, y1), y2);
+	int maxY = MAX(MAX(y0, y1), y2);
+	if (minX < 0) minX = 0;
+	if (minY < 0) minY = 0;
+	if (maxX >= W) maxX = W - 1;
+	if (maxY >= H) maxY = H - 1;
+	if (minX > maxX || minY > maxY) return;
+	const int area = (x1 - x0) * (y2 - y0) - (y1 - y0) * (x2 - x0);
+	if (area == 0) return;
+	const int A01 = y0 - y1, B01 = x1 - x0;
+	const int A12 = y1 - y2, B12 = x2 - x1;
+	const int A20 = y2 - y0, B20 = x0 - x2;
+	int w0_row = (x2 - x1) * (minY - y1) - (y2 - y1) * (minX - x1);
+	int w1_row = (x0 - x2) * (minY - y2) - (y0 - y2) * (minX - x2);
+	int w2_row = (x1 - x0) * (minY - y0) - (y1 - y0) * (minX - x0);
+	for (int py = minY; py <= maxY; py++) {
+		int w0 = w0_row, w1 = w1_row, w2 = w2_row;
+		for (int px = minX; px <= maxX; px++) {
+			// Inside test: all three barycentric weights share a sign
+			// (zero counts as both — edge pixels belong to BOTH adjacent
+			// triangles, then the z-buffer picks one).  The previous
+			// form `(w0 & w1 & w2) < 0` required all three STRICTLY
+			// negative, dropping every shared-edge pixel of CW (negative-
+			// area) triangles — visible as the 1-pixel cracks through
+			// which the UBB background showed.
+			if (((w0 >= 0) && (w1 >= 0) && (w2 >= 0)) ||
+			    ((w0 <= 0) && (w1 <= 0) && (w2 <= 0))) {
+				const int64 zNum = (int64)w0 * z0 + (int64)w1 * z1 +
+				                   (int64)w2 * z2;
+				const int32 z = (int32)(zNum / area);
+				int32 *zp = &zbuf[py * W + px];
+				if (z > *zp) {
+					*zp = z;
+					byte *p = (byte *)surf.getBasePtr(px, py);
+					if (bpp == 2)      *(uint16 *)p = (uint16)color;
+					else if (bpp == 4) *(uint32 *)p = color;
+					else               memcpy(p, &color, bpp);
+				}
+			}
+			w0 += A12; w1 += A20; w2 += A01;
+		}
+		w0_row += B12; w1_row += B20; w2_row += B01;
+	}
+}
+
+// Z-buffered line — draws a triangle edge to close the hairline cracks
+// that a point-sampled rasteriser leaves between adjacent faces.  Uses
+// z >= zbuf (>=, not >) so edge pixels reliably win ties against the
+// fill at shared seams.
+static void drawLineZ(Graphics::Surface &surf, int32 *zbuf,
+                      int x0, int y0, int z0, int x1, int y1, int z1,
+                      uint32 color) {
+	const int W = surf.w, H = surf.h;
+	const int bpp = surf.format.bytesPerPixel;
+	const int dx = ABS(x1 - x0), dy = ABS(y1 - y0);
+	int steps = (dx > dy) ? dx : dy;
+	if (steps == 0) steps = 1;
+	for (int i = 0; i <= steps; i++) {
+		const int px = x0 + (x1 - x0) * i / steps;
+		const int py = y0 + (y1 - y0) * i / steps;
+		const int z  = z0 + (z1 - z0) * i / steps;
+		if (px < 0 || px >= W || py < 0 || py >= H) continue;
+		int32 *zp = &zbuf[py * W + px];
+		if (z >= *zp) {
+			*zp = z;
+			byte *p = (byte *)surf.getBasePtr(px, py);
+			if (bpp == 2)      *(uint16 *)p = (uint16)color;
+			else if (bpp == 4) *(uint32 *)p = color;
+			else               memcpy(p, &color, bpp);
+		}
+	}
+}
+
+// Light level the dialog mouth mesh is shaded at — the `param_2` value
+// captured from the original engine's rasteriser (atlantis.exe FUN_00456d88).
+static const uint kMouthShadeLevel = 15;
+
+// Z-buffered, perspective-correct textured triangle fill.  Mirrors
+// fillTriangleZ's edge-function rasteriser, but instead of a flat colour it
+// samples the .3DM face texture per pixel: U/z, V/z and 1/z are interpolated
+// barycentrically and divided back to recover (u, v).  Each texel's colour
+// index resolves through the `.3DM` shade table at light level `shade`.
+static void fillTriangleTex(Graphics::Surface &surf, int32 *zbuf,
+                            const int sx[3], const int sy[3],
+                            const int sd[3], const double cz[3],
+                            const double tu[3], const double tv[3],
+                            const F3dcTextureMap &tex, uint shade) {
+	const int W = surf.w, H = surf.h;
+	const int bpp = surf.format.bytesPerPixel;
+	int minX = MIN(MIN(sx[0], sx[1]), sx[2]);
+	int maxX = MAX(MAX(sx[0], sx[1]), sx[2]);
+	int minY = MIN(MIN(sy[0], sy[1]), sy[2]);
+	int maxY = MAX(MAX(sy[0], sy[1]), sy[2]);
+	if (minX < 0) minX = 0;
+	if (minY < 0) minY = 0;
+	if (maxX >= W) maxX = W - 1;
+	if (maxY >= H) maxY = H - 1;
+	if (minX > maxX || minY > maxY) return;
+	const int area = (sx[1]-sx[0])*(sy[2]-sy[0]) - (sy[1]-sy[0])*(sx[2]-sx[0]);
+	if (area == 0) return;
+	const double invArea = 1.0 / (double)area;
+	// Perspective-correct attribute setup: interpolate u/z, v/z and 1/z.
+	double iz[3], uoz[3], voz[3];
+	for (int i = 0; i < 3; i++) {
+		double z = cz[i];
+		if (z < 1.0) z = 1.0;
+		iz[i]  = 1.0 / z;
+		uoz[i] = tu[i] * iz[i];
+		voz[i] = tv[i] * iz[i];
+	}
+	const int A01 = sy[0]-sy[1], B01 = sx[1]-sx[0];
+	const int A12 = sy[1]-sy[2], B12 = sx[2]-sx[1];
+	const int A20 = sy[2]-sy[0], B20 = sx[0]-sx[2];
+	int w0_row = (sx[2]-sx[1])*(minY-sy[1]) - (sy[2]-sy[1])*(minX-sx[1]);
+	int w1_row = (sx[0]-sx[2])*(minY-sy[2]) - (sy[0]-sy[2])*(minX-sx[2]);
+	int w2_row = (sx[1]-sx[0])*(minY-sy[0]) - (sy[1]-sy[0])*(minX-sx[0]);
+	for (int py = minY; py <= maxY; py++) {
+		int w0 = w0_row, w1 = w1_row, w2 = w2_row;
+		for (int px = minX; px <= maxX; px++) {
+			// Inside test: all three barycentric weights share a sign
+			// (zero counts as both — edge pixels belong to BOTH adjacent
+			// triangles, then the z-buffer picks one).  The previous
+			// form `(w0 & w1 & w2) < 0` required all three STRICTLY
+			// negative, dropping every shared-edge pixel of CW (negative-
+			// area) triangles — visible as the 1-pixel cracks through
+			// which the UBB background showed.
+			if (((w0 >= 0) && (w1 >= 0) && (w2 >= 0)) ||
+			    ((w0 <= 0) && (w1 <= 0) && (w2 <= 0))) {
+				const int64 zNum = (int64)w0*sd[0] + (int64)w1*sd[1] +
+				                   (int64)w2*sd[2];
+				const int32 z = (int32)(zNum / area);
+				int32 *zp = &zbuf[py * W + px];
+				if (z > *zp) {
+					const double a0 = w0 * invArea;
+					const double a1 = w1 * invArea;
+					const double a2 = w2 * invArea;
+					const double izp = a0*iz[0] + a1*iz[1] + a2*iz[2];
+					// The .3DC UV pair is the standard (u, v) — first
+					// component is the horizontal axis (verified by
+					// dynamic-trace of atlantis.exe 0x004743C0, the textured
+					// span filler used for BadPan's mouth: it fetches
+					// `tex[V*256+U]` per pixel).
+					int u = 0, v = 0;
+					if (izp > 1e-9) {
+						u = (int)((a0*uoz[0]+a1*uoz[1]+a2*uoz[2]) / izp);
+						v = (int)((a0*voz[0]+a1*voz[1]+a2*voz[2]) / izp);
+					}
+					// Just sample the texel and shade.  No chroma test —
+					// the mesh defines what gets drawn; if a triangle
+					// belongs to the face, all of its sampled texels
+					// are valid skin colours.  An earlier session
+					// hypothesised that bit 15 of the shade-table u16
+					// was a chroma flag (R5G5B5 with inverted alpha
+					// polarity), but cross-checking RHEA.3DM against
+					// the artist-source RHEA.BMP proved bit 15 is just
+					// the high R bit of the R5G6B5 colour: 119/256
+					// level-15 entries have bit 15 set and they're all
+					// legitimate face colours.  Discarding them left
+					// gaps in the rendered face that the UBB video
+					// showed through (the "green/black speckles"
+					// artefact reported 2026-05-24).  See memory
+					// `f3dc-colour-format`.
+					byte tr, tg, tb;
+					tex.shadeRGB(tex.texel(u, v), shade, tr, tg, tb);
+					const uint32 c = surf.format.RGBToColor(tr, tg, tb);
+					*zp = z;
+					byte *p = (byte *)surf.getBasePtr(px, py);
+					if (bpp == 2)      *(uint16 *)p = (uint16)c;
+					else if (bpp == 4) *(uint32 *)p = c;
+					else               memcpy(p, &c, bpp);
+				}
+			}
+			w0 += A12; w1 += A20; w2 += A01;
+		}
+		w0_row += B12; w1_row += B20; w2_row += B01;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// F3dcMouthRenderer
+// ---------------------------------------------------------------------------
+
+F3dcMouthRenderer::F3dcMouthRenderer()
+	: _mesh(nullptr), _s3d(nullptr), _anim(nullptr), _smallAnim(nullptr),
+	  _tex(nullptr),
+	  _ready(false), _animated(false), _textured(false), _vertOffset(0),
+	  _camHasXform(false), _camFovDeg(20.0) {
+	for (int i = 0; i < 9; i++) {
+		_camRot[i]      = (i % 4 == 0) ? 1.0 : 0.0;
+		_camChainRot[i] = (i % 4 == 0) ? 1.0 : 0.0;
+	}
+	_camP[0] = _camP[1] = _camP[2] = 0.0;
+}
+
+bool F3dcMouthRenderer::init(const F3dcMouthMesh &mesh, const F3dcMesh &s3d,
+                             const F3dcMouthAnim &anim,
+                             const F3dcTextureMap *tex, int camNum,
+                             const F3dcSmallAnim *smallAnim) {
+	_mesh = &mesh;
+	_s3d  = &s3d;
+	_anim = &anim;
+	_smallAnim = (smallAnim && smallAnim->isLoaded()) ? smallAnim : nullptr;
+	_tex  = tex;
+	_ready = mesh.isLoaded();
+	if (!_ready)
+		return false;
+
+	deriveCamera(camNum);
+
+	// CAM2 close-up fallback -- the real exe-faithful values.
+	//
+	// REVERSE-ENGINEERED 2026-05-26 via x32dbg.  Set BP1 at the cam-setup
+	// function entry (atlantis.exe.c FUN_0044d7b0, VA 0x0044d7b0), ran
+	// the inn-scene Lascoyt dialog, waited for an explicit [cam2] line
+	// (EDX=0 = cam_idx 0).  Captured slot 0's cam-data pointer
+	// `[0xbc16a0]` and dumped the 8 doubles at that pointer:
+	//
+	//   eye    = ( 0.4874, -9.1076,  84.1815)
+	//   target = (-0.1898,  1.6789, -189.3910)
+	//   scale  = 150.0
+	//   fov    = 13.6822  (degrees)
+	//
+	// Those exactly match the adult-character cam2 template that ships
+	// with the 12 .S3D files that DO have a non-zero CAM2 record
+	// (HEROS.S3D, AGAT.S3D, SERVAN1M.S3D, DAGAN.S3D, FELICIE.S3D,
+	// PRET.S3D, VIEAN1.S3D, CONT30.S3D and a few more).  So the exe
+	// PATCHES the all-zero CAM2 records at runtime with this template
+	// (the patch wasn't visible from static analysis -- it must happen
+	// in a different code path than FUN_0044d5f0).  Cainan, Rhea and
+	// RHEA2 are the only characters whose .S3D ships a DIFFERENT cam2
+	// template (the "child face" variant, eye z=33 instead of 84) --
+	// for those, deriveCamera already succeeded above and this fallback
+	// is skipped.
+	//
+	// Re-run the standard look-at pipeline with the captured doubles so
+	// the rendered mesh lands in the cam2 UBB's lower-face chroma-key
+	// hole exactly like the original.
+	if (!_camHasXform && camNum == 2) {
+		// Adult cam2 template (8 doubles in the .S3D layout), captured
+		// at runtime via x32dbg dump of [0xbc16a0] -- the engine patches
+		// every all-zero cam2 record with this template (or the "small"
+		// variant below).
+		const double kCam2AdultEye[3]    = {  0.4874, -9.1076,  84.1815 };
+		const double kCam2AdultTarget[3] = { -0.1898,  1.6789, -189.3910 };
+		const double kCam2AdultScale     = 150.0;
+		const double kCam2AdultFovDeg    = 13.6822;
+
+		// "Small" cam2 template -- adult / 2.540, matching the cam3 size
+		// ratio of the small-character group (Passant, Meljan, Cain,
+		// Chasrat, Lasc, Saddam).  All cam3 records in those characters'
+		// .S3D files have tgt.z near -74.6 (vs -189.5 for adults), and
+		// the cam2 patch the engine applies follows the same proportion.
+		// Memory `mouth-pipeline-synthesis` records the "child face"
+		// variant with eye.z=33 (== 84.18 / 2.54) consistent with this.
+		const double kCam2SmallEye[3]    = {  0.4874 / 2.540, -9.1076 / 2.540,  84.1815 / 2.540 };
+		const double kCam2SmallTarget[3] = { -0.1898 / 2.540,  1.6789 / 2.540, -189.3910 / 2.540 };
+		const double kCam2SmallScale     = 150.0;          // unchanged
+		const double kCam2SmallFovDeg    = 13.6822;        // unchanged
+
+		// Pick the template by inspecting the character's cam3 tgt.z:
+		// abs(tgt.z) > ~130 = adult group, otherwise = small group.
+		// Falls back to adult if cam3 isn't readable.
+		bool useSmall = false;
+		{
+			double xf[8];
+			if (_s3d->getCamTransform(3, xf)) {
+				const double tgtZ = xf[5];
+				if (-tgtZ < 130.0)
+					useSmall = true;
+			}
+		}
+
+		const double *eye      = useSmall ? kCam2SmallEye      : kCam2AdultEye;
+		const double *target   = useSmall ? kCam2SmallTarget   : kCam2AdultTarget;
+		const double scaleSel  = useSmall ? kCam2SmallScale    : kCam2AdultScale;
+		const double fovDegSel = useSmall ? kCam2SmallFovDeg   : kCam2AdultFovDeg;
+		debugC(1, kDebugMesh, "F3dcMouthRenderer: cam2 fallback -- %s template",
+		      useSmall ? "small" : "adult");
+		double fwd[3] = { target[0] - eye[0],
+		                  target[1] - eye[1],
+		                  target[2] - eye[2] };
+		double fl = sqrt(fwd[0]*fwd[0] + fwd[1]*fwd[1] + fwd[2]*fwd[2]);
+		if (fl > 1e-6) {
+			fwd[0] /= fl; fwd[1] /= fl; fwd[2] /= fl;
+			double rgt[3] = { fwd[2], 0.0, -fwd[0] };
+			double rl = sqrt(rgt[0]*rgt[0] + rgt[1]*rgt[1] + rgt[2]*rgt[2]);
+			if (rl > 1e-6) {
+				rgt[0] /= rl; rgt[1] /= rl; rgt[2] /= rl;
+				const double up[3] = {
+				    fwd[1]*rgt[2] - fwd[2]*rgt[1],
+				    fwd[2]*rgt[0] - fwd[0]*rgt[2],
+				    fwd[0]*rgt[1] - fwd[1]*rgt[0] };
+				_camRot[0] = -rgt[0]; _camRot[1] = -rgt[1]; _camRot[2] = -rgt[2];
+				_camRot[3] =  up[0];  _camRot[4] =  up[1];  _camRot[5] =  up[2];
+				_camRot[6] = -fwd[0]; _camRot[7] = -fwd[1]; _camRot[8] = -fwd[2];
+				_camP[0] = scaleSel * target[0];
+				_camP[1] = scaleSel * target[1];
+				_camP[2] = scaleSel * target[2];
+				_camFovDeg = fovDegSel;
+				_camHasXform = true;
+			}
+		}
+	}
+	if (!_camHasXform) {
+		debugC(1, kDebugMesh, "F3dcMouthRenderer: no cam%d transform -- "
+		         "renderer disabled for this line", camNum);
+		_ready = false;
+		return false;
+	}
+
+	// Save the cam translation P before the scene-graph offset is added.
+	// Per-frame head-sway will reset _camP from this base and add a
+	// fresh offset O derived from the .3DA-A keyframes at the current
+	// UBB frame.
+	_camPBase[0] = _camP[0];
+	_camPBase[1] = _camP[1];
+	_camPBase[2] = _camP[2];
+
+	// Apply the .3DC rest-pose scene-graph offset O + chain rotation
+	// R_world.  These are the initial (UBB frame 0) values; renderFrame
+	// overrides them per UBB frame when _smallAnim is loaded.
+	if (_mesh->hasCamOffset()) {
+		double off[3];
+		_mesh->getCamOffset(off);
+		_camP[0] += off[0];
+		_camP[1] += off[1];
+		_camP[2] += off[2];
+		_mesh->getChainRot(_camChainRot);
+	}
+
+	// Wire the per-frame .3DA-M lip-sync animation onto the .3DC topology.
+	_vertOffset = detectVertexOffset();
+	_animated   = (_vertOffset >= 0);
+	if (_animated)
+		debugC(1, kDebugMesh, "F3dcMouthRenderer: lip-sync wired (%u frames, "
+		         "vertex offset %d)", _anim->frameCount(), _vertOffset);
+	else
+		debugC(1, kDebugMesh, "F3dcMouthRenderer: no lip-sync — static bind pose");
+
+	// Texture-mapped rendering enabled.  The texel->colour math
+	// (`shadeRGB(texel, 15)` against the .3DM's [32 light][256 colour]
+	// R5G6B5 shade table — bit 15 = chroma flag + high R bit, see
+	// `f3dc_parser.h`) is verified empirically against the original
+	// engine on 2026-05-24: patch_3dm probes (V1 magenta / V2 red+blue /
+	// V3 chroma flip) prove the on-disk colour format and the chroma
+	// rule.  See memory `f3dc-colour-format`.
+	const bool kTexturedRenderingReady = true;
+	_textured = kTexturedRenderingReady &&
+	            (_tex != nullptr) && _tex->isLoaded() && _mesh->hasUV();
+	debugC(1, kDebugMesh, "F3dcMouthRenderer: %s", _textured ? "texture-mapped"
+	      : "flat-shaded (textured rendering gated off)");
+	return true;
+}
+
+void F3dcMouthRenderer::deriveCamera(int camNum) {
+	_camHasXform = false;
+
+	// The .S3D cam record is a look-at camera: d[0..2] = look-at point,
+	// d[3..5] = camera anchor, d[6] = fixed scale, d[7] = FOV in degrees.
+	// Build the model->camera view matrix M and translation P; the
+	// per-character offset O from the .3DC scene graph completes P.
+	double xf[8];
+	if (camNum >= 2 && camNum <= 5 && _s3d->getCamTransform(camNum, xf)) {
+		const double eye[3]    = { xf[0], xf[1], xf[2] };
+		const double target[3] = { xf[3], xf[4], xf[5] };
+		double fwd[3] = { target[0] - eye[0],
+		                  target[1] - eye[1],
+		                  target[2] - eye[2] };
+		double fl = sqrt(fwd[0]*fwd[0] + fwd[1]*fwd[1] + fwd[2]*fwd[2]);
+		if (fl > 1e-6) {
+			fwd[0] /= fl; fwd[1] /= fl; fwd[2] /= fl;
+			// right = normalize(cross(worldUp, fwd)), worldUp = (0,1,0).
+			double rgt[3] = { fwd[2], 0.0, -fwd[0] };
+			double rl = sqrt(rgt[0]*rgt[0] + rgt[1]*rgt[1] + rgt[2]*rgt[2]);
+			if (rl > 1e-6) {
+				rgt[0] /= rl; rgt[1] /= rl; rgt[2] /= rl;
+				// camUp = cross(fwd, right).
+				const double up[3] = {
+				    fwd[1]*rgt[2] - fwd[2]*rgt[1],
+				    fwd[2]*rgt[0] - fwd[0]*rgt[2],
+				    fwd[0]*rgt[1] - fwd[1]*rgt[0] };
+				// Rows: (-right, +camUp, -forward).
+				_camRot[0] = -rgt[0]; _camRot[1] = -rgt[1]; _camRot[2] = -rgt[2];
+				_camRot[3] =  up[0];  _camRot[4] =  up[1];  _camRot[5] =  up[2];
+				_camRot[6] = -fwd[0]; _camRot[7] = -fwd[1]; _camRot[8] = -fwd[2];
+				_camP[0] = xf[6] * target[0];
+				_camP[1] = xf[6] * target[1];
+				_camP[2] = xf[6] * target[2];
+				_camFovDeg = xf[7];
+				_camHasXform = true;
+			}
+		}
+	}
+
+	debugC(1, kDebugMesh, "F3dcMouthRenderer: cam%d %s (fov %.1f, P=(%.0f, %.0f, %.0f))",
+	      camNum, _camHasXform ? "look-at" : "tumble",
+	      _camFovDeg, _camP[0], _camP[1], _camP[2]);
+}
+
+int F3dcMouthRenderer::detectVertexOffset() const {
+	if (!_anim->isLoaded())
+		return -1;
+	const uint nv  = _mesh->vertexCount();
+	const uint vpf = _anim->verticesPerFrame();
+	if (nv == 0 || vpf < nv)
+		return -1;
+
+	// Mesh bounding-box diagonal — the scale a candidate offset's residual
+	// is judged against.
+	int32 lo[3] = {  0x7FFFFFFF,  0x7FFFFFFF,  0x7FFFFFFF };
+	int32 hi[3] = { -0x7FFFFFFF, -0x7FFFFFFF, -0x7FFFFFFF };
+	for (uint gi = 0; gi < nv; gi++) {
+		int32 v[3];
+		_mesh->getVertex(gi, v[0], v[1], v[2]);
+		for (int a = 0; a < 3; a++) {
+			if (v[a] < lo[a]) lo[a] = v[a];
+			if (v[a] > hi[a]) hi[a] = v[a];
+		}
+	}
+	double diag = 0.0;
+	for (int a = 0; a < 3; a++) {
+		const double d = (double)hi[a] - lo[a];
+		diag += d * d;
+	}
+	diag = sqrt(diag);
+	if (diag < 1.0)
+		diag = 1.0;
+
+	// .3DA-M frame 0 is the rest pose; the .3DC bind pose is the same mesh
+	// preceded by `vpf - nv` leading sentinel vertices.  The two are
+	// authored slightly differently, so don't demand an exact match — pick
+	// the shift with the smallest residual and accept it when that residual
+	// is small relative to the mesh (a wrong shift scrambles the vertices
+	// and lands a residual of tens of percent of the mesh size).
+	const uint maxOff    = vpf - nv;
+	const uint scanLimit = (maxOff < 4) ? maxOff : 4;
+	debugC(1, kDebugMesh, "F3dcMouthRenderer: vertex-offset scan "
+	         "(.3DC %u verts, .3DA-M %u verts, mesh diag %.0f)",
+	      nv, vpf, diag);
+	int    bestOff = -1;
+	double bestRms = 0.0;
+	for (uint off = 0; off <= scanLimit; off++) {
+		double sse = 0.0;
+		for (uint gi = 0; gi < nv; gi++) {
+			int32 bx, by, bz, ax, ay, az;
+			_mesh->getVertex(gi, bx, by, bz);
+			_anim->getVertex(0, gi + off, ax, ay, az);
+			const double dx = (double)ax - bx;
+			const double dy = (double)ay - by;
+			const double dz = (double)az - bz;
+			sse += dx*dx + dy*dy + dz*dz;
+		}
+		const double rms = sqrt(sse / nv);
+		debugC(1, kDebugMesh, "F3dcMouthRenderer:   offset %u -> RMS %.0f (%.1f%% of mesh)",
+		      off, rms, 100.0 * rms / diag);
+		if (bestOff < 0 || rms < bestRms) {
+			bestOff = (int)off;
+			bestRms = rms;
+		}
+	}
+	// Sample pairs at the structurally-expected offset, to diagnose a
+	// scrambled vertex order should the scan reject every shift.
+	{
+		const uint gis[3] = { 0, nv / 2, nv - 1 };
+		for (int s = 0; s < 3; s++) {
+			int32 bx, by, bz, ax, ay, az;
+			_mesh->getVertex(gis[s], bx, by, bz);
+			_anim->getVertex(0, gis[s] + maxOff, ax, ay, az);
+			debugC(1, kDebugMesh, "F3dcMouthRenderer:   .3DC[%u]=(%d,%d,%d) "
+			         ".3DA-M[%u]=(%d,%d,%d)",
+			      gis[s], bx, by, bz, gis[s] + maxOff, ax, ay, az);
+		}
+	}
+	if (bestOff >= 0 && bestRms < diag * 0.15)
+		return bestOff;
+	return -1;
+}
+
+void F3dcMouthRenderer::renderFrame(Graphics::Surface &dst, uint ubbFrame,
+                                    uint32 elapsedMs) {
+	(void)elapsedMs;   // used by sub-frame interpolation (later phase)
+	if (!_ready)
+		return;
+
+	const Graphics::PixelFormat &fmt = dst.format;
+	const uint gNV = _mesh->vertexCount();
+	const uint gNT = _mesh->triangleCount();
+	if (gNV == 0 || gNT == 0)
+		return;
+
+	// Source vertices for this frame: the per-frame .3DA-M viseme when
+	// lip-sync is wired, else the static .3DC bind pose.
+	Common::Array<int32> mvX, mvY, mvZ;
+	mvX.resize(gNV); mvY.resize(gNV); mvZ.resize(gNV);
+
+	const int32 *frameVerts = nullptr;
+	if (_animated) {
+		// Frame 0 is the rest pose; the lip-sync loops the animation
+		// frames 1..N-1, advancing one viseme per UBB video frame (the
+		// original advances the mouth index once per UBB tick).
+		const uint nFrames = _anim->frameCount();
+		const uint k = (nFrames > 1) ? (1 + ubbFrame % (nFrames - 1)) : 0;
+		frameVerts = _anim->frameVertices(k);
+	}
+	if (frameVerts) {
+		for (uint gi = 0; gi < gNV; gi++) {
+			const int32 *v = frameVerts + (gi + _vertOffset) * 3;
+			mvX[gi] = v[0]; mvY[gi] = v[1]; mvZ[gi] = v[2];
+		}
+	} else {
+		for (uint gi = 0; gi < gNV; gi++) {
+			int32 vX, vY, vZ;
+			_mesh->getVertex(gi, vX, vY, vZ);
+			mvX[gi] = vX; mvY[gi] = vY; mvZ[gi] = vZ;
+		}
+	}
+
+	// Head-sway: apply the .3DA-A skeletal animation at the current UBB
+	// frame to recompute the cam offset O.  The .3DA-A's per-bone
+	// quaternion/translation tracks replace each bone's rest-pose
+	// transform; the scene-graph chain walk in computeCamOffsetForFrame
+	// then yields a per-frame O that tracks the head's motion.  See
+	// project_f3dc_head_sway memory for the file-format details and the
+	// verified-empirical keyframe layout.
+	if (_smallAnim && _mesh->boneNodeCount() > 0) {
+		double O[3], rot[9];
+		if (_mesh->computeCamOffsetForFrame(ubbFrame, *_smallAnim, O, rot)) {
+			_camP[0] = _camPBase[0] + O[0];
+			_camP[1] = _camPBase[1] + O[1];
+			_camP[2] = _camPBase[2] + O[2];
+			for (uint i = 0; i < 9; i++)
+				_camChainRot[i] = rot[i];
+			// One-shot debug: confirm per-frame O actually varies.
+			debugC(1, kDebugMesh, "head-sway frame=%u O=(%.0f, %.0f, %.0f) rotZcol=(%.3f %.3f %.3f)",
+			      ubbFrame, O[0], O[1], O[2], rot[2], rot[5], rot[8]);
+		} else {
+			debugC(1, kDebugMesh, "head-sway frame=%u computeCamOffsetForFrame returned FALSE",
+			      ubbFrame);
+		}
+	} else {
+		debugC(1, kDebugMesh, "head-sway frame=%u skipped (smallAnim=%p bonecount=%u)",
+		      ubbFrame, (const void *)_smallAnim, _mesh->boneNodeCount());
+	}
+
+	// Mesh bounds (centroid used by the no-transform debug tumble).
+	int32 gxMin =  0x7FFFFFFF, gxMax = -0x7FFFFFFF;
+	int32 gyMin =  0x7FFFFFFF, gyMax = -0x7FFFFFFF;
+	int32 gzMin =  0x7FFFFFFF, gzMax = -0x7FFFFFFF;
+	for (uint gi = 0; gi < gNV; gi++) {
+		if (mvX[gi] < gxMin) gxMin = mvX[gi];
+		if (mvX[gi] > gxMax) gxMax = mvX[gi];
+		if (mvY[gi] < gyMin) gyMin = mvY[gi];
+		if (mvY[gi] > gyMax) gyMax = mvY[gi];
+		if (mvZ[gi] < gzMin) gzMin = mvZ[gi];
+		if (mvZ[gi] > gzMax) gzMax = mvZ[gi];
+	}
+	const int32 gMidX = (gxMin + gxMax) / 2;
+	const int32 gMidV = (gzMin + gzMax) / 2;
+	const int32 gMidY = (gyMin + gyMax) / 2;
+
+	// Per-frame z-buffer, cleared to "infinitely far" (most-negative —
+	// larger Z = nearer the camera).
+	Common::Array<int32> zbuf;
+	zbuf.resize((uint)dst.w * dst.h);
+	for (uint zi = 0; zi < zbuf.size(); zi++)
+		zbuf[zi] = -0x7FFFFFFF;
+
+	// gR* hold camera-space coords (used for flat shading); gS* hold the
+	// projected screen coords.
+	Common::Array<int> gSX, gSY, gSD;
+	Common::Array<double> gRX, gRY, gRZ;
+	gSX.resize(gNV); gSY.resize(gNV); gSD.resize(gNV);
+	gRX.resize(gNV); gRY.resize(gNV); gRZ.resize(gNV);
+
+	// Full engine pipeline -- init() returns early when no transform was
+	// derived (CAM2 ships an all-zero record on most characters), so we
+	// can assume _camHasXform here.
+	//   camera = M * (R_world*model - P)
+	//   screen = camXY * focal / camZ + centre
+	const double fovR = _camFovDeg * M_PI / 180.0;
+	double focal = (dst.w * 0.5) / tan(fovR * 0.5);
+	if (focal < 1.0) focal = 1.0;
+	const double pcx = dst.w * 0.5;
+	const double pcy = dst.h * 0.5;
+	for (uint vi = 0; vi < gNV; vi++) {
+		// Bake in the scene-graph chain rotation R_world, then translate.
+		const double mx = mvX[vi];
+		const double my = mvY[vi];
+		const double mz = mvZ[vi];
+		const double rx = _camChainRot[0]*mx +
+		    _camChainRot[1]*my + _camChainRot[2]*mz;
+		const double ry = _camChainRot[3]*mx +
+		    _camChainRot[4]*my + _camChainRot[5]*mz;
+		const double rz = _camChainRot[6]*mx +
+		    _camChainRot[7]*my + _camChainRot[8]*mz;
+		const double dx = rx - _camP[0];
+		const double dy = ry - _camP[1];
+		const double dz = rz - _camP[2];
+		const double cX = _camRot[0]*dx + _camRot[1]*dy + _camRot[2]*dz;
+		const double cY = _camRot[3]*dx + _camRot[4]*dy + _camRot[5]*dz;
+		double cZ = _camRot[6]*dx + _camRot[7]*dy + _camRot[8]*dz;
+		if (cZ < 1.0) cZ = 1.0;
+		gRX[vi] = cX; gRY[vi] = cY; gRZ[vi] = cZ;
+		gSX[vi] = (int)(cX * focal / cZ + pcx);
+		gSY[vi] = (int)(cY * focal / cZ + pcy);
+		// Nearer = smaller camZ; store -camZ so the z-buffer's
+		// "larger wins" keeps the nearest surface.
+		gSD[vi] = (int)(-cZ);
+	}
+	(void)gMidX; (void)gMidY; (void)gMidV;
+
+	for (uint ti = 0; ti < gNT; ti++) {
+		uint i0, i1, i2;
+		_mesh->getTriangle(ti, i0, i1, i2);
+		if (i0 >= gNV || i1 >= gNV || i2 >= gNV)
+			continue;
+
+		// Backface cull — match atlantis.exe FUN_00456d88's `if (area < 0.0)`
+		// test (the original engine only emits edge records for triangles
+		// whose screen-space signed area is negative).  Without this,
+		// back-of-head triangles whose UVs map to the unused green chroma
+		// region of the .3DM win the z-test in spots and paint green
+		// patches at the mesh silhouette.  Verified dynamically against
+		// atlantis.exe (x32dbg, 2026-05-23).
+		{
+			const int64 sArea =
+			    (int64)(gSX[i1] - gSX[i0]) * (gSY[i2] - gSY[i0]) -
+			    (int64)(gSY[i1] - gSY[i0]) * (gSX[i2] - gSX[i0]);
+			if (sArea >= 0)
+				continue;
+		}
+
+		if (_textured) {
+			// Perspective-correct textured fill — sample the .3DM face
+			// texture through the UBB palette.  UV corner c pairs with
+			// triangle vertex c (the .3DC stores them as parallel fields).
+			const uint vi[3] = { i0, i1, i2 };
+			int    sx[3], sy[3], sd[3];
+			double cz[3], tu[3], tv[3];
+			for (int c = 0; c < 3; c++) {
+				sx[c] = gSX[vi[c]];
+				sy[c] = gSY[vi[c]];
+				sd[c] = gSD[vi[c]];
+				cz[c] = gRZ[vi[c]];
+				int32 u16, v16;
+				_mesh->getTriangleUV(ti, (uint)c, u16, v16);
+				tu[c] = u16 / 65536.0;
+				tv[c] = v16 / 65536.0;
+			}
+			fillTriangleTex(dst, zbuf.begin(), sx, sy, sd, cz, tu, tv,
+			                *_tex, kMouthShadeLevel);
+			continue;
+		}
+
+		// Flat shade from the rotated triangle normal.
+		const double e1x = gRX[i1] - gRX[i0];
+		const double e1y = gRY[i1] - gRY[i0];
+		const double e1z = gRZ[i1] - gRZ[i0];
+		const double e2x = gRX[i2] - gRX[i0];
+		const double e2y = gRY[i2] - gRY[i0];
+		const double e2z = gRZ[i2] - gRZ[i0];
+		const double nz = e1x * e2y - e1y * e2x;
+		const double nx = e1y * e2z - e1z * e2y;
+		const double ny = e1z * e2x - e1x * e2z;
+		double nlen = sqrt(nx*nx + ny*ny + nz*nz);
+		if (nlen < 1.0) nlen = 1.0;
+		double lit = (nz < 0 ? -nz : nz) / nlen;
+		lit = 0.35 + 0.65 * lit;
+		const uint8 r  = (uint8)(70 + 150 * lit);
+		const uint8 g  = (uint8)(45 + 110 * lit);
+		const uint8 bl = (uint8)(35 + 80 * lit);
+		const uint32 col = fmt.RGBToColor(r, g, bl);
+		fillTriangleZ(dst, zbuf.begin(),
+		              gSX[i0], gSY[i0], gSD[i0],
+		              gSX[i1], gSY[i1], gSD[i1],
+		              gSX[i2], gSY[i2], gSD[i2], col);
+		// Close hairline cracks between adjacent faces by stroking the
+		// 3 edges.
+		drawLineZ(dst, zbuf.begin(),
+		          gSX[i0], gSY[i0], gSD[i0],
+		          gSX[i1], gSY[i1], gSD[i1], col);
+		drawLineZ(dst, zbuf.begin(),
+		          gSX[i1], gSY[i1], gSD[i1],
+		          gSX[i2], gSY[i2], gSD[i2], col);
+		drawLineZ(dst, zbuf.begin(),
+		          gSX[i2], gSY[i2], gSD[i2],
+		          gSX[i0], gSY[i0], gSD[i0], col);
+	}
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/f3dc_renderer.h
+++ b/engines/cryomni3d/atlantis/f3dc_renderer.h
@@ -1,0 +1,111 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CRYOMNI3D_ATLANTIS_F3DC_RENDERER_H
+#define CRYOMNI3D_ATLANTIS_F3DC_RENDERER_H
+
+#include "common/scummsys.h"
+
+namespace Graphics {
+struct Surface;
+}
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+class F3dcMesh;
+class F3dcMouthMesh;
+class F3dcMouthAnim;
+class F3dcSmallAnim;
+class F3dcTextureMap;
+
+// Renders the animated dialog "talking head" mouth mesh into the chroma-key
+// hole of an NPC's UBB talking-head video.  Mirrors the original engine's
+// per-frame draw routine (atlantis.exe FUN_0044e2e0): project the per-character
+// 3D mouth mesh through the cam-specific look-at camera and software-rasterise
+// it over the UBB frame.
+//
+// The three parsed source files are supplied to init():
+//   - F3dcMouthMesh : .3DC bind-pose vertices + triangle topology (the
+//                     "fvi" scene-graph node) + the per-character cam offset
+//   - F3dcMesh      : .S3D per-camera look-at transform
+//   - F3dcMouthAnim : .3DA "M" per-frame mouth vertex animation (the lip-sync
+//                     visemes; frame 0 is the rest pose)
+// All three are caller-owned and must outlive the renderer.
+class F3dcMouthRenderer {
+public:
+	F3dcMouthRenderer();
+
+	// Bind the parsed dialog-mesh files for camera `camNum` (2..5) and
+	// derive the projection.  `tex` is the per-character `.3DM` face
+	// texture (may be nullptr — the renderer then flat-shades).  Returns
+	// true when there is a mesh to draw.
+	bool init(const F3dcMouthMesh &mesh, const F3dcMesh &s3d,
+	          const F3dcMouthAnim &anim, const F3dcTextureMap *tex,
+	          int camNum, const F3dcSmallAnim *smallAnim = nullptr);
+
+	bool isReady() const { return _ready; }
+
+	// True when per-frame .3DA-M lip-sync animation is wired (the .3DA-M
+	// loaded and its vertex order matched the .3DC bind pose).  When false
+	// renderFrame() falls back to the static .3DC bind pose.
+	bool isAnimated() const { return _animated; }
+
+	// True when the mouth mesh is texture-mapped (a `.3DM` texture and
+	// `.3DC` UVs were both available).  When false renderFrame() flat-shades.
+	bool isTextured() const { return _textured; }
+
+	// Rasterise the mouth mesh into `dst`.  `ubbFrame` advances once per
+	// fresh UBB video frame and selects the lip-sync viseme.  `elapsedMs`
+	// is the time since the dialog line started (sub-frame interpolation).
+	// Texture colours come from the `.3DM` shade table — no external palette.
+	void renderFrame(Graphics::Surface &dst, uint ubbFrame, uint32 elapsedMs);
+
+private:
+	void deriveCamera(int camNum);
+	// Find the integer index shift between .3DC mesh vertex N and the
+	// matching .3DA-M frame-0 vertex.  Returns the shift, or -1 if the two
+	// vertex sets do not correspond (animation then stays disabled).
+	int  detectVertexOffset() const;
+
+	const F3dcMouthMesh *_mesh;
+	const F3dcMesh      *_s3d;
+	const F3dcMouthAnim *_anim;
+	const F3dcSmallAnim *_smallAnim;
+	const F3dcTextureMap *_tex;
+	bool  _ready;
+	bool  _animated;
+	bool  _textured;
+	int   _vertOffset;     // .3DA-M index = .3DC mesh index + _vertOffset
+
+	bool   _camHasXform;
+	double _camRot[9];      // model->camera view rotation M (row-major)
+	double _camChainRot[9]; // scene-graph chain rotation R_world
+	double _camP[3];        // camera translation P (with scene-graph offset)
+	double _camPBase[3];    // _camP without the scene-graph offset O --
+	                        // per-frame head-sway uses this + .3DA-A's O
+	double _camFovDeg;      // field of view, degrees
+};
+
+} // namespace Atlantis
+} // namespace CryOmni3D
+
+#endif // CRYOMNI3D_ATLANTIS_F3DC_RENDERER_H

--- a/engines/cryomni3d/atlantis/logic.cpp
+++ b/engines/cryomni3d/atlantis/logic.cpp
@@ -1,0 +1,33 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "cryomni3d/atlantis/engine.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// Place-specific initPlace and filterEvent callbacks.
+
+// Place-specific filterEvent callbacks go here.
+// Guard logic at place 17 is handled by the CON script's /sel(departvue=22) sections.
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/menu_layout.cpp
+++ b/engines/cryomni3d/atlantis/menu_layout.cpp
@@ -1,0 +1,190 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "cryomni3d/atlantis/menu_layout.h"
+
+#include "common/textconsole.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// Parse one ASCII integer starting at *p, advance *p past it.
+// Empty (no digits) → returns false; *outVal untouched.
+static bool consumeInt(const char *&p, int &outVal) {
+	bool neg = false;
+	if (*p == '-') { neg = true; ++p; }
+	if (*p < '0' || *p > '9')
+		return false;
+	int v = 0;
+	while (*p >= '0' && *p <= '9') {
+		v = v * 10 + (*p - '0');
+		++p;
+	}
+	outVal = neg ? -v : v;
+	return true;
+}
+
+static bool startsWithIgnoreCase(const Common::String &s, const char *prefix) {
+	uint n = strlen(prefix);
+	if (s.size() < n) return false;
+	for (uint i = 0; i < n; i++) {
+		char a = s[i], b = prefix[i];
+		if (a >= 'A' && a <= 'Z') a = (char)(a - 'A' + 'a');
+		if (b >= 'A' && b <= 'Z') b = (char)(b - 'A' + 'a');
+		if (a != b) return false;
+	}
+	return true;
+}
+
+bool MenuLayout::loadFromStream(Common::ReadStream &s) {
+	items.clear();
+
+	// Read the whole stream into a heap buffer.  Menu files are tiny
+	// (< 500 bytes typical, < 5 KB for credits), so this is fine.
+	Common::Array<byte> buf;
+	byte chunk[256];
+	while (!s.eos()) {
+		uint32 got = s.read(chunk, sizeof(chunk));
+		if (got == 0)
+			break;
+		for (uint32 i = 0; i < got; i++)
+			buf.push_back(chunk[i]);
+	}
+	buf.push_back(0); // null-terminate so c_str scans are safe.
+
+	const char *cur = (const char *)buf.data();
+	while (*cur) {
+		// Extract one line (terminator-tolerant).
+		Common::String line;
+		while (*cur && *cur != '\n' && *cur != '\r') {
+			line += *cur;
+			++cur;
+		}
+		while (*cur == '\n' || *cur == '\r') ++cur;
+
+		if (line.empty())
+			continue;
+
+		// /fin terminator (case-insensitive).
+		if (startsWithIgnoreCase(line, "/fin"))
+			break;
+
+		// /spr=I,HX,HY,W,H
+		if (startsWithIgnoreCase(line, "/spr=")) {
+			const char *p = line.c_str() + 5;
+			int idx, hx, hy, w, h;
+			if (!consumeInt(p, idx)) continue;
+			if (*p != ',') continue;
+			++p;
+			if (!consumeInt(p, hx))  continue;
+			if (*p != ',') continue;
+			++p;
+			if (!consumeInt(p, hy))  continue;
+			if (*p != ',') continue;
+			++p;
+			if (!consumeInt(p, w))   continue;
+			if (*p != ',') continue;
+			++p;
+			if (!consumeInt(p, h))   continue;
+			MenuItem it;
+			it.kind = MenuItem::kSprite;
+			it.sprIdx = idx;
+			it.hx = hx;
+			it.hy = hy;
+			it.w = w;
+			it.h = h;
+			items.push_back(it);
+			continue;
+		}
+
+		// <X,Y>TEXT — X may be empty meaning "centered".
+		// The original game encodes the empty form as a literal "<>", then
+		// continues with ",Y>TEXT" (so the full line is e.g. "<>,230>LOAD
+		// GAME").  Confirmed against shipped MAINMENU.TXT / SELEMENU.TXT.
+		if (line[0] == '<') {
+			const char *p = line.c_str() + 1;
+			bool centerX = false;
+			int  ax = 0, ay = 0;
+			if (*p == '>') {
+				centerX = true;
+				++p;
+			} else if (*p == ',') {
+				// Legacy/permissive: bare "<,Y>" with no opening number.
+				centerX = true;
+			} else {
+				if (!consumeInt(p, ax))
+					continue;
+			}
+			if (*p != ',') continue;
+			++p;
+			if (!consumeInt(p, ay)) continue;
+			if (*p != '>') continue;
+			++p;
+
+			MenuItem it;
+			it.kind    = MenuItem::kText;
+			it.centerX = centerX;
+			it.anchorX = ax;
+			it.anchorY = ay;
+			it.text    = Common::String(p);
+			// Strip stray trailing whitespace.
+			while (!it.text.empty()) {
+				char c = it.text[it.text.size() - 1];
+				if (c == ' ' || c == '\t')
+					it.text.deleteLastChar();
+				else
+					break;
+			}
+
+			// A "//A&&B" value is a toggle: split the &&-separated option
+			// labels into MenuItem::options and mark the item as kToggle.
+			if (it.text.hasPrefix("//") && it.text.contains("&&")) {
+				const Common::String body(it.text.c_str() + 2);
+				uint segStart = 0;
+				for (uint q = 0; q < body.size(); ) {
+					if (q + 1 < body.size() &&
+					    body[q] == '&' && body[q + 1] == '&') {
+						it.options.push_back(
+						    Common::String(body.c_str() + segStart, q - segStart));
+						q += 2;
+						segStart = q;
+					} else {
+						++q;
+					}
+				}
+				it.options.push_back(Common::String(body.c_str() + segStart));
+				it.kind = MenuItem::kToggle;
+				it.text.clear();
+			}
+
+			items.push_back(it);
+			continue;
+		}
+
+		// Unknown directive — silently skip (credits use $NN section markers,
+		// \ italics, etc.).
+	}
+
+	return true;
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/menu_layout.h
+++ b/engines/cryomni3d/atlantis/menu_layout.h
@@ -1,0 +1,86 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CRYOMNI3D_ATLANTIS_MENU_LAYOUT_H
+#define CRYOMNI3D_ATLANTIS_MENU_LAYOUT_H
+
+#include "common/array.h"
+#include "common/str.h"
+#include "common/stream.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// Parsed entry from a SPRLIST\*MENU.TXT layout file (original Atlantis menu
+// data).  The format is line-oriented:
+//
+//   <X,Y>TEXT          — anchor a FONTMAX label at (X, Y_txt).  X may be
+//                        empty, e.g. "<>,140>SELECT PLAYER NAME", meaning
+//                        the label is horizontally centred on the 640-wide
+//                        screen.  Y is the y_txt baseline (same convention
+//                        as drawFontMaxText).
+//   /spr=I,HX,HY,W,H   — composite SPRMENU.SPR sprite index I with its
+//                        hotspot at screen (HX, HY).  W/H are size hints kept
+//                        in w/h (slider tracks use them); the sprite still
+//                        carries its real pixel size for blitting.
+//   <X,Y>//A&&B[&&C…]   — a toggle: a text anchor whose value cycles through
+//                        the &&-separated option labels.  Parsed as kToggle.
+//   /fin or /FIN       — end of file.  Anything after is ignored.
+//
+// Blank lines and CR characters are tolerated.
+struct MenuItem {
+	enum Kind { kText, kSprite, kToggle };
+
+	Kind kind;
+
+	// Text item fields (anchorX/anchorY/centerX also apply to kToggle).
+	Common::String text;
+	bool centerX;       // true → ignore anchorX and centre on screen.
+	int  anchorX;
+	int  anchorY;       // y_txt baseline.
+
+	// Sprite item fields.  w/h come from the /spr size hint.
+	int sprIdx;
+	int hx, hy;
+	int w, h;
+
+	// Toggle item fields (kToggle).  `options` holds the label of each
+	// state; `selected` indexes the currently active one.
+	Common::Array<Common::String> options;
+	int selected;
+
+	MenuItem()
+	    : kind(kText), centerX(false), anchorX(0), anchorY(0),
+	      sprIdx(0), hx(0), hy(0), w(0), h(0), selected(0) {}
+};
+
+struct MenuLayout {
+	Common::Array<MenuItem> items;
+
+	// Parse the menu-text stream.  Returns false only when the buffer is
+	// unreadable; an empty / truncated file yields an empty layout and true.
+	bool loadFromStream(Common::ReadStream &s);
+};
+
+} // namespace Atlantis
+} // namespace CryOmni3D
+
+#endif // CRYOMNI3D_ATLANTIS_MENU_LAYOUT_H

--- a/engines/cryomni3d/atlantis/menus.cpp
+++ b/engines/cryomni3d/atlantis/menus.cpp
@@ -1,0 +1,1379 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/config-manager.h"
+#include "common/debug.h"
+#include "common/events.h"
+#include "common/keyboard.h"
+#include "common/memstream.h"
+#include "common/savefile.h"
+#include "common/system.h"
+#include "common/util.h"
+#include "audio/decoders/apc.h"
+#include "audio/mixer.h"
+#include "graphics/font.h"
+#include "graphics/fontman.h"
+#include "graphics/managed_surface.h"
+#include "graphics/palette.h"
+
+#include "cryomni3d/atlantis/engine.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// Vertical span allocated to a FONTMAX text item.  FONTMAX glyphs render
+// with their bottom near anchorY; we treat the hit-box as [anchorY-32, anchorY+4].
+static const int kFontMaxHitTop    = 32;
+static const int kFontMaxHitBottom = 4;
+
+// Space advance from exe width table at 0x4965eb[35] = 22.
+static const int kFontMaxSpaceAdvance = 22;
+// FONTMIN is the smaller font; its space advance scales down proportionally.
+static const int kFontMinSpaceAdvance = 18;
+
+int CryOmni3DEngine_Atlantis::fontMaxCharAdvance(unsigned char c) const {
+	if (c == ' ')
+		return kFontMaxSpaceAdvance;
+	int idx = (int)c - 0x20;
+	if (idx < 0 || idx >= (int)_fontMaxSprites.size())
+		return 0;
+	return _fontMaxSprites[idx].w;
+}
+
+int CryOmni3DEngine_Atlantis::fontMaxStringWidth(const Common::String &text) const {
+	int w = 0;
+	for (uint i = 0; i < text.size(); ++i)
+		w += fontMaxCharAdvance((unsigned char)text[i]);
+	return w;
+}
+
+// Glyph-sprite text blitter shared by the FONTMAX and FONTMIN font families.
+// `layoutGlyphs` drives the pen advance so a hover swap to a differently-
+// metricised glyph set never reflows the line; `drawGlyphs` supplies the
+// pixels, each anchored by its own xoff/yoff.  anchorY is the text baseline.
+void CryOmni3DEngine_Atlantis::drawSprFontText(Graphics::ManagedSurface &dst,
+        const Common::String &text, int anchorX, int anchorY,
+        const Common::Array<SubjSprite> &drawGlyphs,
+        const Common::Array<SubjSprite> &layoutGlyphs, int spaceAdvance) const {
+	int cx = anchorX;
+	for (uint i = 0; i < text.size(); ++i) {
+		unsigned char c = (unsigned char)text[i];
+		if (c == ' ') {
+			cx += spaceAdvance;
+			continue;
+		}
+		int idx = (int)c - 0x20;
+		if (idx < 0 || idx >= (int)layoutGlyphs.size())
+			continue;
+		const SubjSprite &lay = layoutGlyphs[idx];   // advance + anchor
+		if (idx < (int)drawGlyphs.size() && !drawGlyphs[idx].pixels.empty()) {
+			const SubjSprite &spr = drawGlyphs[idx]; // pixels
+			// Anchor each glyph by its own offsets so a hover-font glyph whose
+			// metrics differ still lands where that font intends.
+			int dx = cx - spr.xoff;
+			int dy = anchorY - spr.yoff;
+			for (int sy = 0; sy < (int)spr.h; ++sy) {
+				int ty = dy + sy;
+				if (ty < 0 || ty >= dst.h)
+					continue;
+				for (int sx = 0; sx < (int)spr.w; ++sx) {
+					uint sidx = sy * spr.w + sx;
+					uint16 pix = spr.pixels[sidx];
+					if (pix == kSprTransp)
+						continue;
+					int tx = dx + sx;
+					if (tx < 0 || tx >= dst.w)
+						continue;
+					uint16 *dp = (uint16 *)dst.getBasePtr(tx, ty);
+					if (spr.blend[sidx] != kSprNoBlend)
+						pix = blendSprPixel565(pix, *dp, spr.blend[sidx]);
+					*dp = pix;
+				}
+			}
+		}
+		cx += lay.w;
+	}
+}
+
+// FONTMAX.SPR menu font.  `hover` swaps in the FONTMAX2.SPR glyphs for colour;
+// layout always uses FONTMAX so a hovered entry never shifts.
+void CryOmni3DEngine_Atlantis::drawFontMaxText(Graphics::ManagedSurface &dst,
+        const Common::String &text, int anchorX, int anchorY, bool hover) const {
+	drawSprFontText(dst, text, anchorX, anchorY,
+	    (hover && !_fontMaxHoverSprites.empty()) ? _fontMaxHoverSprites
+	                                            : _fontMaxSprites,
+	    _fontMaxSprites, kFontMaxSpaceAdvance);
+}
+
+// FONTMIN.SPR — the smaller, red-tinted font for player names; FONTMIN2.SPR is
+// its hover variant.  Layout always uses FONTMIN so hovering only recolours.
+void CryOmni3DEngine_Atlantis::drawFontMinText(Graphics::ManagedSurface &dst,
+        const Common::String &text, int anchorX, int anchorY, bool hover) const {
+	drawSprFontText(dst, text, anchorX, anchorY,
+	    (hover && !_fontMin2Sprites.empty()) ? _fontMin2Sprites : _fontMinSprites,
+	    _fontMinSprites, kFontMinSpaceAdvance);
+}
+
+// ---------------------------------------------------------------------------
+// CREDBLAN.SPR / CREDBLEU.SPR — credits roll glyph renderer.  Char advance
+// widths come from the atlantis.exe table at VA 0x004966fc (loaded by
+// loadAtlantisExeTables() into _creditCharWidths).  Glyph drawing reuses
+// the same SubjSprite atlas the existing menu code uses, so per-glyph
+// xoff/yoff hotspots are honoured automatically.
+// ---------------------------------------------------------------------------
+
+int CryOmni3DEngine_Atlantis::creditCharAdvance(unsigned char c) const {
+	return (int)_creditCharWidths[c];
+}
+
+int CryOmni3DEngine_Atlantis::creditStringWidth(const Common::String &text) const {
+	int w = 0;
+	for (uint i = 0; i < text.size(); i++)
+		w += creditCharAdvance((unsigned char)text[i]);
+	return w;
+}
+
+void CryOmni3DEngine_Atlantis::drawCreditText(Graphics::ManagedSurface &dst,
+        const Common::String &text, int anchorX, int anchorY, bool blue) const {
+	const Common::Array<SubjSprite> &glyphs = blue ? _creditBleuSprites
+	                                                : _creditBlanSprites;
+	if (glyphs.empty())
+		return;
+	int cx = anchorX;
+	for (uint i = 0; i < text.size(); i++) {
+		unsigned char c = (unsigned char)text[i];
+		int adv = creditCharAdvance(c);
+		if (c == ' ' || c == '\t' || c == '\r' || c == '\n') {
+			cx += adv;
+			continue;
+		}
+		// CREDBLAN.SPR / CREDBLEU.SPR contain 136 glyphs covering chars
+		// 0x21..0xa8 — there is NO sprite for the space character; the
+		// engine renders space by advance-only.  Cross-checking each
+		// stored sprite.w against the char-indexed width table at
+		// atlantis.exe 0x4966fc confirms the mapping:
+		//   sprite_index = char - 0x21      (NOT char - 0x20)
+		// e.g. exe['A']=9 ↔ sprite[32].w=9, exe['I']=4 ↔ sprite[40].w=4.
+		// FONTMAX.SPR is different — it has 137 slots and DOES include
+		// a placeholder for space at slot 0, so its renderer uses
+		// `char - 0x20`.  Keep the two paths separate.
+		int idx = (int)c - 0x21;
+		if (idx < 0 || idx >= (int)glyphs.size()) {
+			cx += adv;
+			continue;
+		}
+		const SubjSprite &spr = glyphs[idx];
+		if (spr.pixels.empty()) {
+			cx += adv;
+			continue;
+		}
+		int dx = cx - spr.xoff;
+		int dy = anchorY - spr.yoff;
+		for (int sy = 0; sy < (int)spr.h; ++sy) {
+			int ty = dy + sy;
+			if (ty < 0 || ty >= dst.h)
+				continue;
+			for (int sx = 0; sx < (int)spr.w; ++sx) {
+				uint sidx = sy * spr.w + sx;
+				uint16 pix = spr.pixels[sidx];
+				if (pix == kSprTransp)
+					continue;
+				int tx = dx + sx;
+				if (tx < 0 || tx >= dst.w)
+					continue;
+				uint16 *dp = (uint16 *)dst.getBasePtr(tx, ty);
+				if (spr.blend[sidx] != kSprNoBlend)
+					pix = blendSprPixel565(pix, *dp, spr.blend[sidx]);
+				*dp = pix;
+			}
+		}
+		cx += adv;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SPRLIST\*MENU.TXT — menu layout parsing, rendering, and event loops.
+// All coordinates come from the original game data; the only constants used
+// here are the FONTMAX hit-box vertical span (above) and the SAVE_GAME /
+// LOAD_GAME / CONTINUE / QUIT pseudo-actions used to thread the click back
+// to the engine's existing menu-return state machine.
+// ---------------------------------------------------------------------------
+
+bool CryOmni3DEngine_Atlantis::loadMenuLayout(const char *baseName,
+        MenuLayout &out) const {
+	Common::ScopedPtr<Common::SeekableReadStream> s(
+	    openBigFileStream(kFileTypeSprite, baseName));
+	if (!s) {
+		warning("loadMenuLayout: cannot open SPRLIST\\%s", baseName);
+		return false;
+	}
+	return out.loadFromStream(*s);
+}
+
+void CryOmni3DEngine_Atlantis::renderMenuLayout(Graphics::ManagedSurface &dst,
+        const MenuLayout &layout, int hoveredTextIdx,
+        Common::Array<Common::Rect> &hitRectsOut) const {
+	hitRectsOut.clear();
+	hitRectsOut.resize(layout.items.size());
+
+	// Sprites first — text labels render on top so they stay legible above
+	// the decorative arrows / ornaments.
+	for (uint i = 0; i < layout.items.size(); i++) {
+		const MenuItem &it = layout.items[i];
+		if (it.kind != MenuItem::kSprite)
+			continue;
+		blitMenuSprite(dst, (uint)it.sprIdx, it.hx, it.hy);
+	}
+
+	// Text labels and toggle values.  Hovered entries are drawn with the
+	// FONTMAX2.SPR glyph set (bright-yellow) — that is how the original
+	// engine produces the hover tint.  A kToggle item renders its currently
+	// selected option string at the same anchor as a plain text label.
+	for (uint i = 0; i < layout.items.size(); i++) {
+		const MenuItem &it = layout.items[i];
+		Common::String label;
+		if (it.kind == MenuItem::kText) {
+			label = it.text;
+		} else if (it.kind == MenuItem::kToggle && !it.options.empty()) {
+			int sel = (it.selected >= 0 && it.selected < (int)it.options.size())
+			          ? it.selected : 0;
+			label = it.options[sel];
+		} else {
+			continue;
+		}
+
+		int w = fontMaxStringWidth(label);
+		int x = it.centerX ? (640 - w) / 2 : it.anchorX;
+		bool hover = ((int)i == hoveredTextIdx);
+		drawFontMaxText(dst, label, x, it.anchorY, hover);
+
+		hitRectsOut[i] = Common::Rect(x, it.anchorY - kFontMaxHitTop,
+		                              x + w, it.anchorY + kFontMaxHitBottom);
+	}
+}
+
+// Map a mouse position to the index of the hovered text/toggle item (or -1).
+static int hitTestMenu(const MenuLayout &layout,
+                       const Common::Array<Common::Rect> &rects,
+                       const Common::Point &mouse) {
+	for (uint i = 0; i < layout.items.size(); i++) {
+		MenuItem::Kind k = layout.items[i].kind;
+		if (k != MenuItem::kText && k != MenuItem::kToggle)
+			continue;
+		if (rects[i].contains(mouse))
+			return (int)i;
+	}
+	return -1;
+}
+
+// Composite the in-game menu over the current panorama snapshot.
+// All UI coordinates come from SPRLIST\MAINMENU.TXT; we synthesize three
+// extra entries (CONTINUE / SAVE GAME / NEW GAME) that the original menu
+// expressed via separate screens.  Each synthetic entry uses the same
+// FONTMAX rendering and a layout-derived y position.
+uint CryOmni3DEngine_Atlantis::displayInGameMenu() {
+	// Snapshot the panorama (or a black frame if none is loaded yet).
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	Graphics::ManagedSurface bg;
+	bg.create(640, 480, fmt);
+	if (_warpLoaded) {
+		const Graphics::Surface *pano = _omni3dMan.getSurface();
+		if (pano)
+			bg.blitFrom(*pano);
+	} else {
+		bg.fillRect(Common::Rect(0, 0, 640, 480),
+		            fmt.RGBToColor(0, 0, 0));
+	}
+
+	// Parse the original menu layout.  MAINMENU.TXT carries three entries
+	// authored by Cryo (LOAD GAME / OPTIONS MENU / QUIT GAME); we follow it
+	// verbatim — no synthetic insertions.  Escape dismisses the menu (the
+	// original behaviour) so a CONTINUE entry is intentionally absent.
+	MenuLayout layout;
+	loadMenuLayout("MAINMENU.TXT", layout);
+
+	// Classify each label by its ordinal position, never by the label text.
+	// MAINMENU.TXT is authored as exactly three buttons in a fixed order —
+	// LOAD GAME, OPTIONS MENU, QUIT GAME — and a localized disc only swaps
+	// the strings, not the order.  Matching on English substrings ("LOAD",
+	// "QUIT") would break every non-English release, so the action for each
+	// button is taken from its position in the file instead.  OPTIONS MENU
+	// drives the OPTMENU sub-menu.
+	enum Action {
+		kNone     = 0,
+		kContinue = 1,
+		kLoad     = 3,
+		kQuit     = 5,
+		kOptions  = 6,
+	};
+	static const int kMainMenuActions[] = { kLoad, kOptions, kQuit };
+	Common::Array<int> actions;
+	actions.resize(layout.items.size());
+	uint textOrdinal = 0;
+	for (uint i = 0; i < layout.items.size(); i++) {
+		if (layout.items[i].kind != MenuItem::kText) {
+			actions[i] = kNone;
+			continue;
+		}
+		actions[i] = (textOrdinal < ARRAYSIZE(kMainMenuActions))
+		             ? kMainMenuActions[textOrdinal] : kNone;
+		textOrdinal++;
+	}
+
+	Graphics::ManagedSurface surf;
+	surf.create(640, 480, fmt);
+
+	Common::Array<Common::Rect> hitRects;
+	int hovered = -1;
+
+	clearKeys();
+	showMouse(true);
+	setArrowCursor();
+
+	// Initial render so hitRects is populated before any pollEvents/hover query.
+	surf.blitFrom(bg);
+	renderMenuLayout(surf, layout, -1, hitRects);
+	g_system->copyRectToScreen(surf.getPixels(), surf.pitch, 0, 0, 640, 480);
+	g_system->updateScreen();
+
+	uint retval = kContinue;
+	bool done = false;
+
+	while (!done && !shouldAbort()) {
+		pollEvents();
+
+		// Escape dismisses the menu.
+		Common::KeyState k = getNextKey();
+		if (k.keycode == Common::KEYCODE_ESCAPE) {
+			retval = kContinue;
+			break;
+		}
+
+		Common::Point mouse = getMousePos();
+		int newHover = hitTestMenu(layout, hitRects, mouse);
+		if (newHover != hovered) {
+			hovered = newHover;
+			surf.blitFrom(bg);
+			renderMenuLayout(surf, layout, hovered, hitRects);
+			g_system->copyRectToScreen(surf.getPixels(), surf.pitch,
+			                           0, 0, 640, 480);
+		}
+
+		if (getCurrentMouseButton() == 1 && hovered >= 0) {
+			int act = actions[hovered];
+			waitMouseRelease();
+			if (act == kNone)
+				continue;
+			if (act == kOptions) {
+				displayOptionsMenu(bg);
+				// Repaint the in-game menu after the sub-menu closes.
+				hovered = -1;
+				surf.blitFrom(bg);
+				renderMenuLayout(surf, layout, -1, hitRects);
+				g_system->copyRectToScreen(surf.getPixels(), surf.pitch,
+				                           0, 0, 640, 480);
+				g_system->updateScreen();
+				continue;
+			}
+			if (act == kQuit && !confirmQuit(bg)) {
+				// Player backed out of the "ARE YOU SURE ?" prompt —
+				// repaint the in-game menu and stay in the loop.
+				hovered = -1;
+				surf.blitFrom(bg);
+				renderMenuLayout(surf, layout, -1, hitRects);
+				g_system->copyRectToScreen(surf.getPixels(), surf.pitch,
+				                           0, 0, 640, 480);
+				g_system->updateScreen();
+				continue;
+			}
+			retval = (uint)act;
+			done = true;
+			break;
+		}
+
+		musicUpdate();
+		g_system->updateScreen();
+		g_system->delayMillis(10);
+	}
+
+	clearKeys();
+
+	switch (retval) {
+	case kContinue:
+		return 0;
+	case kLoad: {
+		// LOAD GAME: the per-episode save picker — every kept checkpoint of
+		// the current player, listed by its EPI.TXT name.  Picking the
+		// current chapter's entry restarts that episode (its save was made
+		// on chapter entry); picking an earlier one rewinds the story.
+		Common::String dummy;
+		uint slot = displaySavePicker(false, dummy);
+		if (slot > 0) {
+			_loadedSave = slot;
+			return 28;
+		}
+		return 0;
+	}
+	case kQuit:
+		// Run the credits slideshow (END.TGA + CREDIT01..10.TGA + 04GENERI.APC)
+		// before signalling kAbortQuit.  Only the in-game menu's explicit
+		// QUIT GAME button triggers this — other quit paths (Esc dismiss,
+		// window close, GMM Quit) bypass the outro by design.
+		playQuitOutro();
+		return 40;
+	default:
+		return 0;
+	}
+}
+
+// Checkpoint name for `chapter`, served from the SPRLIST\EPI.TXT table parsed
+// at startup by loadEpisodeNames(): line (chapter - 1) is the name shown for a
+// save made on entering that chapter.  Chapter 1 (new game) and unused chapter
+// numbers map to an empty entry — they have no checkpoint.
+Common::String CryOmni3DEngine_Atlantis::episodeName(uint chapter) const {
+	if (chapter < 1 || chapter > _episodeNames.size())
+		return Common::String();
+	return _episodeNames[chapter - 1];
+}
+
+// Quit confirmation — composited from SPRLIST\SUREMENU.TXT.  That file is
+// authored as a fixed structure: text item 0 is the prompt ("ARE YOU SURE ?"),
+// item 1 the confirm button, item 2 the cancel button, plus two decorative
+// /spr ornaments.  A localized disc only swaps the strings, never the order,
+// so the buttons are identified by ordinal position rather than label text.
+// The prompt line is drawn but stays inert (not a click target).
+bool CryOmni3DEngine_Atlantis::confirmQuit(const Graphics::ManagedSurface &bg) {
+	MenuLayout layout;
+	if (!loadMenuLayout("SUREMENU.TXT", layout))
+		return true;  // no confirmation data on this disc — proceed to quit
+
+	int confirmIdx = -1, cancelIdx = -1;
+	uint textOrdinal = 0;
+	for (uint i = 0; i < layout.items.size(); i++) {
+		if (layout.items[i].kind != MenuItem::kText)
+			continue;
+		if (textOrdinal == 1)
+			confirmIdx = (int)i;
+		else if (textOrdinal == 2)
+			cancelIdx = (int)i;
+		textOrdinal++;
+	}
+
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	Graphics::ManagedSurface surf;
+	surf.create(640, 480, fmt);
+
+	Common::Array<Common::Rect> hitRects;
+	int hovered = -1;
+
+	clearKeys();
+	showMouse(true);
+	setArrowCursor();
+
+	surf.blitFrom(bg);
+	renderMenuLayout(surf, layout, -1, hitRects);
+	g_system->copyRectToScreen(surf.getPixels(), surf.pitch, 0, 0, 640, 480);
+	g_system->updateScreen();
+
+	while (!shouldAbort()) {
+		pollEvents();
+
+		if (getNextKey().keycode == Common::KEYCODE_ESCAPE)
+			return false;
+
+		// Only the confirm / cancel buttons react; the prompt is inert.
+		int hit = hitTestMenu(layout, hitRects, getMousePos());
+		if (hit != confirmIdx && hit != cancelIdx)
+			hit = -1;
+		if (hit != hovered) {
+			hovered = hit;
+			surf.blitFrom(bg);
+			renderMenuLayout(surf, layout, hovered, hitRects);
+			g_system->copyRectToScreen(surf.getPixels(), surf.pitch,
+			                           0, 0, 640, 480);
+		}
+
+		if (getCurrentMouseButton() == 1 && hovered >= 0) {
+			waitMouseRelease();
+			return hovered == confirmIdx;
+		}
+
+		musicUpdate();
+		g_system->updateScreen();
+		g_system->delayMillis(10);
+	}
+	return false;
+}
+
+// Config key for the OMNI 3D control mode.  MODE 2 (false) is the default
+// look behaviour; MODE 1 (true) inverts the vertical look axis.
+static const char *const kOmni3dInvertKey = "atlantis_omni3d_invert";
+
+// Config key for the SONMENU "Volume" master slider — read here and applied
+// on top of the per-channel volumes by syncSoundSettings() (engine.cpp).
+static const char *const kMasterVolKey = "atlantis_master_volume";
+
+bool CryOmni3DEngine_Atlantis::omni3dInvertY() const {
+	return ConfMan.hasKey(kOmni3dInvertKey) && ConfMan.getBool(kOmni3dInvertKey);
+}
+
+// Options menu — SPRLIST\OPTMENU.TXT.  Fixed structure on every localized
+// disc, classified by ordinal position:
+//   kText   ordinal 0 = "OPTIONS MENU" title  (inert)
+//           ordinal 1 = SOUND OPTIONS button  (opens SONMENU)
+//           ordinal 2 = "SUBTITLES:" label    (inert)
+//           ordinal 3 = "OMNI 3D:"  label     (inert)
+//           ordinal 4 = OK button             (close)
+//   kToggle ordinal 0 = subtitles  ON / OFF
+//           ordinal 1 = omni 3d    MODE 2 / MODE 1
+void CryOmni3DEngine_Atlantis::displayOptionsMenu(const Graphics::ManagedSurface &bg) {
+	MenuLayout layout;
+	if (!loadMenuLayout("OPTMENU.TXT", layout))
+		return;
+
+	int soundIdx = -1, okIdx = -1, subIdx = -1, omniIdx = -1;
+	{
+		int textOrd = 0, toggleOrd = 0;
+		for (uint i = 0; i < layout.items.size(); i++) {
+			if (layout.items[i].kind == MenuItem::kText) {
+				if (textOrd == 1)      soundIdx = (int)i;
+				else if (textOrd == 4) okIdx    = (int)i;
+				textOrd++;
+			} else if (layout.items[i].kind == MenuItem::kToggle) {
+				if (toggleOrd == 0)      subIdx  = (int)i;
+				else if (toggleOrd == 1) omniIdx = (int)i;
+				toggleOrd++;
+			}
+		}
+	}
+
+	// Seed the toggles from the live settings.  Both are authored with the
+	// "default" label first: SUBTITLES "ON&&OFF", OMNI 3D "MODE 2&&MODE 1".
+	if (subIdx >= 0)
+		layout.items[subIdx].selected = showSubtitles() ? 0 : 1;
+	if (omniIdx >= 0)
+		layout.items[omniIdx].selected = omni3dInvertY() ? 1 : 0;
+
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	Graphics::ManagedSurface surf;
+	surf.create(640, 480, fmt);
+
+	Common::Array<Common::Rect> hitRects;
+	int hovered = -1;
+	bool done = false;
+
+	clearKeys();
+	showMouse(true);
+	setArrowCursor();
+
+	surf.blitFrom(bg);
+	renderMenuLayout(surf, layout, -1, hitRects);
+	g_system->copyRectToScreen(surf.getPixels(), surf.pitch, 0, 0, 640, 480);
+	g_system->updateScreen();
+
+	while (!done && !shouldAbort()) {
+		pollEvents();
+
+		if (getNextKey().keycode == Common::KEYCODE_ESCAPE)
+			break;
+
+		Common::Point mouse = getMousePos();
+		int newHover = hitTestMenu(layout, hitRects, mouse);
+		// Only the two buttons and the two toggles react to the mouse.
+		if (newHover != soundIdx && newHover != okIdx &&
+		    newHover != subIdx && newHover != omniIdx)
+			newHover = -1;
+		if (newHover != hovered) {
+			hovered = newHover;
+			surf.blitFrom(bg);
+			renderMenuLayout(surf, layout, hovered, hitRects);
+			g_system->copyRectToScreen(surf.getPixels(), surf.pitch,
+			                           0, 0, 640, 480);
+		}
+
+		if (getCurrentMouseButton() == 1 && hovered >= 0) {
+			waitMouseRelease();
+			if (hovered == okIdx) {
+				done = true;
+			} else if (hovered == soundIdx) {
+				displaySoundMenu(bg);
+			} else {
+				// Cycle the clicked toggle and persist the new value.
+				MenuItem &tog = layout.items[hovered];
+				if (!tog.options.empty())
+					tog.selected = (tog.selected + 1) % (int)tog.options.size();
+				if (hovered == subIdx)
+					ConfMan.setBool("subtitles", tog.selected == 0);
+				else if (hovered == omniIdx)
+					ConfMan.setBool(kOmni3dInvertKey, tog.selected == 1);
+			}
+			// Repaint after any action (sub-menu, toggle flip).
+			hovered = -1;
+			surf.blitFrom(bg);
+			renderMenuLayout(surf, layout, -1, hitRects);
+			g_system->copyRectToScreen(surf.getPixels(), surf.pitch,
+			                           0, 0, 640, 480);
+		}
+
+		musicUpdate();
+		g_system->updateScreen();
+		g_system->delayMillis(10);
+	}
+
+	ConfMan.flushToDisk();
+	clearKeys();
+}
+
+// Play WAV\<apcName> once as an effect with the given stereo balance — the
+// SONMENU Left/Right speaker test.  Reuses the newsound SFX handle.
+void CryOmni3DEngine_Atlantis::playPannedSound(const char *apcName, int8 balance) {
+	Common::SeekableReadStream *apcFile = openBigFileStream(kFileTypeSound, apcName);
+	if (!apcFile)
+		return;
+	Audio::PacketizedAudioStream *apc = Audio::makeAPCStream(*apcFile);
+	if (apc) {
+		int64 remaining = apcFile->size() - apcFile->pos();
+		if (remaining > 0) {
+			byte *buf = new byte[remaining];
+			apcFile->read(buf, (uint32)remaining);
+			apc->queuePacket(new Common::MemoryReadStream(buf, remaining,
+			                                              DisposeAfterUse::YES));
+		}
+		apc->finish();
+		if (_mixer->isSoundHandleActive(_newSoundHandle))
+			_mixer->stopHandle(_newSoundHandle);
+		_mixer->playStream(Audio::Mixer::kSFXSoundType, &_newSoundHandle, apc,
+		                   -1, Audio::Mixer::kMaxChannelVolume, balance);
+	}
+	delete apcFile;
+}
+
+// Sound-options sub-menu — SPRLIST\SONMENU.TXT.  Four horizontal volume
+// sliders (Volume / Music / Effects / Voices), each built from a track
+// sprite plus a knob sprite whose x is derived from the volume.  "Volume"
+// is a master applied by syncSoundSettings().  The Left / Right labels are
+// a speaker test that plays WAV\VAGUE_10.APC panned hard to one side.  OK
+// commits the volumes to the ScummVM config; Cancel or Escape discards.
+void CryOmni3DEngine_Atlantis::displaySoundMenu(const Graphics::ManagedSurface &bg) {
+	MenuLayout layout;
+	if (!loadMenuLayout("SONMENU.TXT", layout))
+		return;
+
+	// SONMENU.TXT lists four track /spr items then four knob /spr items.
+	// Tracks give the slider extent (hx + w); knobs give the sprite index
+	// and the authored knob y for each row.  Only the knob x is computed,
+	// from the live volume.
+	int trackItem[4];
+	int knobItem[4];
+	int nTrack = 0, nKnob = 0;
+	for (uint i = 0; i < layout.items.size(); i++) {
+		if (layout.items[i].kind != MenuItem::kSprite)
+			continue;
+		if (nTrack < 4)
+			trackItem[nTrack++] = (int)i;
+		else if (nKnob < 4)
+			knobItem[nKnob++] = (int)i;
+	}
+	if (nTrack < 4 || nKnob < 4)
+		return;  // not the expected slider layout
+	const int knobSpr = layout.items[knobItem[0]].sprIdx;
+	// The knob travels by its own left edge, so its run stops one knob-width
+	// short of the track end — otherwise it overshoots past the bar.
+	const int knobW = ((uint)knobSpr < _menuSprites.size())
+	                  ? (int)_menuSprites[knobSpr].w : 0;
+
+	// OK / Cancel are text ordinals 7 and 8 (after the title and the six
+	// Volume/Music/Effects/Voices/Left/Right labels).
+	int leftIdx = -1, rightIdx = -1, okIdx = -1, cancelIdx = -1;
+	{
+		int textOrd = 0;
+		for (uint i = 0; i < layout.items.size(); i++) {
+			if (layout.items[i].kind != MenuItem::kText)
+				continue;
+			if (textOrd == 5)      leftIdx   = (int)i;
+			else if (textOrd == 6) rightIdx  = (int)i;
+			else if (textOrd == 7) okIdx     = (int)i;
+			else if (textOrd == 8) cancelIdx = (int)i;
+			textOrd++;
+		}
+	}
+
+	// Four independent volumes (0..kMaxMixerVolume).  Slider 0 ("Volume") is
+	// the master applied by syncSoundSettings(); 1..3 are the ScummVM
+	// per-channel volumes.  Each slider moves on its own.
+	const int kMaxVol = Audio::Mixer::kMaxMixerVolume;
+	int vol[4];
+	vol[0] = ConfMan.hasKey(kMasterVolKey) ? ConfMan.getInt(kMasterVolKey)
+	                                        : kMaxVol;
+	vol[1] = ConfMan.getInt("music_volume");
+	vol[2] = ConfMan.getInt("sfx_volume");
+	vol[3] = ConfMan.getInt("speech_volume");
+
+	// Fixed hit-boxes for the clickable labels (their text never changes).
+	Common::Rect leftRect, rightRect, okRect, cancelRect;
+	for (uint i = 0; i < layout.items.size(); i++) {
+		const MenuItem &it = layout.items[i];
+		if (it.kind != MenuItem::kText)
+			continue;
+		int w = fontMaxStringWidth(it.text);
+		int x = it.centerX ? (640 - w) / 2 : it.anchorX;
+		Common::Rect r(x, it.anchorY - kFontMaxHitTop,
+		               x + w, it.anchorY + kFontMaxHitBottom);
+		if ((int)i == leftIdx)   leftRect   = r;
+		if ((int)i == rightIdx)  rightRect  = r;
+		if ((int)i == okIdx)     okRect     = r;
+		if ((int)i == cancelIdx) cancelRect = r;
+	}
+
+	// Static background: panorama + track sprites + any non-knob ornament.
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	Graphics::ManagedSurface base;
+	base.create(640, 480, fmt);
+	base.blitFrom(bg);
+	for (uint i = 0; i < layout.items.size(); i++) {
+		const MenuItem &it = layout.items[i];
+		if (it.kind == MenuItem::kSprite && it.sprIdx != knobSpr)
+			blitMenuSprite(base, (uint)it.sprIdx, it.hx, it.hy);
+	}
+
+	Graphics::ManagedSurface surf;
+	surf.create(640, 480, fmt);
+
+	int  activeSlider = -1;
+	bool wasDown = false;
+	bool done = false;
+	bool commit = false;
+
+	clearKeys();
+	showMouse(true);
+	setArrowCursor();
+
+	while (!done && !shouldAbort()) {
+		pollEvents();
+
+		if (getNextKey().keycode == Common::KEYCODE_ESCAPE)
+			break;
+
+		Common::Point mouse = getMousePos();
+		bool down = (getCurrentMouseButton() == 1);
+		bool pressEdge = down && !wasDown;
+		wasDown = down;
+
+		if (pressEdge) {
+			activeSlider = -1;
+			for (int t = 0; t < 4; t++) {
+				const MenuItem &tr = layout.items[trackItem[t]];
+				Common::Rect r(tr.hx, tr.hy, tr.hx + tr.w, tr.hy + tr.h);
+				if (r.contains(mouse)) {
+					activeSlider = t;
+					break;
+				}
+			}
+			if (activeSlider < 0) {
+				if (okRect.contains(mouse)) {
+					commit = true;
+					done = true;
+				} else if (cancelRect.contains(mouse)) {
+					done = true;
+				} else if (leftRect.contains(mouse)) {
+					playPannedSound("VAGUE_10.APC", -127);
+				} else if (rightRect.contains(mouse)) {
+					playPannedSound("VAGUE_10.APC", 127);
+				}
+			}
+		}
+
+		if (down && activeSlider >= 0) {
+			const MenuItem &tr = layout.items[trackItem[activeSlider]];
+			int span = MAX(1, tr.w - knobW);
+			// The knob is placed by its left edge; bias by half its width
+			// so it stays centred on the cursor while dragging.
+			int v = ((mouse.x - tr.hx - knobW / 2) * kMaxVol) / span;
+			vol[activeSlider] = CLIP(v, 0, kMaxVol);
+		}
+		if (!down)
+			activeSlider = -1;
+
+		// Render: static background + knobs + text labels.
+		surf.blitFrom(base);
+		for (int t = 0; t < 4; t++) {
+			const MenuItem &tr = layout.items[trackItem[t]];
+			int span = MAX(1, tr.w - knobW);
+			int knobX = tr.hx + (vol[t] * span) / kMaxVol;
+			int knobY = layout.items[knobItem[t]].hy;
+			blitMenuSprite(surf, (uint)knobSpr, knobX, knobY);
+		}
+		for (uint i = 0; i < layout.items.size(); i++) {
+			const MenuItem &it = layout.items[i];
+			if (it.kind != MenuItem::kText)
+				continue;
+			int w = fontMaxStringWidth(it.text);
+			int x = it.centerX ? (640 - w) / 2 : it.anchorX;
+			bool hover = ((int)i == okIdx     && okRect.contains(mouse)) ||
+			             ((int)i == cancelIdx && cancelRect.contains(mouse)) ||
+			             ((int)i == leftIdx   && leftRect.contains(mouse)) ||
+			             ((int)i == rightIdx  && rightRect.contains(mouse));
+			drawFontMaxText(surf, it.text, x, it.anchorY, hover);
+		}
+		g_system->copyRectToScreen(surf.getPixels(), surf.pitch, 0, 0, 640, 480);
+
+		musicUpdate();
+		g_system->updateScreen();
+		g_system->delayMillis(10);
+	}
+
+	waitMouseRelease();
+	clearKeys();
+
+	if (commit) {
+		ConfMan.setInt(kMasterVolKey,   vol[0]);
+		ConfMan.setInt("music_volume",  vol[1]);
+		ConfMan.setInt("sfx_volume",    vol[2]);
+		ConfMan.setInt("speech_volume", vol[3]);
+		ConfMan.flushToDisk();
+		syncSoundSettings();
+	}
+}
+
+// Per-character advance widths for the player-screen name fields, taken from
+// atlantis.exe's table at VA 0x496697 (indexed by glyph = char - 0x20).  These
+// are wider than the FONTMIN glyph bitmaps — they include inter-letter spacing.
+static const uint8 kPlayerCharWidths[137] = {
+	15, 8,13, 6,13,20,17, 6,13,20,11, 6, 4,20,15,12,17, 8,16,16,
+	14,13,15,13,16,15, 7, 6, 6, 6, 6,20, 6,17,19,18,19,16,16,19,
+	18,12,12,17,16,24,20,23,17,22,17,15,19,20,17,23,22,18,17, 7,
+	16, 6,10, 6, 7,16,16,15,15,16,12,16,17, 8, 9,16, 7,19,16,17,
+	16,15,13,12,10,17,15,19,17,15,14,16, 6,17,11,16,17,17,15,16,
+	15,16,16,16,15,15,15,11,10,10,18,18,16,17,17,17,17,15,23,19,
+	15,19, 0,21,17,16,10,17,17,10,20,14,14,13, 3, 5, 8
+};
+
+// Player-name renderer for the player-management screen.  Glyphs come from
+// FONTMIN.SPR (FONTMIN2.SPR when `hover`); each character is advanced by the
+// original's 0x496697 width table, so the layout is identical whichever glyph
+// set is used — a hover swap only recolours, it never reflows.
+void CryOmni3DEngine_Atlantis::drawPlayerText(Graphics::ManagedSurface &dst,
+        const Common::String &text, int anchorX, int anchorY, bool hover) const {
+	const Common::Array<SubjSprite> &glyphs =
+	    (hover && !_fontMin2Sprites.empty()) ? _fontMin2Sprites : _fontMinSprites;
+	int cx = anchorX;
+	for (uint i = 0; i < text.size(); ++i) {
+		int gi = (int)(unsigned char)text[i] - 0x20;
+		if (gi < 0 || gi >= (int)glyphs.size())
+			continue;
+		const SubjSprite &spr = glyphs[gi];
+		if (!spr.pixels.empty()) {
+			int dx = cx - spr.xoff;
+			int dy = anchorY - spr.yoff;
+			for (int sy = 0; sy < (int)spr.h; ++sy) {
+				int ty = dy + sy;
+				if (ty < 0 || ty >= dst.h)
+					continue;
+				for (int sx = 0; sx < (int)spr.w; ++sx) {
+					uint sidx = sy * spr.w + sx;
+					uint16 pix = spr.pixels[sidx];
+					if (pix == kSprTransp)
+						continue;
+					int tx = dx + sx;
+					if (tx < 0 || tx >= dst.w)
+						continue;
+					uint16 *dp = (uint16 *)dst.getBasePtr(tx, ty);
+					if (spr.blend[sidx] != kSprNoBlend)
+						pix = blendSprPixel565(pix, *dp, spr.blend[sidx]);
+					*dp = pix;
+				}
+			}
+		}
+		if (gi < (int)ARRAYSIZE(kPlayerCharWidths))
+			cx += kPlayerCharWidths[gi];
+	}
+}
+
+// Player-management screen — the original game's startup select / create /
+// delete-player flow.  The PREINTRO.TGA artwork and the SELEMENU.TXT frame
+// ("SELECT PLAYER NAME" / "DELETE PLAYER NAME" / "OK") form the backdrop.
+// Existing players and a "New Player" entry are listed in FONTMIN; creating a
+// player shows a dotted name field above the list.  Returns the chosen player
+// id, or -1 if quit.
+int CryOmni3DEngine_Atlantis::displayPlayerScreen() {
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+
+	// Backdrop: the PREINTRO.TGA menu artwork (the "Atlantis" title scene),
+	// with the SELEMENU.TXT ornaments and labels composited on top — the same
+	// background the main menu uses.
+	Graphics::ManagedSurface bg;
+	{
+		Graphics::Surface *raw = loadTGA(kFileTypeImages, "PREINTRO.TGA");
+		if (raw) {
+			bg.copyFrom(*raw);
+			raw->free();
+			delete raw;
+		} else {
+			bg.create(640, 480, fmt);
+			bg.fillRect(Common::Rect(0, 0, 640, 480), fmt.RGBToColor(0, 0, 0));
+		}
+	}
+	MenuLayout decor;
+	loadMenuLayout("SELEMENU.TXT", decor);
+	Common::Array<Common::Rect> decorRects;
+	// Locate the interactive "OK" and "DELETE PLAYER NAME" labels so they can
+	// be hover-lit and hit-tested each frame — "OK" validates a name being
+	// typed, "DELETE PLAYER NAME" toggles delete mode.
+	int okIdx = -1, delIdx = -1;
+	for (uint i = 0; i < decor.items.size(); i++) {
+		if (decor.items[i].kind != MenuItem::kText)
+			continue;
+		if (decor.items[i].text == "OK")
+			okIdx = (int)i;
+		else if (decor.items[i].text == "DELETE PLAYER NAME")
+			delIdx = (int)i;
+	}
+	// Player-row layout — the exact grid the original hit-tests with
+	// (atlantis.exe FUN_004211f0, captured live): a row's clickable cell is
+	// [kGridY0 + j*kGridStep, kGridY0 + (j+1)*kGridStep) x [kGridX0, +kGridW).
+	// The FONTMAX baseline sits on the cell bottom.
+	static const int kGridX0   = 175;
+	static const int kGridW    = 320;
+	static const int kGridY0   = 248;
+	static const int kGridStep = 22;
+	// The dotted name-entry field's fixed anchor, above the list
+	// (atlantis.exe FUN_00420f60 caller at 0x41e3df: EAX=0xA0, EDX=0xBE).
+	static const int kEditFieldX = 160;
+	static const int kEditFieldY = 190;
+
+	Graphics::ManagedSurface surf;
+	surf.create(640, 480, fmt);
+	// Render the SELEMENU frame once so decorRects is populated before the
+	// first hit-test; it is re-rendered with hover state inside the loop.
+	renderMenuLayout(surf, decor, -1, decorRects);
+
+	int  editing    = -1;          // storage slot being typed into, or -1
+	int  selected   = -1;          // existing player picked, shown above list
+	Common::String editBuf;
+	int  result     = -2;          // -2 running, -1 quit, >=0 chosen player
+	uint32 lastClickMs = 0;        // press time of the last player-row click
+	const uint32 kDoubleClickMs = 500;
+
+	clearKeys();
+	showMouse(true);
+	setArrowCursor();
+
+	while (result == -2 && !shouldAbort()) {
+		pollEvents();
+
+		// Build the visible row list: existing players, then a "New Player"
+		// entry while there is still room.  The dotted name-entry field is
+		// drawn separately, above the list (see the redraw below).
+		const int kRowNew = -2;
+		int  rowSlot[kMaxPlayers + 1];
+		int  numRows = 0;
+		uint numPlayers = 0;
+		for (uint i = 0; i < kMaxPlayers; i++) {
+			if (!_players[i].empty()) {
+				rowSlot[numRows++] = (int)i;
+				numPlayers++;
+			}
+		}
+		if ((editing >= 0 ? numPlayers + 1 : numPlayers) < kMaxPlayers)
+			rowSlot[numRows++] = kRowNew;
+
+		// Keyboard: while creating a player, capture the typed name.
+		Common::KeyState k = getNextKey();
+		if (k.keycode != Common::KEYCODE_INVALID) {
+			if (editing >= 0) {
+				if (k.keycode == Common::KEYCODE_ESCAPE) {
+					editing = -1;
+					editBuf.clear();
+				} else if (k.keycode == Common::KEYCODE_RETURN
+				        || k.keycode == Common::KEYCODE_KP_ENTER) {
+					if (!editBuf.empty()) {
+						_players[editing] = editBuf;
+						savePlayers();
+						result = editing;   // the new player becomes current
+					}
+				} else if (k.keycode == Common::KEYCODE_BACKSPACE) {
+					if (!editBuf.empty())
+						editBuf.deleteLastChar();
+				} else if (k.ascii >= 0x20 && k.ascii < 0x7f
+				        && editBuf.size() < kPlayerNameLen) {
+					// The original rejects a leading space or period.
+					if (!(editBuf.empty() && (k.ascii == ' ' || k.ascii == '.')))
+						editBuf += (char)k.ascii;
+				}
+			} else if (k.keycode == Common::KEYCODE_ESCAPE) {
+				result = -1;
+				break;
+			}
+		}
+
+		// Mouse hover / click.
+		Common::Point mouse = getMousePos();
+		int hovered = -1;
+		for (int j = 0; j < numRows; j++) {
+			Common::Rect r(kGridX0, kGridY0 + j * kGridStep,
+			               kGridX0 + kGridW, kGridY0 + (j + 1) * kGridStep);
+			if (r.contains(mouse)) {
+				hovered = j;
+				break;
+			}
+		}
+		// Hover state for the interactive SELEMENU labels.
+		bool okHover  = (okIdx  >= 0) && decorRects[okIdx].contains(mouse);
+		bool delHover = (delIdx >= 0) && decorRects[delIdx].contains(mouse);
+
+		if (getCurrentMouseButton() == 1) {
+			uint32 now = g_system->getMillis();
+			waitMouseRelease();
+			if (editing >= 0) {
+				// While creating a player, clicking OK validates the typed
+				// name — the same as pressing Return.
+				if (okHover && !editBuf.empty()) {
+					_players[editing] = editBuf;
+					savePlayers();
+					result = editing;   // the new player becomes current
+				}
+			} else if (delHover) {
+				// Delete the selected player after a confirmation dialog.
+				// confirmQuit() shows the SUREMENU prompt over the bare title
+				// backdrop (bg) rather than the live player screen, so the
+				// list, "SELECT PLAYER NAME" / "DELETE PLAYER NAME" / "OK"
+				// labels all vanish behind "ARE YOU SURE ?" — matching the
+				// original.  SUREMENU.TXT carries its own ornament sprites.
+				if (selected >= 0 && confirmQuit(bg)) {
+					_players[selected].clear();
+					deletePlayerSaves((uint)selected);
+					savePlayers();
+					selected = -1;
+				}
+			} else if (okHover) {
+				// OK starts the game for the selected existing player.
+				if (selected >= 0)
+					result = selected;
+			} else if (hovered >= 0) {
+				int slot = rowSlot[hovered];
+				if (slot >= 0) {                  // an existing player
+					if (selected == slot
+					        && now - lastClickMs < kDoubleClickMs) {
+						result = slot;            // double-click → play
+					} else {
+						selected = slot;          // single click → show name
+						lastClickMs = now;
+					}
+				} else if (slot == kRowNew) {
+					// Create: type into the first free storage slot.
+					for (uint i = 0; i < kMaxPlayers; i++) {
+						if (_players[i].empty()) {
+							editing = (int)i;
+							editBuf.clear();
+							selected = -1;
+							break;
+						}
+					}
+				}
+			}
+		}
+
+		// Redraw.  The SELEMENU frame is re-rendered each frame so the "OK"
+		// and "DELETE PLAYER NAME" labels can light up on hover.
+		surf.blitFrom(bg);
+		renderMenuLayout(surf, decor, okHover ? okIdx
+		                              : (delHover ? delIdx : -1), decorRects);
+		// Player rows use FONTMIN (FONTMIN2 for the hovered row), left-aligned
+		// at the grid's X origin.
+		for (int j = 0; j < numRows; j++) {
+			int slot = rowSlot[j];
+			Common::String label = (slot == kRowNew)
+			    ? Common::String("New Player") : _players[slot];
+			bool hot = (j == hovered) || (slot >= 0 && slot == selected);
+			drawPlayerText(surf, label, kGridX0,
+			               kGridY0 + (j + 1) * kGridStep, hot);
+		}
+		// The name area above the list shows either the new name being typed
+		// (with the dotted placeholder), or — once an existing player has been
+		// picked — that player's name, plain and not editable.
+		if (editing >= 0) {
+			Common::String field = editBuf;
+			while (field.size() < kPlayerNameLen)
+				field += '.';
+			drawPlayerText(surf, field, kEditFieldX, kEditFieldY, true);
+		} else if (selected >= 0) {
+			drawPlayerText(surf, _players[selected], kEditFieldX, kEditFieldY, true);
+		}
+
+		g_system->copyRectToScreen(surf.getPixels(), surf.pitch, 0, 0, 640, 480);
+		musicUpdate();
+		g_system->updateScreen();
+		g_system->delayMillis(10);
+	}
+
+	clearKeys();
+	return result == -2 ? -1 : result;
+}
+
+// In-game LOAD GAME screen — SPRLIST\LOADMENU.TXT composited over the live
+// panorama.  The current player's per-episode saves are listed in the red
+// FONTMIN font beneath the "LOAD GAME" title (oldest first, up to 11 visible
+// and scrollable), and RESTART EPISODE / OK / Cancel are the FONTMAX buttons
+// from the layout, classified by ordinal so localized discs (which only swap
+// the strings) work unchanged.  Mirrors atlantis.exe FUN_0041cf78: clicking a
+// name selects it, OK loads the selection, RESTART EPISODE reloads the current
+// chapter, Cancel/Escape backs out.  Returns the absolute slot (1-based) to
+// load, or 0 on cancel.
+uint CryOmni3DEngine_Atlantis::displaySavePicker(bool saveMode,
+        Common::String &outSaveName) {
+	(void)saveMode;       // Atlantis has no manual save: this is load-only.
+	(void)outSaveName;
+
+	// SPRLIST\LOADMENU.TXT authored geometry: the episode list sits between
+	// the title (y=50) and RESTART EPISODE (y=390); atlantis.exe shows 11 rows.
+	const int kListX    = 50;
+	const int kListY0   = 133;   // FONTMIN baseline of the first row
+	const int kRowStep  = 20;
+	const int kVisible  = 11;
+
+	Graphics::PixelFormat fmt = g_system->getScreenFormat();
+
+	// Backdrop: the live panorama (the LOAD screen composites over the scene),
+	// or black when the engine is not yet in a place.
+	Graphics::ManagedSurface bg;
+	bg.create(640, 480, fmt);
+	const Graphics::Surface *pano = _warpLoaded ? _omni3dMan.getSurface() : nullptr;
+	if (pano)
+		bg.blitFrom(*pano);
+	else
+		bg.fillRect(Common::Rect(0, 0, 640, 480), fmt.RGBToColor(0, 0, 0));
+
+	// Frame: "LOAD GAME" title (text ordinal 0, inert) + RESTART EPISODE / OK
+	// / Cancel (ordinals 1/2/3) + the ornament sprites.
+	MenuLayout layout;
+	if (!loadMenuLayout("LOADMENU.TXT", layout))
+		return 0;
+	int restartIdx = -1, okIdx = -1, cancelIdx = -1;
+	{
+		uint textOrd = 0;
+		for (uint i = 0; i < layout.items.size(); i++) {
+			if (layout.items[i].kind != MenuItem::kText)
+				continue;
+			if (textOrd == 1)      restartIdx = (int)i;
+			else if (textOrd == 2) okIdx      = (int)i;
+			else if (textOrd == 3) cancelIdx  = (int)i;
+			textOrd++;
+		}
+	}
+
+	// Collect the player's per-episode saves.  A save's local slot index is
+	// its chapter number, so the checkpoint name comes straight from EPI.TXT
+	// (episodeName) — the full text, not the 20-char description truncated
+	// into the save file.  Older/unnamed saves fall back to that description.
+	struct Entry {
+		int            localSlot;   // = chapter number
+		Common::String name;
+	};
+	Common::Array<Entry> saves;
+	int selected = -1;              // index into saves, or -1
+	for (uint ch = 0; ch < kPlayerSlotStride; ch++) {
+		int abs = episodeSaveSlot((uint)_currentPlayer, ch);
+		Common::InSaveFile *in = _saveFileMan->openForLoading(getSaveStateName(abs));
+		if (!in)
+			continue;
+		char desc[kSaveDescriptionLen + 1];
+		memset(desc, 0, sizeof(desc));
+		bool ok = (in->read(desc, kSaveDescriptionLen) == kSaveDescriptionLen);
+		desc[kSaveDescriptionLen] = '\0';
+		delete in;
+		if (!ok)
+			continue;
+		Entry e;
+		e.localSlot = (int)ch;
+		e.name = episodeName(ch);
+		if (e.name.empty())
+			e.name = desc[0] ? Common::String(desc)
+			                 : Common::String::format("Chapter %u", ch);
+		if (ch == _currentCONChapter)
+			selected = (int)saves.size();   // pre-select the current episode
+		saves.push_back(e);
+	}
+
+	// FONTMIN advance width of a name, for a snug per-row hit-box.
+	auto playerTextWidth = [&](const Common::String &s) {
+		int w = 0;
+		for (uint i = 0; i < s.size(); i++) {
+			int gi = (int)(unsigned char)s[i] - 0x20;
+			if (gi >= 0 && gi < (int)ARRAYSIZE(kPlayerCharWidths))
+				w += kPlayerCharWidths[gi];
+		}
+		return w;
+	};
+
+	int scroll = 0;                 // index of the first visible row
+	if (selected >= 0)
+		scroll = CLIP(selected - kVisible / 2, 0,
+		              MAX(0, (int)saves.size() - kVisible));
+
+	Graphics::ManagedSurface surf;
+	surf.create(640, 480, fmt);
+	Common::Array<Common::Rect> hitRects;
+
+	// Scrollbar geometry (LOADMENU.TXT: /spr=4 track at x=601, /spr=13 thumb).
+	// atlantis.exe FUN_0041cf78 makes the list scrollable only once it overflows
+	// the 11 visible rows; the thumb is dragged within the track's interactive
+	// Y span [0x7b, 0x152] = [123, 338] and maps linearly onto the scroll
+	// offset.  Below that count the thumb is parked off-screen (exe sets it to
+	// 0xffce).  Find the thumb sprite so we can position/hide it per frame.
+	const int kBarTop   = 123;   // exe 0x7b
+	const int kBarBot   = 338;   // exe 0x152
+	const int kBarH     = kBarBot - kBarTop;   // 215 (0xd7)
+	const int kBarX0    = 595;   // right-edge scrollbar column (track ~601..638)
+	const int kBarX1    = 640;
+	const int maxScroll = MAX(0, (int)saves.size() - kVisible);
+	const bool scrollable = maxScroll > 0;
+	int thumbItem = -1;
+	for (uint i = 0; i < layout.items.size(); i++)
+		if (layout.items[i].kind == MenuItem::kSprite
+		        && layout.items[i].sprIdx == 13) {
+			thumbItem = (int)i;
+			break;
+		}
+
+	clearKeys();
+	showMouse(true);
+	setArrowCursor();
+
+	uint result = 0;
+	bool done = false;
+	while (!done && !shouldAbort()) {
+		pollEvents();
+
+		// Keyboard: Escape / Enter act on the selection; the arrows scroll it.
+		Common::KeyState k = getNextKey();
+		if (k.keycode == Common::KEYCODE_ESCAPE) {
+			result = 0;
+			break;
+		} else if ((k.keycode == Common::KEYCODE_RETURN
+		         || k.keycode == Common::KEYCODE_KP_ENTER) && selected >= 0) {
+			result = (uint)episodeSaveSlot((uint)_currentPlayer,
+			             (uint)saves[selected].localSlot) + 1;
+			done = true;
+			break;
+		} else if (k.keycode == Common::KEYCODE_UP && selected > 0) {
+			selected--;
+		} else if (k.keycode == Common::KEYCODE_DOWN
+		        && selected + 1 < (int)saves.size()) {
+			selected++;
+		} else if (k.keycode == Common::KEYCODE_PAGEUP) {
+			selected = MAX(0, selected - kVisible);
+		} else if (k.keycode == Common::KEYCODE_PAGEDOWN) {
+			selected = MIN((int)saves.size() - 1, selected + kVisible);
+		}
+		// Keep the selected row inside the visible window.
+		if (selected >= 0) {
+			if (selected < scroll)
+				scroll = selected;
+			else if (selected >= scroll + kVisible)
+				scroll = selected - kVisible + 1;
+		}
+
+		// Per-row hit-boxes for the visible window.
+		Common::Point mouse = getMousePos();
+		int rowHover = -1;
+		for (int i = 0; i + scroll < (int)saves.size() && i < kVisible; i++) {
+			int entry = scroll + i;
+			int ay = kListY0 + i * kRowStep;
+			int w  = MAX(playerTextWidth(saves[entry].name), 60);
+			Common::Rect r(kListX, ay - 17, kListX + w, ay + 4);
+			if (r.contains(mouse)) {
+				rowHover = entry;
+				break;
+			}
+		}
+
+		// Button hover (only RESTART / OK / Cancel react; the title is inert).
+		int btnHover = hitRects.empty() ? -1
+		             : hitTestMenu(layout, hitRects, mouse);
+		if (btnHover != restartIdx && btnHover != okIdx && btnHover != cancelIdx)
+			btnHover = -1;
+
+		// Scrollbar drag (atlantis.exe FUN_0041cf78): holding the button in the
+		// track column scrolls the list continuously as the cursor moves.  A
+		// single click in the track jumps the thumb there.  Handled before the
+		// click logic and without waitMouseRelease so the drag stays live.
+		bool draggingBar = false;
+		if (scrollable && getCurrentMouseButton() == 1
+		        && mouse.x >= kBarX0 && mouse.x <= kBarX1
+		        && mouse.y >= kBarTop && mouse.y <= kBarBot) {
+			scroll = CLIP((mouse.y - kBarTop) * maxScroll / kBarH, 0, maxScroll);
+			draggingBar = true;
+		}
+
+		if (!draggingBar && getCurrentMouseButton() == 1) {
+			waitMouseRelease();
+			if (rowHover >= 0) {
+				selected = rowHover;
+			} else if (btnHover == okIdx) {
+				if (selected >= 0) {
+					result = (uint)episodeSaveSlot((uint)_currentPlayer,
+					             (uint)saves[selected].localSlot) + 1;
+					done = true;
+					break;
+				}
+			} else if (btnHover == restartIdx) {
+				// RESTART EPISODE — reload the current chapter's checkpoint.
+				int slot = episodeSaveSlot((uint)_currentPlayer, _currentCONChapter);
+				if (saveSlotExists(slot)) {
+					result = (uint)slot + 1;
+					done = true;
+					break;
+				}
+			} else if (btnHover == cancelIdx) {
+				result = 0;
+				break;
+			}
+		}
+
+		// Position the scrollbar thumb to reflect the scroll offset, or park it
+		// off-screen when the list fits (mirrors the exe's 0xffce hide).
+		if (thumbItem >= 0)
+			layout.items[thumbItem].hy = scrollable
+			    ? kBarTop + (maxScroll > 0 ? scroll * kBarH / maxScroll : 0)
+			    : -100;
+
+		// Redraw: backdrop, LOADMENU frame, then the episode list on top.
+		surf.blitFrom(bg);
+		renderMenuLayout(surf, layout, btnHover, hitRects);
+		for (int i = 0; i + scroll < (int)saves.size() && i < kVisible; i++) {
+			int entry = scroll + i;
+			drawPlayerText(surf, saves[entry].name, kListX,
+			               kListY0 + i * kRowStep, entry == selected);
+		}
+
+		g_system->copyRectToScreen(surf.getPixels(), surf.pitch, 0, 0, 640, 480);
+
+		musicUpdate();
+		g_system->updateScreen();
+		g_system->delayMillis(10);
+	}
+
+	clearKeys();
+	return result;
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/music.cpp
+++ b/engines/cryomni3d/atlantis/music.cpp
@@ -1,0 +1,218 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "audio/audiostream.h"
+#include "audio/decoders/apc.h"
+#include "audio/decoders/raw.h"
+#include "audio/mixer.h"
+#include "common/memstream.h"
+#include "common/scummsys.h"
+#include "common/system.h"
+#include "common/util.h"
+
+#include "cryomni3d/atlantis/engine.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// Music track table — 1-based, matching the startmusik / stopmusik / loadmusik
+// CON command IDs.  Transcribed in full from atlantis.exe's table at VA
+// 0x00495eec (13-byte records).  Filenames live in the BigFile's WAV\ dir.
+static const char *const kMusicTrackNames[] = {
+	nullptr,           // index 0 unused
+	"01ATLAN1.APC",    // track  1 — Atlantis area 1 ambient
+	"10ATLAN2.APC",    // track  2
+	"23_PALA1.APC",    // track  3
+	"02AUBERG.APC",    // track  4
+	"24_RATS.APC",     // track  5
+	"DAUPHINS.APC",    // track  6
+	"05SSTRON.APC",    // track  7
+	"METAMORF.APC",    // track  8
+	"LABYRINT.APC",    // track  9
+	"31CRANES.APC",    // track 10
+	"STONEHEG.APC",    // track 11
+	"ASCENSE1.APC",    // track 12
+	"FORET_35.APC",    // track 13
+	"23_PRET1.APC",    // track 14
+	"20SORCIE.APC",    // track 15
+	"06SPITZ2.APC",    // track 16
+	"30SHAMAN.APC",    // track 17
+	"21PACQUE.APC",    // track 18
+	"08TISSE2.APC",    // track 19
+	"33INTRO.APC",     // track 20 — narration for CINEM020.HNM
+	"HANGAR1.APC",     // track 21
+	"04GENERI.APC",    // track 22
+	"TETE1.APC",       // track 23
+	"TETE2.APC",       // track 24
+	"03ATTACK.APC",    // track 25
+	"09VOLTOT.APC",    // track 26
+	"CINE101.APC",     // track 27
+	"LAC.APC",         // track 28
+	"CINE147.APC",     // track 29
+	"CINE172.APC",     // track 30
+	"CINE194.APC",     // track 31
+};
+
+// Number of per-channel samples to fade in/out at each loop boundary (~46ms at 22050 Hz).
+// Both ends ramp to zero so the loop-point discontinuity (IMA predictor reset) is inaudible.
+static const int kLoopFadeSamples = 1024;
+
+// Decode an APC file from raw bytes into a PCM buffer, apply a linear fade-in at the
+// start and fade-out at the end, and return an infinitely-looping RewindableAudioStream.
+// The caller must not free `data` while the stream is alive (it reads only during this call).
+static Audio::AudioStream *buildLoopingMusicStream(const byte *data, uint32 size) {
+	Common::MemoryReadStream *raw = new Common::MemoryReadStream(data, size, DisposeAfterUse::NO);
+	Audio::PacketizedAudioStream *apc = Audio::makeAPCStream(*raw);
+	if (!apc) {
+		delete raw;
+		return nullptr;
+	}
+
+	const bool stereo = apc->isStereo();
+	const int  rate   = apc->getRate();
+	const int  ch     = stereo ? 2 : 1;
+
+	// Queue all remaining compressed data for decode.
+	int64 remaining = (int64)size - (int64)raw->pos();
+	if (remaining > 0) {
+		byte *buf = new byte[(uint32)remaining];
+		raw->read(buf, (uint32)remaining);
+		apc->queuePacket(new Common::MemoryReadStream(buf, (uint32)remaining,
+		                                              DisposeAfterUse::YES));
+	}
+	apc->finish();
+	delete raw;
+
+	// Each compressed byte → 2 int16 output samples (one per nibble).
+	int64 totalSamples = remaining * 2;
+	byte *pcmBytes = new byte[(uint32)(totalSamples * 2)];  // int16 = 2 bytes
+	int got = apc->readBuffer((int16 *)pcmBytes, (int)totalSamples);
+	delete apc;
+
+	// Apply fade-in to the first kLoopFadeSamples per-channel frames and
+	// fade-out to the last kLoopFadeSamples per-channel frames, so the loop
+	// restarts cleanly even though the IMA predictor is reset from the header.
+	if (got > kLoopFadeSamples * ch * 2) {
+		int16 *pcm = (int16 *)pcmBytes;
+		for (int i = 0; i < kLoopFadeSamples * ch; i++)
+			pcm[i] = (int16)(pcm[i] * (i / ch) / kLoopFadeSamples);
+		for (int i = got - kLoopFadeSamples * ch; i < got; i++)
+			pcm[i] = (int16)(pcm[i] * ((got - 1 - i) / ch) / kLoopFadeSamples);
+	}
+
+	byte flags = Audio::FLAG_16BITS;
+	if (stereo)
+		flags |= Audio::FLAG_STEREO;
+#ifdef SCUMM_LITTLE_ENDIAN
+	flags |= Audio::FLAG_LITTLE_ENDIAN;
+#endif
+
+	Audio::SeekableAudioStream *rawStream = Audio::makeRawStream(
+	    pcmBytes, (uint32)(got * 2), rate, flags, DisposeAfterUse::YES);
+	return Audio::makeLoopingAudioStream(rawStream, 0);
+}
+
+static void startMusicFromBuffer(Audio::Mixer *mixer, Audio::SoundHandle &handle,
+                                 const byte *data, uint32 size) {
+	Audio::AudioStream *stream = buildLoopingMusicStream(data, size);
+	if (stream)
+		mixer->playStream(Audio::Mixer::kMusicSoundType, &handle, stream);
+}
+
+// Stop mixer playback and release the decoded buffer, keeping _musicTrackId so
+// the selected track can be resumed later (e.g. after unmuting).
+void CryOmni3DEngine_Atlantis::musicHaltPlayback() {
+	if (_mixer->isSoundHandleActive(_musicHandle)) {
+		// Smooth fade-out over ~160ms (32 steps of ~3% each).
+		byte vol = _mixer->getChannelVolume(_musicHandle);
+		for (int step = 0; step < 32 && vol > 0; step++) {
+			vol = (vol > 8) ? vol - 8 : 0;
+			_mixer->setChannelVolume(_musicHandle, vol);
+			g_system->delayMillis(5);
+		}
+		_mixer->stopHandle(_musicHandle);
+	}
+	delete[] _musicRawData;
+	_musicRawData = nullptr;
+	_musicRawSize = 0;
+	_musicCurrentFile = nullptr;
+}
+
+// stopmusik (CON), chapter change, and the credits sequence — clear the music
+// selection entirely and stop playback.
+void CryOmni3DEngine_Atlantis::musicStop() {
+	_musicTrackId = 0;
+	musicHaltPlayback();
+}
+
+// startmusik=N (CON) — select track N and start it looping.  Also used by
+// musicUpdate() to (re)start the selected track after a mute or chapter change.
+void CryOmni3DEngine_Atlantis::musicPlayTrack(int trackId) {
+	if (trackId < 1 || trackId >= (int)ARRAYSIZE(kMusicTrackNames)
+	        || !kMusicTrackNames[trackId]) {
+		warning("musicPlayTrack: invalid track %d", trackId);
+		return;
+	}
+	_musicTrackId = trackId;
+
+	const char *musicFile = kMusicTrackNames[trackId];
+	// Already playing this track — leave it (a place re-issuing the same
+	// startmusik must not cause a restart hiccup).
+	if (_musicCurrentFile == musicFile && _mixer->isSoundHandleActive(_musicHandle))
+		return;
+
+	musicHaltPlayback();
+
+	Common::SeekableReadStream *apcFile = openBigFileStream(kFileTypeSound, musicFile);
+	if (!apcFile) {
+		warning("musicPlayTrack: cannot open track %d '%s'", trackId, musicFile);
+		return;
+	}
+	_musicRawSize = (uint32)apcFile->size();
+	_musicRawData = new byte[_musicRawSize];
+	apcFile->read(_musicRawData, _musicRawSize);
+	delete apcFile;
+
+	_musicCurrentFile = musicFile;
+	startMusicFromBuffer(_mixer, _musicHandle, _musicRawData, _musicRawSize);
+	debugC(1, kDebugMusic, "musicPlayTrack: track %d '%s'", trackId, musicFile);
+}
+
+// Called every frame.  The music *selection* is owned by the startmusik /
+// stopmusik CON commands (_musicTrackId); this only keeps the mixer in sync —
+// pausing playback while music is muted and resuming the selected track on
+// unmute or after a chapter change.
+void CryOmni3DEngine_Atlantis::musicUpdate() {
+	const bool muted = _mixer->isSoundTypeMuted(Audio::Mixer::kMusicSoundType)
+	                || _mixer->getVolumeForSoundType(Audio::Mixer::kMusicSoundType) == 0;
+	if (muted) {
+		musicHaltPlayback();   // keep _musicTrackId so unmuting resumes it
+		return;
+	}
+	if (_musicTrackId <= 0)
+		return;                // nothing selected, or stopped by stopmusik
+	if (_mixer->isSoundHandleActive(_musicHandle))
+		return;                // selected track already looping
+	musicPlayTrack(_musicTrackId);  // first play, or resume after a mute
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/puzzle_eclipse.cpp
+++ b/engines/cryomni3d/atlantis/puzzle_eclipse.cpp
@@ -1,0 +1,469 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "cryomni3d/atlantis/puzzle_eclipse.h"
+
+#include "cryomni3d/atlantis/engine.h"
+#include "cryomni3d/atlantis/sprite_blend.h"
+
+#include "audio/audiostream.h"
+#include "audio/decoders/apc.h"
+#include "audio/mixer.h"
+#include "common/debug.h"
+#include "common/events.h"
+#include "common/memstream.h"
+#include "common/ptr.h"
+#include "common/rect.h"
+#include "common/stream.h"
+#include "common/system.h"
+#include "graphics/managed_surface.h"
+#include "graphics/pixelformat.h"
+#include "graphics/surface.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// ===========================================================================
+// Constants reverse-engineered from atlantis.exe.
+// ===========================================================================
+
+static const int kScreenW = 640;
+static const int kScreenH = 480;
+
+static const uint16 kPuzzleSprTransp = 0x0001;
+
+// Click hotspots -- FUN_00441cd8 lines 441daa-441ddb / 441e59-441e8d.
+static const int kLever1X0 = 0x78 + 1;   // 121
+static const int kLever1X1 = 0xf0;       // 240
+static const int kLever2X0 = 0x1ae + 1;  // 431
+static const int kLever2X1 = 0x226;      // 550
+static const int kLeverY0  = 0x172 + 1;  // 371
+static const int kLeverY1  = 0x1e0;      // 480
+static const int kLeverYUp = 0x1a9 + 1;  // 426 -- y < this = step up
+
+// Top-corner exit zones -- FUN_00441cd8 lines 441cf0-441d2a / 441d2f-441d6c.
+static const int kExitLeftX0  = 0;
+static const int kExitLeftX1  = 0xa0;    // 160
+static const int kExitRightX0 = 0x21d;   // 541
+static const int kExitRightX1 = 0x280;   // 640
+static const int kExitY1      = 0xdc;    // 220
+
+// Return codes -- .rdata at 0x496d0c (abort) and 0x496d14 (win).
+static const int kFinPuzzleWin   = 255;
+static const int kFinPuzzleAbort = 1;
+
+// Layer-swap thresholds for the moon (record 5) vs earth (record 6)
+// rendering order -- FUN_00441828 lines 441956-44196b.
+static const int kLayerSwapLo = 0x60;    // 96
+static const int kLayerSwapHi = 0x83;    // 131
+
+// Special PZ1L sprite frames used by the win highlight overlay --
+// FUN_00441828 lines 441a8c / 441ab8.
+static const int kHighlightFrameSun  = 0xd5;  // 213
+static const int kHighlightFrameMoon = 0xd6;  // 214
+
+// Win-animation length -- FUN_00441724 lines 441813-441818 (`< 0x50` iterations).
+static const int kWinAnimFrames = 0x50;     // 80
+
+// Initial record table -- baked into .rdata at 0x49745E (16-bit shorts).
+struct RecordInit {
+	int dir, x, y, min, max;
+};
+static const RecordInit kRecordInit[7] = {
+	{ 0, 215, 308,   0,   7 },   // 0  PZ2L 0..7   -- idle decoration
+	{ 1, 298, 308,   8,  15 },   // 1  PZ2L 8..15  -- auto-cycling (DIR=1)
+	{ 0, 227, 384,  16,  86 },   // 2  PZ2L 16..86 -- lever 1 mechanism
+	{ 0, 443, 373,  87, 157 },   // 3  PZ2L 87..157 -- lever 2 mechanism
+	{ 0, 319, 204,   0,  70 },   // 4  PZ1L 0..70  -- SUN sphere    (lever 2)
+	{ 0, 236, 222,  71, 141 },   // 5  PZ1L 71..141 -- MOON sphere   (lever 1)
+	{ 0, 271, 198, 142, 212 },   // 6  PZ1L 142..212 -- EARTH sphere (lever 1)
+};
+static const bool kRecordUsesPz1l[7] = { false, false, false, false, true, true, true };
+static const int kLever1Records[] = { 2, 5, 6 };
+static const int kLever2Records[] = { 3, 4 };
+
+// ===========================================================================
+// SPR loader.
+// ===========================================================================
+static bool loadPuzzleSpr(CryOmni3DEngine_Atlantis *engine, const char *fname,
+                          Common::Array<PuzzleSpr> &out) {
+	Common::ScopedPtr<Common::SeekableReadStream> stream(
+	    engine->openBigFileStream(kFileTypePuzzles, fname));
+	if (!stream) {
+		warning("EclipsePuzzle: cannot open PUZZLES\\%s", fname);
+		return false;
+	}
+
+	uint16 flags = stream->readUint16LE();
+	uint16 colorTable[256];
+	memset(colorTable, 0, sizeof(colorTable));
+	if (flags & 0x4) {
+		for (int i = 0; i < 256; i++) {
+			uint16 rgb555 = stream->readUint16LE();
+			uint16 r = (rgb555 >> 10) & 0x1f;
+			uint16 g = (rgb555 >>  5) & 0x1f;
+			uint16 b =  rgb555        & 0x1f;
+			colorTable[i] = (r << 11) | (g << 6) | b;
+		}
+	}
+	if (flags & 0x8)
+		stream->skip(512);
+
+	uint16 count = stream->readUint16LE();
+	if (count == 0 || count > 1024) return false;
+
+	const int64 sprDataBase = stream->pos();
+	Common::Array<uint32> offsets(count);
+	for (uint16 i = 0; i < count; i++)
+		offsets[i] = stream->readUint32LE();
+
+	out.resize(count);
+	for (uint16 si = 0; si < count; si++) {
+		if (!stream->seek(sprDataBase + offsets[si])) continue;
+		PuzzleSpr &spr = out[si];
+		spr.w    = stream->readUint16LE();
+		spr.h    = stream->readUint16LE();
+		spr.xoff = stream->readSint16LE();
+		spr.yoff = stream->readSint16LE();
+		if (spr.w == 0 || spr.h == 0 || spr.w > 640 || spr.h > 480) continue;
+
+		Common::Array<uint32> rowOff(spr.h);
+		for (uint16 r = 0; r < spr.h; r++)
+			rowOff[r] = stream->readUint32LE();
+		const int64 pixBase = stream->pos();
+
+		spr.pixels.resize((uint)spr.w * spr.h, kPuzzleSprTransp);
+		spr.blend.resize((uint)spr.w * spr.h, (uint8)kSprNoBlend);
+
+		for (uint16 ry = 0; ry < spr.h; ry++) {
+			stream->seek(pixBase + rowOff[ry]);
+			int rx = 0;
+			while (rx < (int)spr.w && !stream->eos()) {
+				byte b = stream->readByte();
+				int btype = (b >> 6) & 0x3;
+				int cnt   = b & 0x3F;
+				if (btype == 0) {
+					rx += cnt;
+				} else if (btype == 1) {
+					for (int i = 0; i < cnt && rx < (int)spr.w; i++, rx++) {
+						uint16 col = colorTable[stream->readByte()];
+						if (col == kPuzzleSprTransp) col = 0x0000;
+						spr.pixels[ry * spr.w + rx] = col;
+					}
+				} else {
+					for (int i = 0; i < cnt && rx < (int)spr.w; i++, rx++) {
+						byte factor = stream->readByte() & 0x1f;
+						uint16 col  = colorTable[stream->readByte()];
+						if (col == kPuzzleSprTransp) col = 0x0000;
+						spr.pixels[ry * spr.w + rx] = col;
+						spr.blend[ry * spr.w + rx]  = factor;
+					}
+				}
+			}
+		}
+	}
+	debugC(1, kDebugScript, "EclipsePuzzle: loaded %u frames from PUZZLES\\%s", count, fname);
+	return true;
+}
+
+static void blitFrame(Graphics::ManagedSurface &out, const PuzzleSpr &spr,
+                      int cx, int cy) {
+	if (spr.pixels.empty() || out.format.bytesPerPixel != 2) return;
+	int dx0 = cx - spr.xoff;
+	int dy0 = cy - spr.yoff;
+	for (int y = 0; y < spr.h; y++) {
+		int dy = dy0 + y;
+		if (dy < 0 || dy >= out.h) continue;
+		for (int x = 0; x < spr.w; x++) {
+			int dx = dx0 + x;
+			if (dx < 0 || dx >= out.w) continue;
+			uint16 src = spr.pixels[y * spr.w + x];
+			if (src == kPuzzleSprTransp) continue;
+			uint8 factor = spr.blend[y * spr.w + x];
+			uint16 *p = (uint16 *)out.getBasePtr(dx, dy);
+			*p = (factor == (uint8)kSprNoBlend) ? src
+			                                     : blendSprPixel565(src, *p, factor);
+		}
+	}
+}
+
+static bool loadPuzzleTGA(CryOmni3DEngine_Atlantis *engine, const char *fname,
+                          Common::Array<uint16> &outPixels) {
+	Common::ScopedPtr<Common::SeekableReadStream> stream(
+	    engine->openBigFileStream(kFileTypePuzzles, fname));
+	if (!stream) return false;
+	byte idLen = stream->readByte();
+	/* cmType = */ stream->readByte();
+	byte imgType = stream->readByte();
+	stream->skip(9);
+	uint16 w = stream->readUint16LE();
+	uint16 h = stream->readUint16LE();
+	byte depth = stream->readByte();
+	stream->readByte();
+	stream->skip(idLen);
+	if (imgType != 2 || depth != 15 || w != kScreenW || h != kScreenH) return false;
+	const Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	outPixels.resize((uint)w * h);
+	for (uint16 y = 0; y < h; y++) {
+		uint16 *row = outPixels.begin() + (uint)(h - 1 - y) * w;
+		for (uint16 x = 0; x < w; x++) {
+			uint16 px = stream->readUint16LE();
+			uint8 r = (uint8)(((px >> 10) & 0x1f) << 3);
+			uint8 g = (uint8)(((px >>  5) & 0x1f) << 3);
+			uint8 b = (uint8)(( px        & 0x1f) << 3);
+			row[x] = (uint16)fmt.RGBToColor(r, g, b);
+		}
+	}
+	return true;
+}
+
+// ===========================================================================
+EclipsePuzzle::EclipsePuzzle(CryOmni3DEngine_Atlantis *engine)
+    : _engine(engine), _frameCounter(0), _bgLoaded(false) {
+	loadPuzzleSpr(engine, "PZ1L.SPR", _pz1lFrames);
+	loadPuzzleSpr(engine, "PZ2L.SPR", _pz2lFrames);
+	_bgLoaded = loadPuzzleTGA(engine, "PZLION.TGA", _bgPixels);
+
+	for (int i = 0; i < kNumRecords; i++) {
+		_records[i].dir  = kRecordInit[i].dir;
+		_records[i].x    = kRecordInit[i].x;
+		_records[i].y    = kRecordInit[i].y;
+		_records[i].min  = kRecordInit[i].min;
+		_records[i].max  = kRecordInit[i].max;
+		_records[i].curr = (i >= 2) ? (_records[i].min + 0x25)
+		                            : _records[i].min;
+	}
+}
+
+EclipsePuzzle::~EclipsePuzzle() {
+}
+
+// Mirrors FUN_00441f50.
+void EclipsePuzzle::tick(int recIdx) {
+	Record &r = _records[recIdx];
+	if (r.dir == 0) return;
+	if (r.dir == 1) {
+		r.curr++;
+		if (r.curr > r.max) r.curr = r.min;
+	} else if (r.dir == 2) {
+		r.curr--;
+		if (r.curr < r.min) r.curr = r.max;
+	}
+}
+
+// Mirrors FUN_00441cd8 lines 441f0b-441f32.
+bool EclipsePuzzle::isWin() const {
+	return _records[4].curr == _records[4].min + 1 &&
+	       _records[5].curr == _records[5].min;
+}
+
+// Mirrors FUN_00441828 in full.
+void EclipsePuzzle::renderFrame(Graphics::ManagedSurface &out) {
+	const Graphics::PixelFormat fmt = out.format;
+
+	// 1. Background.
+	if (_bgLoaded && fmt.bytesPerPixel == 2 &&
+	    _bgPixels.size() == (uint)kScreenW * kScreenH) {
+		for (int y = 0; y < kScreenH; y++)
+			memcpy(out.getBasePtr(0, y),
+			       _bgPixels.begin() + (uint)y * kScreenW, kScreenW * 2);
+	} else {
+		out.fillRect(Common::Rect(0, 0, kScreenW, kScreenH),
+		             fmt.RGBToColor(8, 12, 32));
+	}
+
+	// 2. Records 0..3: tick + blit PZ2L (FUN_00441828 lines 38212-38216).
+	for (int i = 0; i < 4; i++) {
+		tick(i);
+		if (_records[i].curr >= 0 && (uint)_records[i].curr < _pz2lFrames.size())
+			blitFrame(out, _pz2lFrames[_records[i].curr],
+			          _records[i].x, _records[i].y);
+	}
+
+	// 3. Records 4..6: tick first (FUN_00441828 lines 38217-38219).
+	tick(4);
+	tick(5);
+	tick(6);
+
+	// 4. Layer-swap: default render order is (record6 back, record4
+	// middle, record5 front).  When record5.CURR is in (96, 131) the
+	// exe swaps records 5 and 6 -- mirrors lines 441948-441974.
+	int backIdx  = 6;
+	int frontIdx = 5;
+	if (_records[5].curr > kLayerSwapLo && _records[5].curr < kLayerSwapHi) {
+		backIdx  = 5;
+		frontIdx = 6;
+	}
+
+	auto blitPz1l = [&](int recIdx, int frameOverride) {
+		int frame = (frameOverride >= 0) ? frameOverride : _records[recIdx].curr;
+		if (frame >= 0 && (uint)frame < _pz1lFrames.size())
+			blitFrame(out, _pz1lFrames[frame],
+			          _records[recIdx].x, _records[recIdx].y);
+	};
+
+	blitPz1l(backIdx, -1);
+	blitPz1l(4, -1);              // SUN
+	blitPz1l(frontIdx, -1);
+
+	// 5. Win highlight (FUN_00441828 lines 441a26-441ae1): when the win
+	// condition holds AND (_frameCounter & 2) != 0, draw three extra
+	// PZ1L blits to pulse the eclipse alignment:
+	//   - record6 at its current frame (redrawn on top for z-order);
+	//   - PZ1L frame 213 at record 4's position (SUN highlight sprite);
+	//   - PZ1L frame 214 at record 5's position (MOON highlight sprite).
+	if (isWin() && (_frameCounter & 2)) {
+		blitPz1l(6, -1);
+		blitPz1l(4, kHighlightFrameSun);
+		blitPz1l(5, kHighlightFrameMoon);
+	}
+
+	_frameCounter++;
+}
+
+// Open WAV/<name>.APC, queue and play.  When `wait`, blocks until the
+// sound finishes (used for the win sound which leads straight to puzzle
+// exit).  Click sounds fire-and-forget.
+void EclipsePuzzle::playSound(const char *name, bool wait) {
+	Common::String fname = Common::String::format("%s.APC", name);
+	Common::SeekableReadStream *apcFile =
+	    _engine->openBigFileStream(kFileTypeSound, fname);
+	if (!apcFile) {
+		warning("EclipsePuzzle: cannot open WAV\\%s", fname.c_str());
+		return;
+	}
+	Audio::PacketizedAudioStream *apc = Audio::makeAPCStream(*apcFile);
+	if (!apc) { delete apcFile; return; }
+	int64 remaining = apcFile->size() - apcFile->pos();
+	if (remaining > 0) {
+		byte *buf = new byte[remaining];
+		apcFile->read(buf, (uint32)remaining);
+		apc->queuePacket(new Common::MemoryReadStream(buf, remaining,
+		                                              DisposeAfterUse::YES));
+	}
+	apc->finish();
+	delete apcFile;
+
+	Audio::SoundHandle handle;
+	_engine->_mixer->playStream(Audio::Mixer::kSFXSoundType, &handle, apc);
+	if (wait) {
+		while (!_engine->shouldAbort() &&
+		       _engine->_mixer->isSoundHandleActive(handle)) {
+			_engine->pollEvents();
+			g_system->delayMillis(15);
+		}
+	}
+}
+
+int EclipsePuzzle::run() {
+	const Graphics::PixelFormat fmt = g_system->getScreenFormat();
+	Graphics::ManagedSurface working(kScreenW, kScreenH, fmt);
+
+	g_system->lockMouse(false);
+	_engine->setMousePos(Common::Point(kScreenW / 2, kScreenH / 2));
+	_engine->setArrowCursor();
+	_engine->showMouse(true);
+
+	bool exitLoop = false;
+	int  result = kFinPuzzleAbort;
+	bool prevButton = (_engine->getCurrentMouseButton() != 0);
+
+	while (!exitLoop && !_engine->shouldAbort()) {
+		_engine->pollEvents();
+
+		bool nowButton = (_engine->getCurrentMouseButton() == 1);
+		if (nowButton && !prevButton) {
+			Common::Point m = _engine->getMousePos();
+
+			bool inExitL = (m.x >= kExitLeftX0  && m.x < kExitLeftX1  &&
+			                m.y >= 0            && m.y < kExitY1);
+			bool inExitR = (m.x >= kExitRightX0 && m.x < kExitRightX1 &&
+			                m.y >= 0            && m.y < kExitY1);
+			if (inExitL || inExitR) {
+				result = kFinPuzzleAbort;
+				exitLoop = true;
+			} else if (m.y >= kLeverY0 && m.y < kLeverY1) {
+				int dir = (m.y < kLeverYUp) ? 1 : 2;
+				bool clicked = false;
+				if (m.x >= kLever1X0 && m.x < kLever1X1) {
+					for (uint k = 0; k < ARRAYSIZE(kLever1Records); k++) {
+						int idx = kLever1Records[k];
+						_records[idx].dir = dir;
+						tick(idx);
+						_records[idx].dir = 0;
+					}
+					clicked = true;
+				} else if (m.x >= kLever2X0 && m.x < kLever2X1) {
+					for (uint k = 0; k < ARRAYSIZE(kLever2Records); k++) {
+						int idx = kLever2Records[k];
+						_records[idx].dir = dir;
+						tick(idx);
+						_records[idx].dir = 0;
+					}
+					clicked = true;
+				}
+				// Click sound -- mirrors FUN_00441cd8 lines 441e43-441e58
+				// (lever 1) and 441edd-441eee (lever 2): both branches
+				// of both levers play LION1.APC unconditionally.
+				if (clicked)
+					playSound("LION1", false);
+			}
+
+			if (!exitLoop && isWin()) {
+				// Win path -- mirrors FUN_0044154c lines 38097-38108:
+				// run FUN_00441724 (which plays LION3.APC and renders
+				// 80 more frames) then return DAT_00496d14 = 255.
+				playSound("LION3", false);
+				for (int f = 0; f < kWinAnimFrames && !_engine->shouldAbort(); f++) {
+					_engine->pollEvents();
+					renderFrame(working);
+					g_system->copyRectToScreen(working.getPixels(), working.pitch,
+					                           0, 0, kScreenW, kScreenH);
+					g_system->updateScreen();
+					g_system->delayMillis(40);
+				}
+				result = kFinPuzzleWin;
+				exitLoop = true;
+			}
+		}
+		prevButton = nowButton;
+
+		Common::KeyCode kc = _engine->getNextKey().keycode;
+		if (kc == Common::KEYCODE_ESCAPE) {
+			result = kFinPuzzleAbort;
+			exitLoop = true;
+		}
+
+		renderFrame(working);
+		g_system->copyRectToScreen(working.getPixels(), working.pitch,
+		                           0, 0, kScreenW, kScreenH);
+		g_system->updateScreen();
+		g_system->delayMillis(15);
+	}
+
+	debugC(1, kDebugScript, "EclipsePuzzle::run: levers L1=(r2=%d,r5=%d,r6=%d) L2=(r3=%d,r4=%d) result=%d",
+	      _records[2].curr, _records[5].curr, _records[6].curr,
+	      _records[3].curr, _records[4].curr, result);
+	return result;
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/puzzle_eclipse.h
+++ b/engines/cryomni3d/atlantis/puzzle_eclipse.h
@@ -1,0 +1,93 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CRYOMNI3D_ATLANTIS_PUZZLE_ECLIPSE_H
+#define CRYOMNI3D_ATLANTIS_PUZZLE_ECLIPSE_H
+
+#include "common/array.h"
+#include "common/scummsys.h"
+
+namespace Graphics {
+struct Surface;
+class ManagedSurface;
+}
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+class CryOmni3DEngine_Atlantis;
+
+// Decoded single SPR frame -- RGB565 pixels + per-pixel blend factor.
+struct PuzzleSpr {
+	uint16 w, h;
+	int16  xoff, yoff;
+	Common::Array<uint16> pixels;
+	Common::Array<uint8>  blend;
+	PuzzleSpr() : w(0), h(0), xoff(0), yoff(0) {}
+};
+
+// StartPuzzle=0: celestial-alignment minigame at CHAPI012 vue 221.
+// Reverse-engineered from atlantis.exe (puzzle dispatch case 0,
+// FUN_0044154c, called from FUN_0043a1e0).
+class EclipsePuzzle {
+public:
+	explicit EclipsePuzzle(CryOmni3DEngine_Atlantis *engine);
+	~EclipsePuzzle();
+
+	// Returns 255 on win, 1 on abort (mirrors DAT_00496d14 / 00496d0c
+	// at the exe's two return-code sites in FUN_0044154c).
+	int run();
+
+private:
+	CryOmni3DEngine_Atlantis *_engine;
+
+	struct Record {
+		int dir;        // 0 idle / 1 step-up / 2 step-down (transient on click)
+		int x, y;
+		int min, max;
+		int curr;
+	};
+	enum { kNumRecords = 7 };
+	Record _records[kNumRecords];
+
+	// Frame counter -- _DAT_007bebf0 in the exe; drives the alternate-
+	// frame test on the win highlight (`(_frameCounter & 2) != 0`).
+	uint32 _frameCounter;
+
+	Common::Array<PuzzleSpr> _pz1lFrames;  // _DAT_007beae0
+	Common::Array<PuzzleSpr> _pz2lFrames;  // _DAT_007beadc
+	Common::Array<uint16>    _bgPixels;    // PZLION.TGA
+	bool _bgLoaded;
+
+	void tick(int recIdx);
+	void renderFrame(Graphics::ManagedSurface &out);
+	bool isWin() const;
+
+	// Play one of the eclipse-puzzle APC sounds (synchronous setup,
+	// asynchronous playback).  `name` is "LION1" / "LION2" / "LION3".
+	// `wait` blocks until the sound finishes (used for the win sound).
+	void playSound(const char *name, bool wait);
+};
+
+} // namespace Atlantis
+} // namespace CryOmni3D
+
+#endif

--- a/engines/cryomni3d/atlantis/saveload.cpp
+++ b/engines/cryomni3d/atlantis/saveload.cpp
@@ -1,0 +1,554 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses.
+ *
+ */
+
+#include "common/debug.h"
+#include "common/ptr.h"
+#include "common/savefile.h"
+#include "common/system.h"
+
+#include "cryomni3d/atlantis/engine.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// Fixed save-file block layout (1792 bytes):
+//   20  — save description (kSaveDescriptionLen, null-padded)
+//   12  — dummy padding (3 × uint32, currently zeros)
+//  200  — dialog variables (reserved, all zero)
+//   80  — inventory (20 × uint32BE object index, uint(-1) = empty)
+//    4  — current chapter (uint32BE)
+//   32  — current WAM filename (null-padded, may be a sub-WAM)
+//    4  — current place ID (uint32BE)
+//    8  — camera alpha (doubleBE)
+//    8  — camera beta (doubleBE)
+// 1024  — place states (256 × uint32BE)
+//  400  — game variables (100 × uint32BE)
+//
+// Extended block appended after the fixed block (magic 'ATLS', version 3):
+//   4  — magic 0x41544C53 ('ATLS')
+//   4  — version (uint32BE, currently 3)
+//   4  — hiddenPersos count N (uint32BE)
+//   N×4 — hidden perso IDs (int32BE each)
+//   4  — sujEnabled entries M (uint32BE)
+//   M × (4 + 4 + K×4) — persoId (int32BE), numSujs K (uint32BE), suj IDs (int32BE each)
+//   4  — gameVars count G (uint32BE)
+//   G × (4 + keyLen + 4) — keyLen (uint32BE), key bytes (no null), value (int32BE)
+//   4  — CON script chapter (uint32BE) — version 2+ only
+//   4  — selected music track (uint32BE) — version 3+ only
+static const int32 kSaveSize = 1792;
+static const uint kWAMNameLen = 32;
+static const uint32 kExtMagic = 0x41544C53u;  // 'ATLS'
+static const uint32 kExtVersion = 3;
+
+void CryOmni3DEngine_Atlantis::saveGame(uint saveNum, const Common::String &saveName) {
+	Common::String saveFileName = getSaveStateName((int)saveNum - 1);
+
+	Common::OutSaveFile *out = _saveFileMan->openForSaving(saveFileName);
+	if (!out) {
+		warning("saveGame: cannot open '%s' for writing", saveFileName.c_str());
+		return;
+	}
+
+	// Save description (20 bytes)
+	char saveNameC[kSaveDescriptionLen + 1];
+	memset(saveNameC, 0, sizeof(saveNameC));
+	strncpy(saveNameC, saveName.c_str(), kSaveDescriptionLen);
+	out->write(saveNameC, kSaveDescriptionLen);
+
+	// Dummy padding
+	out->writeUint32LE(0);
+	out->writeUint32BE(0);
+	out->writeUint32BE(0);
+
+	// Dialog variables (not used; write zeros)
+	for (uint i = 0; i < 200; i++)
+		out->writeByte(0);
+
+	// Inventory (20 slots × uint32BE)
+	for (Inventory::const_iterator it = _inventory.begin(); it != _inventory.end(); ++it) {
+		uint objId = uint(-1);
+		if (*it != nullptr)
+			objId = (uint)(*it - _objects.begin());
+		out->writeUint32BE(objId);
+	}
+
+	// Chapter
+	out->writeUint32BE(_currentChapter);
+
+	// Current WAM filename (32 bytes, null-padded)
+	char wamNameC[kWAMNameLen];
+	memset(wamNameC, 0, sizeof(wamNameC));
+	strncpy(wamNameC, _currentWAMName.c_str(), kWAMNameLen - 1);
+	out->write(wamNameC, kWAMNameLen);
+
+	// Current place ID
+	out->writeUint32BE(_currentPlaceId);
+
+	// Camera angles
+	out->writeDoubleBE(_omni3dMan.getAlpha());
+	out->writeDoubleBE(_omni3dMan.getBeta());
+
+	// Place states (256 × uint32BE)
+	for (uint i = 0; i < 256; i++) {
+		uint32 state = (i < _placeStates.size()) ? _placeStates[i].state : 0;
+		out->writeUint32BE(state);
+	}
+
+	// Game variables (100 × uint32BE)
+	for (uint i = 0; i < 100; i++) {
+		uint val = (i < _gameVariables.size()) ? _gameVariables[i] : 0;
+		out->writeUint32BE(val);
+	}
+
+	// Extended block: CON script state.
+	out->writeUint32BE(kExtMagic);
+	out->writeUint32BE(kExtVersion);
+
+	// Hidden persos
+	out->writeUint32BE((uint32)_hiddenPersos.size());
+	for (int pid : _hiddenPersos)
+		out->writeSint32BE(pid);
+
+	// Enabled subjects per NPC
+	out->writeUint32BE((uint32)_sujEnabled.size());
+	for (const SujState &ss : _sujEnabled) {
+		out->writeSint32BE(ss.persoId);
+		out->writeUint32BE((uint32)ss.sujs.size());
+		for (int s : ss.sujs)
+			out->writeSint32BE(s);
+	}
+
+	// Named game variables — only the 7 persistent ones (VARIAS.CON idx 0-6).
+	// The rest are chapter-transient and the original never saves them.
+	uint32 nPersist = 0;
+	for (const auto &kv : _gameVars)
+		if (isPersistentGameVar(kv._key))
+			nPersist++;
+	out->writeUint32BE(nPersist);
+	for (const auto &kv : _gameVars) {
+		if (!isPersistentGameVar(kv._key))
+			continue;
+		uint32 klen = (uint32)kv._key.size();
+		out->writeUint32BE(klen);
+		out->write(kv._key.c_str(), klen);
+		out->writeSint32BE(kv._value);
+	}
+
+	// CON script chapter (ext v2).  loadConScript() clears _gameVars, so the
+	// active chapter is not reliably present among the named variables above —
+	// persist it explicitly so loadGame restores the correct CHAPI*.CON.
+	out->writeUint32BE(_currentCONChapter);
+
+	// Selected music track (ext v3).  The startmusik/stopmusik CON commands
+	// own _musicTrackId; it is not a game variable, so persist it explicitly
+	// or a reloaded save runs in silence until the next startmusik.
+	out->writeUint32BE((uint32)_musicTrackId);
+
+	out->finalize();
+	delete out;
+}
+
+bool CryOmni3DEngine_Atlantis::loadGame(uint saveNum) {
+	Common::String saveFileName = getSaveStateName((int)saveNum - 1);
+
+	Common::InSaveFile *in = _saveFileMan->openForLoading(saveFileName);
+	if (!in) {
+		warning("loadGame: cannot open '%s'", saveFileName.c_str());
+		return false;
+	}
+
+	if (in->size() < kSaveSize) {
+		warning("loadGame: '%s' too small (%d bytes, need at least %d)",
+		        saveFileName.c_str(), (int)in->size(), kSaveSize);
+		delete in;
+		return false;
+	}
+
+	// Save description (skip)
+	char saveNameC[kSaveDescriptionLen];
+	in->read(saveNameC, sizeof(saveNameC));
+
+	// Dummy padding
+	(void)in->readUint32LE();
+	(void)in->readUint32BE();
+	(void)in->readUint32BE();
+
+	// Dialog variables (skip — superseded by extended block)
+	for (uint i = 0; i < 200; i++)
+		(void)in->readByte();
+
+	// Inventory
+	for (Inventory::iterator it = _inventory.begin(); it != _inventory.end(); ++it) {
+		uint objId = in->readUint32BE();
+		if (objId >= _objects.size())
+			objId = uint(-1);
+		*it = (objId != uint(-1)) ? (_objects.begin() + objId) : nullptr;
+	}
+
+	// Chapter
+	uint32 chapter = in->readUint32BE();
+
+	// WAM filename
+	char wamNameC[kWAMNameLen];
+	in->read(wamNameC, kWAMNameLen);
+	wamNameC[kWAMNameLen - 1] = '\0';
+
+	// Place, camera angles
+	uint32 placeId = in->readUint32BE();
+	double alpha = in->readDoubleBE();
+	double beta  = in->readDoubleBE();
+
+	// Place states
+	uint32 savedPlaceStates[256];
+	for (uint i = 0; i < 256; i++)
+		savedPlaceStates[i] = in->readUint32BE();
+
+	// Game variables
+	for (uint i = 0; i < 100; i++) {
+		uint val = in->readUint32BE();
+		if (i < _gameVariables.size())
+			_gameVariables[i] = val;
+	}
+
+	// Extended block (optional — present when file > kSaveSize)
+	bool hasExt = (in->size() > kSaveSize);
+	Common::Array<int> savedHiddenPersos;
+	Common::Array<SujState> savedSujEnabled;
+	Common::HashMap<Common::String, int> savedGameVars;
+	uint32 savedCONChapter = 0;  // ext v2+: active CHAPI*.CON chapter
+	int savedMusicTrack = 0;     // ext v3+: selected music track
+
+	if (hasExt) {
+		uint32 magic = in->readUint32BE();
+		uint32 ver   = in->readUint32BE();
+
+		if (magic != kExtMagic || ver < 1) {
+			warning("loadGame: unrecognised extended block (magic=%08x ver=%u)", magic, ver);
+			hasExt = false;
+		} else {
+			// Hidden persos
+			uint32 nHidden = in->readUint32BE();
+			for (uint32 i = 0; i < nHidden && !in->eos(); i++)
+				savedHiddenPersos.push_back(in->readSint32BE());
+
+			// Enabled subjects
+			uint32 nSuj = in->readUint32BE();
+			for (uint32 i = 0; i < nSuj && !in->eos(); i++) {
+				SujState ss;
+				ss.persoId = in->readSint32BE();
+				uint32 nK = in->readUint32BE();
+				for (uint32 j = 0; j < nK && !in->eos(); j++)
+					ss.sujs.push_back(in->readSint32BE());
+				savedSujEnabled.push_back(ss);
+			}
+
+			// Named game variables
+			uint32 nVars = in->readUint32BE();
+			for (uint32 i = 0; i < nVars && !in->eos(); i++) {
+				uint32 klen = in->readUint32BE();
+				if (klen > 256) break;  // sanity
+				char kbuf[257];
+				in->read(kbuf, klen);
+				kbuf[klen] = '\0';
+				int32 val = in->readSint32BE();
+				savedGameVars[Common::String(kbuf)] = val;
+			}
+
+			// CON script chapter (ext v2+).
+			if (ver >= 2 && !in->eos())
+				savedCONChapter = in->readUint32BE();
+
+			// Selected music track (ext v3+).
+			if (ver >= 3 && !in->eos())
+				savedMusicTrack = (int)in->readUint32BE();
+		}
+	}
+
+	delete in;
+
+	// Restore game state
+	_currentChapter = chapter;
+
+	// Load the base chapter WAM (sets up chapter-level place state callbacks, loads CON,
+	// and runs INIT commands — which establishes baseline _sujEnabled/_gameVars).
+	setupChapterWAM((int)chapter);
+
+	// If a sub-WAM was active, load it over the chapter WAM.
+	Common::String wamName(wamNameC);
+	if (!wamName.empty() && !wamName.equalsIgnoreCase(_currentWAMName))
+		setupWAMByName(wamName);
+
+	// Restore the active CON script.  Which CHAPI*.CON is loaded is driven by
+	// the CON `chapter=N` command, independent of the WAM chapter used above,
+	// so loadGame must reload it explicitly or a save made past chapter 1
+	// would resume running chapter 1's script.  The chapter is read from the
+	// ext-v2 field (savedCONChapter) — not a game variable, since
+	// loadConScript() clears _gameVars.  Do this before the extended block is
+	// applied: loadConScript() clears _sujEnabled/_gameVars and re-runs the
+	// chapter's INIT block, which the extended-block restore below then
+	// overrides with the saved state.
+	//
+	// ALWAYS re-load — even when the saved chapter matches _currentCONChapter.
+	// loadConScript() clears the transient half of _gameVars (every var
+	// except the 7 persistent ones the save actually carries), and a game-over
+	// reload of the *current* chapter is the canonical case where that matters:
+	// without it, post-death values of time2, wsprframe, flagtemp3, flaggarde,
+	// etc. survive into the reloaded checkpoint and the next /tim2 tick at the
+	// next place re-fires the same death chain on its first frame.
+	if (savedCONChapter >= 1) {
+		_currentCONChapter = savedCONChapter;
+		loadConScript((int)savedCONChapter);
+	}
+
+	// Restore camera and place.
+	_nextPlaceId = placeId;
+	_omni3dMan.setAlpha(alpha);
+	_omni3dMan.setBeta(beta);
+
+	// Restore place states.
+	for (uint i = 0; i < _placeStates.size() && i < 256; i++)
+		_placeStates[i].state = savedPlaceStates[i];
+
+	// NbVisite counters are not yet persisted in the save: start the loaded
+	// game with a fresh set so first-visit /sel sections behave predictably.
+	for (byte &b : _placeVisits)
+		b = 0;
+
+	// Reset every persistent CON variable before the save's values are
+	// applied.  setupChapterWAM() -> loadConScript() above carries the 7
+	// persistent vars (VARIAS.CON idx 0-6) across, so a var that is live now
+	// but ABSENT from the save would otherwise survive the load unchanged.
+	// A persistent var missing from the save was 0 when the save was written
+	// (saveGame only emits keys that exist in _gameVars), so 0 is its correct
+	// restored value.  Without this, a game-over reload restores the very
+	// state that triggered it — e.g. FlagChp8 stays 2, so arriving back at
+	// place 133 immediately re-fires the death /sel and loops forever.
+	{
+		Common::Array<Common::String> persistKeys;
+		for (const auto &kv : _gameVars)
+			if (isPersistentGameVar(kv._key))
+				persistKeys.push_back(kv._key);
+		for (const Common::String &k : persistKeys)
+			_gameVars[k] = 0;
+	}
+
+	// Overlay CON script state from extended block (overrides INIT-derived baseline).
+	if (hasExt) {
+		_hiddenPersos = savedHiddenPersos;
+		_sujEnabled   = savedSujEnabled;
+		// Restore only the persistent variables; ignore any transient ones a
+		// save written by an older build may still contain.
+		for (const auto &kv : savedGameVars)
+			if (isPersistentGameVar(kv._key))
+				_gameVars[kv._key] = kv._value;
+	}
+
+	// Restore the music selection last: setupChapterWAM() / loadConScript()
+	// above may have run musicStop(); musicUpdate() picks the saved track
+	// back up on the next frame.
+	_musicTrackId = savedMusicTrack;
+
+	// A load is not itself a chapter transition: drop any autosave armed
+	// before the load so the next place change does not redundantly re-save.
+	_autosavePending = false;
+
+	// Drop any object held on the cursor.  The held object is transient UI
+	// state, not part of the save (ObjetEnMain is a transient CON variable,
+	// already cleared by loadConScript) -- the original load path likewise
+	// zeroes it (atlantis.exe FUN_0042de5c, _DAT_006cd7e4 = 0).  Without
+	// this, a game-over reload leaves the player still carrying whatever was
+	// in hand when they died.
+	_inventory.deselectObject();
+
+	// The player is now positioned in the loaded episode: point their resume
+	// pointer at it so a later relaunch reloads this chapter (and not, say, a
+	// further episode that was reached then abandoned).  Mirrors the original
+	// load screen writing the picked save's chapter back to the per-player
+	// chapter byte (atlantis.exe @ 0x6ce246).
+	if (_currentPlayer >= 0 && _currentPlayer < (int)kMaxPlayers &&
+	        _currentCONChapter >= 1 && _currentCONChapter < kPlayerSlotStride) {
+		_playerChapter[_currentPlayer] = (int)_currentCONChapter;
+		savePlayers();
+	}
+
+	return true;
+}
+
+// --- Player profiles ------------------------------------------------------
+// The list of named players is persisted in the save directory as
+// "atlantis-players.dat" — a name that cannot collide with the "atlantis.NNNN"
+// save-game files.  Each of the kMaxPlayers fixed slots holds a name, or an
+// empty string when unused; a slot's index is the player's stable id.
+
+static const char  *kPlayersFile    = "atlantis-players.dat";
+static const uint32 kPlayersMagic   = 0x41504c52u;  // 'APLR'
+// Version 2 appends a per-player current-chapter array — the resume pointer.
+// A version-1 file (no array) still loads; those players fall back to the
+// legacy single-autosave slot (see playerResumeSave()).
+static const uint32 kPlayersVersion = 2;
+
+void CryOmni3DEngine_Atlantis::loadPlayers() {
+	for (uint i = 0; i < kMaxPlayers; i++) {
+		_players[i].clear();
+		_playerChapter[i] = 0;
+	}
+
+	Common::InSaveFile *in = _saveFileMan->openForLoading(kPlayersFile);
+	if (!in)
+		return;
+	uint32 magic   = in->readUint32BE();
+	uint32 version = in->readUint32BE();
+	if (magic == kPlayersMagic && version >= 1) {
+		uint32 count = in->readUint32BE();
+		for (uint32 i = 0; i < count && i < kMaxPlayers && !in->eos(); i++) {
+			uint16 len = in->readUint16BE();
+			Common::String name;
+			for (uint16 j = 0; j < len && !in->eos(); j++)
+				name += (char)in->readByte();
+			_players[i] = name;
+		}
+		// Version 2+: the per-player resume chapter follows the names.
+		if (version >= 2) {
+			for (uint32 i = 0; i < count && i < kMaxPlayers && !in->eos(); i++)
+				_playerChapter[i] = in->readSint32BE();
+		}
+	}
+	delete in;
+}
+
+void CryOmni3DEngine_Atlantis::savePlayers() {
+	Common::OutSaveFile *out = _saveFileMan->openForSaving(kPlayersFile, false);
+	if (!out) {
+		warning("savePlayers: cannot write %s", kPlayersFile);
+		return;
+	}
+	out->writeUint32BE(kPlayersMagic);
+	out->writeUint32BE(kPlayersVersion);
+	out->writeUint32BE(kMaxPlayers);
+	for (uint i = 0; i < kMaxPlayers; i++) {
+		out->writeUint16BE((uint16)_players[i].size());
+		out->write(_players[i].c_str(), _players[i].size());
+	}
+	for (uint i = 0; i < kMaxPlayers; i++)
+		out->writeSint32BE(_playerChapter[i]);
+	out->finalize();
+	delete out;
+}
+
+void CryOmni3DEngine_Atlantis::deletePlayerSaves(uint player) {
+	// Every local slot of the block may hold a per-episode save.
+	for (uint i = 0; i < kPlayerSlotStride; i++)
+		_saveFileMan->removeSavefile(
+		    getSaveStateName(episodeSaveSlot(player, i)));
+	if (player < kMaxPlayers)
+		_playerChapter[player] = 0;
+}
+
+// --- Per-episode saves ----------------------------------------------------
+// Atlantis has no manual save: the game keeps one named save per episode and
+// rewrites it whenever that episode is (re-)entered.  Chapter N's save lives
+// at local slot N of the player's block; the per-player resume chapter
+// (_playerChapter) tracks which one a relaunch should reload.
+
+bool CryOmni3DEngine_Atlantis::saveSlotExists(int absSlot) const {
+	Common::InSaveFile *in = _saveFileMan->openForLoading(getSaveStateName(absSlot));
+	if (!in)
+		return false;
+	delete in;
+	return true;
+}
+
+uint CryOmni3DEngine_Atlantis::playerResumeSave(uint player) const {
+	if (player >= kMaxPlayers)
+		return 0;
+	// Preferred: the player's tracked current chapter.
+	int ch = _playerChapter[player];
+	if (ch >= 1 && ch < (int)kPlayerSlotStride) {
+		int slot = episodeSaveSlot(player, (uint)ch);
+		if (saveSlotExists(slot))
+			return (uint)slot + 1;
+	}
+	// Fallback: a save written by the pre-episode build sat at local slot 0.
+	int legacy = episodeSaveSlot(player, 0);
+	if (saveSlotExists(legacy))
+		return (uint)legacy + 1;
+	return 0;
+}
+
+bool CryOmni3DEngine_Atlantis::playerHasSave(uint player) const {
+	return playerResumeSave(player) != 0;
+}
+
+void CryOmni3DEngine_Atlantis::autosave() {
+	// The slot is the chapter number; the description is its EPI.TXT
+	// checkpoint name.  Chapters outside a player's block (the end-game
+	// sentinels chapter=99/999) and unused chapter numbers — which have no
+	// EPI.TXT name — get no checkpoint, matching the original.
+	uint chapter = _currentCONChapter;
+	if (chapter < 1 || chapter >= kPlayerSlotStride)
+		return;
+	Common::String name = episodeName(chapter);
+	if (name.empty())
+		return;
+	saveGame((uint)episodeSaveSlot((uint)_currentPlayer, chapter) + 1, name);
+	if (_currentPlayer >= 0 && _currentPlayer < (int)kMaxPlayers) {
+		_playerChapter[_currentPlayer] = (int)chapter;
+		savePlayers();
+	}
+}
+
+// SPRLIST\EPI.TXT — a CR/LF-separated list of episode checkpoint names,
+// terminated by a `/FIN` line.  Parsed once at startup; episodeName() then
+// serves chapter N from index N - 1.
+void CryOmni3DEngine_Atlantis::loadEpisodeNames() {
+	_episodeNames.clear();
+
+	Common::ScopedPtr<Common::SeekableReadStream> s(
+	    openBigFileStream(kFileTypeSprite, "EPI.TXT"));
+	if (!s) {
+		warning("loadEpisodeNames: cannot open SPRLIST\\EPI.TXT");
+		return;
+	}
+
+	uint32 sz = (uint32)s->size();
+	Common::Array<char> buf;
+	buf.resize(sz + 1);
+	if (sz)
+		s->read(buf.data(), sz);
+	buf[sz] = '\0';
+
+	Common::String cur;
+	for (uint32 i = 0; i <= sz; i++) {
+		char c = buf[i];
+		if (c == '\n' || c == '\0') {
+			if (cur.equalsIgnoreCase("/FIN"))
+				break;
+			_episodeNames.push_back(cur);
+			cur.clear();
+		} else if (c != '\r') {
+			cur += c;
+		}
+	}
+	debugC(1, kDebugSaveLoad, "loadEpisodeNames: %u episode checkpoint names", _episodeNames.size());
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/sprite_blend.h
+++ b/engines/cryomni3d/atlantis/sprite_blend.h
@@ -1,0 +1,85 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CRYOMNI3D_ATLANTIS_SPRITE_BLEND_H
+#define CRYOMNI3D_ATLANTIS_SPRITE_BLEND_H
+
+#include "common/scummsys.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// The original game (atlantis.exe) anti-aliases sprite edges by blending each
+// edge pixel against the framebuffer.  Every blend pixel carries a 5-bit
+// coverage `factor` (0..31) and a colour that is *already premultiplied* by
+// factor/32 in the sprite data; the destination then contributes the
+// remaining (32 - factor)/32 of itself, per RGB565 channel.
+//
+// This reproduces the original's three precomputed per-channel tables (built
+// by FUN_0042b930, consumed by the sprite blitter FUN_0041047f).  The integer
+// math here is bit-exact against the runtime table dumps: each table entry is
+// (channel * (32 - factor)) / 32, so a `>> 5` reproduces every table lookup
+// (the 6-bit green channel's *2/64 reduces to the same *1/32).
+//
+// A value of kSprNoBlend in a sprite's parallel blend array marks a pixel that
+// is opaque (or fully transparent) and needs no framebuffer blending.
+enum { kSprNoBlend = 0xFF };
+
+inline uint16 blendSprPixel565(uint16 src, uint16 dst, byte factor) {
+	uint inv = 32 - (factor & 0x1f);
+	uint b = (( dst        & 0x1f) * inv) >> 5;
+	uint g = (((dst >>  5) & 0x3f) * inv) >> 5;
+	uint r = (((dst >> 11) & 0x1f) * inv) >> 5;
+	return (uint16)(src + (uint16)((r << 11) | (g << 5) | b));
+}
+
+// UBB dialog-compositor blend — atlantis.exe FUN_00450b08's shade path (the
+// indirect PTR_FUN_00497c8c blend).  Unlike the sprite blend, the foreground
+// here is the RAW palette colour (not premultiplied): the 5-bit `shade`
+// (0..31) is the foreground coverage and the background contributes the
+// remaining (32 - shade)/32.  shade == 0x1f is full intensity and is handled
+// by a plain copy at the call site; this is the partial-coverage path that
+// anti-aliases the UBB head edge against the cyclo panorama, so the head
+// blends smoothly instead of leaving a hard black outline.
+inline uint16 blendUbbPixel565(uint16 fg, uint16 dst, uint shade) {
+	uint inv = 32 - shade;
+	uint b = ((( fg        & 0x1f) * shade) + (( dst        & 0x1f) * inv)) >> 5;
+	uint g = ((((fg >>  5) & 0x3f) * shade) + (((dst >>  5) & 0x3f) * inv)) >> 5;
+	uint r = ((((fg >> 11) & 0x1f) * shade) + (((dst >> 11) & 0x1f) * inv)) >> 5;
+	return (uint16)((r << 11) | (g << 5) | b);
+}
+
+// SPW (panorama animated sprite) blend — atlantis.exe FUN_00452bde /
+// FUN_00452d39, with tables built by FUN_00452ac8.  Same premultiplied-alpha
+// model as blendSprPixel565, but the SPW tables scale the green channel one
+// bit coarser (>>6, placed via <<6), so green is effectively 5-bit here.
+inline uint16 blendSpwPixel565(uint16 src, uint16 dst, byte factor) {
+	uint inv = 32 - (factor & 0x1f);
+	uint b = (( dst        & 0x1f) * inv) >> 5;
+	uint g = (((dst >>  5) & 0x3f) * inv) >> 6;
+	uint r = (((dst >> 11) & 0x1f) * inv) >> 5;
+	return (uint16)(src + (uint16)((r << 11) | (g << 6) | b));
+}
+
+} // End of namespace Atlantis
+} // End of namespace CryOmni3D
+
+#endif

--- a/engines/cryomni3d/atlantis/sprite_renderer.cpp
+++ b/engines/cryomni3d/atlantis/sprite_renderer.cpp
@@ -1,0 +1,730 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+// NPC and prop sprite rendering for panoramic views.
+//
+// Data flow:
+//   loadSpritePlaceList() — called after WAM load; parses the sprite list text
+//       file (e.g. SPWATL1.TXT from SPRLIST\) into _spritePlaceList.
+//   compositeNPCSprites() — called after loadCycloHNM(); for each entry
+//       matching _currentPlaceId, reads the SPW file, decodes pixel data,
+//       and blits pixels onto _warpSurface.
+//
+// SPW file layout (confirmed from atlantis.exe decompilation):
+//
+//   File header (20 bytes):
+//     [0x00] uint32 file_size
+//     [0x04] uint32 num_frames
+//     [0x08] uint32 format  (9 = 16-bit palette; 8 = 15-bit palette)
+//     [0x0C] uint32 unknown
+//     [0x10] uint32 unknown
+//   Frame offset table (4 bytes per frame, starting at [0x14]):
+//     [0x14] uint32 frame_offsets[0]   (low 2 bits may hold flags; mask with ~3)
+//     [0x18] uint32 frame_offsets[1]   (for multi-frame sprites)
+//     ...
+//
+//   Each frame (at file + frame_offsets[n]):
+//     frame[0x00..0x01] uint16  x1        (sprite bounding box left)
+//     frame[0x02..0x03] uint16  (unknown)
+//     frame[0x04..0x07] uint32  y_bot     (sprite bounding box bottom)
+//     frame[0x08..0x0B] uint32  x2        (sprite bounding box right)
+//     frame[0x0C..0x0D] uint16  y_top     (sprite bounding box top)
+//     frame[0x0E..0x0F] uint16  (unknown)
+//     frame[0x10..0x13] uint32  format    (same as file-level format)
+//     frame[0x14..0x17] uint32  pixel_stream_off  (from frame start)
+//     frame[0x18 .. 0x18+palette_bytes-1]  palette  (RGB565 entries, 2 bytes each)
+//     frame[pixel_stream_off ..]           RLE pixel stream
+//
+//   Pixel stream opcodes (uint16 control words, little-endian):
+//     ctrl == 0x0000          : no-op (skip)
+//     0x0001 <= ctrl < 0x4000 : DRAW ctrl pixels; next ctrl BYTES = palette indices (1/pixel)
+//     0x4000 <= ctrl < 0x8000 : BLEND (ctrl & 0x3FFF) pixels; next 2*(ctrl&0x3FFF) BYTES =
+//                               pairs (lo=palette_index, hi=alpha_byte)
+//     ctrl == 0x8000          : END of sprite
+//     0x8001 <= ctrl < 0xC000 : ROW_SEP short — advance (ctrl & 0x7FFF) pixels in flat buffer
+//     ctrl >= 0xC000          : ROW_SEP long — reads one extra uint16 word; advance =
+//                               (ctrl & 0x3FFF) * 65536 + extra_word   (pixel count)
+//
+//   The pixel stream uses a flat-buffer model: the output pointer starts at
+//   the beginning of the 2048-wide panoramic framebuffer (flat offset 0), and
+//   ROW_SEP opcodes advance the pointer by an arbitrary number of pixels, which
+//   may be either an intra-row skip (skipping transparent gaps within one
+//   scanline) or an end-of-row jump (crossing the scanline boundary to reach
+//   the sprite's x1 in the next row).  The first ROW_SEP in the stream is
+//   always a large jump from flat=0 to the sprite's first pixel row.
+//   The last ROW_SEP before END is a large jump to the very last pixel of
+//   the framebuffer (sentinel that need not be drawn).
+//
+//   The bounding box fields (x1, y_top, x2, y_bot) are used for NPC mouse
+//   hit-testing.  The x1/x2 values match the framebuffer column range exactly.
+//   The y_top/y_bot values do NOT match framebuffer rows (they appear to be in
+//   a different vertical coordinate system, offset by a sprite-dependent amount).
+//
+// SPWATL1.TXT line formats:
+//   NPC:   placeId  0  0  -persoId  angle  spwFile
+//   Torch: placeId  type  frames  spwFile
+// The two are distinguished by field[1] (type): 0 → NPC entry.
+
+#include "common/array.h"
+#include "common/debug.h"
+#include "common/rect.h"
+#include "common/scummsys.h"
+#include "common/str.h"
+#include "common/stream.h"
+#include "common/textconsole.h"
+#include "graphics/surface.h"
+
+#include "cryomni3d/atlantis/engine.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// ---------------------------------------------------------------------------
+// loadSpritePlaceList
+// ---------------------------------------------------------------------------
+
+void CryOmni3DEngine_Atlantis::loadSpritePlaceList() {
+	_spritePlaceList.clear();
+
+	const Common::String &listFile = _wam.spwListFile;
+	if (listFile.empty()) {
+		debugC(1, kDebugVideo, "loadSpritePlaceList: WAM has no SPW list");
+		return;
+	}
+
+	Common::SeekableReadStream *s = openBigFileStream(kFileTypeSprite, listFile);
+	if (!s) {
+		warning("loadSpritePlaceList: cannot open '%s'", listFile.c_str());
+		return;
+	}
+
+	uint32 fileSize = (uint32)s->size();
+	byte *buf = new byte[fileSize + 1];
+	s->read(buf, fileSize);
+	buf[fileSize] = '\0';
+	delete s;
+
+	const char *p = (const char *)buf;
+	int lineNum = 0;
+
+	while (*p) {
+		// Skip blank / whitespace-only prefixes between lines.
+		while (*p == '\r' || *p == '\n' || *p == ' ' || *p == '\t')
+			p++;
+		if (!*p)
+			break;
+
+		// Find end of this line.
+		const char *eol = p;
+		while (*eol && *eol != '\r' && *eol != '\n')
+			eol++;
+		lineNum++;
+
+		Common::String line(p, (uint32)(eol - p));
+		p = eol;
+
+		// Skip comments.
+		if (line.empty() || line[0] == '#' || line[0] == ';')
+			continue;
+
+		// Tokenise on whitespace.
+		Common::Array<Common::String> tok;
+		const char *tp = line.c_str();
+		while (*tp) {
+			while (*tp == ' ' || *tp == '\t') tp++;
+			if (!*tp) break;
+			const char *te = tp;
+			while (*te && *te != ' ' && *te != '\t') te++;
+			tok.push_back(Common::String(tp, (uint32)(te - tp)));
+			tp = te;
+		}
+
+		if (tok.size() < 4) {
+			debugC(3, kDebugVideo, "loadSpritePlaceList: line %d skipped (only %u tokens): '%s'",
+			      lineNum, tok.size(), line.c_str());
+			continue;
+		}
+
+		SpritePlaceEntry entry;
+		entry.placeId = (uint16)atoi(tok[0].c_str());
+		entry.type    = atoi(tok[1].c_str());
+		entry.frames  = atoi(tok[2].c_str());
+		entry.angle   = 0.f;
+		entry.persoId = 0;
+		entry.interactive = false;
+		// Trailing '-' on the placeId token marks the sprite as starting
+		// INACTIVE (atlantis.exe sprite-record field +0x04 = 0).  Such
+		// entries only render after /set(ShowPerso=N) or /set(NewWsprAnim=N)
+		// flips them active.  Atomic example: CHAPI012 vue 180 has
+		//   180  1 1 atorc180.spw            (no dash -> torch, always on)
+		//   180- 0 0 -617 00 a183h180.spw    (dash    -> guard, requires command)
+		entry.startActive = !tok[0].empty() && tok[0][tok[0].size() - 1] != '-';
+		entry.active = entry.startActive;
+		entry.frame  = 0;
+
+		// The SPW list has two row formats, distinguished by token COUNT
+		// (not by type) — every SPW*.TXT in the data uses exactly 4 or 6
+		// tokens, never 5 or 7:
+		//   4 tokens: placeId type frames spwFile
+		//   6 tokens: placeId type frames -persoId angle spwFile
+		// Both formats can carry any type value.  type=1 torches are
+		// usually 4-token; type=0 NPCs and type=2/3 wspranim alt-positions
+		// are usually 6-token; but palais2 has a handful of 4-token type=0
+		// puzzle decorations (e.g. "196 0 0 aoeil196.spw") with no perso
+		// reference.  The previous type-based branching mis-parsed every
+		// 6-token type=2 entry (the moving-guard alt-positions) as a
+		// 4-token row — the spwFile field came out as "-617" instead of
+		// the real "a183g180.spw" filename, so the moving guard never
+		// rendered.
+		if (tok.size() >= 6) {
+			int signedId  = atoi(tok[3].c_str());
+			entry.persoId = (signedId < 0) ? -signedId : signedId;
+			entry.angle   = (float)atof(tok[4].c_str());
+			// Interaction gate: the SPW list encodes "this is the NPC's home
+			// place — clickable here, look-only elsewhere" as a leading `-`
+			// on the angle token (e.g. `-00` vs. plain `00`).  atof drops
+			// the sign on a zero magnitude, so check the raw token.
+			entry.interactive = (!tok[4].empty() && tok[4][0] == '-');
+			entry.spwFile = tok[5];
+		} else {
+			// 4-token row: no perso/angle, just placeId/type/frames/file.
+			entry.spwFile = tok[3];
+		}
+
+		debugC(2, kDebugVideo, "  sprite: place=%u type=%d frames=%d perso=%d angle=%.2f %sfile=%s",
+		      entry.placeId, entry.type, entry.frames, entry.persoId,
+		      entry.angle, entry.interactive ? "[talk] " : "",
+		      entry.spwFile.c_str());
+		_spritePlaceList.push_back(entry);
+	}
+
+	delete[] buf;
+	debugC(1, kDebugVideo, "loadSpritePlaceList: %u entries from '%s'",
+	      _spritePlaceList.size(), listFile.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// loadSpfList
+// ---------------------------------------------------------------------------
+//
+// SPF list file (e.g. SPFATL1.TXT) lists, for each place-to-place
+// transition, which NPCs to show animated during the camera move:
+//
+//   fromPlace toPlace persoId spfFile
+//   001 002 600 a1001002.spf
+//   002 013 600 a1002013.spf
+//   ...
+//   #014 016 612 a8014016.spf   <- '#' starts a comment / disabled entry
+//   FIN
+//
+// Stored verbatim into _spriteTransList; playTransitionVideo filters by
+// the active (fromPlace,toPlace) pair when a transition starts.
+
+void CryOmni3DEngine_Atlantis::loadSpfList() {
+	_spriteTransList.clear();
+
+	const Common::String &listFile = _wam.spfListFile;
+	if (listFile.empty()) {
+		debugC(1, kDebugVideo, "loadSpfList: WAM has no SPF list");
+		return;
+	}
+
+	Common::SeekableReadStream *s = openBigFileStream(kFileTypeSprite, listFile);
+	if (!s) {
+		warning("loadSpfList: cannot open '%s'", listFile.c_str());
+		return;
+	}
+
+	uint32 fileSize = (uint32)s->size();
+	byte *buf = new byte[fileSize + 1];
+	s->read(buf, fileSize);
+	buf[fileSize] = '\0';
+	delete s;
+
+	const char *p = (const char *)buf;
+	while (*p) {
+		while (*p == '\r' || *p == '\n' || *p == ' ' || *p == '\t') p++;
+		if (!*p) break;
+
+		// Skip comment / disabled lines (leading '#').
+		if (*p == '#') {
+			while (*p && *p != '\r' && *p != '\n') p++;
+			continue;
+		}
+
+		// Find end of line.
+		const char *eol = p;
+		while (*eol && *eol != '\r' && *eol != '\n') eol++;
+		Common::String line(p, (uint32)(eol - p));
+		p = eol;
+
+		if (line.equalsIgnoreCase("FIN")) break;
+
+		Common::Array<Common::String> tok;
+		const char *tp = line.c_str();
+		while (*tp) {
+			while (*tp == ' ' || *tp == '\t') tp++;
+			if (!*tp) break;
+			const char *te = tp;
+			while (*te && *te != ' ' && *te != '\t') te++;
+			tok.push_back(Common::String(tp, (uint32)(te - tp)));
+			tp = te;
+		}
+
+		if (tok.size() < 4) continue;
+		SpriteTransEntry entry;
+		entry.fromPlace = (uint16)atoi(tok[0].c_str());
+		entry.toPlace   = (uint16)atoi(tok[1].c_str());
+		entry.persoId   = atoi(tok[2].c_str());
+		entry.spfFile   = tok[3];
+		_spriteTransList.push_back(entry);
+		debugC(3, kDebugVideo, "  spf: %u->%u perso=%d file=%s",
+		      entry.fromPlace, entry.toPlace, entry.persoId, entry.spfFile.c_str());
+	}
+
+	delete[] buf;
+	debugC(1, kDebugVideo, "loadSpfList: %u entries from '%s'",
+	      _spriteTransList.size(), listFile.c_str());
+}
+
+// ---------------------------------------------------------------------------
+// compositeNPCSprites
+// ---------------------------------------------------------------------------
+
+// Read frame_offsets[frameIdx] from the file header (frame table starts at file[0x14]).
+// Returns the frame offset with the low 2 flag bits masked off.
+static uint32 readSPWFrameOffset(Common::SeekableReadStream *s, uint frameIdx = 0) {
+	if (!s->seek(0x14 + frameIdx * 4))
+		return 0;
+	return s->readUint32LE() & 0xFFFFFFFCU;
+}
+
+
+// Read bounding box from SPW frame header.
+// frame[0x00]: x1 (uint16), frame[0x04]: y_bot (uint32),
+// frame[0x08]: x2 (uint32), frame[0x0C]: y_top (uint16).
+// Returns false on read error.
+static bool readSPWBounds(Common::SeekableReadStream *s,
+                          int16 &x1, int16 &y1, int16 &x2, int16 &y2,
+                          uint frameIdx = 0) {
+	uint32 frameOff = readSPWFrameOffset(s, frameIdx);
+	if (!frameOff || s->err())
+		return false;
+
+	if (!s->seek(frameOff))
+		return false;
+
+	x1 = (int16)s->readUint16LE();  // frame[0x00]: x_left
+	s->readUint16LE();               // frame[0x02]: skip
+	y2 = (int16)s->readUint32LE();  // frame[0x04]: y_bottom
+	x2 = (int16)s->readUint32LE();  // frame[0x08]: x_right
+	y1 = (int16)s->readUint16LE();  // frame[0x0C]: y_top
+
+	return !s->err();
+}
+
+static inline uint32 rgb565ToSurfaceColor(uint16 v, const Graphics::PixelFormat &fmt) {
+	uint8 r = ((v >> 11) & 0x1F) * 255 / 31;
+	uint8 g = ((v >>  5) & 0x3F) * 255 / 63;
+	uint8 b = (v & 0x1F) * 255 / 31;
+	return fmt.RGBToColor(r, g, b);
+}
+
+static inline void putSurfacePixel(Graphics::Surface &surf, int x, int y, uint32 color) {
+	byte *dst = (byte *)surf.getBasePtr(x, y);
+	switch (surf.format.bytesPerPixel) {
+	case 2: *(uint16 *)dst = (uint16)color; break;
+	case 4: *(uint32 *)dst = color;         break;
+	default: break;
+	}
+}
+
+// Decode SPW sprite and composite onto surf.
+//
+// The pixel stream uses a flat-buffer model matching the original engine:
+// the output pointer starts at flat offset 0 of the panoramic framebuffer,
+// and ROW_SEP opcodes advance it by an arbitrary pixel count that may cross
+// row boundaries.  Pixel coordinates are derived by dividing the flat offset
+// by the surface width.
+static void decodeSPWPixels(Common::SeekableReadStream *spw,
+                             Graphics::Surface &surf, uint frameIdx = 0) {
+	// Locate frame.
+	uint32 frameOff = readSPWFrameOffset(spw, frameIdx);
+	if (!frameOff)
+		return;
+
+	// Read pixel-stream offset (relative to frame start).
+	if (!spw->seek(frameOff + 0x14))
+		return;
+	uint32 pixOff = spw->readUint32LE();
+	if (spw->err() || pixOff < 0x18)
+		return;
+
+	// Read palette: frame[0x18 .. frame+pixOff-1], 2 bytes per RGB565 entry.
+	uint32 palBytes = pixOff - 0x18;
+	uint32 palCount = palBytes / 2;
+	if (palCount > 256)
+		palCount = 256;
+
+	uint16 palette[256] = {};
+	if (!spw->seek(frameOff + 0x18))
+		return;
+	for (uint32 i = 0; i < palCount; ++i)
+		palette[i] = spw->readUint16LE();
+	if (spw->err())
+		return;
+
+	// Seek to pixel stream.
+	if (!spw->seek(frameOff + pixOff))
+		return;
+
+	const Graphics::PixelFormat &fmt = surf.format;
+	const int32 surfW = surf.w;
+	const int32 surfH = surf.h;
+	const int64 surfArea = (int64)surfW * surfH;
+
+	// Flat pixel offset into the framebuffer, starting at 0.
+	// The first ROW_SEP in the stream is a large jump from 0 to the sprite's
+	// first actual pixel position (matching the original engine where param_4
+	// is initialized to the buffer base address).
+	int64 curFlat = 0;
+
+	while (!spw->eos()) {
+		uint16 ctrl = spw->readUint16LE();
+
+		if (ctrl == 0x8000)
+			break;  // END
+
+		if (ctrl >= 0xC000) {
+			// ROW_SEP long form: advance = (ctrl & 0x3FFF) * 65536 + extra_word.
+			// Derived from atlantis.exe FUN_00452bde:
+			//   param_4 += CONCAT22((short)(((uVar6 & 0x7ffe) << 0xf) >> 0x10), *puVar8)
+			// where uVar6 = (ctrl * 2) & 0xFFFF, yielding high = ctrl & 0x3FFF.
+			uint16 extra = spw->readUint16LE();
+			int64 advance = (int64)(ctrl & 0x3FFF) * 65536 + extra;
+			curFlat += advance;
+			if (curFlat >= surfArea)
+				break;
+		} else if (ctrl >= 0x8000) {
+			// ROW_SEP short form: advance = ctrl & 0x7FFF pixels.
+			// Derived from: param_4 = (ushort*)((int)param_4 + uVar6)
+			// where uVar6 = (ctrl * 2) & 0xFFFF bytes, i.e. (ctrl & 0x7FFF) pixels.
+			curFlat += (ctrl & 0x7FFF);
+			if (curFlat >= surfArea)
+				break;
+		} else if (ctrl >= 0x4000) {
+			// BLEND: (ctrl & 0x3FFF) pixels; 2 bytes each (palette index, factor).
+			// atlantis.exe FUN_00452bde/FUN_00452d39: the palette colour is
+			// premultiplied; the framebuffer contributes (32-factor)/32 of
+			// itself via the SPW blend tables (see blendSpwPixel565).
+			int count = ctrl & 0x3FFF;
+			for (int i = 0; i < count && !spw->eos(); ++i) {
+				uint8 idx    = spw->readByte();
+				uint8 factor = spw->readByte();
+				if (curFlat >= 0 && curFlat < surfArea) {
+					int cx = (int)(curFlat % surfW);
+					int cy = (int)(curFlat / surfW);
+					uint16 src = (idx < palCount) ? palette[idx] : 0;
+					// The panorama framebuffer is RGB565; blend in that space.
+					uint16 dst = ((const uint16 *)surf.getBasePtr(cx, cy))[0];
+					uint16 out = blendSpwPixel565(src, dst, factor);
+					putSurfacePixel(surf, cx, cy, rgb565ToSurfaceColor(out, fmt));
+				}
+				++curFlat;
+			}
+		} else if (ctrl > 0) {
+			// DRAW: ctrl pixels; 1 byte each (palette index).
+			int count = ctrl;
+			for (int i = 0; i < count && !spw->eos(); ++i) {
+				uint8 idx = spw->readByte();
+				if (curFlat >= 0 && curFlat < surfArea) {
+					int cx = (int)(curFlat % surfW);
+					int cy = (int)(curFlat / surfW);
+					uint16 c = (idx < palCount) ? palette[idx] : 0;
+					putSurfacePixel(surf, cx, cy, rgb565ToSurfaceColor(c, fmt));
+				}
+				++curFlat;
+			}
+		}
+		// ctrl == 0: no-op, continue
+	}
+}
+
+void CryOmni3DEngine_Atlantis::rebuildNpcPlaceBounds() {
+	// Always clear, even if !_warpLoaded — leaving stale bounds from a
+	// previous place is what would let npcPanoHitTest false-positive after
+	// a transition where loadCycloHNM hasn't completed yet.
+	_npcPlaceBounds.clear();
+	if (!_warpLoaded)
+		return;
+	for (const SpritePlaceEntry &entry : _spritePlaceList) {
+		if (entry.placeId != (uint16)_currentPlaceId)
+			continue;
+		// Click target: a real perso AND marked interactive.  Skip the
+		// non-interactive "distance" sprites (NPC drawn but too far to talk
+		// -- recompositeSpriteLayer still draws those; only the click list is
+		// gated here) and any perso currently hidden.
+		//
+		// Type filter: type-0 is the normal NPC click target; type-3 are
+		// script-managed sprites (rope at the Cockerel inn vue 158, palace
+		// traps at vue 194/215, Echelle character at vue 114) that the data
+		// flags as interactive via the `-00` angle prefix.  Those need to be
+		// clickable so /con(ClicPerso=N) sections like CHAPI015 section 203
+		// (`/con*(ClicPerso=277)&(ObjetEnMain=262)` -- cut the rope with the
+		// knife) can fire.  Atlantis.exe's hit-test loop iterates every
+		// sprite regardless of type; only the pickup branch (FUN_004278a0)
+		// then gates on `sprite.type != 3`, leaving the click action
+		// available for the generic /con scan to consume.
+		if (entry.persoId <= 0 || !entry.interactive)
+			continue;
+		if (entry.type != 0 && entry.type != 3)
+			continue;
+		// Invisible sprites must not be clickable.  Atlantis.exe's perso
+		// hit-test (FUN_004261a0) only considers sprites whose active flag
+		// (record +0x04) is set -- the same flag recompositeSpriteLayer
+		// gates rendering on.  Sprites that start inactive via the leading
+		// dash on the placeId token (e.g. CHAPI015's `151- 0 0 -579 -00
+		// a151p151.spw`) are extras the chapter never shows, but they were
+		// landing in the click list and stealing clicks from real NPCs
+		// behind them -- CHAPI015's Lascoyt menu wouldn't open because
+		// perso 579 at vue 151 was eating the click and producing "no
+		// options found" (no /con(ClicPerso=579) exists anywhere).
+		if (!entry.active)
+			continue;
+
+		bool hidden = false;
+		for (int h : _hiddenPersos) if (h == entry.persoId) { hidden = true; break; }
+		if (hidden) continue;
+
+		Common::SeekableReadStream *spw =
+		    openBigFileStream(kFileTypeSpriteCyclo, entry.spwFile);
+		if (!spw) continue;
+
+		// Frame 0 bounds are representative.
+		int16 x1, y1, x2, y2;
+		if (readSPWBounds(spw, x1, y1, x2, y2) && y2 >= y1) {
+			if (x2 >= x1) {
+				NPCBound nb;
+				nb.persoId    = entry.persoId;
+				nb.panoBounds = Common::Rect(x1, y1, x2 + 1, y2 + 1);
+				_npcPlaceBounds.push_back(nb);
+			} else {
+				// Sprite wraps the panorama's 360-degree boundary --
+				// e.g. CHAPI013 vue 126's `apotf126.spw` reports
+				// x1=1931 x2=25 (the priest sprite straddles the
+				// 0/2048 seam).  Split into two NPCBound entries so
+				// hit-test still works on both sides.
+				const int16 panoW = 2048;
+				NPCBound nbR, nbL;
+				nbR.persoId    = entry.persoId;
+				nbR.panoBounds = Common::Rect(x1, y1, panoW, y2 + 1);
+				_npcPlaceBounds.push_back(nbR);
+				nbL.persoId    = entry.persoId;
+				nbL.panoBounds = Common::Rect(0, y1, x2 + 1, y2 + 1);
+				_npcPlaceBounds.push_back(nbL);
+			}
+		}
+		delete spw;
+	}
+}
+
+void CryOmni3DEngine_Atlantis::compositeNPCSprites() {
+	if (!_warpLoaded)
+		return;
+
+	_propAnimFrames = 0;
+	_propAnimFrame  = 0;
+	_wsprAnimActiveIdx = -1;
+
+	// Reset each entry at the new place to its parsed startActive baseline
+	// (no-dash entries on; dashed entries off), so wspranim activations from
+	// a previous place don't leak.  Persistent hide/show state from
+	// _hiddenPersos is reapplied below by leaving entries with persoId in
+	// the hidden list deactivated.
+	for (SpritePlaceEntry &e : _spritePlaceList) {
+		if (e.placeId != (uint16)_currentPlaceId) continue;
+		e.active = e.startActive;
+		e.frame  = 0;
+		if (e.persoId > 0) {
+			for (int h : _hiddenPersos)
+				if (h == e.persoId) { e.active = false; break; }
+			// Companion NPCs added via /set(addguest=N) override the
+			// hidden list -- a guest is always visible at every place
+			// they have a sprite, regardless of any prior HidePerso.
+			// This is what makes Servage / Lascoyt etc. follow Seth
+			// across the city/palace after the script attaches them.
+			for (int g : _guests)
+				if (g == e.persoId) { e.active = true; break; }
+		}
+	}
+
+	// Detect the animated prop (if any) at the current place.
+	//
+	// The TXT `frames` field is NOT the animation cycle length — every
+	// type-1 SPW in the data has 8 actual frame offsets, while the TXT
+	// frames field ranges 1..6 across chapters (palais2's torches even
+	// say "1", which would mean static).  The cycle length comes from the
+	// SPW file header (uint32 at +0x04, equal to the count of valid frame
+	// offsets at +0x14..).  Without this, palais2 torches/fountains
+	// rendered as a single frozen frame; reading the actual count makes
+	// them flicker again.
+	//
+	// Selection rule: prefer the LONGEST animation that carries a
+	// persoId (the "main" animated character at the place) over the
+	// nearest perso-less prop (torches etc.).  CHAPI013 vue 126 has
+	// both atorc126.spw (torch, perso=0, 8 frames) and a086m126.spw
+	// (priest aide, perso=529, 126 frames).  The script's WSprFrame
+	// gates need the 126-frame animation -- /con sections like line 92
+	// (`/con(vue=126)&(ObjetEnMain=261)&...&(Wsprframe>7)&(Wsprframe<34)`)
+	// only fire on the priest's idle frame range, not the torch's
+	// 8-frame loop.  Falls back to any type-1 sprite if no perso-bearing
+	// candidate exists.
+	int   bestNFrames = 0;
+	const SpritePlaceEntry *bestEntry = nullptr;
+	bool  bestHasPerso = false;
+	for (const SpritePlaceEntry &entry : _spritePlaceList) {
+		if (entry.placeId != (uint16)_currentPlaceId)
+			continue;
+		if (entry.type != 1)
+			continue;
+		Common::SeekableReadStream *spw =
+		    openBigFileStream(kFileTypeSpriteCyclo, entry.spwFile);
+		if (!spw)
+			continue;
+		spw->seek(0x04);
+		uint32 nFrames = spw->readUint32LE();
+		delete spw;
+		if (nFrames <= 1 || nFrames > 256)
+			continue;
+		bool hasPerso = (entry.persoId > 0);
+		// Perso-bearing wins over perso-less; among same group pick longer.
+		if ((hasPerso && !bestHasPerso) ||
+		    (hasPerso == bestHasPerso && (int)nFrames > bestNFrames)) {
+			bestNFrames = (int)nFrames;
+			bestEntry   = &entry;
+			bestHasPerso = hasPerso;
+		}
+	}
+	if (bestEntry) {
+		_propAnimFrames = bestNFrames;
+		_propAnimFrame  = 0;
+		_propAnimNextMs = g_system->getMillis() + kPropAnimIntervalMs;
+		_gameVars["wsprframe"] = 0;
+	}
+
+	rebuildNpcPlaceBounds();
+	recompositeSpriteLayer();
+}
+
+void CryOmni3DEngine_Atlantis::recompositeSpriteLayer() {
+	if (!_warpLoaded)
+		return;
+
+	// Start from the clean cyclo to avoid stacking animation frames.
+	_warpSurface.copyFrom(_cycloSurface);
+
+	// Render every sprite at the current place whose `active` flag is set.
+	// This mirrors atlantis.exe's render loop (FUN at ~0x420060) which
+	// gates rendering on sprite-record field +0x04 (`!= 0`).  Active state
+	// starts from the parsed trailing-dash flag (no dash = active, dash =
+	// inactive) and is toggled by /set(ShowPerso=N), /set(HidePerso=N),
+	// /set(NewWsprAnim=K), /set(StopWsprAnim=K).
+	for (const SpritePlaceEntry &entry : _spritePlaceList) {
+		if (entry.placeId != (uint16)_currentPlaceId)
+			continue;
+		if (!entry.active)
+			continue;
+
+		Common::SeekableReadStream *spw =
+		    openBigFileStream(kFileTypeSpriteCyclo, entry.spwFile);
+		if (!spw) {
+			warning("recompositeSpriteLayer: cannot open '%s'", entry.spwFile.c_str());
+			continue;
+		}
+
+		// Frame index per sprite type:
+		//   type=0 NPC: frame 0 (static).
+		//   type=1 ambient prop: cycles through _propAnimFrame, then
+		//                        wraps modulo this sprite's own frame
+		//                        count (different type-1 sprites at the
+		//                        same place can have different lengths --
+		//                        CHAPI013 vue 126 has atorc126 with 8
+		//                        frames AND a086m126 with 126).
+		//   type>=2 wspranim: entry's own per-sprite frame counter
+		//                     (incremented by the timer tick, exposed as
+		//                     the script's WSPRFRAME variable each tick).
+		uint frameIdx;
+		if (entry.type == 1 && _propAnimFrames > 0) {
+			spw->seek(0x04);
+			uint32 nF = spw->readUint32LE();
+			frameIdx = (nF > 0) ? _propAnimFrame % nF : 0;
+		} else if (entry.type >= 2) {
+			spw->seek(0x04);
+			uint32 nFrames = spw->readUint32LE();
+			int wf = entry.frame;
+			if (wf < 0) wf = 0;
+			frameIdx = (nFrames > 0) ? (uint)wf % nFrames : 0;
+		} else {
+			frameIdx = 0;
+		}
+
+		int16 x1, y1, x2, y2;
+		if (!readSPWBounds(spw, x1, y1, x2, y2, frameIdx)) {
+			warning("recompositeSpriteLayer: bad header in '%s' frame %u",
+			        entry.spwFile.c_str(), frameIdx);
+			delete spw;
+			continue;
+		}
+
+		debugC(5, kDebugVideo, "recompositeSpriteLayer: place=%u %s frame=%u bounds [%d,%d]-[%d,%d]",
+		      entry.placeId, entry.spwFile.c_str(), frameIdx, x1, y1, x2, y2);
+
+		decodeSPWPixels(spw, _warpSurface, frameIdx);
+		delete spw;
+	}
+}
+
+// ---------------------------------------------------------------------------
+// compositeSpfFrame — used by playTransitionVideo
+// ---------------------------------------------------------------------------
+//
+// SPF files share the SPW on-disk format (file_size / num_frames / format
+// header followed by per-frame palette + RLE pixel stream), so we drive
+// the same decoder against the transition video's 640×480 frame surface.
+// Out-of-range frameIdx (transition video longer than the SPF animation)
+// degrades to a no-op: each SPF is at most ~39 frames; if the HNM has
+// more, the last frame stays on screen instead of glitching.
+
+void CryOmni3DEngine_Atlantis::compositeSpfFrame(Common::SeekableReadStream *spf,
+                                                  uint frameIdx,
+                                                  Graphics::Surface &dst) {
+	if (!spf) return;
+
+	// Bounds check against header[0x04] = num_frames.
+	if (!spf->seek(4)) return;
+	uint32 numFrames = spf->readUint32LE();
+	if (frameIdx >= numFrames) frameIdx = numFrames - 1;
+
+	decodeSPWPixels(spf, dst, frameIdx);
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/toolbar.cpp
+++ b/engines/cryomni3d/atlantis/toolbar.cpp
@@ -1,0 +1,516 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/system.h"
+
+#include "cryomni3d/cryomni3d.h"
+
+#include "cryomni3d/atlantis/engine.h"
+#include "cryomni3d/atlantis/toolbar.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+Atlantis_Toolbar::Atlantis_Toolbar() :
+	_sprites(nullptr), _inventory(nullptr), _engine(nullptr),
+	_inventoryOffset(0), _inventoryMaxOffset(0),
+	_inventoryHovered(uint(-1)), _inventorySelected(uint(-1)),
+	_inventoryButtonDragging(false),
+	_position(82) {
+}
+
+Atlantis_Toolbar::~Atlantis_Toolbar() {
+	_bgSurface.free();
+	_destSurface.free();
+}
+
+void Atlantis_Toolbar::init(const Sprites *sprites, Inventory *inventory, CryOmni3DEngine_Atlantis *engine) {
+	_sprites  = sprites;
+	_inventory = inventory;
+	_engine   = engine;
+
+	_format = g_system->getScreenFormat();
+	// 82 rows: matches the height of OBJETS0.SPR, the single inventory-bar
+	// background sprite in the original game.  The bar slides up from
+	// y=screen.h to y=screen.h-82.
+	_bgSurface.create(640, 82, _format);
+	_destSurface.create(640, 82, _format);
+
+	// 9 inventory slot rectangles.  Slot centres come straight from
+	// atlantis.exe (toolbar setup FUN_0042c2c4): the slot-X table at
+	// 0x00611710 is filled with  x = i * 0x46 + 0x2a  →  i * 70 + 42, and the
+	// slot-Y table at 0x00611788 settles at 0x1bb = 443 (screen coords).  The
+	// toolbar surface is 640 wide at screen y = 480-82 = 398, so the slot
+	// centre in toolbar-local coords is (i*70+42, 443-398 = 45).  Confirmed by
+	// dynamic dump: 0x611710 = {42,112,182,...}, 0x611788 = {443,443,...}.
+	static const int kSlotCenters[kInventorySlots] = {
+		42, 112, 182, 252, 322, 392, 462, 532, 602
+	};
+	const int kSlotHalfW = 25;
+	const int kSlotTop   = 25;   // toolbar-local; centre y = 45 → screen 443
+	const int kSlotBot   = 65;
+	ZoneCallback kSlotCbs[kInventorySlots] = {
+		&Atlantis_Toolbar::callbackInventory<0>,
+		&Atlantis_Toolbar::callbackInventory<1>,
+		&Atlantis_Toolbar::callbackInventory<2>,
+		&Atlantis_Toolbar::callbackInventory<3>,
+		&Atlantis_Toolbar::callbackInventory<4>,
+		&Atlantis_Toolbar::callbackInventory<5>,
+		&Atlantis_Toolbar::callbackInventory<6>,
+		&Atlantis_Toolbar::callbackInventory<7>,
+		&Atlantis_Toolbar::callbackInventory<8>,
+	};
+	for (uint i = 0; i < kInventorySlots; i++)
+		addZone(Common::Rect(kSlotCenters[i] - kSlotHalfW, kSlotTop,
+		                     kSlotCenters[i] + kSlotHalfW, kSlotBot),
+		        kSlotCbs[i]);
+}
+
+void Atlantis_Toolbar::addZone(Common::Rect rect, ZoneCallback callback) {
+	Zone zone = { rect, callback, true, false };
+	_zones.push_back(zone);
+}
+
+void Atlantis_Toolbar::inventoryChanged(uint newPosition) {
+	if (newPosition != uint(-1) && newPosition > _inventoryOffset)
+		_inventoryOffset = newPosition - (kInventorySlots - 1);
+	updateZones();
+}
+
+void Atlantis_Toolbar::updateZones() {
+	// Compute max scroll offset (how far we can scroll right).  No prev/next
+	// buttons on the bar, but inventoryChanged() still pages forward
+	// automatically when a new item lands outside the visible window.
+	_inventoryMaxOffset = 0;
+	for (uint i = kInventorySlots; i < _inventory->size(); i++) {
+		if ((*_inventory)[i] != nullptr)
+			_inventoryMaxOffset = i - (kInventorySlots - 1);
+	}
+
+	if (_inventoryOffset > _inventoryMaxOffset)
+		_inventoryOffset = _inventoryMaxOffset;
+}
+
+Common::Array<Atlantis_Toolbar::Zone>::const_iterator Atlantis_Toolbar::hitTestZones(
+	const Common::Point &mousePos) const {
+	// atlantis.exe FUN_0042c098 hit-tests the inventory bar as 9 full-width
+	// 70-px columns (slot = mouseX / 70) — not the icon-sized rects — so a
+	// click anywhere in a slot's column counts.  Valid while the cursor is
+	// inside the bar: screen y >= 409, i.e. toolbar-local y >= 11.  (The Zone
+	// rects themselves only position the item icons; see drawToolbar().)
+	if (mousePos.y < 11 || mousePos.y >= (int)_destSurface.h)
+		return _zones.end();
+	int column = mousePos.x / 70;
+	if (column < 0 || column >= (int)_zones.size())
+		return _zones.end();
+	Common::Array<Zone>::const_iterator it = _zones.begin() + column;
+	if (it->hidden || !it->callback)
+		return _zones.end();
+	return it;
+}
+
+uint Atlantis_Toolbar::captureEvent(const Common::Point &mousePos, uint dragStatus) {
+	Common::Array<Zone>::const_iterator it = hitTestZones(mousePos);
+	if (it != _zones.end())
+		return (this->*(it->callback))(dragStatus);
+	return 0;
+}
+
+// -----------------------------------------------------------------------
+// Drawing
+// -----------------------------------------------------------------------
+
+void Atlantis_Toolbar::addMenuSprite(uint16 w, uint16 h, int16 xoff, int16 yoff,
+                                      uint16 transpKey, int tx, int ty, const uint16 *pix,
+                                      const uint8 *blend) {
+	MenuSprData s;
+	s.w = w; s.h = h;
+	s.xoff = xoff; s.yoff = yoff;
+	s.tx = tx; s.ty = ty;
+	s.transpKey = transpKey;
+	s.pixels.assign(pix, pix + (uint)w * h);
+	s.blend.assign(blend, blend + (uint)w * h);
+	_menuSprData.push_back(s);
+}
+
+void Atlantis_Toolbar::drawBackground(const Graphics::Surface *original) {
+	if (!original)
+		return;
+	// Capture the bottom 60 rows of the current scene *unmodified*.  Atlantis
+	// does not paint a darkened panel under the toolbar -- the SPRMENU sprites
+	// composited on top (golden filigree line + options emblem + corner
+	// ornaments) are the entirety of the visible toolbar, with the scene
+	// showing through everywhere else.  Previous code halved every pixel,
+	// which produced a dark band that doesn't match the original game.
+	const int srcY = original->h - _bgSurface.h;
+	if (srcY < 0)
+		return;
+	const byte *src = (const byte *)original->getBasePtr(0, srcY);
+	byte *dst = (byte *)_bgSurface.getPixels();
+	const uint rowBytes = _bgSurface.w * _format.bytesPerPixel;
+	for (int y = 0; y < _bgSurface.h; y++)
+		memcpy(dst + y * _bgSurface.pitch, src + y * original->pitch, rowBytes);
+}
+
+void Atlantis_Toolbar::drawToolbar(const Graphics::Surface *original) {
+	if (_position > 82)
+		_position = 82;
+
+	if (_position != 0) {
+		// Not fully visible: copy the top _position rows from original
+		if (original) {
+			int srcY = original->h - _destSurface.h;
+			Common::Rect srcRct(0, srcY, 640, srcY + _position);
+			_destSurface.copyRectToSurface(*original, 0, 0, srcRct);
+		}
+	}
+
+	if (_position == (uint)_destSurface.h) {
+		// Fully hidden
+		return;
+	}
+
+	// Copy the (unmodified) scene strip into the visible region.
+	{
+		Common::Rect visRct(0, _position, 640, _destSurface.h);
+		_destSurface.copyRectToSurface(_bgSurface, 0, _position, visRct);
+	}
+
+	// Draw SPRMENU decorative sprites over the darkened background
+	for (const MenuSprData &spr : _menuSprData) {
+		int baseX = spr.tx - spr.xoff;
+		int baseY = (spr.ty - spr.yoff) + _position;
+		for (int y = 0; y < (int)spr.h; y++) {
+			int dy = baseY + y;
+			if (dy < 0 || dy >= _destSurface.h)
+				continue;
+			for (int x = 0; x < (int)spr.w; x++) {
+				int dx = baseX + x;
+				if (dx < 0 || dx >= _destSurface.w)
+					continue;
+				uint sidx = y * spr.w + x;
+				uint16 pix = spr.pixels[sidx];
+				if (pix == spr.transpKey)
+					continue;
+				uint16 *dp = (uint16 *)_destSurface.getBasePtr(dx, dy);
+				if (spr.blend[sidx] != kSprNoBlend)
+					pix = blendSprPixel565(pix, *dp, spr.blend[sidx]);
+				*dp = pix;
+			}
+		}
+	}
+
+	// Draw inventory item icons on top of the OBJETS0 star ornaments.  No
+	// per-slot fill/frame -- the bar background already shows the slot
+	// position; an empty slot just leaves the star ornament visible.
+	for (uint i = 0; i < kInventorySlots; i++) {
+		uint invIdx = i + _inventoryOffset;
+		Object *obj = (invIdx < _inventory->size()) ? (*_inventory)[invIdx] : nullptr;
+		if (obj == nullptr)
+			continue;
+		// The item currently in hand (taken out to be used) is not shown in
+		// the bar — its slot reads as empty, matching atlantis.exe
+		// FUN_0042cc98, which skips the held slot while it is on the cursor.
+		if (obj == _inventory->selectedObject())
+			continue;
+
+		// Slot rect in toolbar-local coords, offset by the slide position.
+		// Deliberately NOT clipped to the surface: clipping the rect first
+		// would shift its centre once it overlaps an edge, so the icon would
+		// lag behind the bar and get trimmed mid-slide.  drawInventoryIcon()
+		// clips to the surface itself.
+		Common::Rect r = _zones[kZoneInventory0 + i].rect;
+		r.translate(0, _position);
+		if (r.bottom <= 0 || r.top >= (int)_destSurface.h)
+			continue;
+
+		_engine->drawInventoryIcon(_destSurface, obj, r);
+	}
+}
+
+// -----------------------------------------------------------------------
+// Event loop
+// -----------------------------------------------------------------------
+
+bool Atlantis_Toolbar::displayToolbar(const Graphics::Surface *original) {
+	_engine->setCursor(181 < (int)_sprites->getSpritesCount() ? 181 : 0);
+
+	// Capture the current scene as the (unmodified) toolbar background.
+	drawBackground(original);
+
+	// Reset selection state
+	_inventorySelected = uint(-1);
+	_inventoryHovered  = uint(-1);
+
+	updateZones();
+
+	// Slide toolbar up
+	for (_position = _destSurface.h; _position > 0 && !_engine->shouldAbort(); _position--) {
+		drawToolbar(original);
+		g_system->copyRectToScreen(_destSurface.getPixels(), _destSurface.pitch, 0,
+		                           original ? original->h - _destSurface.h : (480 - 82),
+		                           _destSurface.w, _destSurface.h);
+		g_system->updateScreen();
+		g_system->delayMillis(10);
+		_engine->pollEvents();
+	}
+
+	if (_engine->shouldAbort())
+		return false;
+
+	_engine->clearKeys();
+	_engine->waitMouseRelease();
+
+	bool itemTaken = handleToolbarEvents(original);
+
+	if (_engine->shouldAbort())
+		return false;
+
+	// Slide the toolbar down — skipped when an item was just taken, so the bar
+	// clears at once and the carried object reaches the centred navigation
+	// crosshair without waiting out the slide.
+	if (!itemTaken) {
+		for (_position = 0; _position <= (uint)_destSurface.h && !_engine->shouldAbort(); _position++) {
+			drawToolbar(original);
+			g_system->copyRectToScreen(_destSurface.getPixels(), _destSurface.pitch, 0,
+			                           original ? original->h - _destSurface.h : (480 - 82),
+			                           _destSurface.w, _destSurface.h);
+			g_system->updateScreen();
+			g_system->delayMillis(10);
+			_engine->pollEvents();
+		}
+	}
+
+	return false;
+}
+
+bool Atlantis_Toolbar::handleToolbarEvents(const Graphics::Surface *original) {
+	_inventoryHovered  = uint(-1);
+	_inventorySelected = uint(-1);
+	_inventoryButtonDragging = false;
+	// The in-hand object (selectedObject) is deliberately NOT cleared here:
+	// reopening the bar must keep the item you are carrying, so it can be put
+	// back only by an explicit action (right-click, or a left-click on an
+	// empty part of the bar).
+
+	updateZones();
+	drawToolbar(original);
+	g_system->copyRectToScreen(_destSurface.getPixels(), _destSurface.pitch, 0,
+	                           original ? original->h - _destSurface.h : (480 - 82),
+	                           _destSurface.w, _destSurface.h);
+	g_system->updateScreen();
+
+	if (_sprites->getSpritesCount() > 181)
+		_engine->setCursor(181);
+
+	// Toolbar covers screen.h - toolbar.h .. screen.h, plus a 32px hover
+	// buffer above it — i.e. 480 - 82 - 32 = 366.
+	const int kInsideY = 480 - (int)_destSurface.h - 32;
+	bool mouseInsideToolbar = (_engine->getMousePos().y > kInsideY);
+	bool exitToolbar = false;
+	bool itemTaken = false;   // set when the loop ends because an item was taken
+	bool rightReleasedSinceOpen = false;  // gates the put-back/close right-click
+
+	// Edge-hover scroll throttle: the exe pages one item per frame, which is
+	// far too fast at this loop's 10ms cadence, so step at a fixed interval.
+	const uint32 kScrollIntervalMs = 110;
+	uint32 nextScrollMs = 0;
+
+	while (!exitToolbar) {
+		_engine->pollEvents();
+		if (_engine->shouldAbort()) {
+			exitToolbar = true;
+			break;
+		}
+
+		// A right-click is acted on only once the button has been released at
+		// least once since the bar opened, so the right-click that OPENED the
+		// bar is not also consumed as the put-back / close click.
+		if (_engine->getCurrentMouseButton() != 2)
+			rightReleasedSinceOpen = true;
+
+		// Escape / Space always close the bar.
+		if (_engine->checkKeysPressed(2, Common::KEYCODE_ESCAPE, Common::KEYCODE_SPACE)) {
+			exitToolbar = true;
+			break;
+		}
+		// Right-click: while carrying an item it drops the item back into its
+		// slot (the original uses the right button for this); then — like any
+		// right-click — the bar closes.  The slide-down redraws the bar with
+		// the item back in place, so it visibly returns before the bar slides
+		// away.
+		if (_engine->getCurrentMouseButton() == 2 && rightReleasedSinceOpen) {
+			_engine->waitMouseRelease();
+			if (_inventory->selectedObject() != nullptr) {
+				_inventory->setSelectedObject(nullptr);
+				_engine->setArrowCursor();   // object leaves the cursor at once
+				updateZones();
+			}
+			exitToolbar = true;
+			break;
+		}
+
+		Common::Point mousePosInToolbar = _engine->getMousePos();
+		mousePosInToolbar -= Common::Point(0, 480 - _destSurface.h);
+
+		DragStatus drag = _engine->getDragStatus();
+		bool redrawToolbar = false;
+		bool tookItem = false;
+		if (captureEvent(mousePosInToolbar, drag)) {
+			updateZones();
+			redrawToolbar = true;
+			// A completed click that leaves an object in hand is a "take".
+			// Clicking the held item's own slot is a put-back instead and
+			// leaves selectedObject() null, so it is not treated as a take.
+			if (drag == kDragStatus_Finished && _inventory->selectedObject() != nullptr)
+				tookItem = true;
+		} else if (drag == kDragStatus_Pressed) {
+			// Left-click on an empty part of the bar: put any in-hand item
+			// back into the inventory.
+			_inventorySelected = uint(-1);
+			_inventory->setSelectedObject(nullptr);
+			_engine->setArrowCursor();   // object leaves the cursor at once
+			updateZones();
+			redrawToolbar = true;
+		}
+
+		// Taking an item closes the bar at once: the original (FUN_0042c098)
+		// slides the toolbar down as soon as the in-hand object is set.  The
+		// slide-down then draws the bar with the taken slot already empty.
+		if (tookItem) {
+			// Snap the cursor — now carrying the taken item — to the screen
+			// centre (matches the original's SetCursorPos(320,240); effective
+			// in fullscreen where warpMouse works).  The caller skips the
+			// slide-down so navigation resumes — and recentres — at once.
+			_engine->setMousePos(Common::Point(g_system->getWidth() / 2, 240));
+			itemTaken = true;
+			exitToolbar = true;
+			break;
+		}
+
+		// Edge-hover scrolling (atlantis.exe FUN_0042c8ac): holding the cursor
+		// against the right/left screen edge inside the bar pages the visible
+		// inventory window.  The exe tests mouse X beyond 0x276 (630) / below
+		// 5; here it is throttled to stay usable.
+		{
+			Common::Point ms = _engine->getMousePos();
+			if (ms.y > kInsideY && g_system->getMillis() >= nextScrollMs) {
+				if (ms.x > 630 && _inventoryOffset < _inventoryMaxOffset) {
+					_inventoryOffset++;
+					nextScrollMs = g_system->getMillis() + kScrollIntervalMs;
+					redrawToolbar = true;
+				} else if (ms.x < 5 && _inventoryOffset > 0) {
+					_inventoryOffset--;
+					nextScrollMs = g_system->getMillis() + kScrollIntervalMs;
+					redrawToolbar = true;
+				}
+			}
+		}
+
+		// Exit when mouse leaves toolbar area
+		if (!mouseInsideToolbar) {
+			mouseInsideToolbar = (_engine->getMousePos().y > kInsideY);
+		} else if (_engine->getMousePos().y <= kInsideY) {
+			exitToolbar = true;
+			break;
+		}
+
+		// Hover inventory items
+		if (_inventory->selectedObject() == nullptr) {
+			auto zoneIt = hitTestZones(mousePosInToolbar);
+			uint zoneId = (uint)(zoneIt - _zones.begin());
+			uint invIdx = zoneId + _inventoryOffset;
+			bool shouldHover = (zoneId < kInventorySlots &&
+			                    invIdx < _inventory->size() &&
+			                    (*_inventory)[invIdx] != nullptr);
+			if (shouldHover) {
+				if (_inventoryHovered != invIdx && (*_inventory)[invIdx]->valid()) {
+					_inventoryHovered = invIdx;
+					redrawToolbar = true;
+				}
+			} else if (_inventoryHovered != uint(-1)) {
+				_inventoryHovered  = uint(-1);
+				_inventorySelected = uint(-1);
+				updateZones();
+				if (!_inventory->selectedObject() && _sprites->getSpritesCount() > 181)
+					_engine->setCursor(181);
+				redrawToolbar = true;
+			}
+			_inventoryButtonDragging = false;
+		}
+
+		if (redrawToolbar) {
+			drawToolbar(original);
+			g_system->copyRectToScreen(_destSurface.getPixels(), _destSurface.pitch, 0,
+			                           original ? original->h - _destSurface.h : (480 - 82),
+			                           _destSurface.w, _destSurface.h);
+		}
+
+		g_system->updateScreen();
+		g_system->delayMillis(10);
+	}
+	return itemTaken;
+}
+
+// -----------------------------------------------------------------------
+// Zone callbacks
+// -----------------------------------------------------------------------
+
+uint Atlantis_Toolbar::callbackInventory(uint invId, uint dragStatus) {
+	invId += _inventoryOffset;
+	Object *obj = (invId < _inventory->size()) ? (*_inventory)[invId] : nullptr;
+	if (obj == nullptr || !obj->valid())
+		return 0;
+
+	switch (dragStatus) {
+	case kDragStatus_Pressed:
+		_inventorySelected = invId;
+		if (_sprites->getSpritesCount() > 181)
+			_engine->setCursor(181);
+		_inventoryButtonDragging = true;
+		return 1;
+	case kDragStatus_Dragging:
+		if (_inventorySelected != invId) {
+			_inventorySelected = invId;
+			_inventoryButtonDragging = true;
+		}
+		return 1;
+	case kDragStatus_Finished:
+		if (obj == _inventory->selectedObject()) {
+			// Clicking the slot of the item already in hand puts it back
+			// (atlantis.exe FUN_0042c098: curObj == slot item → curObj = 0).
+			_inventory->setSelectedObject(nullptr);
+			_engine->setArrowCursor();   // object leaves the cursor at once
+			_inventorySelected = uint(-1);
+			return 1;
+		}
+		if (_sprites->getSpritesCount() > obj->idSl())
+			_engine->setCursor(obj->idSl());
+		_inventory->setSelectedObject(obj);
+		_inventorySelected = invId;
+		return 1;
+	default:
+		return 0;
+	}
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/toolbar.h
+++ b/engines/cryomni3d/atlantis/toolbar.h
@@ -1,0 +1,123 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CRYOMNI3D_ATLANTIS_TOOLBAR_H
+#define CRYOMNI3D_ATLANTIS_TOOLBAR_H
+
+#include "common/array.h"
+#include "common/rect.h"
+#include "graphics/managed_surface.h"
+#include "graphics/pixelformat.h"
+#include "graphics/surface.h"
+
+#include "cryomni3d/objects.h"
+#include "cryomni3d/sprites.h"
+
+namespace CryOmni3D {
+
+namespace Atlantis {
+
+class CryOmni3DEngine_Atlantis;
+
+class Atlantis_Toolbar {
+public:
+	Atlantis_Toolbar();
+	~Atlantis_Toolbar();
+
+	void init(const Sprites *sprites, Inventory *inventory, CryOmni3DEngine_Atlantis *engine);
+	void addMenuSprite(uint16 w, uint16 h, int16 xoff, int16 yoff, uint16 transpKey,
+	                   int tx, int ty, const uint16 *pix, const uint8 *blend);
+
+	bool displayToolbar(const Graphics::Surface *original);
+	void inventoryChanged(uint newPosition);
+	uint inventoryOffset() const { return _inventoryOffset; }
+	void setInventoryOffset(uint offset) { _inventoryOffset = offset; }
+
+private:
+	typedef uint(Atlantis_Toolbar::*ZoneCallback)(uint dragStatus);
+
+	struct Zone {
+		Common::Rect rect;
+		ZoneCallback callback;
+		bool secondary;  // true = inactive / grayed
+		bool hidden;
+	};
+
+	Common::Array<Zone> _zones;
+	const Sprites *_sprites;
+	Inventory *_inventory;
+	CryOmni3DEngine_Atlantis *_engine;
+
+	Graphics::PixelFormat _format;
+
+	uint _inventoryOffset;
+	uint _inventoryMaxOffset;
+	uint _inventoryHovered;
+	uint _inventorySelected;
+	bool _inventoryButtonDragging;
+
+	uint _position;
+
+	struct MenuSprData {
+		Common::Array<uint16> pixels;
+		Common::Array<uint8>  blend;   // per-pixel blend factor; kSprNoBlend = opaque
+		uint16 w, h;
+		int16  xoff, yoff;
+		int    tx, ty;
+		uint16 transpKey;
+	};
+	Common::Array<MenuSprData> _menuSprData;
+
+	Graphics::Surface _bgSurface;
+	Graphics::ManagedSurface _destSurface;
+
+	// Zone indices within _zones — must match the order added in init().
+	// The original Atlantis toolbar has no on-bar widgets for options /
+	// prev / next / view-object: the auxiliary buttons we used to draw were
+	// guesses that never matched a real sprite, so they are gone.
+	enum ZoneIdx {
+		kZoneInventory0 = 0  // inventory slots 0-8 occupy indices 0-8
+	};
+
+	// 9 visible inventory slots, one per star-of-David ornament in
+	// OBJETS0.SPR (the inventory-bar background).
+	static const uint kInventorySlots = 9;
+
+	void addZone(Common::Rect rect, ZoneCallback callback);
+	void updateZones();
+	Common::Array<Zone>::const_iterator hitTestZones(const Common::Point &mousePos) const;
+	uint captureEvent(const Common::Point &mousePos, uint dragStatus);
+	void drawBackground(const Graphics::Surface *original);
+	void drawToolbar(const Graphics::Surface *original);
+	// Runs the open toolbar's event loop.  Returns true when the loop ended
+	// because an inventory item was taken (the caller then skips the
+	// slide-down so the carried object reaches navigation immediately).
+	bool handleToolbarEvents(const Graphics::Surface *original);
+
+	template<uint N>
+	uint callbackInventory(uint dragStatus) { return callbackInventory(N, dragStatus); }
+	uint callbackInventory(uint invId, uint dragStatus);
+};
+
+} // namespace Atlantis
+} // namespace CryOmni3D
+
+#endif // CRYOMNI3D_ATLANTIS_TOOLBAR_H

--- a/engines/cryomni3d/atlantis/wam_parser.cpp
+++ b/engines/cryomni3d/atlantis/wam_parser.cpp
@@ -1,0 +1,244 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/stream.h"
+#include "common/debug.h"
+
+#include "cryomni3d/cryomni3d.h"
+#include "cryomni3d/atlantis/wam_parser.h"
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// Binary WAM format (Atlantis), reverse-engineered from the loader in
+// atlantis.exe (FUN at ~0x42xxxx, _GL_ReadFile_20 calls at decompile
+// lines 18491-18560 + sub-WAM/refs/NPC sections at 18563-18596).
+//
+// Every record uses FIXED-SIZE fields — no C-string terminators are
+// needed to walk the stream.  Names are stored in NUL-padded 13-byte
+// slots; a name shorter than the slot is followed by NUL bytes that
+// must be skipped, not interpreted as a record-end sentinel.
+//
+//   File header (16 bytes):
+//     uint8[14] zeros
+//     uint16 LE nPlaces
+//
+//   nPlaces × place record:
+//     char[13]   cycloHnm (NUL-padded; sometimes leading NUL when the
+//                          name is stored without its 'a' prefix —
+//                          e.g. "\0tl16217.hnm")
+//     uint16 LE  placeId
+//     uint8      unk
+//     uint8      nTransitions
+//     nTransitions × 32-byte transition:
+//       char[13] videoName  (NUL-padded)
+//       uint16 LE dstPlaceId
+//       uint8     flags
+//       float32   srcAlpha, srcBeta, dstAlpha, dstBeta
+//     uint8      nZones
+//     nZones × 10-byte zone:
+//       int16    x, y, w, h, action
+//     uint8      nTrailing
+//     nTrailing × 17-byte ambient record (skipped; pecheur-style places
+//                                         carry these, ordinary places
+//                                         have nTrailing == 0)
+//
+//   Sub-WAM cross-area transitions — always exactly 8 fixed 18-byte
+//   entries (NOT sentinel-terminated; unused slots are zero-filled):
+//     uint8     unk
+//     uint16 LE srcPlaceId
+//     uint16 LE dstPlaceId
+//     char[13]  wamName
+//
+//   File-ref section:
+//     uint8     nRefs
+//     nRefs × 14-byte entry:  uint8 type (1=SPW, 2=SPF, 3=VUE) + char[13] name
+//
+//   NPC section:
+//     uint8     nNPCs
+//     nNPCs × 108-byte block:
+//       uint16 LE index
+//       uint32 LE persoId
+//       char[13]  spriteFile
+//       (rest = unrelated per-NPC fields, skipped)
+//
+// Earlier versions of this parser used C-string-with-sentinel logic and a
+// signature scan to relocate past misaligned data — neither was correct.
+// The file uses nPlaces from the header as authoritative; the leading-NUL
+// names ("\0tl16NNN.hnm") are not sentinels but stub place records that
+// sit alongside the proper "atl16NNN.hnm" copies (e.g. palais2.wam has 83
+// places total — both a stub at offset 0x3d1 with placeId=0 AND a proper
+// atl16217.hnm at offset 0x27d4 with placeId=217).  The sentinel-based
+// parser bailed at the first stub and missed the proper copy, leaving
+// CON-script transitions like vue 218 → 217 with no destination.
+
+static void readFixedName13(Common::SeekableReadStream &s, Common::String &out) {
+	char buf[14];
+	s.read(buf, 13);
+	buf[13] = 0;
+	const char *start = buf;
+	while (*start == 0 && start - buf < 13)
+		start++;
+	out = Common::String(start);
+}
+
+void AtlantisWAMParser::clear() {
+	_places.clear();
+	_subWAMs.clear();
+	_npcEntries.clear();
+	spwListFile.clear();
+	spfListFile.clear();
+	centVueFile.clear();
+}
+
+void AtlantisWAMParser::loadStream(Common::SeekableReadStream &stream) {
+	clear();
+
+	for (int i = 0; i < 14; i++)
+		stream.readByte();
+	uint16 nPlaces = stream.readUint16LE();
+
+	for (uint16 p = 0; p < nPlaces && !stream.err() && !stream.eos(); p++) {
+		AtlantisPlace place;
+
+		readFixedName13(stream, place.cycloHnm);
+		place.placeId = stream.readUint16LE();
+		/* unk = */     stream.readByte();
+		uint8 nTransitions = stream.readByte();
+
+		for (uint8 t = 0; t < nTransitions; t++) {
+			AtlantisTransition trans;
+			readFixedName13(stream, trans.videoName);
+			trans.dstPlaceId = stream.readUint16LE();
+			trans.flags      = stream.readByte();
+			trans.srcAlpha   = stream.readFloatLE();
+			trans.srcBeta    = stream.readFloatLE();
+			trans.dstAlpha   = stream.readFloatLE();
+			trans.dstBeta    = stream.readFloatLE();
+			place.transitions.push_back(trans);
+		}
+
+		uint8 nZones = stream.readByte();
+		for (uint8 z = 0; z < nZones; z++) {
+			AtlantisZone zone;
+			zone.x      = stream.readSint16LE();
+			zone.y      = stream.readSint16LE();
+			zone.w      = stream.readSint16LE();
+			zone.h      = stream.readSint16LE();
+			zone.action = stream.readSint16LE();
+			place.zones.push_back(zone);
+		}
+
+		uint8 nTrailing = stream.readByte();
+		for (uint32 i = 0; i < (uint32)nTrailing * 17; i++)
+			stream.readByte();
+
+		debugC(2, kDebugFile, "  place %u '%s' trans=%u zones=%u",
+		      place.placeId, place.cycloHnm.c_str(), nTransitions, nZones);
+		_places.push_back(place);
+	}
+
+	// Sub-WAM section: always 8 fixed 18-byte slots; unused slots are
+	// zero-filled and produce src=0 (filtered out below).
+	for (int s = 0; s < 8 && !stream.err() && !stream.eos(); s++) {
+		/* unk = */              stream.readByte();
+		uint16 srcPlace        = stream.readUint16LE();
+		uint16 dstPlace        = stream.readUint16LE();
+		Common::String name;
+		readFixedName13(stream, name);
+		if (srcPlace == 0)
+			continue;
+		AtlantisSubWAM sub;
+		sub.srcPlaceId = srcPlace;
+		sub.dstPlaceId = dstPlace;
+		sub.wamName    = name;
+		_subWAMs.push_back(sub);
+		debugC(2, kDebugFile, "  sub-WAM: %u->%u '%s'", srcPlace, dstPlace, name.c_str());
+	}
+
+	if (stream.err() || stream.eos())
+		return;
+
+	// File-ref section: nRefs byte + nRefs × 14-byte entry.
+	uint8 nRefs = stream.readByte();
+	for (uint8 r = 0; r < nRefs; r++) {
+		uint8 type = stream.readByte();
+		Common::String name;
+		readFixedName13(stream, name);
+		if (type == 1)
+			spwListFile = name;
+		else if (type == 2)
+			spfListFile = name;
+		else if (type == 3)
+			centVueFile = name;
+		debugC(2, kDebugFile, "  file-ref type=%u: '%s'", (uint)type, name.c_str());
+	}
+
+	if (stream.err() || stream.eos())
+		return;
+
+	// NPC section: nNPCs byte + nNPCs × 108-byte block.  Each block
+	// carries far more than persoId+spriteFile (per-NPC dialog hooks,
+	// animation tables, ...), but only those two fields feed the port.
+	uint8 nNPCs = stream.readByte();
+	for (uint8 n = 0; n < nNPCs; n++) {
+		/* index = */    stream.readUint16LE();
+		uint32 persoId = stream.readUint32LE();
+		Common::String spriteName;
+		readFixedName13(stream, spriteName);
+		for (uint32 p = 2 + 4 + 13; p < 108; p++)
+			stream.readByte();
+		AtlantisNPCEntry npc;
+		npc.persoId    = persoId;
+		npc.spriteFile = spriteName;
+		_npcEntries.push_back(npc);
+		debugC(2, kDebugFile, "  NPC perso=%u sprite='%s'", persoId, spriteName.c_str());
+	}
+}
+
+const AtlantisPlace *AtlantisWAMParser::findPlaceById(uint16 placeId) const {
+	for (const AtlantisPlace &p : _places) {
+		if (p.placeId == placeId)
+			return &p;
+	}
+	return nullptr;
+}
+
+const AtlantisTransition *AtlantisPlace::findTransition(uint16 dstPlaceId) const {
+	for (const AtlantisTransition &t : transitions) {
+		if (t.dstPlaceId == dstPlaceId)
+			return &t;
+	}
+	return nullptr;
+}
+
+int16 AtlantisPlace::hitTest(int16 x, int16 y) const {
+	for (const AtlantisZone &z : zones) {
+		if (z.action == 0)
+			continue;
+		if (x >= z.x && x < z.x + z.w && y >= z.y && y < z.y + z.h)
+			return z.action;
+	}
+	return 0;
+}
+
+} // namespace Atlantis
+} // namespace CryOmni3D

--- a/engines/cryomni3d/atlantis/wam_parser.h
+++ b/engines/cryomni3d/atlantis/wam_parser.h
@@ -1,0 +1,106 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CRYOMNI3D_ATLANTIS_WAM_PARSER_H
+#define CRYOMNI3D_ATLANTIS_WAM_PARSER_H
+
+#include "common/array.h"
+#include "common/rect.h"
+#include "common/str.h"
+
+namespace Common {
+class SeekableReadStream;
+}
+
+namespace CryOmni3DEngine {
+class Omni3DManager;
+}
+
+namespace CryOmni3D {
+namespace Atlantis {
+
+// A clickable zone on the panoramic view.  Coordinates are in panorama space
+// (x: 0-2047, y: 0-767). action is the place ID to transition to.
+struct AtlantisZone {
+	int16 x, y, w, h;
+	int16 action;
+};
+
+// A transition between two places.  Plays a UBB/HNM video then loads dstPlaceId.
+struct AtlantisTransition {
+	Common::String videoName;  // e.g. "at001013.UBB"
+	uint16 dstPlaceId;
+	uint8 flags;               // 0x01 = normal transition
+	float srcAlpha, srcBeta;   // camera angle when leaving source
+	float dstAlpha, dstBeta;   // camera angle when entering destination
+};
+
+// A sub-WAM reference: cross-level transition pointing to another WAM file.
+struct AtlantisSubWAM {
+	uint16 srcPlaceId;
+	uint16 dstPlaceId;
+	Common::String wamName;    // e.g. "atlan2.wam"
+};
+
+// An NPC entry from the WAM tail: identifies a character active in this WAM area.
+struct AtlantisNPCEntry {
+	uint32 persoId;            // character ID referenced by CON scripts as ClicPerso
+	Common::String spriteFile; // canonical SPW file (others found via SPWATL*.TXT)
+};
+
+struct AtlantisPlace {
+	uint16 placeId;
+	Common::String cycloHnm;   // panoramic view HNM file, e.g. "atl16001.hnm"
+	Common::Array<AtlantisTransition> transitions;
+	Common::Array<AtlantisZone> zones;
+
+	// Returns the transition to dstPlaceId, or nullptr.
+	const AtlantisTransition *findTransition(uint16 dstPlaceId) const;
+
+	// Returns the action for the point (panorama coordinates), or 0.
+	int16 hitTest(int16 x, int16 y) const;
+};
+
+class AtlantisWAMParser {
+public:
+	void loadStream(Common::SeekableReadStream &stream);
+	void clear();
+
+	const AtlantisPlace *findPlaceById(uint16 placeId) const;
+	const Common::Array<AtlantisSubWAM> &getSubWAMs() const { return _subWAMs; }
+	const Common::Array<AtlantisPlace> &getPlaces() const { return _places; }
+	const Common::Array<AtlantisNPCEntry> &getNPCEntries() const { return _npcEntries; }
+
+	// Sprite and view list filenames embedded in the WAM.
+	Common::String spwListFile;   // e.g. "spwatl1.txt"
+	Common::String spfListFile;   // e.g. "spfatl1.txt"
+	Common::String centVueFile;   // e.g. "atl1cent.vue"
+
+private:
+	Common::Array<AtlantisPlace> _places;
+	Common::Array<AtlantisSubWAM> _subWAMs;
+	Common::Array<AtlantisNPCEntry> _npcEntries;
+};
+
+} // namespace Atlantis
+} // namespace CryOmni3D
+
+#endif // CRYOMNI3D_ATLANTIS_WAM_PARSER_H

--- a/engines/cryomni3d/configure.engine
+++ b/engines/cryomni3d/configure.engine
@@ -1,3 +1,4 @@
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine cryomni3d "Cryo Omni3D games" yes "versailles" "" "highres hnm"
+add_engine cryomni3d "Cryo Omni3D games" yes "versailles atlantis" "" "highres hnm"
 add_engine versailles "Versailles 1685" yes
+add_engine atlantis "Atlantis: The Lost Tale" yes

--- a/engines/cryomni3d/cryomni3d.cpp
+++ b/engines/cryomni3d/cryomni3d.cpp
@@ -225,6 +225,8 @@ void CryOmni3DEngine::setCursor(const Graphics::Cursor &cursor) const {
 }
 
 void CryOmni3DEngine::setCursor(uint cursorId) const {
+	if (cursorId >= _sprites.getSpritesCount())
+		return;
 	const Graphics::Cursor &cursor = _sprites.getCursor(cursorId);
 	CursorMan.replaceCursor(&cursor);
 }
@@ -253,6 +255,9 @@ bool CryOmni3DEngine::pollEvents() {
 			transitionalMask |= Common::EventManager::LBUTTON;
 		} else if (event.type == Common::EVENT_RBUTTONDOWN) {
 			transitionalMask |= Common::EventManager::RBUTTON;
+		} else if (event.type == Common::EVENT_MOUSEMOVE) {
+			// Accumulate relative motion for locked-cursor FPS look.
+			_mouseRel += event.relMouse;
 		}
 		hasEvents = true;
 	}
@@ -369,6 +374,8 @@ void CryOmni3DEngine::copySubPalette(byte *dst, const byte *src, uint start, uin
 }
 
 void CryOmni3DEngine::setPalette(const byte *colors, uint start, uint num) {
+	if (g_system->getScreenFormat().bytesPerPixel > 1)
+		return;
 	if (start < _lockPaletteStartRW) {
 		colors = colors + 3 * (_lockPaletteStartRW - start);
 		start = _lockPaletteStartRW;
@@ -383,6 +390,8 @@ void CryOmni3DEngine::setPalette(const byte *colors, uint start, uint num) {
 }
 
 void CryOmni3DEngine::fadeOutPalette() {
+	if (g_system->getScreenFormat().bytesPerPixel > 1)
+		return;
 	byte palOut[256 * 3];
 	uint16 palWork[256 * 3];
 	uint16 delta[256 * 3];
@@ -413,6 +422,8 @@ void CryOmni3DEngine::fadeOutPalette() {
 }
 
 void CryOmni3DEngine::fadeInPalette(const byte *palette) {
+	if (g_system->getScreenFormat().bytesPerPixel > 1)
+		return;
 	byte palOut[256 * 3];
 	uint16 palWork[256 * 3];
 	uint16 delta[256 * 3];
@@ -444,6 +455,10 @@ void CryOmni3DEngine::fadeInPalette(const byte *palette) {
 }
 
 void CryOmni3DEngine::setBlackPalette() {
+	if (g_system->getScreenFormat().bytesPerPixel > 1) {
+		g_system->updateScreen();
+		return;
+	}
 	byte pal[256 * 3];
 	memset(pal, 0, 256 * 3);
 	g_system->getPaletteManager()->setPalette(pal, 0, 256);

--- a/engines/cryomni3d/cryomni3d.h
+++ b/engines/cryomni3d/cryomni3d.h
@@ -50,6 +50,10 @@ namespace Image {
 class ImageDecoder;
 }
 
+namespace Graphics {
+class ManagedSurface;
+}
+
 /**
  * This is the namespace of the Cryo Omni3D engine.
  *
@@ -68,6 +72,10 @@ enum {
 	kDebugFile = 1,
 	kDebugVariable,
 	kDebugSaveLoad,
+	kDebugScript,   // Atlantis: CON script interpreter, game flow, dialog
+	kDebugMesh,     // Atlantis: F3DC dialog mouth-mesh pipeline
+	kDebugVideo,    // Atlantis: SPW/SPF sprite + video compositing
+	kDebugMusic,    // Atlantis: music playlist
 };
 
 enum DragStatus {
@@ -120,6 +128,13 @@ public:
 	bool pollEvents();
 	Common::Point getMousePos();
 	void setMousePos(const Common::Point &point);
+	// Relative mouse motion accumulated since the last call, then cleared.
+	// Used for FPS-style look when the cursor is locked (g_system->lockMouse).
+	Common::Point takeMouseRelative() {
+		Common::Point p = _mouseRel;
+		_mouseRel = Common::Point(0, 0);
+		return p;
+	}
 	uint getCurrentMouseButton() { return _lastMouseButton; }
 	Common::KeyState getNextKey();
 	bool checkKeysPressed();
@@ -134,6 +149,11 @@ public:
 	virtual bool displayPlaceDocumentation() = 0;
 	virtual uint displayOptions() = 0;
 	virtual bool shouldAbort() { return g_engine->shouldQuit(); }
+
+	// Optional per-game hook for drawing an inventory object icon inside slot rect r.
+	// Called by the toolbar after the background slot is drawn.  Default: no-op.
+	virtual void drawInventoryIcon(Graphics::ManagedSurface &dst, const Object *obj,
+	                               const Common::Rect &r) {}
 
 	virtual void makeTranslucent(Graphics::Surface &dst, const Graphics::Surface &src) const = 0;
 	virtual void setupPalette(const byte *colors, uint start, uint num) = 0;
@@ -164,6 +184,7 @@ protected:
 
 	DragStatus _dragStatus;
 	Common::Point _dragStart;
+	Common::Point _mouseRel;   // relative motion accumulated by pollEvents()
 	uint _lastMouseButton;
 	uint _autoRepeatNextEvent;
 

--- a/engines/cryomni3d/detection.cpp
+++ b/engines/cryomni3d/detection.cpp
@@ -41,6 +41,10 @@ static const DebugChannelDef debugFlagList[] = {
 	{CryOmni3D::kDebugFile, "File", "Track File Accesses"},
 	{CryOmni3D::kDebugVariable, "Variable", "Track Variable Accesses"},
 	{CryOmni3D::kDebugSaveLoad, "SaveLoad", "Track Save/Load Function"},
+	{CryOmni3D::kDebugScript, "Script", "Atlantis CON script / game flow / dialog"},
+	{CryOmni3D::kDebugMesh, "Mesh", "Atlantis F3DC dialog mouth-mesh pipeline"},
+	{CryOmni3D::kDebugVideo, "Video", "Atlantis sprite + video compositing"},
+	{CryOmni3D::kDebugMusic, "Music", "Atlantis music playlist"},
 	DEBUG_CHANNEL_END
 };
 

--- a/engines/cryomni3d/detection.h
+++ b/engines/cryomni3d/detection.h
@@ -28,7 +28,8 @@ namespace CryOmni3D {
 
 enum CryOmni3DGameType {
 	GType_VERSAILLES,
-	GType_HNM_PLAYER
+	GType_HNM_PLAYER,
+	GType_ATLANTIS
 };
 
 enum CryOmni3DGameFeatures {

--- a/engines/cryomni3d/detection_tables.h
+++ b/engines/cryomni3d/detection_tables.h
@@ -23,6 +23,7 @@ namespace CryOmni3D {
 
 #define GUI_OPTIONS_VERSAILLES                   GUIO3(GUIO_NOMIDI, GUIO_NOSFX, GUIO_NOASPECT)
 #define GUI_OPTIONS_HNM_PLAYER                   GUIO4(GUIO_NOMIDI, GUIO_NOSFX, GUIO_NOSPEECH, GUIO_NOASPECT)
+#define GUI_OPTIONS_ATLANTIS                     GUIO2(GUIO_NOMIDI, GUIO_NOASPECT)
 
 // To correctly detect root we need files from various places: CD1, CD2, HDD, on-CD install files
 // We use files common to all installations except the documentation links and the binary
@@ -611,10 +612,27 @@ static const CryOmni3DGameDescription gameDescriptions[] = {
 			AD_ENTRY1s("ATLANTIS.UBB", "f5b41b857678a61d7f9bd6eb41916ce5", 106611456),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
-			ADGF_DEMO,
-			GUI_OPTIONS_HNM_PLAYER
+			ADGF_DEMO | ADGF_UNSTABLE,
+			GUI_OPTIONS_ATLANTIS
 		},
-		GType_HNM_PLAYER,
+		GType_ATLANTIS,
+		0,
+	},
+
+	// Atlantis: The Lost Tales
+	// English Windows CD (4-disc; detected via BIGCD1.BIG)
+	{
+		{
+			"atlantis",
+			"",
+			AD_ENTRY2s("atlantis.exe", "83ba66f0b9e49535c1592ba1fd071a0a", 714240,
+			           "BIGCD1.BIG",  "e68fd05b1b84914204fcf195c06bc180", 635406545),
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_UNSTABLE,
+			GUI_OPTIONS_ATLANTIS
+		},
+		GType_ATLANTIS,
 		0,
 	},
 
@@ -649,6 +667,12 @@ static const char *const directoryGlobs[] = {
 	"DATAV_HD",
 	/* lien_doc.* */
 	"TEXTES",
+
+	/** Atlantis: The Lost Tale **/
+	/* ATL_DOS/ */
+	"ATL_DOS",
+	/* DEMOS1/ */
+	"DEMOS1",
 
 	/** End of list **/
 	nullptr

--- a/engines/cryomni3d/metaengine.cpp
+++ b/engines/cryomni3d/metaengine.cpp
@@ -35,6 +35,10 @@
 #include "cryomni3d/versailles/engine.h"
 #endif
 
+#ifdef ENABLE_ATLANTIS
+#include "cryomni3d/atlantis/engine.h"
+#endif
+
 #include "cryomni3d/detection.h"
 
 namespace CryOmni3D {
@@ -102,6 +106,28 @@ SaveStateList CryOmni3DMetaEngine::listSaves(const char *target) const {
 
 	Common::SaveFileManager *saveMan = g_system->getSavefileManager();
 
+	// Atlantis partitions save slots into per-player blocks of 100; load the
+	// player-profile names so each save can be labelled with its owner.  For
+	// other games this file is absent and no prefix is applied.
+	Common::String playerNames[5];
+	{
+		Common::InSaveFile *pin = saveMan->openForLoading("atlantis-players.dat");
+		if (pin) {
+			if (pin->readUint32BE() == 0x41504c52u /* 'APLR' */
+			        && pin->readUint32BE() >= 1) {
+				uint32 count = pin->readUint32BE();
+				for (uint32 i = 0; i < count && i < 5 && !pin->eos(); i++) {
+					uint16 len = pin->readUint16BE();
+					Common::String name;
+					for (uint16 j = 0; j < len && !pin->eos(); j++)
+						name += (char)pin->readByte();
+					playerNames[i] = name;
+				}
+			}
+			delete pin;
+		}
+	}
+
 	char saveName[kSaveDescriptionLen + 1];
 	saveName[kSaveDescriptionLen] = '\0';
 	Common::StringArray filenames = saveMan->listSavefiles(getSavegameFilePattern(target));
@@ -114,11 +140,15 @@ SaveStateList CryOmni3DMetaEngine::listSaves(const char *target) const {
 		// Obtain the last 4 digits of the filename, since they correspond to the save slot
 		slotNum = atoi(file->c_str() + file->size() - 4);
 
-		if (slotNum >= 1 && slotNum <= 99) {
+		if (slotNum >= 1 && slotNum <= 999) {
 			Common::InSaveFile *in = saveMan->openForLoading(*file);
 			if (in) {
 				if (in->read(saveName, kSaveDescriptionLen) == kSaveDescriptionLen) {
-					saveList.push_back(SaveStateDescriptor(this, slotNum - 1, saveName));
+					Common::String desc(saveName);
+					int player = (slotNum - 1) / 100;
+					if (player >= 0 && player < 5 && !playerNames[player].empty())
+						desc = playerNames[player] + ": " + desc;
+					saveList.push_back(SaveStateDescriptor(this, slotNum - 1, desc));
 				}
 				delete in;
 			}
@@ -145,6 +175,13 @@ Common::Error CryOmni3DMetaEngine::createInstance(OSystem *syst, Engine **engine
 	case GType_HNM_PLAYER:
 		*engine = new CryOmni3DEngine_HNMPlayer(syst, gd);
 		return Common::kNoError;
+	case GType_ATLANTIS:
+#ifdef ENABLE_ATLANTIS
+		*engine = new Atlantis::CryOmni3DEngine_Atlantis(syst, gd);
+		return Common::kNoError;
+#else
+		return Common::Error(Common::kUnsupportedGameidError, _s("Atlantis: The Lost Tale support is not compiled in"));
+#endif
 	default:
 		return Common::kUnsupportedGameidError;
 	}

--- a/engines/cryomni3d/module.mk
+++ b/engines/cryomni3d/module.mk
@@ -31,6 +31,25 @@ MODULE_OBJS += \
 	versailles/toolbar.o
 endif
 
+ifdef ENABLE_ATLANTIS
+MODULE_OBJS += \
+	atlantis/bigfile.o \
+	atlantis/con_script.o \
+	atlantis/dialogs_manager.o \
+	atlantis/engine.o \
+	atlantis/f3dc_parser.o \
+	atlantis/f3dc_renderer.o \
+	atlantis/logic.o \
+	atlantis/menu_layout.o \
+	atlantis/menus.o \
+	atlantis/music.o \
+	atlantis/puzzle_eclipse.o \
+	atlantis/saveload.o \
+	atlantis/sprite_renderer.o \
+	atlantis/toolbar.o \
+	atlantis/wam_parser.o
+endif
+
 # This module can be built as a plugin
 ifeq ($(ENABLE_CRYOMNI3D), DYNAMIC_PLUGIN)
 PLUGIN := 1

--- a/engines/cryomni3d/objects.h
+++ b/engines/cryomni3d/objects.h
@@ -55,7 +55,7 @@ public:
 	// Takes ownership of the pointer
 	void setViewCallback(ViewCallback callback) { _viewCallback = callback; }
 
-	void rename(uint newIdOBJ) { _idOBJ = newIdOBJ; }
+	void rename(uint newIdOBJ) { _idOBJ = newIdOBJ; _valid = true; }
 
 private:
 	uint _idOBJ;

--- a/engines/cryomni3d/omni3d.cpp
+++ b/engines/cryomni3d/omni3d.cpp
@@ -31,6 +31,16 @@ void Omni3DManager::init(double hfov) {
 	_xSpeed = 0.;
 	_ySpeed = 0.;
 
+	setHFov(hfov);
+
+	_bytesPerPixel = 1;
+	_surface.create(640, 480, Graphics::PixelFormat::createFormatCLUT8());
+	clearConstraints();
+}
+
+void Omni3DManager::setHFov(double hfov) {
+	_hfov = hfov;
+
 	double oppositeSide = tan(hfov / 2.) / (4. / 3.);
 	double vf = atan2(oppositeSide, 1.);
 	_vfov = (M_PI_2 - vf - (13. / 180.*M_PI)) * 10. / 9.;
@@ -61,12 +71,23 @@ void Omni3DManager::init(double hfov) {
 		}
 	}
 
-	_surface.create(640, 480, Graphics::PixelFormat::createFormatCLUT8());
-	clearConstraints();
+	_dirty = true;
+	_dirtyCoords = true;
+}
+
+double Omni3DManager::getHFov() const {
+	return _hfov;
 }
 
 Omni3DManager::~Omni3DManager() {
 	_surface.free();
+}
+
+void Omni3DManager::setPixelFormat(const Graphics::PixelFormat &fmt) {
+	_bytesPerPixel = fmt.bytesPerPixel;
+	_surface.free();
+	_surface.create(640, 480, fmt);
+	_dirty = true;
 }
 
 void Omni3DManager::updateCoords(int xDelta, int yDelta, bool useOldSpeed) {
@@ -189,6 +210,10 @@ const Graphics::Surface *Omni3DManager::getSurface() {
 		uint off = 2;
 		byte *dst = (byte *)_surface.getBasePtr(0, 0);
 		const byte *src = (const byte *)_sourceSurface->getBasePtr(0, 0);
+		const uint bpp = _bytesPerPixel;
+		const uint dstRowStep  = 640 * bpp;
+		const uint dstTileBack = (16 * 640 - 16) * bpp;
+		const uint dstRowSkip  = 15 * 640 * bpp;
 
 		for (uint i = 0; i < 30; i++) {
 			for (uint j = 0; j < 40; j++) {
@@ -213,23 +238,35 @@ const Graphics::Surface *Omni3DManager::getSurface() {
 					uint deltaX = x1 * 32;
 					uint deltaY = y1;
 
-					for (uint x = 0; x < 16; x++) {
-						uint srcOff = (py & 0x1ff800) | (px >> 21);
-						dst[x] = src[srcOff];
-						px += deltaX;
-						py += deltaY;
+					if (bpp == 1) {
+						for (uint x = 0; x < 16; x++) {
+							uint srcOff = (py & 0x1ff800) | (px >> 21);
+							dst[x] = src[srcOff];
+							px += deltaX;
+							py += deltaY;
+						}
+					} else {
+						// 16bpp: srcOff is pixel index, write uint16
+						uint16 *dst16 = (uint16 *)dst;
+						const uint16 *src16 = (const uint16 *)src;
+						for (uint x = 0; x < 16; x++) {
+							uint srcOff = (py & 0x1ff800) | (px >> 21);
+							dst16[x] = src16[srcOff];
+							px += deltaX;
+							py += deltaY;
+						}
 					}
-					dst += 640;
+					dst += dstRowStep;
 
 					x1 += dx1;
 					y1 += dy1;
 					x2 += dx2;
 					y2 += dy2;
 				}
-				dst -= 16 * 640 - 16;
+				dst -= dstTileBack;
 				off += 2;
 			}
-			dst += 15 * 640;
+			dst += dstRowSkip;
 			off += 2;
 		}
 

--- a/engines/cryomni3d/omni3d.h
+++ b/engines/cryomni3d/omni3d.h
@@ -28,12 +28,21 @@ namespace CryOmni3D {
 
 class Omni3DManager {
 public:
-	Omni3DManager() : _vfov(0), _alpha(0), _beta(0), _xSpeed(0), _ySpeed(0), _alphaMin(0), _alphaMax(0),
+	Omni3DManager() : _hfov(0), _vfov(0), _alpha(0), _beta(0), _xSpeed(0), _ySpeed(0), _alphaMin(0), _alphaMax(0),
 		_betaMin(0), _betaMax(0), _helperValue(0), _dirty(true), _dirtyCoords(true),
-		_sourceSurface(nullptr) {}
+		_bytesPerPixel(1), _sourceSurface(nullptr) {}
 	virtual ~Omni3DManager();
 
 	void init(double hfov);
+	// Call after init() to switch to a non-paletted pixel format (e.g. 16bpp for Atlantis).
+	void setPixelFormat(const Graphics::PixelFormat &fmt);
+
+	// Change the camera FOV without resetting alpha/beta/speeds.  Used by the
+	// Atlantis dialog renderer to apply the per-cam FOV table (cam2..cam5)
+	// extracted from atlantis.exe at VA 0x00496080.  Recomputes the
+	// projection helpers; the next getSurface() call re-renders.
+	void setHFov(double hfov);
+	double getHFov() const;
 
 	void setSourceSurface(const Graphics::Surface *surface) { _sourceSurface = surface; _dirty = true; }
 
@@ -58,6 +67,7 @@ public:
 private:
 	void updateImageCoords();
 
+	double _hfov;  // last hfov passed to init()/setHFov(); needed for FOV save/restore
 	double _vfov;
 
 	double _alpha, _beta;
@@ -75,6 +85,7 @@ private:
 
 	bool _dirty;
 	bool _dirtyCoords;
+	uint _bytesPerPixel;
 	const Graphics::Surface *_sourceSurface;
 	Graphics::Surface _surface;
 };

--- a/video/hnm_decoder.cpp
+++ b/video/hnm_decoder.cpp
@@ -166,9 +166,35 @@ bool HNMDecoder::loadStream(Common::SeekableReadStream *stream) {
 			audioSampleRate = ((audioflags >> 4) & 6) * 11025;
 			_audioTrack = new APCAudioTrack(audioSampleRate, stereo, getSoundType());
 		}
+		// Peek at the first video chunk to determine if this is a warp-mode (IW) file.
+		// Warp mode uses a keyframe-only panorama decoder and is mutually exclusive with
+		// video mode (which allocates a second buffer for inter-frame delta decoding).
+		bool hnm6WarpMode = false;
+		{
+			int64 savedPos = _stream->pos();
+			uint32 scSize = _stream->readUint32LE() & 0x00ffffff;
+			uint32 scRemaining = scSize >= 4 ? scSize - 4 : 0;
+			while (scRemaining >= 8) {
+				uint32 cSize = _stream->readUint32LE();
+				uint16 cType = _stream->readUint16BE();
+				_stream->skip(2); // flags
+				if (cType == MKTAG16('I', 'W')) {
+					hnm6WarpMode = true;
+					break;
+				} else if (cType == MKTAG16('I', 'X')) {
+					break;
+				}
+				// Skip non-video chunks (audio etc.)
+				uint32 alignedSize = ((cSize + 3) / 4) * 4;
+				if (alignedSize < 8) break;
+				_stream->skip(alignedSize - 8);
+				scRemaining -= MIN(alignedSize, scRemaining);
+			}
+			_stream->seek(savedPos);
+		}
 		_videoTrack = new HNM6VideoTrack(width, height, frameSize, frameCount,
 		                                 _regularFrameDelayMs, audioSampleRate,
-		                                 _format);
+		                                 _format, hnm6WarpMode);
 	} else {
 		// We should never be here
 		close();
@@ -200,7 +226,7 @@ void HNMDecoder::readNextPacket() {
 	// We are called to feed a frame
 	// Each chunk is packetized and a packet seems to contain only one frame
 	uint32 superchunkRemaining = _stream->readUint32LE();
-	if (!superchunkRemaining) {
+	if (!superchunkRemaining || _stream->eos()) {
 		if (!_loop) {
 			error("End of file but still requesting data");
 		} else {
@@ -222,7 +248,25 @@ void HNMDecoder::readNextPacket() {
 		_dataBufferAlloc = superchunkRemaining;
 	}
 	if (_stream->read(_dataBuffer, superchunkRemaining) != superchunkRemaining) {
-		error("Not enough data in file");
+		if (!_loop) {
+			error("Not enough data in file");
+		}
+		// UBB2 files may not have a zero-terminator at EOF; treat as end of stream and loop.
+		_videoTrack->restart();
+		_stream->seek(64, SEEK_SET);
+		superchunkRemaining = _stream->readUint32LE() & 0x00ffffff;
+		if (superchunkRemaining < 4) {
+			error("Invalid superchunk header after loop restart");
+		}
+		superchunkRemaining -= 4;
+		if (_dataBufferAlloc < superchunkRemaining) {
+			delete[] _dataBuffer;
+			_dataBuffer = new byte[superchunkRemaining];
+			_dataBufferAlloc = superchunkRemaining;
+		}
+		if (_stream->read(_dataBuffer, superchunkRemaining) != superchunkRemaining) {
+			error("Not enough data in file after loop restart");
+		}
 	}
 
 	// We use -1 here to discrimate a possibly empty sound frame
@@ -245,6 +289,8 @@ void HNMDecoder::readNextPacket() {
 			error("Chunk has a bogus size");
 		}
 
+		debug(5, "HNM chunk: type='%c%c' (0x%04x) size=%u",
+		      (char)(chunkType >> 8), (char)(chunkType & 0xff), chunkType, chunkSize);
 		if (chunkType == MKTAG16('S', 'D') ||
 		    chunkType == MKTAG16('A', 'A') ||
 		    chunkType == MKTAG16('B', 'B')) {
@@ -657,10 +703,46 @@ void HNMDecoder::HNM5VideoTrack::decodeChunk(byte *data, uint32 size,
 	if (chunkType == MKTAG16('P', 'L')) {
 		decodePalette(data, size);
 	} else if (chunkType == MKTAG16('I', 'V')) {
-		decodeFrame(data, size);
+		if (_dialogCodec)
+			decodeFrameAtlantisDialog(data, size);
+		else
+			decodeFrame(data, size);
+	} else if (chunkType == MKTAG16('I', 'A')) {
+		// IA chunk in Atlantis dialog UBBs carries the FUN_00450b08
+		// compositor opcode stream (SKIP/RUN/RUN-shaded), NOT inline
+		// audio.  When opcode capture is enabled, stash the payload
+		// verbatim for the engine to walk after the frame is decoded.
+		// Other HNM consumers leave _captureOpcodes false and the
+		// chunk is silently discarded as before.
+		if (_captureOpcodes) {
+			if (_opcodesAlloc < size) {
+				delete[] _opcodes;
+				_opcodes = new byte[size];
+				_opcodesAlloc = size;
+			}
+			memcpy(_opcodes, data, size);
+			_opcodesSize = size;
+		}
 	} else {
-		error("HNM5: Got %d chunk: size %d", chunkType, size);
+		warning("HNM5: Unknown chunk type 0x%04x: size %d, skipping", chunkType, size);
 	}
+}
+
+void HNMDecoder::setDialogCodec(bool b) {
+	if (HNM5VideoTrack *v5 = dynamic_cast<HNM5VideoTrack *>(_videoTrack))
+		v5->setDialogCodec(b);
+}
+
+void HNMDecoder::setCaptureOpcodeStream(bool b) {
+	if (HNM5VideoTrack *v5 = dynamic_cast<HNM5VideoTrack *>(_videoTrack))
+		v5->setCaptureOpcodes(b);
+}
+
+const byte *HNMDecoder::getOpcodeStream(uint32 &size) const {
+	if (HNM5VideoTrack *v5 = dynamic_cast<HNM5VideoTrack *>(_videoTrack))
+		return v5->getOpcodes(size);
+	size = 0;
+	return nullptr;
 }
 
 static inline byte *HNM5_getSourcePtr(byte *&data, uint32 &size,
@@ -901,6 +983,115 @@ static const byte HNM5_WIDTHS[3][32] = {
 	}, /* 4 */
 };
 
+// Atlantis: The Lost Tale dialog video 'IV' codec (FUN_0041101f in atlantis.exe).
+// All non-control tokens are 3 bytes: [count_code, u16lo, u16hi].
+//   count = (count_code & 0x1f) + 1 bytes per row-pair.
+// Mode 0x28 (keyframe): src = dst + u16off - 65536 (backward LZ in output buffer).
+// All other modes: src = prev + (dst - curr) + u16off - 0x8000 (inter-frame ref).
+// Strip control: [0xe0, next_mode] = advance 2 rows; [0xe0, 0x00, cnt, col] = RLE fill.
+// Opcode 0x20: [0x20, count] = copy count+1 bytes from same position in prev frame.
+void HNMDecoder::HNM5VideoTrack::decodeFrameAtlantisDialog(byte *data, uint32 size) {
+	SWAP(_frameBufferC, _frameBufferP);
+
+	if (size < 2) {
+		_surface.setPixels(_frameBufferC);
+		return;
+	}
+
+	int mode = data[1];
+	debug(3, "AtlantisDialog IV: size=%u mode=0x%02x", size, mode);
+
+	if (mode == 1) {
+		_surface.setPixels(_frameBufferC);
+		return;
+	}
+
+	byte *tokens  = data + 2;
+	byte *tokEnd  = data + size;
+	byte *curr    = _frameBufferC;
+	byte *prev    = _frameBufferP;
+	int   pitch   = _surface.pitch;
+	int   frameBytes = pitch * _surface.h;
+	byte *currEnd = curr + frameBytes;
+	byte *prevEnd = prev + frameBytes;
+	ptrdiff_t prevDiff = prev - curr;
+
+	byte *dst       = curr;
+	byte *stripBase = curr;
+	bool  done      = false;
+
+	// Copy n bytes from src rows N and N+1 to dst rows N and N+1.
+	// sBuf/sBufEnd guard source reads; byte-by-byte loop supports LZ self-overlap.
+	auto copy2 = [&](byte *d, byte *s, int n, byte *sBuf, byte *sBufEnd) {
+		for (int i = 0; i < n; i++) {
+			byte *s0 = s + i;
+			byte *s1 = s + pitch + i;
+			byte v0 = (s0 >= sBuf && s0 < sBufEnd) ? *s0 : 0;
+			byte v1 = (s1 >= sBuf && s1 < sBufEnd) ? *s1 : 0;
+			if (d + i < currEnd)         d[i]         = v0;
+			if (d + pitch + i < currEnd) (d + pitch)[i] = v1;
+		}
+	};
+
+	while (!done && tokens < tokEnd) {
+		byte b0 = tokens[0];
+
+		if (b0 == 0xe0) {
+			if (tokens + 2 > tokEnd) break;
+			byte b1 = tokens[1];
+			if (b1 == 0) {
+				if (tokens + 4 > tokEnd) break;
+				int  cnt = tokens[2] + 1;
+				byte col = tokens[3];
+				tokens += 4;
+				byte *d1 = dst + pitch;
+				for (int i = 0; i < cnt; i++, dst++, d1++) {
+					if (dst < currEnd) *dst = col;
+					if (d1  < currEnd) *d1  = col;
+				}
+			} else {
+				tokens    += 2;
+				stripBase += 2 * pitch;
+				dst        = stripBase;
+				if (b1 == 1) done = true; else mode = b1;
+			}
+			continue;
+		}
+
+		if (b0 == 0x20) {
+			if (tokens + 2 > tokEnd) break;
+			int cnt = tokens[1] + 1;
+			tokens += 2;
+			byte *src = dst + prevDiff;
+			copy2(dst, src, cnt, prev, prevEnd);
+			dst += cnt;
+			continue;
+		}
+
+		// 3-byte token: [count_code, u16lo, u16hi]
+		if (tokens + 3 > tokEnd) break;
+		uint16 u16off = READ_LE_UINT16(tokens + 1);
+		int    cnt    = (b0 & 0x1f) + 1;
+		tokens += 3;
+
+		byte *src;
+		byte *sBuf, *sBufEnd;
+		if (mode == 0x28) {
+			src  = dst + ((ptrdiff_t)(uint32)u16off - 65536);
+			sBuf = curr; sBufEnd = currEnd;
+			if (src < curr) src = curr;
+		} else {
+			src  = dst + prevDiff + ((ptrdiff_t)u16off - 0x8000);
+			sBuf = prev; sBufEnd = prevEnd;
+			if (src < prev) src = prev;
+		}
+		copy2(dst, src, cnt, sBuf, sBufEnd);
+		dst += cnt;
+	}
+
+	_surface.setPixels(_frameBufferC);
+}
+
 void HNMDecoder::HNM5VideoTrack::decodeFrame(byte *data, uint32 size) {
 	SWAP(_frameBufferC, _frameBufferP);
 
@@ -1037,10 +1228,12 @@ void HNMDecoder::HNM5VideoTrack::decodeFrame(byte *data, uint32 size) {
 
 HNMDecoder::HNM6VideoTrack::HNM6VideoTrack(uint32 width, uint32 height, uint32 frameSize,
         uint32 frameCount, uint32 regularFrameDelayMs, uint32 audioSampleRate,
-        const Graphics::PixelFormat &format) :
+        const Graphics::PixelFormat &format, bool warpMode) :
 	HNMVideoTrack(frameCount, regularFrameDelayMs, audioSampleRate),
-	_decoder(Image::createHNM6Decoder(width, height, format, frameSize, true)),
+	_decoder(Image::createHNM6Decoder(width, height, format, frameSize, !warpMode)),
 	_surface(nullptr) {
+	if (warpMode)
+		_decoder->setWarpMode(true);
 }
 
 HNMDecoder::HNM6VideoTrack::~HNM6VideoTrack() {
@@ -1067,6 +1260,8 @@ void HNMDecoder::HNM6VideoTrack::decodeChunk(byte *data, uint32 size,
         uint16 chunkType, uint16 flags) {
 	if (chunkType == MKTAG16('I', 'X') ||
 	    chunkType == MKTAG16('I', 'W')) {
+		// IW chunks use the warp (panorama) decoder; IX uses the standard decoder.
+		_decoder->setWarpMode(chunkType == MKTAG16('I', 'W'));
 		Common::MemoryReadStream stream(data, size);
 		_surface = _decoder->decodeFrame(stream);
 	} else {

--- a/video/hnm_decoder.h
+++ b/video/hnm_decoder.h
@@ -63,6 +63,22 @@ public:
 	void close() override;
 
 	void setRegularFrameDelay(uint32 regularFrameDelay) { _regularFrameDelayMs = regularFrameDelay; }
+	void setDialogCodec(bool b);
+	/** Atlantis dialog UBBs interleave the IV (CLUT8 video) chunk with an IA
+	 *  chunk that contains the per-frame compositor opcode stream (3 op
+	 *  types — SKIP / RUN-shaded / RUN-per-pixel-shade — consumed by the
+	 *  original engine's FUN_00450b08 to bleed the cyclo through SKIP
+	 *  pixels).  ScummVM's HNM5 decoder normally treats IA as "inline
+	 *  audio" and discards it.  When opcode capture is enabled the most
+	 *  recent IA payload is stashed verbatim for the consumer to read.
+	 *  Default off; only HNM5 honours the flag — Versailles/Eden see no
+	 *  behavioural change. */
+	void setCaptureOpcodeStream(bool b);
+	/** Returns the most recent IA chunk's payload (nullptr if capture
+	 *  disabled or no IA chunk seen yet for this frame).  `size` receives
+	 *  the payload length in bytes.  Pointer is valid until the next
+	 *  decodeNextFrame() call. */
+	const byte *getOpcodeStream(uint32 &size) const;
 
 private:
 	class HNMVideoTrack : public VideoTrack {
@@ -147,21 +163,38 @@ private:
 		               uint32 regularFrameDelayMs, uint32 audioSampleRate,
 		               const byte *initialPalette = nullptr) :
 			HNM45VideoTrack(width, height, frameSize, frameCount, regularFrameDelayMs, audioSampleRate,
-			                initialPalette) {}
+			                initialPalette), _dialogCodec(false),
+			_captureOpcodes(false), _opcodes(nullptr), _opcodesSize(0), _opcodesAlloc(0) {}
+		~HNM5VideoTrack() override { delete[] _opcodes; }
+
 		/** Decode a video chunk. */
 		void decodeChunk(byte *data, uint32 size,
 		                 uint16 chunkType, uint16 flags) override;
 
+		void setDialogCodec(bool b) { _dialogCodec = b; }
+		void setCaptureOpcodes(bool b) { _captureOpcodes = b; }
+		const byte *getOpcodes(uint32 &size) const { size = _opcodesSize; return _opcodes; }
+
 	protected:
 		/** Really decode */
 		void decodeFrame(byte *data, uint32 size);
+		/** Atlantis: The Lost Tale dialog video 'IV' codec (FUN_0041101f) */
+		void decodeFrameAtlantisDialog(byte *data, uint32 size);
+
+		bool _dialogCodec;
+
+		// IA-chunk capture for Atlantis dialog compositor.
+		bool   _captureOpcodes;
+		byte  *_opcodes;
+		uint32 _opcodesSize;
+		uint32 _opcodesAlloc;
 	};
 
 	class HNM6VideoTrack : public HNMVideoTrack {
 	public:
 		HNM6VideoTrack(uint32 width, uint32 height, uint32 frameSize, uint32 frameCount,
 		               uint32 regularFrameDelayMs, uint32 audioSampleRate,
-		               const Graphics::PixelFormat &format);
+		               const Graphics::PixelFormat &format, bool warpMode = false);
 		~HNM6VideoTrack() override;
 
 		uint16 getWidth() const override;


### PR DESCRIPTION
## CRYOMNI3D: Add support for Atlantis: The Lost Tales (UNSTABLE)

This adds a new sub-engine to **CryOmni3D** for *Atlantis: The Lost Tales* (Cryo
Interactive, 1997), the studio's first-person pre-rendered adventure built on the
same in-house engine as *Versailles 1685*. The two games share the CryOmni3D core
(OmniMap navigation, HNM video, APC audio, the fixed-image/zone system) but differ in
their data layout and in a number of game-specific subsystems, so most of the new code
lives under `engines/cryomni3d/atlantis/`.

The engine is flagged **`ADGF_UNSTABLE`**. It is completable and faithful in its core
systems; the one area that is still a best-effort reconstruction is the 3D dialog mouth
mesh (see *Known issues* below).

Game has been tested and is fully playable until the Ratcatcher, before the second full screen puzzle.

### Detection

One new game, the 4-disc English Windows CD, detected via `atlantis.exe` + `BIGCD1.BIG`:

```
atlantis  Atlantis: The Lost Tales  Windows  EN  ADGF_UNSTABLE
  atlantis.exe  83ba66f0b9e49535c1592ba1fd071a0a  714240
  BIGCD1.BIG    e68fd05b1b84914204fcf195c06bc180  635406545
```

The existing demo entry is promoted from the generic HNM player to the Atlantis engine.

### What's implemented

- **Archive + map parsing** — the `BigFile` (BIGCD1–4.BIG) archive across all four discs,
  and the `WAM` navigation maps, parsed with the executable's fixed-size record layout.
- **CON scenario-script interpreter** — places, transitions, `/sel` and `/tim` sections,
  left-to-right condition evaluation, events, inventory, companion NPCs, and puzzle
  dispatch, matching the original interpreter's semantics.
- **Panoramic navigation** — HNM6 16-bit cyclo panoramas with per-place camera and FOV,
  relative-mouse look, and the warp cursor set.
- **Dialog system** — subject menus, speaker resolution from the executable's fixed
  speaker table, UBB talking-head video composited over the live panorama via the game's
  IA compositor opcode stream, and subtitles in a proportional font.
- **2D rendering** — SPW/SPF/SPR sprite codecs, the OBJETS inventory bar and icons, the
  SPRMENU / menu / toolbar UI, and anti-aliased sprite-edge blending.
- **Save / load** — per-chapter named checkpoints driven by `EPI.TXT`, the episode load
  screen, autosave on chapter change, and game-over checkpoint reload.
- **Audio** — the CON-driven music playlist and APC sound playback.
- **Eclipse minigame** — the interactive lever/sphere puzzle, rewritten to match the
  executable's hit-rectangles and win condition.
- **F3DC dialog mouth mesh** — lip-sync driven by `.3DA` visemes, rendered through a
  `.3DM`-textured software rasteriser with per-cam look-at cameras derived from the
  `.S3D` files.

### Changes to shared code

Two shared decoders needed changes. Both are isolated in their own commits.

**`AUDIO: APC`** — `decodeIMA()` previously stored the IMA predictor truncated to `int16`
and fed that truncated value forward, so a single out-of-range sample wrapped and the
wrapped value diverged the differential predictor for the rest of a loud passage (audible
distortion on music; speech never drove it out of range, which is why it went unnoticed).
The original Cryo decoder (`atlantis.exe` `FUN_004101ce`, verified by decompilation)
accumulates the predictor in full 32-bit precision and truncates to `int16` only when
emitting each sample. The fix matches that exactly — it is bit-exact to the original and
removes the distortion. **Versailles is regression-checked** (see below).

**`VIDEO: HNM`** — adds what Atlantis needs to play its dialog and panorama video:
- the dialog `IV` frame codec (`FUN_0041101f`), selected per-decoder via `setDialogCodec()`;
- IA-chunk opcode-stream capture (`setCaptureOpcodeStream()`/`getOpcodeStream()`), off by
  default so other consumers discard the chunk exactly as before;
- HNM6 warp-mode detection so panorama files allocate the keyframe-only decoder.

Two of these touch paths shared with Versailles, deliberately: an unknown HNM5 chunk now
*warns and skips* instead of being fatal, and `readNextPacket()` *loop-restarts* a looping
stream on a short read at EOF instead of erroring. Both only soften former hard-error
(crash) conditions on malformed/terminator-less streams; non-looping consumers still error
exactly as before.

### Known issues (why UNSTABLE)

- The **F3DC 3D mouth mesh** is a best-effort reconstruction. It renders correctly for most
  characters, but the *Passant* character and the chapter 4/5 entry-point cameras are not
  yet right. Everything else (navigation, scripting, dialog/UBB video, saves, 2D
  rendering) follows the executable.

### Testing

- Builds cleanly (Linux/g++ and MinGW/Windows cross-build), no new warnings.
- Played from the start through the early chapters: navigation, dialogs with UBB video,
  inventory, music, saves/loads, the eclipse puzzle, and game-over/reload.
- **Versailles regression (shared HNM/APC code):** verified by static analysis — for clean
  streams the new `readNextPacket` paths are byte-identical to the old ones, and the only
  divergence is on malformed streams Versailles never produces — and confirmed empirically
  by running *Versailles 1685*, which plays its intro HNM video with no decoder errors and
  no regression.

### Notes for reviewers

- The new code carries detailed reverse-engineering provenance comments (executable VAs,
  the data-format models, and which behaviours are exe-faithful vs. reconstructed).
- Engine logging is routed through new debug channels (`Script`, `Mesh`, `Video`, `Music`)
  and is silent by default.
- Three commits, shared-code first so history stays bisectable:
  `AUDIO: APC …` → `VIDEO: HNM …` → `CRYOMNI3D: Add Atlantis …`.
