### PR TITLE
SCUMM: RA: Default framerate is 15fps

### DIFF
--- a/engines/scumm/insane/rebel1/runlevels.cpp
+++ b/engines/scumm/insane/rebel1/runlevels.cpp
@@ -159,7 +159,7 @@ void InsaneRebel1::playCinematic(const char *filename, int32 startFrame) {
 	splayer->setCurVideoFlags(0x28);  // Cinematic mode + buffer preserve
 	splayer->setFastForwardFromFrame(0);
 	splayer->setFastForwardToFrame(startFrame > 0 ? startFrame : 0);
-	splayer->play(filename, 12);
+	splayer->play(filename, 15);
 
 	// Level-title text is only meant for the intro cinematic that armed it.
 	// Clear it even when the movie ended through ESC, so it cannot leak into
@@ -1693,7 +1693,7 @@ void InsaneRebel1::releaseInteractiveVideoInput() {
 }
 
 void InsaneRebel1::playInteractiveVideoFile(const char *filename, int32 videoOffset, int32 videoStartFrame) {
-	_vm->_splayer->play(filename, 12, videoOffset, videoStartFrame);
+	_vm->_splayer->play(filename, 15, videoOffset, videoStartFrame);
 	restoreInteractiveVideoAudioState();
 	_interactiveVideoActive = false;
 }

--- a/engines/scumm/insane/rebel2/levels.cpp
+++ b/engines/scumm/insane/rebel2/levels.cpp
@@ -59,7 +59,7 @@ void InsaneRebel2::runGame() {
 
 	// Demo: just play the demo video and return
 	if (_vm->_game.features & GF_DEMO) {
-		splayer->play("OPEN/O_DEMO.SAN", 12);
+		splayer->play("OPEN/O_DEMO.SAN", 15);
 		return;
 	}
 
@@ -147,7 +147,7 @@ void InsaneRebel2::playIntroSequence() {
 	// Original: FUN_0041f4d0("OPEN/O_OPEN_A.SAN", 0x28, 0xffff, 0xffff, 0)
 	debug("Rebel2: Playing main intro (O_OPEN_A.SAN)");
 	splayer->setCurVideoFlags(0x28);
-	splayer->play("OPEN/O_OPEN_A.SAN", 12);
+	splayer->play("OPEN/O_OPEN_A.SAN", 15);
 
 	if (_vm->shouldQuit())
 		return;
@@ -157,7 +157,7 @@ void InsaneRebel2::playIntroSequence() {
 	// We play unconditionally (matches "Continue Intro" menu behavior)
 	debug("Rebel2: Playing additional intro (O_OPEN_B.SAN)");
 	splayer->setCurVideoFlags(0x28);
-	splayer->play("OPEN/O_OPEN_B.SAN", 12);
+	splayer->play("OPEN/O_OPEN_B.SAN", 15);
 }
 
 // playMissionBriefing -- Mission briefing screen (FUN_00415CF8).
@@ -167,7 +167,7 @@ void InsaneRebel2::playMissionBriefing() {
 
 	SmushPlayer *splayer = ((ScummEngine_v7 *)_vm)->_splayer;
 	splayer->setCurVideoFlags(0x08);  // Briefing mode flag
-	splayer->play("OPEN/O_LEVEL.SAN", 12);
+	splayer->play("OPEN/O_LEVEL.SAN", 15);
 }
 
 // playCinematic -- Play a cinematic/cutscene video.
@@ -179,7 +179,7 @@ void InsaneRebel2::playCinematic(const char *filename) {
 
 	SmushPlayer *splayer = ((ScummEngine_v7 *)_vm)->_splayer;
 	splayer->setCurVideoFlags(0x28);  // Cinematic mode + buffer preserve (0x20 | 0x08)
-	splayer->play(filename, 12);
+	splayer->play(filename, 15);
 }
 
 // playVideoWithText -- Video with progressive text overlay (FUN_004171c5).
@@ -201,7 +201,7 @@ void InsaneRebel2::playVideoWithText(const char *filename, int textID, int textX
 
 	SmushPlayer *splayer = ((ScummEngine_v7 *)_vm)->_splayer;
 	splayer->setCurVideoFlags(0x28);
-	splayer->play(filename, 12);
+	splayer->play(filename, 15);
 
 	_textOverlayActive = false;
 }
@@ -270,7 +270,7 @@ void InsaneRebel2::playLevelEnd(int levelId) {
 	SmushPlayer *splayer = ((ScummEngine_v7 *)_vm)->_splayer;
 	// Original: FUN_00417327 adds | 8, so flags = 0x20 | 0x08 = 0x28
 	splayer->setCurVideoFlags(0x28);
-	splayer->play(filename.c_str(), 12);
+	splayer->play(filename.c_str(), 15);
 }
 
 // playLevelRetry -- Retry prompt video (LEVXX/XXRETRY.SAN, FUN_00417168).
@@ -288,7 +288,7 @@ void InsaneRebel2::playLevelRetry(int levelId) {
 	SmushPlayer *splayer = ((ScummEngine_v7 *)_vm)->_splayer;
 	// Original: FUN_00417168 adds | 8, so flags = 0x20 | 0x08 = 0x28
 	splayer->setCurVideoFlags(0x28);
-	splayer->play(filename.c_str(), 12);
+	splayer->play(filename.c_str(), 15);
 }
 
 // playLevelGameOver -- Game over video (FUN_00417ab2).
@@ -306,7 +306,7 @@ void InsaneRebel2::playLevelGameOver(int levelId) {
 	SmushPlayer *splayer = ((ScummEngine_v7 *)_vm)->_splayer;
 	// Original: FUN_00417ab2 adds | 8, so flags = 0x20 | 0x08 = 0x28
 	splayer->setCurVideoFlags(0x28);
-	splayer->play(filename.c_str(), 12);
+	splayer->play(filename.c_str(), 15);
 }
 
 // playEndingSequence -- Finale + credits + epilogue (FUN_0041bbe8).
@@ -363,7 +363,7 @@ void InsaneRebel2::playCreditsSequence() {
 
 	SmushPlayer *splayer = ((ScummEngine_v7 *)_vm)->_splayer;
 	splayer->setCurVideoFlags(0x20);
-	splayer->play("OPEN/O_CREDIT.SAN", 12);
+	splayer->play("OPEN/O_CREDIT.SAN", 15);
 }
 
 void InsaneRebel2::centerGameplayAim() {
@@ -697,7 +697,7 @@ void InsaneRebel2::playLevelDeathVariant(int levelId, int phase, int frame) {
 	SmushPlayer *splayer = ((ScummEngine_v7 *)_vm)->_splayer;
 	// Original: FUN_00417168 adds | 8, so flags = 0x20 | 0x08 = 0x28
 	splayer->setCurVideoFlags(0x28);
-	splayer->play(filename.c_str(), 12);
+	splayer->play(filename.c_str(), 15);
 }
 
 // playLevelRetryVariant -- Phase-specific retry video.
@@ -723,7 +723,7 @@ void InsaneRebel2::playLevelRetryVariant(int levelId, int phase) {
 	SmushPlayer *splayer = ((ScummEngine_v7 *)_vm)->_splayer;
 	// Original: FUN_00417168 adds | 8, so flags = 0x20 | 0x08 = 0x28
 	splayer->setCurVideoFlags(0x28);
-	splayer->play(filename.c_str(), 12);
+	splayer->play(filename.c_str(), 15);
 }
 
 

--- a/engines/scumm/insane/rebel2/menu.cpp
+++ b/engines/scumm/insane/rebel2/menu.cpp
@@ -622,7 +622,7 @@ int InsaneRebel2::runMainMenu() {
 		// Play the menu video
 		// Input is processed in procPostRendering during playback
 		// When user confirms selection, _vm->_smushVideoShouldFinish is set
-		splayer->play(menuVideo.c_str(), 12);
+		splayer->play(menuVideo.c_str(), 15);
 
 		// Check for quit
 		if (_vm->shouldQuit()) {
@@ -678,9 +678,9 @@ int InsaneRebel2::runMainMenu() {
 			_menuInputActive = false;
 			// Play intro sequence again (O_OPEN_A/B)
 			splayer->setCurVideoFlags(0x20);
-			splayer->play("OPEN/O_OPEN_A.SAN", 12);
+			splayer->play("OPEN/O_OPEN_A.SAN", 15);
 			if (!_vm->shouldQuit()) {
-				splayer->play("OPEN/O_OPEN_B.SAN", 12);
+				splayer->play("OPEN/O_OPEN_B.SAN", 15);
 			}
 			// Restore menu state
 			_gameState = kStateMainMenu;
@@ -697,7 +697,7 @@ int InsaneRebel2::runMainMenu() {
 			_gameState = kStateCredits;
 			_menuInputActive = false;
 			splayer->setCurVideoFlags(0x20);
-			splayer->play("OPEN/O_CREDIT.SAN", 12);
+			splayer->play("OPEN/O_CREDIT.SAN", 15);
 			_gameState = kStateMainMenu;
 			_menuInputActive = true;
 			// Returns 1 in original -> stays at stage 1 (main menu)
@@ -780,7 +780,7 @@ int InsaneRebel2::runChapterSelect() {
 		splayer->setCurVideoFlags(0x28);
 
 		// Play O_LEVEL.SAN — preview thumbnails are rendered by FOBJ offset
-		splayer->play("OPEN/O_LEVEL.SAN", 12);
+		splayer->play("OPEN/O_LEVEL.SAN", 15);
 
 		if (_vm->shouldQuit()) {
 			setVirtualKeyboardVisible(false);
@@ -1233,7 +1233,7 @@ int InsaneRebel2::runLevelSelect() {
 
 		Common::String menuVideo = getRandomMenuVideo();
 		splayer->setCurVideoFlags(0x20);
-		splayer->play(menuVideo.c_str(), 12);
+		splayer->play(menuVideo.c_str(), 15);
 
 		if (_vm->shouldQuit()) {
 			setVirtualKeyboardVisible(false);
@@ -1732,7 +1732,7 @@ void InsaneRebel2::showTopPilots() {
 
 	Common::String menuVideo = getRandomMenuVideo();
 	splayer->setCurVideoFlags(0x20);
-	splayer->play(menuVideo.c_str(), 12);
+	splayer->play(menuVideo.c_str(), 15);
 
 	_gameState = kStateMainMenu;
 	_menuInputActive = true;
@@ -1839,7 +1839,7 @@ void InsaneRebel2::showOptionsMenu() {
 
 		Common::String menuVideo = getRandomMenuVideo();
 		splayer->setCurVideoFlags(0x20);
-		splayer->play(menuVideo.c_str(), 12);
+		splayer->play(menuVideo.c_str(), 15);
 	}
 
 	_gameState = kStateMainMenu;

--- a/engines/scumm/insane/rebel2/runlevels.cpp
+++ b/engines/scumm/insane/rebel2/runlevels.cpp
@@ -198,7 +198,7 @@ bool InsaneRebel2::playLevelSegment(const char *filename, uint16 flags, bool rec
 		centerGameplayAim();
 
 	splayer->setCurVideoFlags(flags);
-	splayer->play(filename, 12);
+	splayer->play(filename, 15);
 	if (recordFrame)
 		_deathFrame = splayer->_frame;
 	return !_vm->shouldQuit();


### PR DESCRIPTION
The default frame rate for all RA1 ANM and RA2 SAN files is 15fps.

ANIMv2 (RA2+) SAN files have an FPS indicator at file offset 0x316, which for all RA2 files is 15.
ANIMv1 (RA1) does not have this in the .ANM file; rather the engine sets a default of 15 fps (DAT_002b2392 in V1.7) which can be overridden with the "/F" cmdline switch.

