### PR TITLE
SCUMM: RA: support female voice output

### DIFF
--- a/engines/scumm/insane/rebel1/menu.cpp
+++ b/engines/scumm/insane/rebel1/menu.cpp
@@ -1192,6 +1192,7 @@ void InsaneRebel1::runOptionsMenu() {
 				return;
 			case 1: // Toggle Rookie One gender
 				_optRookieOneFemale = !_optRookieOneFemale;
+				_player->_smushAudioTable[4] = _optRookieOneFemale ? 1 : 0;
 				break;
 			case 2: // Toggle music
 				_optMusicEnabled = !_optMusicEnabled;


### PR DESCRIPTION
When the player speaks, both gender tracks are present; the one to play is determined by the STRK script which evaluates the _smushAudioTable[4] value check to true.  For female voice, [4] needs to be set to 1.
