### PR TITLE
JANITORIAL: GLK: pass strings as references

### DIFF
--- a/engines/glk/quetzal.cpp
+++ b/engines/glk/quetzal.cpp
@@ -258,7 +258,7 @@ void QuetzalWriter::addCommonChunks(const Common::String &saveName) {
 		else
 			ws.writeByte('\0');
 
-		Common::String md5 = g_vm->getGameMD5();
+		const auto &md5 = g_vm->getGameMD5();
 		ws.write(md5.c_str(), md5.size());
 		ws.writeByte('\0');
 	}

--- a/engines/glk/scott/c64_checksums.cpp
+++ b/engines/glk/scott/c64_checksums.cpp
@@ -402,7 +402,7 @@ int detectC64(uint8_t **sf, size_t *extent) {
 	if (*extent > MAX_LENGTH || *extent < MIN_LENGTH)
 		return 0;
 
-	Common::String md5 = g_vm->getGameMD5();
+	const auto &md5 = g_vm->getGameMD5();
 	int index = _G(_md5Index)[md5];
 	if (g_C64Registry[index]._id == SAVAGE_ISLAND_C64) {
 		return savageIslandMenu(sf, extent, index);

--- a/engines/glk/scott/load_game.cpp
+++ b/engines/glk/scott/load_game.cpp
@@ -87,8 +87,8 @@ void loadGameFile(Common::SeekableReadStream *f) {
 
 	_G(_game) = &_G(_fallbackGame);
 
-	Common::String md5 = g_vm->getGameMD5();
-	Common::String filename = g_vm->getFilename();
+	const auto &md5 = g_vm->getGameMD5();
+	const auto &filename = g_vm->getFilename();
 
 	if (filename.hasSuffixIgnoreCase(".tap") || filename.hasSuffixIgnoreCase(".tzx")) {
 		loadZXSpectrumTape(f);

--- a/engines/glk/scott/load_game.cpp
+++ b/engines/glk/scott/load_game.cpp
@@ -54,7 +54,7 @@
 namespace Glk {
 namespace Scott {
 
-void loadC64(Common::SeekableReadStream* f, Common::String md5) {
+void loadC64(Common::SeekableReadStream* f) {
 	_G(_entireFile) = new uint8_t[_G(_fileLength)];
 	size_t result = f->read(_G(_entireFile), _G(_fileLength));
 	if (result != _G(_fileLength))
@@ -104,7 +104,7 @@ void loadGameFile(Common::SeekableReadStream *f) {
 					loadZXSpectrum(f, md5);
 					break;
 				} else if (!scumm_stricmp(p->_extra, "C64")) {
-					loadC64(f, md5);
+					loadC64(f);
 					break;
 				} else {
 					loadTI994A(f);

--- a/engines/glk/scott/load_zx_spectrum.cpp
+++ b/engines/glk/scott/load_zx_spectrum.cpp
@@ -49,7 +49,7 @@ namespace Scott {
 
 #define TITLE_SCREEN g_globals->_spectrumTitleScreen
 
-static void loadZXSpectrumGame(Common::String md5) {
+static void loadZXSpectrumGame(const Common::String &md5) {
 	int offset;
 	DictionaryType dict_type = getId(&offset);
 	if (dict_type == NOT_A_GAME)
@@ -61,7 +61,7 @@ static void loadZXSpectrumGame(Common::String md5) {
 	}
 }
 
-void loadZXSpectrum(Common::SeekableReadStream *f, Common::String md5) {
+void loadZXSpectrum(Common::SeekableReadStream *f, const Common::String &md5) {
 	TITLE_SCREEN.clear();
 
 	_G(_entireFile) = new uint8_t[_G(_fileLength)];

--- a/engines/glk/scott/load_zx_spectrum.h
+++ b/engines/glk/scott/load_zx_spectrum.h
@@ -40,7 +40,7 @@
 namespace Glk {
 namespace Scott {
 
-void loadZXSpectrum(Common::SeekableReadStream *f, Common::String md5);
+void loadZXSpectrum(Common::SeekableReadStream *f, const Common::String &md5);
 void loadZXSpectrumTape(Common::SeekableReadStream *f);
 void showZXSpectrumTapeTitleScreen();
 


### PR DESCRIPTION
Resolve redundant string copying by passing or storing strings as references instead of values.
Also resolve one related case of an unused function argument.