### PR TITLE
MM: MM1: Fix stale view close handling, crash in spells and text fix

### DIFF
--- a/engines/mm/mm1/events.cpp
+++ b/engines/mm/mm1/events.cpp
@@ -134,7 +134,7 @@ void Events::replaceView(UIElement *ui, bool replaceAllViews) {
 }
 
 void Events::replaceView(const Common::String &name, bool replaceAllViews) {
-	replaceView(findView(name));
+	replaceView(findView(name), replaceAllViews);
 }
 
 void Events::addView(UIElement *ui) {
@@ -272,8 +272,10 @@ void UIElement::focus() {
 }
 
 void UIElement::close() {
-	assert(g_engine->focusedView() == this);
-	g_engine->popView();
+	if (g_events->focusedView() != this)
+		return;
+
+	g_events->popView();
 }
 
 bool UIElement::isFocused() const {

--- a/engines/mm/mm1/game/combat.cpp
+++ b/engines/mm/mm1/game/combat.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "mm/mm1/game/combat.h"
+#include "mm/mm1/game/spell_casting.h"
 #include "mm/mm1/globals.h"
 #include "mm/mm1/mm1.h"
 #include "mm/mm1/sound.h"
@@ -1107,8 +1108,7 @@ void Combat::resetDestMonster() {
 void Combat::spellFailed() {
 	g_globals->_combatParty[_currentChar]->_checked = true;
 
-	SoundMessage msg(10, 2, Common::String::format("*** %s ***",
-		STRING["spells.failed"].c_str()));
+	SoundMessage msg(10, 2, SpellCasting::spellResultMessage(STRING["spells.failed"]));
 	msg._delaySeconds = 3;
 	displaySpellResult(msg);
 }

--- a/engines/mm/mm1/game/spell_casting.cpp
+++ b/engines/mm/mm1/game/spell_casting.cpp
@@ -179,12 +179,16 @@ Common::String SpellCasting::getSpellError() const {
 	}
 
 	if (!isInCombat())
-		msg = Common::String::format("*** %s ***", msg.c_str());
+		msg = spellResultMessage(msg);
 	return msg;
 }
 
 bool SpellCasting::isInCombat() const {
 	return g_events->isPresent("Combat");
+}
+
+Common::String SpellCasting::spellResultMessage(const Common::String &msg) {
+	return Common::String::format("*** %s ***", msg.c_str());
 }
 
 } // namespace Game

--- a/engines/mm/mm1/game/spell_casting.h
+++ b/engines/mm/mm1/game/spell_casting.h
@@ -98,6 +98,11 @@ public:
 	 * Returns the error message
 	 */
 	Common::String getSpellError() const;
+
+	/**
+	 * Returns a spell result message formatted as in the DOS executable.
+	 */
+	static Common::String spellResultMessage(const Common::String &msg);
 };
 
 } // namespace Game

--- a/engines/mm/mm1/views/spells/cast_spell.cpp
+++ b/engines/mm/mm1/views/spells/cast_spell.cpp
@@ -183,7 +183,8 @@ bool CastSpell::msgAction(const ActionMessage &msg) {
 
 	} else if (msg._action == KEYBIND_SELECT) {
 		// Time to execute the spell
-		performSpell();
+		if (_state == PRESS_ENTER)
+			performSpell();
 
 	} else if (_state == SELECT_CHAR &&
 		msg._action >= KEYBIND_VIEW_PARTY1 &&

--- a/engines/mm/mm1/views/spells/cast_spell.cpp
+++ b/engines/mm/mm1/views/spells/cast_spell.cpp
@@ -241,16 +241,20 @@ void CastSpell::spellDone() {
 }
 
 void CastSpell::spellDone(const Common::String &msg, int xp) {
+	Common::String result = msg.hasPrefix("*** ") ? msg :
+		spellResultMessage(msg);
+	xp = 20 - (result.size() / 2);
+
 	if (isInCombat()) {
 		close();
 
-		GameMessage gameMsg("SPELL_RESULT", msg);
+		GameMessage gameMsg("SPELL_RESULT", result);
 		gameMsg._value = xp;
 		g_events->focusedView()->send(gameMsg);
 
 	} else {
 		Sound::sound(SOUND_2);
-		_spellResult = msg;
+		_spellResult = result;
 		_spellResultX = xp;
 		setState(ENDING);
 	}

--- a/engines/mm/mm1/views/spells/spell_view.cpp
+++ b/engines/mm/mm1/views/spells/spell_view.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "mm/mm1/views/spells/spell_view.h"
+#include "mm/mm1/game/spell_casting.h"
 #include "mm/mm1/globals.h"
 #include "mm/mm1/sound.h"
 
@@ -31,7 +32,7 @@ namespace Spells {
 void SpellView::spellFailed() {
 	// Spell failed
 	clearSurface();
-	writeString(10, 2, STRING["spells.failed"]);
+	writeString(10, 2, Game::SpellCasting::spellResultMessage(STRING["spells.failed"]));
 
 	Sound::sound(SOUND_2);
 	delaySeconds(3);
@@ -39,7 +40,7 @@ void SpellView::spellFailed() {
 
 void SpellView::spellDone() {
 	clearSurface();
-	writeString(14, 2, STRING["spells.done"]);
+	writeString(14, 2, Game::SpellCasting::spellResultMessage(STRING["spells.done"]));
 	g_globals->_party.updateAC();
 
 	Sound::sound(SOUND_2);


### PR DESCRIPTION
Fixes an MM1 crash when a stale UI element attempts to close after focus has already moved to another view.

This could happen around delayed location messages, for example pressing a key after a beep/message near the Inn. The old code asserted that the closing element was still the focused view, which could crash ScummVM.

Fixes a classic MM1 spell casting crash for targeted spells. The original DOS flow only executes targeted spells after a valid character selection; Enter is only accepted in the non-target “ENTER TO CAST” branch. ScummVM could execute a targeted spell with no target selected, leading to a null character pointer.

Finally to matcch original spell result formatting add *** markers around spell result to use shared formatter (for no reason before only one of results had this formatting) and proper text positioning afterwards.