### PR TITLE
SCUMM: RA: add more RA1 hashes

### DIFF
--- a/devtools/scumm-md5.txt
+++ b/devtools/scumm-md5.txt
@@ -448,7 +448,9 @@ ft	Full Throttle
 	8ead2c01c48c2e3d15d6a89b86cd84ab	19697	he	DOS	-	-	-	Hebrew fan translation
 
 rebel1	Star Wars: Rebel Assault
-	b9ac90e4411da1b6f7dd075cc4b03c2a	214435	en	DOS	-	-	-	-
+	b9ac90e4411da1b6f7dd075cc4b03c2a	214435	en	DOS	-	v1.0	-	-
+	e210a57b756473be705d24b9378a8233	212383	en	DOS	-	v1.3	-	-
+	6bb0fe2d7816c5528c773f2898e4e0ff	212915	en	DOS	-	v1.7	-	-	
 
 rebel2	Star Wars: Rebel Assault II: The Hidden Empire
 	6b73a08c535c0544785d73ff812908a0	9430	en	DOS	-	-	-	-


### PR DESCRIPTION
Add hashes for the V1.3 and V1.7 DOS EXEs, which can be found in the GOG package.
