### PR TITLE
Director:Fixes for various German Games

### DIFF
--- a/engines/director/archive-save.cpp
+++ b/engines/director/archive-save.cpp
@@ -47,11 +47,36 @@ bool RIFXArchive::writeToFile(Common::String filename, Movie *movie) {
 	}
 
 	Common::String saveFileName = g_director->getTargetName() + "-" + filename;
+
+	// We may be saving over the very file this archive was loaded from: TKKG2
+	// re-saves "score.dxr" over the savegame it loaded. openForSaving() below
+	// truncates that file, after which every verbatim-copied resource read from
+	// _stream (getResource) would return zero bytes -- silently zeroing MCsL,
+	// Sord, VWFI, VWSC, etc. and corrupting the savegame. Snapshot the source
+	// bytes into memory first and read resources from that copy for the duration
+	// of the write, then restore the original stream.
+	Common::SeekableReadStream *origStream = _stream;
+	byte *srcSnapshot = nullptr;
+	if (_stream) {
+		uint32 savedPos = _stream->pos();
+		_stream->seek(0);
+		uint32 srcSize = _stream->size();
+		srcSnapshot = (byte *)malloc(srcSize);
+		_stream->read(srcSnapshot, srcSize);
+		_stream->seek(savedPos);
+		_stream = new Common::MemoryReadStream(srcSnapshot, srcSize, DisposeAfterUse::NO);
+	}
+
 	// Don't open the save file as compressed which doesn't support seeking
 	Common::OutSaveFile *saveFile = g_engine->getSaveFileManager()->openForSaving(saveFileName, false);
 
 	if (!saveFile) {
 		warning("RIFXArchive::writeToFile: Failed to open file %s for saving", saveFileName.c_str());
+		if (srcSnapshot) {
+			delete _stream;
+			_stream = origStream;
+			free(srcSnapshot);
+		}
 		return false;
 	}
 
@@ -217,9 +242,18 @@ bool RIFXArchive::writeToFile(Common::String filename, Movie *movie) {
 	}
 
 	delete saveFile;
+
 	for (auto it : builtResources) {
 		delete it;
 	}
+
+	// Restore the original source stream and free the in-memory snapshot.
+	if (srcSnapshot) {
+		delete _stream;
+		_stream = origStream;
+		free(srcSnapshot);
+	}
+
 	return true;
 }
 

--- a/engines/director/archive-save.cpp
+++ b/engines/director/archive-save.cpp
@@ -64,7 +64,12 @@ bool RIFXArchive::writeToFile(Common::String filename, Movie *movie) {
 	_size = getArchiveSize(builtResources);
 	saveFile->writeUint32LE(_metaTag); // The _metaTag is "RIFX" or "XFIR"
 
-	saveFile->writeUint32LE(getResourceSize(_metaTag, 0) - 8); // The size of the RIFX archive, except header and size
+	// The RIFX chunk size field = size of everything after this size field, i.e.
+	// rifxType(4) + all sub-chunks = getArchiveSize + 4 (== total file size - 8).
+	// Use the freshly recomputed size, NOT getResourceSize() which returns the
+	// stale ORIGINAL size from the loaded archive (which left the RIFX header
+	// disagreeing with the mmap/actual file -- TKKG2 savegame).
+	saveFile->writeUint32LE(getArchiveSize(builtResources) + 4);
 	saveFile->writeUint32LE(_rifxType);	// e.g. "MV93", "MV95"
 
 	switch (_rifxType) {
@@ -167,7 +172,28 @@ bool RIFXArchive::writeToFile(Common::String filename, Movie *movie) {
 			break;
 
 		case MKTAG('V', 'W', 'S', 'C'):
-			movie->getScore()->writeVWSCResource(saveFile, it->offset);
+			// Option A: the savegame does not modify the score, and the D6 score
+			// re-serializer (writeVWSCResource) is not byte-faithful for D6 -- it
+			// omits the leading sprite-detail offset table and emits fixed-size
+			// channels, producing a score that differs from (and is larger than)
+			// the original. Copy the original VWSC bytes verbatim instead, exactly
+			// like the default (unmodified-resource) path.
+			saveFile->seek(it->offset, SEEK_SET);
+			saveFile->writeUint32LE(it->tag);
+			saveFile->writeUint32LE(it->size);
+			saveFile->writeStream(getResource(it->tag, it->index));
+			break;
+
+		case MKTAG('f', 'r', 'e', 'e'):
+		case MKTAG('j', 'u', 'n', 'k'):
+			// Placeholder/empty chunks: rebuildResources() reserves only the
+			// 8-byte header (size 0). Write exactly that. The default case would
+			// write getResource() content, which for these stale slots is
+			// unrelated data and overruns into the following resources, corrupting
+			// the archive (TKKG2 savegame: junk slots emitted up to 6655 bytes).
+			saveFile->seek(it->offset, SEEK_SET);
+			saveFile->writeUint32LE(it->tag);
+			saveFile->writeUint32LE(0);
 			break;
 
 		default:
@@ -276,13 +302,23 @@ bool RIFXArchive::writeAfterBurnerMap(Common::SeekableWriteStream *writeStream) 
 bool RIFXArchive::writeKeyTable(Common::SeekableWriteStream *writeStream, uint32 offset) {
 	writeStream->seek(offset);
 
+	// The number of entries we actually write is the number of mappings held in
+	// _keyData. We only keep the entries we parsed on load, which can be fewer
+	// than the original used/capacity counts (empty slots are dropped), and
+	// rebuildResources() reserved exactly getKeyTableResourceSize() bytes for
+	// this resource. The chunk's own size field and entry counts must therefore
+	// be derived from what we actually write -- not from the original values --
+	// otherwise a reader trusts the (too-large) counts and reads past the real
+	// KEY* into the following resource, corrupting the archive (TKKG2 savegame).
+	uint32 numEntries = (getKeyTableResourceSize() - 12) / 12;
+
 	writeStream->writeUint32LE(MKTAG('K', 'E', 'Y', '*'));
-	writeStream->writeUint32LE(getResourceSize(MKTAG('K', 'E', 'Y', '*'), getResourceIDList(MKTAG('K', 'E', 'Y', '*'))[0]));
+	writeStream->writeUint32LE(getKeyTableResourceSize());
 
 	writeStream->writeUint16LE(_keyTableEntrySize);
 	writeStream->writeUint16LE(_keyTableEntrySize2);
-	writeStream->writeUint32LE(_keyTableEntryCount);
-	writeStream->writeUint32LE(_keyTableUsedCount);
+	writeStream->writeUint32LE(numEntries);
+	writeStream->writeUint32LE(numEntries);
 
 	debugC(3, kDebugSaving, "RIFXArchive::writeKeyTable: writing key table:");
 
@@ -571,8 +607,10 @@ Common::Array<Resource *> RIFXArchive::rebuildResources(Movie *movie) {
 			break;
 
 		case MKTAG('V', 'W', 'S', 'C'):
-			resSize = movie->getScore()->getVWSCResourceSize();
-			it->size = resSize;
+			// Option A: keep the original VWSC size; we copy the score verbatim in
+			// writeToFile rather than re-serializing it (see there). it->size is the
+			// original size carried over from _resources.
+			resSize = it->size;
 			it->offset = currentSize;
 			currentSize += resSize + 8;		// The size doesn't include the header and the size entry
 			break;
@@ -597,10 +635,13 @@ Common::Array<Resource *> RIFXArchive::rebuildResources(Movie *movie) {
 			it->index, tag2str(it->tag), it->size, it->offset, it->offset, it->flags, it->unk1, it->nextFreeResourceID);
 	}
 
-	// Now that all sizes have been updated, we can safely calculate the overall archive size
+	// Now that all sizes have been updated, set the RIFX resource's own size. The
+	// RIFX chunk's data is rifxType(4) + all sub-chunks, so its size (excluding the
+	// 8-byte tag+size header) is getArchiveSize + 4 -- the same value written into
+	// the RIFX header size field, keeping the mmap entry and header consistent.
 	for (auto &it : builtResources) {
 		if (it->tag == MKTAG('R', 'I', 'F', 'X') || it->tag == MKTAG('X', 'F', 'I', 'R')) {
-			it->size = getArchiveSize(builtResources) + 8;
+			it->size = getArchiveSize(builtResources) + 4;
 		}
 	}
 

--- a/engines/director/archive-save.cpp
+++ b/engines/director/archive-save.cpp
@@ -30,6 +30,7 @@
 #include "director/score.h"
 #include "director/window.h"
 #include "director/sprite.h"
+#include "director/util.h"
 
 #include "director/castmember/castmember.h"
 #include "director/castmember/bitmap.h"
@@ -46,7 +47,13 @@ bool RIFXArchive::writeToFile(Common::String filename, Movie *movie) {
 		filename = movie->getMacName();
 	}
 
-	Common::String saveFileName = g_director->getTargetName() + "-" + filename;
+	// Normalise the name the same way the movie loader does (convertPath strips
+	// the drive letter / Mac-style separators), so the key the save is stored
+	// under matches the one used when the movie is later loaded by fileName.
+	// Otherwise e.g. saving "C:\SCORES.DXR" and loading it back (which resolves
+	// to "SCORES.DXR") would not find the saved file. ("Ein Fall fuer Muetze &
+	// Co" saves player profiles to such a drive-qualified path.)
+	Common::String saveFileName = g_director->getTargetName() + "-" + convertPath(filename);
 
 	// We may be saving over the very file this archive was loaded from: TKKG2
 	// re-saves "score.dxr" over the savegame it loaded. openForSaving() below
@@ -773,7 +780,10 @@ SavedArchive::SavedArchive(Common::String target) {
 	for (auto saveFileName : saveFileList) {
 		// Derive the original file name from the save file name
 		// Save files are named target_name-save_filename
-		Common::String origFileName = saveFileName.substr(target.size() + 1);
+		// Normalise it with convertPath so the key matches the path the movie
+		// loader resolves to (it strips drive letters etc.); otherwise a movie
+		// saved as e.g. "C:\SCORES.DXR" could never be loaded back by fileName.
+		Common::String origFileName = convertPath(saveFileName.substr(target.size() + 1));
 		debugC(3, kDebugLoading, "Found save file: %s -> %s", saveFileName.c_str(), origFileName.c_str());
 
 		_files[origFileName] = saveFileName;

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -891,6 +891,17 @@ void Cast::loadCast() {
 	if (_castArchive->hasResource(MKTAG('S', 'C', 'R', 'F'), -1)) {
 		debugC(4, kDebugLoading, "'SCRF' resource skipped");
 	}
+
+	// When dumping, force-load every bitmap so its decoded image gets
+	// exported as PNG. Bitmaps are otherwise loaded lazily (only when
+	// shown on stage), so without this only the few displayed members
+	// would be dumped.
+	if (ConfMan.getBool("dump_scripts")) {
+		for (auto &it : *_loadedCast) {
+			if (it._value && it._value->_type == kCastBitmap)
+				it._value->load();
+		}
+	}
 }
 
 void Cast::saveCastData(Common::SeekableWriteStream *writeStream, Resource *res) {

--- a/engines/director/cast.h
+++ b/engines/director/cast.h
@@ -92,6 +92,7 @@ public:
 	void loadArchive();
 	void setArchive(Archive *archive);
 	Archive *getArchive() const { return _castArchive; };
+	Movie *getMovie() const { return _movie; }
 	Common::String getMacName() const { return _macName; }
 	Common::String getCastName() const { return _castName; }
 	void setCastName(const Common::String &name) { _castName = name; }

--- a/engines/director/castmember/bitmap.cpp
+++ b/engines/director/castmember/bitmap.cpp
@@ -91,10 +91,11 @@ BitmapCastMember::BitmapCastMember(Cast *cast, uint16 castId, Common::SeekableRe
 			_bitsPerPixel = stream.readUint16();
 			int clutId = stream.readSint16();
 
-			if (clutId <= 0) // builtin palette
+			if (clutId < 0) // builtin palette (negative IDs map to system palettes)
 				_clut = CastMemberID(clutId - 1, -1);
-			else
+			else if (clutId > 0)
 				_clut = CastMemberID(clutId, DEFAULT_CAST_LIB);
+			// clutId == 0 means "use movie's current palette"; leave _clut as null CastMemberID(0,0)
 		} else {
 			_bitsPerPixel = 1;
 			_clut = CastMemberID(kClutSystemMac, -1);
@@ -138,14 +139,30 @@ BitmapCastMember::BitmapCastMember(Cast *cast, uint16 castId, Common::SeekableRe
 			}
 			int clutId = stream.readSint16();
 
-			if (clutId <= 0) // builtin palette
+			if (clutId < 0) // builtin palette (negative IDs map to system palettes)
 				_clut = CastMemberID(clutId - 1, -1);
 			else if (clutId > 0) {
-				if (clutCastLib == -1) {
+				if (clutCastLib <= 0) {
+					// clutCastLib <= 0 means no explicit cast lib was specified:
+					//   -1: ScummVM write convention for "same cast as bitmap"
+					//    0: Mac Director 6 convention for "primary/default palette cast"
+					// Try the bitmap's own cast first, then search all movie casts
+					// for a registered palette with this member ID.
 					clutCastLib = _cast->_castLibID;
+					Movie *paletteMovie = _cast->getMovie();
+					if (paletteMovie && !g_director->hasPalette(CastMemberID(clutId, clutCastLib))) {
+						for (auto &castPair : *paletteMovie->getCasts()) {
+							CastMemberID candidate(clutId, castPair._key);
+							if (g_director->hasPalette(candidate)) {
+								clutCastLib = castPair._key;
+								break;
+							}
+						}
+					}
 				}
 				_clut = CastMemberID(clutId, clutCastLib);
 			}
+			// clutId == 0 means "use movie's current palette"; leave _clut as null CastMemberID(0,0)
 			if (stream.pos() < stream.size()) {
 				// castSize > 26 bytes on D4, > 28 bytes on D5
 				stream.readUint16();
@@ -210,14 +227,30 @@ BitmapCastMember::BitmapCastMember(Cast *cast, uint16 castId, Common::SeekableRe
 				}
 				int clutId = stream.readSint16();
 
-				if (clutId <= 0) // builtin palette
+				if (clutId < 0) // builtin palette (negative IDs map to system palettes)
 					_clut = CastMemberID(clutId - 1, -1);
 				else if (clutId > 0) {
-					if (clutCastLib == -1) {
+					if (clutCastLib <= 0) {
+						// clutCastLib <= 0 means no explicit cast lib was specified:
+						//   -1: ScummVM write convention for "same cast as bitmap"
+						//    0: Mac Director 6 convention for "primary/default palette cast"
+						// Try the bitmap's own cast first, then search all movie casts
+						// for a registered palette with this member ID.
 						clutCastLib = _cast->_castLibID;
+						Movie *paletteMovie = _cast->getMovie();
+						if (paletteMovie && !g_director->hasPalette(CastMemberID(clutId, clutCastLib))) {
+							for (auto &castPair : *paletteMovie->getCasts()) {
+								CastMemberID candidate(clutId, castPair._key);
+								if (g_director->hasPalette(candidate)) {
+									clutCastLib = castPair._key;
+									break;
+								}
+							}
+						}
 					}
 					_clut = CastMemberID(clutId, clutCastLib);
 				}
+				// clutId == 0 means "use movie's current palette"; leave _clut as null CastMemberID(0,0)
 			} else {
 				_bitsPerPixel = 1;
 			}

--- a/engines/director/castmember/bitmap.cpp
+++ b/engines/director/castmember/bitmap.cpp
@@ -193,31 +193,38 @@ BitmapCastMember::BitmapCastMember(Cast *cast, uint16 castId, Common::SeekableRe
 
 		_regY = stream.readUint16();
 		_regX = stream.readUint16();
+		// 22 bytes of mandatory header
 
-		_updateFlags = stream.readByte();
+		if (stream.pos() < stream.size()) {
+			_updateFlags = stream.readByte();
 
-		// 22 bytes
-		// This is color image flag
-		if (_pitch & 0x8000) {
-			_pitch &= 0x3fff;
+			// This is color image flag
+			if (_pitch & 0x8000) {
+				_pitch &= 0x3fff;
 
-			_bitsPerPixel = stream.readByte();
+				_bitsPerPixel = stream.readByte();
 
-			int clutCastLib = -1;
-			if (version >= kFileVer500) {
-				clutCastLib = stream.readSint16();
-			}
-			int clutId = stream.readSint16();
-
-			if (clutId <= 0) // builtin palette
-				_clut = CastMemberID(clutId - 1, -1);
-			else if (clutId > 0) {
-				if (clutCastLib == -1) {
-					clutCastLib = _cast->_castLibID;
+				int clutCastLib = -1;
+				if (version >= kFileVer500) {
+					clutCastLib = stream.readSint16();
 				}
-				_clut = CastMemberID(clutId, clutCastLib);
+				int clutId = stream.readSint16();
+
+				if (clutId <= 0) // builtin palette
+					_clut = CastMemberID(clutId - 1, -1);
+				else if (clutId > 0) {
+					if (clutCastLib == -1) {
+						clutCastLib = _cast->_castLibID;
+					}
+					_clut = CastMemberID(clutId, clutCastLib);
+				}
+			} else {
+				_bitsPerPixel = 1;
 			}
 		} else {
+			// Minimal 22-byte header — no colour info present
+			if (_pitch & 0x8000)
+				_pitch &= 0x3fff;
 			_bitsPerPixel = 1;
 		}
 

--- a/engines/director/castmember/castmember.cpp
+++ b/engines/director/castmember/castmember.cpp
@@ -383,7 +383,12 @@ uint32 CastMember::writeCAStResource(Common::SeekableWriteStream *writeStream) {
 		if (castInfoToWrite) {
 			_cast->writeCastInfo(writeStream, _castId);
 		}
-	} else if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer600) {
+	} else if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer1200) {
+		// Director 5 and up share the same 12-byte CASt header (castType,
+		// castInfoSize, castDataSize); loadCastData() handles them with a single
+		// ">= kFileVer500" branch ("After D5 there are no changes"). This must
+		// therefore cover D6+ as well, otherwise D6 movies (e.g. TKKG2, version
+		// 0x4C7) write only the 8-byte CASt header with no body. D12 unverified.
 		writeStream->writeUint32BE((uint32)_type);
 		writeStream->writeUint32BE(castInfoToWrite);
 		writeStream->writeUint32BE(castDataToWrite);
@@ -439,8 +444,11 @@ uint32 CastMember::getCastResourceSize() {
 		if (_flags1 != 0xFF) {
 			headerSize += 1;
 		}
-	} else if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer600) {
-		// Header size for director version 5
+	} else if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer1200) {
+		// Header size for Director 5 and up. loadCastData() reads the same
+		// 12-byte CASt header (castType, castInfoSize, castDataSize) for every
+		// version from D5 onwards ("After D5 there are no changes"), so the
+		// size accounting must cover D6+ too. D12 is not yet verified.
 		headerSize = 12;		// See Cast::loadCastData() for director version 5
 	}
 

--- a/engines/director/castmember/digitalvideo.cpp
+++ b/engines/director/castmember/digitalvideo.cpp
@@ -740,7 +740,11 @@ uint32 DigitalVideoCastMember::getCastDataSize() {
 	if (_cast->_version >= kFileVer400 && _cast->_version < kFileVer500) {
 		// It has been observed that the DigitalVideoCastMember has _flags set to 0x00
 		return (_flags1 == 0xFF) ? 13 : 14;
-	} else if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer600) {
+	} else if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer1100) {
+		// The loader reads initialRect(8) + _vflags(4) regardless of version, so
+		// D6+ uses the same 12-byte layout as D5. Cover it here too -- otherwise
+		// saving a D6 digital video emits a 0-byte member while writeCastData()
+		// still writes 12 bytes.
 		return 8 + 4;
 	}
 

--- a/engines/director/castmember/filmloop.cpp
+++ b/engines/director/castmember/filmloop.cpp
@@ -36,6 +36,7 @@
 #include "director/window.h"
 #include "director/castmember/bitmap.h"
 #include "director/castmember/filmloop.h"
+#include "director/picture.h"
 
 
 namespace Director {
@@ -132,6 +133,15 @@ Common::Array<Channel> *FilmLoopCastMember::getSubChannels(Common::Rect &bbox, u
 		scaleY = (float)bbox.height() / _initialRect.height();
 	}
 
+	// Film loop placement/scaling diagnostics. Enable with: --debugflags=images --debuglevel=3
+	// If the placement bbox differs from the film loop's _initialRect, the sub-sprites
+	// get stretched (needToScale=1), which shows up as a distorted/oversized figure.
+	debugC(3, kDebugImages, "FilmLoopCastMember::getSubChannels(): cast %d, frame %d, %d sprites: filmloop _initialRect %dx%d@%d,%d, placement bbox %dx%d@%d,%d, needToScale %d (scaleX %.3f scaleY %.3f)",
+		_castId, frame, (int)spriteIds.size(),
+		_initialRect.width(), _initialRect.height(), _initialRect.left, _initialRect.top,
+		bbox.width(), bbox.height(), bbox.left, bbox.top,
+		needToScale, scaleX, scaleY);
+
 	// copy the sprites in order to the list
 	for (auto &iter : spriteIds) {
 		Sprite src = *_score->_scoreCache[frame]->_sprites[iter];
@@ -158,8 +168,49 @@ Common::Array<Channel> *FilmLoopCastMember::getSubChannels(Common::Rect &bbox, u
 			src._startPoint.x = (src._startPoint.x - _initialRect.left) + bbox.left;
 			src._startPoint.y = (src._startPoint.y - _initialRect.top) + bbox.top;
 
+			// Film-loop cells store each sprite at the loop's full canvas size,
+			// while the per-frame bitmaps are content-cropped to different widths
+			// and positioned inside that canvas via their registration point (the
+			// varying regX - initialRect.left is what makes the figure walk).
+			// Drawing them at the stored canvas width would stretch every frame by
+			// a different factor (and scale the registration offset), producing a
+			// distorted, oversized figure inside a fixed rectangle. Restore the
+			// bitmap's native size so it renders 1:1, anchored by its unscaled
+			// registration offset. Bitmaps already stored at native size (e.g.
+			// full-frame film loops) are unaffected.
+			if (src._cast && src._cast->_type == kCastBitmap) {
+				src._width = src._cast->_initialRect.width();
+				src._height = src._cast->_initialRect.height();
+			}
+
 			debugCN(5, kDebugImages, ", no scaling");
 		}
+
+		// Sub-sprite ink/transparency diagnostics (--debugflags=images --debuglevel=3).
+		// Each sub-sprite is drawn with its OWN ink; if the figure sub-sprite uses an
+		// opaque ink (Copy) or its background colour is not keyed, an opaque rectangle
+		// shows around the figure. Sample the raw bitmap's corners + centre: a uniform
+		// keyable margin means the background should be transparent (Fall 1); a textured
+		// margin means a baked scene background (Fall 2).
+		Common::Rect natRect = src._cast ? src._cast->_initialRect : Common::Rect();
+		int pTL = -1, pTR = -1, pBL = -1, pBR = -1, pC = -1;
+		if (src._cast && src._cast->_type == kCastBitmap) {
+			Picture *pic = ((BitmapCastMember *)src._cast)->_picture;
+			if (pic && pic->_surface.getPixels() && pic->_surface.format.bytesPerPixel == 1) {
+				const Graphics::Surface &s = pic->_surface;
+				int xr = s.w - 1, yb = s.h - 1, xc = s.w / 2, yc = s.h / 2;
+				pTL = *(const byte *)s.getBasePtr(0, 0);
+				pTR = *(const byte *)s.getBasePtr(xr, 0);
+				pBL = *(const byte *)s.getBasePtr(0, yb);
+				pBR = *(const byte *)s.getBasePtr(xr, yb);
+				pC  = *(const byte *)s.getBasePtr(xc, yc);
+			}
+		}
+		debugC(3, kDebugImages, "  film-loop sub-sprite %d: cast %s, ink %d, blend %d, NAT %dx%d, sprW/H %dx%d, final pos %d,%d, stretch %d, corners[TL=%d TR=%d BL=%d BR=%d C=%d]",
+			iter, src._castId.asString().c_str(), src._ink, src._blendAmount,
+			natRect.width(), natRect.height(), src._width, src._height,
+			src._startPoint.x, src._startPoint.y, src._stretch,
+			pTL, pTR, pBL, pBR, pC);
 
 		// Film loop frames are constructed as a series of Channels, much like how a normal frame
 		// is rendered by the Score. We don't include a pointer to the current Score here,

--- a/engines/director/castmember/filmloop.cpp
+++ b/engines/director/castmember/filmloop.cpp
@@ -318,7 +318,11 @@ uint32 FilmLoopCastMember::getCastDataSize() {
 	if (_cast->_version >= kFileVer400 && _cast->_version < kFileVer500) {
 		// It has been observed that the FilmCastMember has _flags as 0x00
 		return 8 + 4 + 2 + 2;
-	} else if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer600) {
+	} else if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer700) {
+		// D5 and D6 share the same cast-data layout (the loader reads them in a
+		// single ">= kFileVer400 && < kFileVer700" branch), so D6 must be covered
+		// here too -- otherwise saving a D6 film loop emits a 0-byte member while
+		// writeCastData() still writes 14 bytes.
 		return 8 + 4 + 2;
 	}
 

--- a/engines/director/castmember/palette.cpp
+++ b/engines/director/castmember/palette.cpp
@@ -138,8 +138,10 @@ void PaletteCastMember::unload() {
 // PaletteCastMember has no data in the 'CASt' resource or is ignored
 // This is the data in 'CASt' resource
 uint32 PaletteCastMember::getCastDataSize() {
-	if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer600) {
-		// It has been observed as well that the Data size in PaletteCastMember's CASt resource is 0 for d5
+	if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer1100) {
+		// The palette's member data size is 0 from D5 onward (the loader reads
+		// D5..D10 in one branch; the actual palette lives in the CLUT resource).
+		// Covering D6+ explicitly keeps this consistent with the loader.
 		return 0;
 	} else if (_cast->_version >= kFileVer400 && _cast->_version < kFileVer500) {
 		// (castType (see Cast::loadCastData() for Director 4 only) 1 byte

--- a/engines/director/castmember/script.cpp
+++ b/engines/director/castmember/script.cpp
@@ -146,17 +146,20 @@ uint32 ScriptCastMember::getCastDataSize() {
 	if (_cast->_version >= kFileVer400 && _cast->_version < kFileVer500) {
 		// 2 bytes for type and unk1 + 2 byte for castType and flags ma(see Cast::loadCastData() for Director 4 only
 		return 2 + 2;
-	} else if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer600) {
-		// type and unk1: 2 bytes
+	} else if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer1200) {
+		// Director 5 and up: the script type is stored as a single uint16BE
+		// (see the ScriptCastMember constructor, which reads it for every
+		// version < kFileVer1100). loadCastData() is unchanged from D5 onwards,
+		// so this applies to D6+ as well. D12 is not yet verified.
 		return 2;
 	} else {
-		warning("ScriptCastMember::writeCastData(): invalid or unhandled Script version: %d", _cast->_version);
+		warning("ScriptCastMember::getCastDataSize(): invalid or unhandled Script version: %d", _cast->_version);
 		return 0;
 	}
 }
 
 void ScriptCastMember::writeCastData(Common::SeekableWriteStream *writeStream) {
-	if (_cast->_version >= kFileVer400 && _cast->_version < kFileVer600) {
+	if (_cast->_version >= kFileVer400 && _cast->_version < kFileVer1200) {
 		writeStream->writeByte(0);		// unknown
 
 		switch (_scriptType) {

--- a/engines/director/castmember/script.cpp
+++ b/engines/director/castmember/script.cpp
@@ -54,7 +54,7 @@ ScriptCastMember::ScriptCastMember(Cast *cast, uint16 castId, Common::SeekableRe
 			break;
 		case 7:
 			_scriptType = kParentScript;
-			warning("Unhandled kParentScript %d", castId);
+			debugC(3, kDebugLoading, "  CASt: kParentScript %d", castId);
 			break;
 		default:
 			error("ScriptCastMember: Unprocessed script type: %d", type);

--- a/engines/director/castmember/shape.cpp
+++ b/engines/director/castmember/shape.cpp
@@ -222,10 +222,14 @@ uint32 ShapeCastMember::getCastDataSize() {
 	// For Director 4 : 1 byte extra for casttype (See Cast::loadCastData())
 	if (_cast->_version >= kFileVer400 && _cast->_version < kFileVer500) {
 		return 17 + 1;
-	} else if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer600) {
+	} else if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer1100) {
+		// D5 through D10 share the same shape layout (the loader reads them in a
+		// single ">= kFileVer400 && < kFileVer1100" branch), so D6+ must be
+		// covered here too -- otherwise saving a D6 shape emits a 0-byte member
+		// while writeCastData() still writes 17 bytes.
 		return 17;
 	} else {
-		warning("ScriptCastMember::writeCastData(): invalid or unhandled Script version: %d", _cast->_version);
+		warning("ShapeCastMember::getCastDataSize(): invalid or unhandled cast version: %d", _cast->_version);
 		return 0;
 	}
 }

--- a/engines/director/castmember/sound.cpp
+++ b/engines/director/castmember/sound.cpp
@@ -303,7 +303,10 @@ void SoundCastMember::setField(int field, const Datum &d) {
 // Similar to PaletteCastMember, SoundCastMember has no data in the 'CASt' resource or is ignored
 // This is the data in 'CASt' resource
 uint32 SoundCastMember::getCastDataSize() {
-	if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer600) {
+	if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer700) {
+		// Sound member data size is 0 from D5 onward (the sound samples live in
+		// the snd/sndH children, not the cast member data). Cover D6 explicitly
+		// (the loader has a dedicated D6 branch) to stay consistent.
 		return 0;
 	} else if (_cast->_version >= kFileVer400 && _cast->_version < kFileVer500) {
 		// (castType (see Cast::loadCastData() for Director 4 only) 1 byte

--- a/engines/director/castmember/text.cpp
+++ b/engines/director/castmember/text.cpp
@@ -134,8 +134,11 @@ TextCastMember::TextCastMember(Cast *cast, uint16 castId, Common::SeekableReadSt
 		_initialRect = Movie::readRect(stream);
 		_maxHeight = stream.readUint16();
 		_textShadow = stream.readByte();
-		_textFlags = stream.readByte(); // 1: editable, 2: auto tab 4: don't wrap
-		_editable = _textFlags & 0x1;
+		_textFlags = stream.readByte(); // 0x1 and 0x2: editable, 4: don't wrap
+		// Both 0x1 and 0x2 are seen on editable fields. "Ein Fall fuer Muetze &
+		// Co" marks its editable login fields with 0x2 (| 0x4 don't-wrap), while
+		// other games use 0x1, so treat either bit as editable.
+		_editable = (_textFlags & 0x3) != 0;
 
 		_textHeight = stream.readUint16();
 		_textSlant = 0;

--- a/engines/director/castmember/transition.cpp
+++ b/engines/director/castmember/transition.cpp
@@ -126,12 +126,16 @@ Common::String TransitionCastMember::formatInfo() {
 }
 
 uint32 TransitionCastMember::getCastDataSize() {
-	if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer600) {
+	// The loader (TransitionCastMember ctor) reads the same 6-byte layout for
+	// every version below kFileVer1100, so D6+ must be covered here too -- not
+	// just D5. Otherwise saving a movie with a transition cast member emits a
+	// 0-byte / unwritten member for D6.
+	if (_cast->_version >= kFileVer500 && _cast->_version < kFileVer1100) {
 		// Ignored 1 byte
 		// _chunkSize 1 byte
 		// _transType 1 byte
 		// _flags 1 byte
-		// _durationMiilis 2 bytes
+		// _durationMillis 2 bytes
 		return 6;
 	} else {
 		warning("TransitionCastMember()::getCastDataSize(): CastMember version invalid or not handled");
@@ -140,12 +144,14 @@ uint32 TransitionCastMember::getCastDataSize() {
 }
 
 void TransitionCastMember::writeCastData(Common::SeekableWriteStream *writeStream) {
-	if (_cast->_version >= kFileVer400 && _cast->_version < kFileVer600) {
+	if (_cast->_version >= kFileVer400 && _cast->_version < kFileVer1100) {
 		writeStream->writeByte(0);
 		writeStream->writeByte(_chunkSize);
 		writeStream->writeByte((uint8)_transType);
 		writeStream->writeByte(_flags);
-		writeStream->writeUint16LE(_durationMillis);
+		// The loader reads this with readUint16BE; write it big-endian to match,
+		// otherwise the duration is byte-swapped on reload.
+		writeStream->writeUint16BE(_durationMillis);
 	} else {
 		warning("TransitionCastMember()::writeCastData(): CastMember version invalid or not handled");
 	}

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -818,6 +818,13 @@ bool Channel::hasSubChannels() {
 Common::Array<Channel> *Channel::getSubChannels() {
 	if (_sprite->_cast) {
 		Common::Rect bbox = getBbox();
+		// Film loop placement diagnostics (--debugflags=images --debuglevel=3):
+		// the score sprite's width/height drive the bbox passed to getSubChannels;
+		// if they differ from the film loop's natural size the figure is scaled.
+		debugC(3, kDebugImages, "Channel::getSubChannels(): filmloop cast %s, sprW/H %dx%d, bbox %dx%d@%d,%d, loopFrame %d, ink %d, stretch %d",
+			_sprite->_castId.asString().c_str(), _sprite->_width, _sprite->_height,
+			bbox.width(), bbox.height(), bbox.left, bbox.top,
+			_filmLoopFrame, _sprite->_ink, _sprite->_stretch);
 		if (_sprite->_cast->_type == kCastFilmLoop)
 			return ((FilmLoopCastMember *)_sprite->_cast)->getSubChannels(bbox, _filmLoopFrame);
 		else if (_sprite->_cast->_type == kCastMovie)

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -510,6 +510,41 @@ void Channel::setClean(Sprite *nextSprite, bool partial) {
 		if (_sprite->_puppet || _sprite->_autoPuppet || (!nextSprite->isQDShape() && partial)) {
 			// Updating scripts, etc. does not require a full re-render
 			_sprite->_scriptId = nextSprite->_scriptId;
+
+			// When Lingo overrides only a sprite's cast member (`set the member of
+			// sprite`) on a sprite the score is still animating, the member is
+			// auto-puppeted but the position should keep following the score --
+			// otherwise the swapped-in member is stranded at the previous member's
+			// stale loc. We re-sync the position from the score only in exactly
+			// that case: the member was puppeted to something different than the
+			// score expects, the loc itself wasn't puppeted, and the score
+			// actually specified a position this frame (kSCBStartPoint). This
+			// deliberately leaves alone sprites whose member matches the score
+			// (their own loc is authoritative) and never touches anything but the
+			// position.
+			if (!_sprite->_puppet && _sprite->getAutoPuppet(kAPCast) &&
+					_sprite->_castId != nextSprite->_castId &&
+					!_sprite->getAutoPuppet(kAPLoc) && !_sprite->getAutoPuppet(kAPLocH) &&
+					!_sprite->getAutoPuppet(kAPLocV) && !_sprite->getAutoPuppet(kAPBbox) &&
+					!_sprite->getAutoPuppet(kAPRect) &&
+					(nextSprite->_copyBackMask & kSCBStartPoint) &&
+					_sprite->_startPoint != nextSprite->_startPoint) {
+				// Only adopt the score position if it actually places the sprite on
+				// the stage. A cleared/transitioning score track reports a (0,0)
+				// loc which, for a centre-registered sprite, would shove it mostly
+				// off the top-left -- never an intended placement (e.g. the
+				// full-screen backgrounds during a scene change). The genuine cases
+				// (the localised logo) land on-screen.
+				Common::Point regOff = _sprite->_cast ?
+					_sprite->_cast->getRegistrationOffset(_sprite->_width, _sprite->_height) :
+					Common::Point(0, 0);
+				int newLeft = nextSprite->_startPoint.x - regOff.x;
+				int newTop = nextSprite->_startPoint.y - regOff.y;
+				if (newLeft > -_sprite->_width / 2 && newTop > -_sprite->_height / 2) {
+					_sprite->_startPoint = nextSprite->_startPoint;
+					setDirty();
+				}
+			}
 		} else {
 			previousCastId = _sprite->_castId;
 			replaceSprite(nextSprite);

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -963,6 +963,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "kjoeties",			"Invasie van de Kjoeties" },
 	{ "klikker1", 			"Klikkerdeklik" },
 	{ "lannoo",				"Lannoo Nieuwe Media Demo" },
+	{ "lannoodummy",		"Lannoo Placeholder Dummy" },
 	{ "moordspel",			"Moordspel: Moord in Huize Huiver" },
 	{ "samson",				"Op Reis Met Samson & Gert" },
 	{ "welkom",				"Welkom op the Wereld" },
@@ -7627,7 +7628,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 	WINDEMO2_l("osaka2", "Demo", "OSAKA2.EXE",		  	 "t:a1b15df3e663f99b015753bc82e22bcd", 1410110,
 								 "WINMOVIE/BARGAIN.DIR", "d:949640df6d4db94e85b466da5e5d8470", 1880116, Common::JA_JPN, 501),
 
-    WINDEMO1_l("oscar2", "Demo", "Oscar2/START.EXE", "a288605e511c815d7fcea9de6780d548", 1287391, Common::NL_NLD, 501),
+    WINDEMO1_l("oscar2", "Demo", "Oscar2/START.EXE", "t:a288605e511c815d7fcea9de6780d548", 1287391, Common::NL_NLD, 501),
 
  	WINGAME1("oscar2", "Windows 3.1", "oshof16.exe", "t:f7eee50cc1e538417a969f6a26b449a4", 1081413, 501),
  	WINGAME1("oscar2", "Windows 95",  "oshof32.exe", "t:c65ee08c70eab2ff6ef2ac32bd93031c", 1559831, 501),
@@ -7701,7 +7702,7 @@ static const DirectorGameDescription gameDescriptions[] = {
 
 	//found on TKKG4 Verraad bij TKKG by Lannoo (Belgium)
 	WINDEMO1_l("pettson2dutchdemo", "", "pettdemo.exe", "t:99186d8de1156cabce545f66f413f9d0", 1430755, Common::NL_NLD, 501),
-
+	WINDEMO1_l("pettson2dutchdemo", "", "Pettson/pettdemo.exe", "t:99186d8de1156cabce545f66f413f9d0", 1430755, Common::NL_NLD, 501),
 
 	// From Japanese Star Trek: Borg DVD (2000)
 	WINGAME1_l("picarddossier", "DVD", "OMNIBORG.EXE",	"t:312801acbcbedcb6825414dad03538e8", 1501528, Common::JA_JPN, 501),
@@ -9623,6 +9624,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1("kgbpocahontas", "", "Pocahontas",	 "rt:3994eb4201e400d9baea84ac555e73dc", 112502, 702),
 	WINGAME2("kgbpocahontas", "", "CDGe.EXE",	 "t:7d1d6dba1026a1be63d60b7f14111619", 3037522,
 								  "CBAIOBJ.dir", "f:5f374ed90aca597fd43a0726ff2cf710",	204224, 702),
+
+	//found on TKKG Releases by Lannoo (Belgium)
+	WINGAME1_l("lannoodummy", "", "start_pc.exe", "t:2b8f3db3c94ebb395938ae2dc5bbb425", 1901292, Common::NL_NLD, 702),
 
 	WINDEMO1_l("kidpix", "Demo", "kidpix.exe", "t:edb63181702824aaacfffe73012cbff3", 7445882, Common::KO_KOR, 702),
 

--- a/engines/director/director.cpp
+++ b/engines/director/director.cpp
@@ -157,7 +157,6 @@ DirectorEngine::DirectorEngine(OSystem *syst, const DirectorGameDescription *gam
 		_machineType = 9;	// Macintosh IIci
 	}
 
-	_playbackPaused = false;
 	_centerStage = true;
 
 	_surface = nullptr;

--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -267,7 +267,6 @@ public:
 	int _colorDepth;
 	Common::HashMap<int, int> _KeyCodes;
 	int _machineType;
-	bool _playbackPaused;
 	bool _centerStage;
 	char _dirSeparator;
 	bool _fixStageSize;

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -860,6 +860,10 @@ void Frame::readMainChannelsD5(Common::MemoryReadStreamEndian &stream, uint16 of
 			break;
 		case 26:
 			_mainChannels.palette.paletteId.member = stream.readSint16();
+			// See case 240+2: {castLib 0, negative member} is not a valid palette;
+			// drop it so it is neither used nor cached.
+			if (_mainChannels.palette.paletteId.castLib == 0 && _mainChannels.palette.paletteId.member < 0)
+				_mainChannels.palette.paletteId = CastMemberID();
 			if (!g_director->hasPalette(_mainChannels.palette.paletteId)) {
 				// Mac Director may store castLib=0 as a "default palette cast" sentinel.
 				// Search all movie casts for a palette with this member number.
@@ -1287,6 +1291,10 @@ void Frame::readMainChannelsD6(Common::MemoryReadStreamEndian &stream, uint16 of
 			break;
 		case 120+2:
 			_mainChannels.palette.paletteId.member = stream.readSint16();
+			// See case 240+2: {castLib 0, negative member} is not a valid palette;
+			// drop it so it is neither used nor cached.
+			if (_mainChannels.palette.paletteId.castLib == 0 && _mainChannels.palette.paletteId.member < 0)
+				_mainChannels.palette.paletteId = CastMemberID();
 			if (!g_director->hasPalette(_mainChannels.palette.paletteId)) {
 				// Mac Director may store castLib=0 as a "default palette cast" sentinel.
 				// Search all movie casts for a palette with this member number.
@@ -1760,6 +1768,13 @@ void Frame::readMainChannelsD7(Common::MemoryReadStreamEndian &stream, uint16 of
 			break;
 		case 240+2:
 			_mainChannels.palette.paletteId.member = stream.readSint16();
+			// A palette of {castLib 0, negative member} (e.g. {0,-1}) is not a valid
+			// reference (castLib 0 is no real cast; a genuine built-in uses castLib -1).
+			// hasPalette() would still accept it as the built-in Mac palette via its
+			// member<0 normalization. Treat it as "no palette" so it is neither used
+			// nor cached into scoreCachedPaletteId, keeping the scene's real palette.
+			if (_mainChannels.palette.paletteId.castLib == 0 && _mainChannels.palette.paletteId.member < 0)
+				_mainChannels.palette.paletteId = CastMemberID();
 			if (!g_director->hasPalette(_mainChannels.palette.paletteId)) {
 				// Mac Director 6 may store castLib=0 as a "default palette cast" sentinel.
 				// When the explicit ID fails, search all movie casts for a palette with

--- a/engines/director/frame.cpp
+++ b/engines/director/frame.cpp
@@ -860,8 +860,24 @@ void Frame::readMainChannelsD5(Common::MemoryReadStreamEndian &stream, uint16 of
 			break;
 		case 26:
 			_mainChannels.palette.paletteId.member = stream.readSint16();
-			if (!g_director->hasPalette(_mainChannels.palette.paletteId))
-				_mainChannels.palette.paletteId = CastMemberID();
+			if (!g_director->hasPalette(_mainChannels.palette.paletteId)) {
+				// Mac Director may store castLib=0 as a "default palette cast" sentinel.
+				// Search all movie casts for a palette with this member number.
+				if (_mainChannels.palette.paletteId.castLib == 0 && _mainChannels.palette.paletteId.member > 0) {
+					Movie *palMovie = _score->getMovie();
+					if (palMovie) {
+						for (auto &castPair : *palMovie->getCasts()) {
+							CastMemberID candidate(_mainChannels.palette.paletteId.member, castPair._key);
+							if (g_director->hasPalette(candidate)) {
+								_mainChannels.palette.paletteId = candidate;
+								break;
+							}
+						}
+					}
+				}
+				if (!g_director->hasPalette(_mainChannels.palette.paletteId))
+					_mainChannels.palette.paletteId = CastMemberID();
+			}
 			if (!_mainChannels.palette.paletteId.isNull())
 				_mainChannels.scoreCachedPaletteId = _mainChannels.palette.paletteId;
 			break;
@@ -1271,8 +1287,24 @@ void Frame::readMainChannelsD6(Common::MemoryReadStreamEndian &stream, uint16 of
 			break;
 		case 120+2:
 			_mainChannels.palette.paletteId.member = stream.readSint16();
-			if (!g_director->hasPalette(_mainChannels.palette.paletteId))
-				_mainChannels.palette.paletteId = CastMemberID();
+			if (!g_director->hasPalette(_mainChannels.palette.paletteId)) {
+				// Mac Director may store castLib=0 as a "default palette cast" sentinel.
+				// Search all movie casts for a palette with this member number.
+				if (_mainChannels.palette.paletteId.castLib == 0 && _mainChannels.palette.paletteId.member > 0) {
+					Movie *palMovie = _score->getMovie();
+					if (palMovie) {
+						for (auto &castPair : *palMovie->getCasts()) {
+							CastMemberID candidate(_mainChannels.palette.paletteId.member, castPair._key);
+							if (g_director->hasPalette(candidate)) {
+								_mainChannels.palette.paletteId = candidate;
+								break;
+							}
+						}
+					}
+				}
+				if (!g_director->hasPalette(_mainChannels.palette.paletteId))
+					_mainChannels.palette.paletteId = CastMemberID();
+			}
 			if (!_mainChannels.palette.paletteId.isNull())
 				_mainChannels.scoreCachedPaletteId = _mainChannels.palette.paletteId;
 			break;
@@ -1728,8 +1760,25 @@ void Frame::readMainChannelsD7(Common::MemoryReadStreamEndian &stream, uint16 of
 			break;
 		case 240+2:
 			_mainChannels.palette.paletteId.member = stream.readSint16();
-			if (!g_director->hasPalette(_mainChannels.palette.paletteId))
-				_mainChannels.palette.paletteId = CastMemberID();
+			if (!g_director->hasPalette(_mainChannels.palette.paletteId)) {
+				// Mac Director 6 may store castLib=0 as a "default palette cast" sentinel.
+				// When the explicit ID fails, search all movie casts for a palette with
+				// this member number before giving up.
+				if (_mainChannels.palette.paletteId.castLib == 0 && _mainChannels.palette.paletteId.member > 0) {
+					Movie *palMovie = _score->getMovie();
+					if (palMovie) {
+						for (auto &castPair : *palMovie->getCasts()) {
+							CastMemberID candidate(_mainChannels.palette.paletteId.member, castPair._key);
+							if (g_director->hasPalette(candidate)) {
+								_mainChannels.palette.paletteId = candidate;
+								break;
+							}
+						}
+					}
+				}
+				if (!g_director->hasPalette(_mainChannels.palette.paletteId))
+					_mainChannels.palette.paletteId = CastMemberID();
+			}
 			if (!_mainChannels.palette.paletteId.isNull())
 				_mainChannels.scoreCachedPaletteId = _mainChannels.palette.paletteId;
 			break;

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -2008,7 +2008,11 @@ void LB::b_cancelIdleLoad(int nargs) {
 }
 
 void LB::b_continue(int nargs) {
-	g_director->_playbackPaused = false;
+	// pause/continue act on the current movie's playback head, which may be a
+	// MIAW selected via `tell window ...`. Pausing/continuing must not affect
+	// other movies (e.g. the stage), so the state lives on the Score.
+	if (g_director->getCurrentMovie())
+		g_director->getCurrentMovie()->getScore()->_playbackPaused = false;
 }
 
 void LB::b_dontPassEvent(int nargs) {
@@ -2141,7 +2145,9 @@ void LB::b_pass(int nargs) {
 }
 
 void LB::b_pause(int nargs) {
-	g_director->_playbackPaused = true;
+	// See b_continue(): pause only the current movie's playback head.
+	if (g_director->getCurrentMovie())
+		g_director->getCurrentMovie()->getScore()->_playbackPaused = true;
 }
 
 void LB::b_play(int nargs) {

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -3516,6 +3516,12 @@ void LB::b_sendAllSprites(int nargs) {
 	if (!score)
 		return;
 
+	// Ensure the current frame's sprite behaviors are instantiated before
+	// resolving the message (see b_sendSprite for the rationale). Otherwise a
+	// message sent during startMovie/initHotspots falls through to a me-less
+	// handler call, leaving `me` VOID.
+	score->createScriptInstances(score->getCurrentFrameNum());
+
 	bool anyHandled = false;
 	for (uint ch = 1; ch < score->_channels.size(); ch++) {
 		Channel *channel = score->_channels[ch];
@@ -3567,6 +3573,15 @@ void LB::b_sendSprite(int nargs) {
 	Channel *channel = score->getChannelById((uint16)spriteNum);
 	if (!channel)
 		return;
+
+	// The sprite's behaviors may not have been instantiated yet, e.g. when
+	// sendSprite is called from startMovie/initHotspots before the score has
+	// rendered the frame. Without an instance, the message would fall through
+	// to a plain (me-less) handler below, leaving `me` VOID and crashing on the
+	// first property access. Instantiate the current frame's behaviors first so
+	// the message reaches the real behavior instance with a valid `me`.
+	if (channel->_scriptInstanceList.empty() && channel->_sprite && !channel->_sprite->_behaviors.empty())
+		score->createScriptInstances(score->getCurrentFrameNum());
 
 	bool handled = false;
 	for (uint i = 0; i < channel->_scriptInstanceList.size(); i++) {

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -3355,8 +3355,17 @@ void LB::b_puppetSprite(int nargs) {
 			int spriteId = sprite.asInt();
 			Sprite *target = sc->getSpriteById(spriteId);
 			bool val = (bool)state.asInt();
-			bool refresh = (!val) && (target->_puppet);
+			bool refresh = (!val) && (target->_puppet || target->_autoPuppet);
 			target->_puppet = val;
+			if (!val) {
+				// Explicitly un-puppeting a sprite returns full control to the
+				// score, so also drop any auto-puppet flags that Lingo set
+				// implicitly (e.g. via `set the member of sprite`). Otherwise the
+				// sprite would stay frozen on screen and never be replaced by the
+				// score data again (e.g. TKKG2 rollover head/portrait sprites that
+				// are shown by puppeting and hidden with `puppetSprite n, FALSE`).
+				target->_autoPuppet = kAPNone;
+			}
 			if (refresh) {
 				// puppetSprite set to FALSE, copy back sprite data from frame cache
 				Channel *chan = sc->getChannelById(spriteId);

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1204,11 +1204,21 @@ void LB::b_getAt(int nargs) {
 	case ARRAY:
 	case POINT:
 	case RECT:
-		ARRBOUNDSCHECK(index, list);
+		// Original Director returns VOID for out-of-bounds access rather than erroring
+		if (index - 1 < 0 || index > (int)list.u.farr->arr.size()) {
+			debugC(3, kDebugLingoExec, "b_getAt: index out of bounds (%d of %d), returning VOID", index, (int)list.u.farr->arr.size());
+			g_lingo->pushVoid();
+			break;
+		}
 		g_lingo->push(list.u.farr->arr[index - 1]);
 		break;
 	case PARRAY:
-		ARRBOUNDSCHECK(index, list);
+		// Original Director returns VOID for out-of-bounds access rather than erroring
+		if (index - 1 < 0 || index > (int)list.u.parr->arr.size()) {
+			debugC(3, kDebugLingoExec, "b_getAt: index out of bounds (%d of %d), returning VOID", index, (int)list.u.parr->arr.size());
+			g_lingo->pushVoid();
+			break;
+		}
 		g_lingo->push(list.u.parr->arr[index - 1].v);
 		break;
 	default:

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -3523,6 +3523,7 @@ void LB::b_sendAllSprites(int nargs) {
 	score->createScriptInstances(score->getCurrentFrameNum());
 
 	bool anyHandled = false;
+	uint savedSpriteNum = movie->_currentSpriteNum;
 	for (uint ch = 1; ch < score->_channels.size(); ch++) {
 		Channel *channel = score->_channels[ch];
 		if (!channel)
@@ -3534,7 +3535,11 @@ void LB::b_sendAllSprites(int nargs) {
 			Symbol sym = instance.u.obj->getMethod(msgName);
 			if (sym.type == VOIDSYM)
 				continue;
+			// `the spriteNum of me` must resolve to the sprite whose behavior is
+			// running (see b_sendSprite), so set it per channel around the call.
+			movie->_currentSpriteNum = ch;
 			callBehaviorHandler(instance, msgName, extraArgs);
+			movie->_currentSpriteNum = savedSpriteNum;
 			anyHandled = true;
 		}
 	}
@@ -3584,6 +3589,7 @@ void LB::b_sendSprite(int nargs) {
 		score->createScriptInstances(score->getCurrentFrameNum());
 
 	bool handled = false;
+	uint savedSpriteNum = movie->_currentSpriteNum;
 	for (uint i = 0; i < channel->_scriptInstanceList.size(); i++) {
 		Datum instance = channel->_scriptInstanceList[i];
 		if (instance.type != OBJECT)
@@ -3591,7 +3597,14 @@ void LB::b_sendSprite(int nargs) {
 		Symbol sym = instance.u.obj->getMethod(msgName);
 		if (sym.type == VOIDSYM)
 			continue;
+		// Within the handler, `the spriteNum of me` must resolve to the target
+		// sprite, matching how processEvent sets _currentSpriteNum for real
+		// sprite events. Otherwise the behavior reads spriteNum 0 and operates
+		// on the wrong sprite (e.g. `set the cursor of sprite (the spriteNum of
+		// me)` ends up setting the stage cursor, sprite 0).
+		movie->_currentSpriteNum = (uint)spriteNum;
 		callBehaviorHandler(instance, msgName, extraArgs);
+		movie->_currentSpriteNum = savedSpriteNum;
 		handled = true;
 	}
 

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -2428,9 +2428,10 @@ void LB::b_startTimer(int nargs) {
 }
 
 void LB::b_stopEvent(int nargs) {
-	warning("STUB: b_stopEvent");
-	// TEquivalent to the dontPassEvent command used in earlier
-	//versions of Director, this command also applies to sprite scripts.
+	// Equivalent to the dontPassEvent command used in earlier versions of
+	// Director; this command also applies to sprite scripts. It prevents the
+	// current event message from being passed to subsequent locations in the
+	// message hierarchy.
 	g_lingo->_passEvent = false;
 }
 

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1940,9 +1940,51 @@ void LB::b_abort(int nargs) {
 	g_lingo->_abort = true;
 }
 
+// Helper: call a named handler on a single behavior instance with extra args.
+// extraArgs is stored in reverse order (as popped from stack).
+static void callBehaviorHandler(Datum &instance, const Common::String &msgName, const Common::Array<Datum> &extraArgs) {
+	Symbol sym = instance.u.obj->getMethod(msgName);
+	if (sym.type == VOIDSYM)
+		return;
+
+	g_lingo->push(instance);
+	for (int j = (int)extraArgs.size() - 1; j >= 0; j--)
+		g_lingo->push(extraArgs[j]);
+
+	int frame = g_lingo->_state->callstack.size();
+	LC::call(sym, 1 + (int)extraArgs.size(), false);
+	g_lingo->execute(frame);
+}
+
 void LB::b_call(int nargs) {
-	g_lingo->printSTUBWithArglist("b_call", nargs);
-	g_lingo->dropStack(nargs);
+	// call(#message, scriptInstance [, args...])
+	if (nargs < 2) {
+		warning("b_call: expected at least 2 args, got %d", nargs);
+		g_lingo->dropStack(nargs);
+		return;
+	}
+
+	int numExtraArgs = nargs - 2;
+	Common::Array<Datum> extraArgs;
+	for (int i = 0; i < numExtraArgs; i++)
+		extraArgs.push_back(g_lingo->pop());
+
+	Datum script = g_lingo->pop();
+	Datum message = g_lingo->pop();
+	Common::String msgName = message.asString();
+
+	if (script.type == OBJECT) {
+		callBehaviorHandler(script, msgName, extraArgs);
+	} else if (script.type == ARRAY) {
+		// call() accepts a list of instances
+		for (uint i = 0; i < script.u.farr->arr.size(); i++) {
+			Datum instance = script.u.farr->arr[i];
+			if (instance.type == OBJECT)
+				callBehaviorHandler(instance, msgName, extraArgs);
+		}
+	} else {
+		warning("b_call: expected OBJECT or list for script argument");
+	}
 }
 
 void LB::b_callAncestor(int nargs) {
@@ -3443,13 +3485,97 @@ void LB::b_rollOver(int nargs) {
 }
 
 void LB::b_sendAllSprites(int nargs) {
-	g_lingo->printSTUBWithArglist("b_sendAllSprites", nargs);
-	g_lingo->dropStack(nargs);
+	// sendAllSprites(#message [, args...])
+	if (nargs < 1) {
+		warning("b_sendAllSprites: expected at least 1 arg, got %d", nargs);
+		return;
+	}
+
+	int numExtraArgs = nargs - 1;
+	Common::Array<Datum> extraArgs;
+	for (int i = 0; i < numExtraArgs; i++)
+		extraArgs.push_back(g_lingo->pop());
+
+	Datum message = g_lingo->pop();
+	Common::String msgName = message.asString();
+
+	Movie *movie = g_director->getCurrentMovie();
+	if (!movie)
+		return;
+	Score *score = movie->getScore();
+	if (!score)
+		return;
+
+	bool anyHandled = false;
+	for (uint ch = 1; ch < score->_channels.size(); ch++) {
+		Channel *channel = score->_channels[ch];
+		if (!channel)
+			continue;
+		for (uint i = 0; i < channel->_scriptInstanceList.size(); i++) {
+			Datum instance = channel->_scriptInstanceList[i];
+			if (instance.type != OBJECT)
+				continue;
+			Symbol sym = instance.u.obj->getMethod(msgName);
+			if (sym.type == VOIDSYM)
+				continue;
+			callBehaviorHandler(instance, msgName, extraArgs);
+			anyHandled = true;
+		}
+	}
+
+	if (!anyHandled) {
+		for (int j = (int)extraArgs.size() - 1; j >= 0; j--)
+			g_lingo->push(extraArgs[j]);
+		g_lingo->executeHandler(msgName, numExtraArgs);
+	}
 }
 
 void LB::b_sendSprite(int nargs) {
-	g_lingo->printSTUBWithArglist("b_sendSprite", nargs);
-	g_lingo->dropStack(nargs);
+	// sendSprite(whichSprite, #message [, args...])
+	if (nargs < 2) {
+		warning("b_sendSprite: expected at least 2 args, got %d", nargs);
+		g_lingo->dropStack(nargs);
+		return;
+	}
+
+	int numExtraArgs = nargs - 2;
+	Common::Array<Datum> extraArgs;
+	for (int i = 0; i < numExtraArgs; i++)
+		extraArgs.push_back(g_lingo->pop());
+
+	Datum message = g_lingo->pop();
+	int spriteNum = g_lingo->pop().asInt();
+	Common::String msgName = message.asString();
+
+	Movie *movie = g_director->getCurrentMovie();
+	if (!movie)
+		return;
+	Score *score = movie->getScore();
+	if (!score)
+		return;
+
+	Channel *channel = score->getChannelById((uint16)spriteNum);
+	if (!channel)
+		return;
+
+	bool handled = false;
+	for (uint i = 0; i < channel->_scriptInstanceList.size(); i++) {
+		Datum instance = channel->_scriptInstanceList[i];
+		if (instance.type != OBJECT)
+			continue;
+		Symbol sym = instance.u.obj->getMethod(msgName);
+		if (sym.type == VOIDSYM)
+			continue;
+		callBehaviorHandler(instance, msgName, extraArgs);
+		handled = true;
+	}
+
+	if (!handled) {
+		// Pass down the hierarchy: frame script, movie scripts
+		for (int j = (int)extraArgs.size() - 1; j >= 0; j--)
+			g_lingo->push(extraArgs[j]);
+		g_lingo->executeHandler(msgName, numExtraArgs);
+	}
 }
 
 void LB::b_spriteBox(int nargs) {

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -4245,10 +4245,12 @@ void LB::b_member(int nargs) {
 	}
 
 	if (res.member > g_lingo->getMembersNum(res.castLib)) {
-		// D6 and up does not error on non-existing cast members
-		if (g_director->getVersion() < 600) {
-			g_lingo->lingoError("b_member: Cast member ID out of range");
-		}
+		// Referencing a not-yet-existing cast member is legal in Director: the
+		// reference is used to create the member (e.g. pasteClipBoardInto() or
+		// "set the name of member ..."). Don't halt execution -- "Ein Fall fuer
+		// Muetze & Co" clones a template player into the next free slot to save
+		// a new profile. (D6+ already didn't error here.)
+		debugC(3, kDebugLingoExec, "b_member: Cast member %s does not (yet) exist", res.asString().c_str());
 	}
 	g_lingo->push(res);
 }

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -1664,6 +1664,23 @@ void LC::call(const Common::String &name, int nargs, bool allowRetVal) {
 		}
 	}
 
+	// Lingo builtin functions in the "List" category have very strange override mechanics.
+	// If the first argument is an ARRAY or PARRAY (or POINT/RECT), it will use the builtin.
+	// Otherwise, it will fall back to whatever handler is defined globally.
+	//
+	// This must be decided before the me-object method lookup below: a parent/movie
+	// script that defines its own handler with the same name as a list builtin (e.g. a
+	// custom `getLast`) would otherwise shadow the builtin when calling it on a list from
+	// within one of its own methods (where `me` is an object holding that method).
+	bool useListBuiltin = false;
+	if (g_lingo->_builtinListHandlers.contains(name) && nargs >= 1) {
+		Datum firstArg = g_lingo->peek(nargs - 1);
+		if (firstArg.type == ARRAY || firstArg.type == PARRAY ||
+				firstArg.type == POINT || firstArg.type == RECT) {
+			useListBuiltin = true;
+		}
+	}
+
 	// If we're calling from within a me object, and it has a function handler with a
 	// matching name, include the me object in the CFrame (so we still get property lookups).
 	// Doesn't matter that the first arg isn't the me object (which would have been caught
@@ -1672,7 +1689,7 @@ void LC::call(const Common::String &name, int nargs, bool allowRetVal) {
 	// If the method is called from outside and without the object as the first arg,
 	// it will still work using the normal getHandler lookup.
 	// However properties will return garbage (the number 3??).
-	if (g_lingo->_state->me.type == OBJECT) {
+	if (!useListBuiltin && g_lingo->_state->me.type == OBJECT) {
 		AbstractObject *target = g_lingo->_state->me.u.obj;
 		funcSym = target->getMethod(name);
 		if (funcSym.type != VOIDSYM) {
@@ -1684,16 +1701,8 @@ void LC::call(const Common::String &name, int nargs, bool allowRetVal) {
 	// Handler
 	funcSym = g_lingo->getHandler(name);
 
-	if (g_lingo->_builtinListHandlers.contains(name) && nargs >= 1) {
-		// Lingo builtin functions in the "List" category have very strange override mechanics.
-		// If the first argument is an ARRAY or PARRAY, it will use the builtin.
-		// Otherwise, it will fall back to whatever handler is defined globally.
-		Datum firstArg = g_lingo->peek(nargs - 1);
-		if (firstArg.type == ARRAY || firstArg.type == PARRAY ||
-				firstArg.type == POINT || firstArg.type == RECT) {
-			funcSym = g_lingo->_builtinListHandlers[name];
-		}
-	}
+	if (useListBuiltin)
+		funcSym = g_lingo->_builtinListHandlers[name];
 
 	if (funcSym.type == VOIDSYM) { // The built-ins could be overridden
 		// Builtin

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -1784,7 +1784,7 @@ void LC::call(const Symbol &funcSym, int nargs, bool allowRetVal) {
 					nargs++;
 				}
 			}
-		} else if (funcSym.nargs > nargs || funcSym.maxArgs < nargs) {
+		} else if (funcSym.nargs > nargs) {
 			warning("Incorrect number of arguments for builtin '%s' (%d, expected %d to %d). Dropping %d stack items.",
 						funcSym.name->c_str(), nargs, funcSym.nargs, funcSym.maxArgs, nargs);
 
@@ -1796,6 +1796,19 @@ void LC::call(const Symbol &funcSym, int nargs, bool allowRetVal) {
 				g_lingo->pushVoid();
 
 			return;
+		} else if (funcSym.maxArgs < nargs) {
+			// Lingo ignores extra (trailing) arguments passed to a builtin, and
+			// several games rely on this -- e.g. "Mütze & Co" calls getLast(list, 2)
+			// even though getLast() takes a single argument. The surplus arguments
+			// are the last ones pushed, i.e. on top of the stack, so drop them and
+			// call the builtin normally instead of erroring out.
+			debugC(1, kDebugLingoExec, "Dropping %d extra argument(s) for builtin '%s' (%d, expected %d to %d)",
+						nargs - funcSym.maxArgs, funcSym.name->c_str(), nargs, funcSym.nargs, funcSym.maxArgs);
+
+			while (nargs > funcSym.maxArgs) {
+				g_lingo->pop();
+				nargs--;
+			}
 		}
 	}
 

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -801,7 +801,41 @@ Datum Score::createScriptInstance(BehaviorElement *behavior) {
 
 	debugC(1, kDebugLingoExec, "   Instantiated behavior %s", behavior->toString().c_str());
 
-	// No initializer, we are done
+	// Seed properties from the behavior's getPropertyDescriptionList #default
+	// values. Director initialises behavior properties to these declared
+	// defaults; the score's initializerParams (applied below) then override
+	// them. Without this, a placement with empty/absent params leaves the
+	// properties VOID instead of their default (e.g. #default: EMPTY -> "").
+	{
+		Symbol descSym = instance.u.obj->getMethod("getPropertyDescriptionList");
+		if (descSym.type != VOIDSYM) {
+			g_lingo->push(instance);
+			int callFrame = g_lingo->_state->callstack.size();
+			LC::call(descSym, 1, true);
+			g_lingo->execute(callFrame);
+			Datum descList = g_lingo->pop();
+
+			if (descList.type == PARRAY) {
+				for (uint k = 0; k < descList.u.parr->arr.size(); k++) {
+					Datum propName = descList.u.parr->arr[k].p;
+					Datum propDesc = descList.u.parr->arr[k].v;
+					if (propDesc.type != PARRAY)
+						continue;
+
+					// Each property's description is itself a proplist; pull
+					// out its #default entry and assign it to the instance.
+					for (uint d = 0; d < propDesc.u.parr->arr.size(); d++) {
+						if (propDesc.u.parr->arr[d].p.asString().equalsIgnoreCase("default")) {
+							instance.u.obj->setProp(propName.asString(), propDesc.u.parr->arr[d].v);
+							break;
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// No initializer, the defaults seeded above are all we have
 	if (behavior->initializerIndex == 0)
 		return instance;
 

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -863,9 +863,30 @@ void Score::createScriptInstances(int frameNum) {
 		Channel *channel = _channels[i];
 		Sprite *sprite = channel->_sprite;
 
-		// The frame does not belong to the range
-		if (frameNum < channel->_startFrame || frameNum > channel->_endFrame)
+		// The frame does not belong to the range.
+		// If the channel has not been set up yet (startFrame == -1), setClean() has not
+		// run for this frame yet — e.g. createScriptInstances was called early to allow
+		// prepareFrame to fire before rendering. Fall back to the current frame's sprite
+		// info to detect new sprites entering this frame.
+		if (channel->_startFrame == -1) {
+			if (i < (int)_currentFrame->_sprites.size()) {
+				Sprite *nextSprite = _currentFrame->_sprites[i];
+				if (nextSprite && nextSprite->_spriteInfo.startFrame == frameNum) {
+					// New sprite enters on this channel at this frame.
+					// Use it for behavior instantiation and pre-set the channel range
+					// so that subsequent calls (from updateSprites) find it correctly.
+					sprite = nextSprite;
+					channel->_startFrame = nextSprite->_spriteInfo.startFrame;
+					channel->_endFrame   = nextSprite->_spriteInfo.endFrame;
+				} else {
+					continue;
+				}
+			} else {
+				continue;
+			}
+		} else if (frameNum < channel->_startFrame || frameNum > channel->_endFrame) {
 			continue;
+		}
 
 		// We create scriptInstance only for new sprites
 		if (channel->_scriptInstanceList.size() != 0)

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -350,7 +350,15 @@ void Movie::resolveScriptEvent(LingoEvent &event) {
 				return;
 
 			if (_vm->getVersion() >= 600) {
-				if (_score->_scriptChannelScriptInstance.type == OBJECT) {
+				// Only resolve the frame script-channel behavior if it actually
+				// has a handler for this event. Otherwise a handler-less frame
+				// behavior (e.g. a "go the frame" Loop with only on exitFrame)
+				// would be run as a no-op for keyDown/mouseDown yet still consume
+				// the pass-through (_passEvent = passByDefault = false), swallowing
+				// the subsequent movie-level handler. This matches the cast-handler
+				// branch below, which checks _eventHandlers.contains(event.event).
+				if (_score->_scriptChannelScriptInstance.type == OBJECT &&
+						_score->_scriptChannelScriptInstance.u.obj->getMethod(_lingo->_eventHandlerTypes[event.event]).type != VOIDSYM) {
 					event.scriptType = kScoreScript;
 					event.scriptId = CastMemberID(); // No ID for the script channel script
 					event.scriptInstance = _score->_scriptChannelScriptInstance.u.obj;

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -622,8 +622,19 @@ void Movie::queueInputEvent(LEvent event, int targetId, Common::Point pos) {
 void Movie::processEvent(LEvent event, int targetId) {
 	Common::Queue<LingoEvent> queue;
 	queueEvent(queue, event, targetId);
+	// This may be invoked synchronously from deep inside another movie's Lingo
+	// execution (e.g. `set the fileName of window ...` triggers a stopMovie
+	// event on the window's old movie). Switching the current window to this
+	// movie's window is required so the event handlers resolve against the
+	// right movie, but we must restore it afterwards, otherwise the caller's
+	// movie-relative lookups (handlers, `script ...`, cast members) would keep
+	// targeting this window's movie. The main loop only resets the current
+	// window at frame boundaries, which is too late for nested calls.
+	Window *savedWindow = _vm->getCurrentWindow();
 	_vm->setCurrentWindow(this->getWindow());
 	_lingo->processEvents(queue, false);
+	if (savedWindow)
+		_vm->setCurrentWindow(savedWindow);
 }
 
 void Movie::broadcastEvent(LEvent event) {
@@ -634,8 +645,14 @@ void Movie::broadcastEvent(LEvent event) {
 			queueEvent(queue, event, i);
 		}
 	}
+	// See processEvent(): restore the current window after dispatching, so a
+	// nested broadcast does not leave the current window pointing at this
+	// movie's window for the caller.
+	Window *savedWindow = _vm->getCurrentWindow();
 	_vm->setCurrentWindow(this->getWindow());
 	_lingo->processEvents(queue, false);
+	if (savedWindow)
+		_vm->setCurrentWindow(savedWindow);
 }
 
 void Lingo::processEvents(Common::Queue<LingoEvent> &queue, bool isInputEvent) {

--- a/engines/director/lingo/lingo-funcs.cpp
+++ b/engines/director/lingo/lingo-funcs.cpp
@@ -40,10 +40,11 @@
 namespace Director {
 
 void Lingo::func_goto(Datum &frame, Datum &movie, bool calledfromgo) {
-	_vm->_playbackPaused = false;
-
 	if (!_vm->getCurrentMovie())
 		return;
+
+	// A `go` resumes the current movie's playback head.
+	_vm->getCurrentMovie()->getScore()->_playbackPaused = false;
 
 	if (movie.type == VOID && frame.type == VOID)
 		return;

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -2620,6 +2620,16 @@ void Lingo::getObjectProp(Datum &obj, Common::String &propName) {
 		LC::call(_builtinFuncs[propName], 1, true);
 		return;
 	}
+	// Accessing a property on VOID (e.g. an uninitialised "me", or a getAt() that
+	// returned VOID for an out-of-bounds index) is not a fatal error in original
+	// Director: it simply yields VOID. Several TKKG behaviors rely on this (e.g.
+	// initHotspots -> isHot, where the hotspot list can contain/return VOID),
+	// otherwise scene initialisation aborts with an "Uncaught Lingo error".
+	if (obj.type == VOID) {
+		debugC(3, kDebugLingoExec, "Lingo::getObjectProp: property '%s' on VOID object, returning VOID", propName.c_str());
+		g_lingo->push(d);
+		return;
+	}
 	g_lingo->lingoError("Lingo::getObjectProp: Invalid object: %s", obj.asString(true).c_str());
 	g_lingo->push(d);
 }

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -961,7 +961,7 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d = g_lingo->_state->callstack[g_lingo->_state->callstack.size() - 1]->paramCount;
 		break;
 	case kThePauseState:
-		d = (int) g_director->_playbackPaused;
+		d = (int) (g_director->getCurrentMovie() ? g_director->getCurrentMovie()->getScore()->_playbackPaused : 0);
 		break;
 	case kThePerFrameHook:
 		d = _perFrameHook;

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -2060,6 +2060,10 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 		if (!d.asInt()) {
 			// TODO: Properly reset sprite properties after puppet disabled.
 			sprite->_moveable = false;
+			// Returning control to the score also clears any implicit auto-puppet
+			// flags, so the sprite can be replaced by score data again instead of
+			// staying frozen on screen.
+			sprite->_autoPuppet = kAPNone;
 		}
 		break;
 	case kTheRect:

--- a/engines/director/lingo/xtras/f/filextra.cpp
+++ b/engines/director/lingo/xtras/f/filextra.cpp
@@ -20,8 +20,10 @@
  */
 
 #include "common/system.h"
+#include "common/fs.h"
 
 #include "director/director.h"
+#include "director/util.h"
 #include "director/lingo/lingo.h"
 #include "director/lingo/lingo-object.h"
 #include "director/lingo/lingo-utils.h"
@@ -153,12 +155,63 @@ XOBJSTUB(FileXtra::m_RenameFile, 0)
 XOBJSTUB(FileXtra::m_DeleteFile, 0)
 XOBJSTUB(FileXtra::m_CopyFile, 0)
 XOBJSTUB(FileXtra::m_GetFileModDate, 0)
-XOBJSTUB(FileXtra::m_DirectoryExists, 0)
+// DirectoryExists string dirName
+// FileXtra convention: returns 0 if the directory exists, a negative error
+// code otherwise.
+void FileXtra::m_DirectoryExists(int nargs) {
+	ARGNUMCHECK(1)
+	Common::String dirName = g_lingo->pop().asString();
+
+	Common::Path path = findPath(dirName, true, true, true);
+	g_lingo->push(Datum(path.empty() ? -1 : 0));
+}
+
+// DirectoryToList string dirName
+// Returns a Lingo list of the files and folders in dirName. Folder names are
+// suffixed with the platform path delimiter. Returns VOID if dirName is not a
+// valid directory (matching the original FileXtra behaviour).
+void FileXtra::m_DirectoryToList(int nargs) {
+	ARGNUMCHECK(1)
+	Common::String dirName = g_lingo->pop().asString();
+
+	Datum result; // VOID by default
+
+	Common::Path path = findPath(dirName, true, true, true);
+	if (path.empty()) {
+		warning("FileXtra::m_DirectoryToList(): directory not found: %s", dirName.c_str());
+		g_lingo->push(result);
+		return;
+	}
+
+	Common::FSNode dir(path);
+	Common::FSList fslist;
+	if (!dir.isDirectory() || !dir.getChildren(fslist, Common::FSNode::kListAll)) {
+		g_lingo->push(result);
+		return;
+	}
+
+	result.type = ARRAY;
+	result.u.farr = new FArray();
+	for (auto &node : fslist) {
+		Common::String name = node.getName();
+		if (node.isDirectory())
+			name += g_director->_dirSeparator;
+		result.u.farr->arr.push_back(Datum(name));
+	}
+
+	g_lingo->push(result);
+}
+
+// The following directory functions modify the filesystem (create/delete/copy).
+// ScummVM intentionally sandboxes the game's filesystem access: FSNode offers no
+// recursive delete, and writing outside the save area is not supported. These
+// are therefore left as stubs returning 0 ("success") so that callers relying on
+// their side effects do not error out; implement properly only if a target game
+// actually requires the mutation.
 XOBJSTUB(FileXtra::m_CreateDirectory, 0)
 XOBJSTUB(FileXtra::m_DeleteDirectory, 0)
 XOBJSTUB(FileXtra::m_XDeleteDirectory, 0)
 XOBJSTUB(FileXtra::m_CopyDirectory, 0)
 XOBJSTUB(FileXtra::m_XCopyDirectory, 0)
-XOBJSTUB(FileXtra::m_DirectoryToList, 0)
 
 }

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -135,6 +135,12 @@ void Movie::setArchive(Archive *archive) {
 		// D4 or lower, only 1 cast
 		_cast->setArchive(archive);
 	}
+	// The cast-lib mapping (MCsL) may be empty or may not list the default
+	// internal library (e.g. TKKG2's score.dxr). In that case the main cast was
+	// never given an archive, so loadConfig() would fail with "No archive
+	// specified" and the movie load aborts. Fall back to the movie's own archive.
+	if (!_cast->getArchive())
+		_cast->setArchive(archive);
 	// Frame Labels
 	if ((r = archive->getMovieResourceIfPresent(MKTAG('V', 'W', 'L', 'B')))) {
 		_score->loadLabels(*r);
@@ -369,7 +375,12 @@ void Movie::loadFileInfo(Common::SeekableReadStreamEndian &stream) {
 	_allowOutdatedLingo = (fileInfo.flags & kMovieFlagAllowOutdatedLingo) != 0;
 	_remapPalettesWhenNeeded = (fileInfo.flags & kMovieFlagRemapPalettesWhenNeeded) != 0;
 
-	_script = fileInfo.strings[0].readString(false);
+	// A VWFI resource can carry fewer entries than usual (e.g. TKKG2's score.dxr
+	// has an empty info table). Guard every access so we don't read past the end.
+	uint numStrings = fileInfo.strings.size();
+
+	if (numStrings > 0)
+		_script = fileInfo.strings[0].readString(false);
 
 	if (!_script.empty() && ConfMan.getBool("dump_scripts"))
 		_cast->dumpScript(_script.c_str(), kMovieScript, 0);
@@ -377,12 +388,15 @@ void Movie::loadFileInfo(Common::SeekableReadStreamEndian &stream) {
 	if (!_script.empty())
 		_cast->_lingoArchive->addCode(_script, kMovieScript, 0, nullptr, kLPPTrimGarbage);
 
-	_changedBy = fileInfo.strings[1].readString();
-	_createdBy = fileInfo.strings[2].readString();
-	_origDirectory = fileInfo.strings[3].readString();
+	if (numStrings > 1)
+		_changedBy = fileInfo.strings[1].readString();
+	if (numStrings > 2)
+		_createdBy = fileInfo.strings[2].readString();
+	if (numStrings > 3)
+		_origDirectory = fileInfo.strings[3].readString();
 
 	uint16 preload = 0;
-	if (fileInfo.strings[4].len) {
+	if (numStrings > 4 && fileInfo.strings[4].len) {
 		if (stream.isBE())
 			preload = READ_BE_INT16(fileInfo.strings[4].data);
 		else

--- a/engines/director/resource.cpp
+++ b/engines/director/resource.cpp
@@ -603,7 +603,17 @@ void Window::loadXtrasFromPath() {
 	// five layers deep in nested folders within this folder,
 	// and they'll still be recognized.
 	Common::ArchiveMemberList targets;
+	// Xtras folder at the game/search root.
 	SearchMan.listMatchingMembers(targets, Common::Path("xtras/*"), true);
+	// Director treats the Xtras folder as the one on the same level as the
+	// application. For titles whose projector is nested below the game root
+	// (e.g. installers under SETUP/WINxx/), the Xtras folder is not at the root.
+	// Match an "xtras" folder at any depth as well. matchPathComponents=false
+	// lets '*' span path separators; the leading "*/" requires a real path
+	// segment before "xtras/" so unrelated names ending in "xtras" are skipped.
+	// openXLib() dedups by xlib name, so overlaps with the root search above
+	// (and across WINxx/WIN95 variants) are harmless.
+	SearchMan.listMatchingMembers(targets, Common::Path("*/xtras/*"), false);
 	for (auto &it : targets) {
 		if (it->isDirectory())
 			continue;

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1155,6 +1155,14 @@ void Score::setLastPalette() {
 			return;
 	}
 
+	// The resolved palette can still be the bogus {castLib 0, negative member}
+	// value (e.g. via the movie default palette, which is often {-1,0} for these
+	// scene movies). That is not a real palette; switching to it would display
+	// the scene with the wrong (Mac system) palette. Keep the palette currently
+	// in effect instead.
+	if (currentPalette.castLib == 0 && currentPalette.member < 0)
+		return;
+
 	// If the palette is defined in the frame and doesn't match
 	// the current one, set it
 	bool paletteChanged = (currentPalette != g_director->_lastPalette) && (!currentPalette.isNull());
@@ -1165,9 +1173,22 @@ void Score::setLastPalette() {
 
 		// Switch to a new palette immediately if:
 		// - this is color cycling mode, or
-		// - the cached palette ID is different (i.e. we jumped in the score)
-		if (_currentFrame->_mainChannels.palette.colorCycling || isCachedPalette)
+		// - the cached palette ID is different (i.e. we jumped in the score), or
+		// - this is a normal (non-fade) palette set from the frame.
+		//
+		// In all these cases the whole stage must be re-rendered against the new
+		// palette. Otherwise only the per-frame dirty rectangles (e.g. a moving
+		// character) get the new palette while the static background keeps the old
+		// one, which shows up as a brighter/mismatched rectangle around the moving
+		// sprite (observed in TKKG1/TKKG2 when a figure carrying its own palette
+		// "member 1 of castLib 2" walks into the scene).
+		if (_currentFrame->_mainChannels.palette.colorCycling || isCachedPalette
+				|| _currentFrame->_mainChannels.palette.normal) {
 			g_director->setPalette(g_director->_lastPalette);
+			// Force a full-stage redraw so the background is re-rendered with the
+			// new palette, not just the dirty rectangles.
+			_window->_resetScreen = true;
+		}
 	}
 
 }

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -86,6 +86,7 @@ Score::Score(Movie *movie, bool haveInteractivity) {
 	_activeFade = false;
 	_exitFrameCalled = false;
 	_stopPlayCalled = false;
+	_playbackPaused = false;
 	_playState = kPlayNotStarted;
 
 	_numChannelsDisplayed = 0;
@@ -440,7 +441,7 @@ bool Score::isWaitingForNextFrame() {
 void Score::updateCurrentFrame() {
 	uint32 nextFrameNumberToLoad = _curFrameNumber;
 
-	if (!_vm->_playbackPaused) {
+	if (!_playbackPaused) {
 		if (_nextFrame) {
 			// With the advent of demand loading frames and due to partial updates, we rebuild our channel data
 			// when jumping.
@@ -506,7 +507,7 @@ void Score::updateCurrentFrame() {
 		// Finally, update the channels and buffer any dirty rectangles.
 		// This will ignore any channel data that is overridden with the puppet flag.
 		updateSprites(kRenderModeNormal, true);
-	} else if (!_vm->_playbackPaused) {
+	} else if (!_playbackPaused) {
 		// Loading the same frame; e.g. "go to frame".
 		// This is mostly a no-op, however any sprite changes for
 		// non-puppet sprites will be reverted.
@@ -626,7 +627,7 @@ void Score::update() {
 	}
 
 	// Process timeout events independently of the frame delay
-	if (_haveInteractivity && !_vm->_playbackPaused) {
+	if (_haveInteractivity && !_playbackPaused) {
 		if (_vm->getMacTicks() - _movie->_lastTimeOut >= _movie->_timeOutLength) {
 			_movie->processEvent(kEventTimeout);
 			_movie->_lastTimeOut = _vm->getMacTicks();
@@ -651,7 +652,7 @@ void Score::update() {
 	}
 
 	// For previous frame
-	if (!_window->_newMovieStarted && !_vm->_playbackPaused) {
+	if (!_window->_newMovieStarted && !_playbackPaused) {
 		// When Lingo::func_goto* is called, _nextFrame is set
 		// and _skipFrameAdvance is set to true.
 		// exitFrame is not called in this case.
@@ -685,7 +686,7 @@ void Score::update() {
 	}
 
 	// Kill behaviors if they are going to expire next frame
-	if (!_vm->_playbackPaused)
+	if (!_playbackPaused)
 		killScriptInstances(_nextFrame ? _nextFrame : _curFrameNumber + 1);
 
 	CastMemberID oldSound1 = _currentFrame->_mainChannels.sound1;
@@ -716,7 +717,7 @@ void Score::update() {
 		// Director 4 and below will allow infinite recursion via the perFrameHook.
 		if (_version < kFileVer500) {
 			// new frame, first call the perFrameHook (if one exists)
-			if (!_window->_newMovieStarted && !_vm->_playbackPaused) {
+			if (!_window->_newMovieStarted && !_playbackPaused) {
 				// Call the perFrameHook as soon as a frame switch is done.
 				// If there is a transition, the perFrameHook is called
 				// after each transition subframe instead of here.
@@ -742,7 +743,7 @@ void Score::update() {
 		// Director 5 and above actually check for recursion for the perFrameHook.
 		if (_version >= kFileVer500) {
 			// new frame, first call the perFrameHook (if one exists)
-			if (!_window->_newMovieStarted && !_vm->_playbackPaused) {
+			if (!_window->_newMovieStarted && !_playbackPaused) {
 				// Call the perFrameHook as soon as a frame switch is done.
 				// If there is a transition, the perFrameHook is called
 				// after each transition subframe instead of here.
@@ -812,7 +813,7 @@ void Score::update() {
 	// then call the stepMovie hook (if one exists)
 	// D4 and above only call it if _allowOutdatedLingo is enabled.
 	count = _window->frozenLingoStateCount();
-	if (!_vm->_playbackPaused && (_version < kFileVer400 || _movie->_allowOutdatedLingo)) {
+	if (!_playbackPaused && (_version < kFileVer400 || _movie->_allowOutdatedLingo)) {
 		_movie->processEvent(kEventStepMovie);
 	}
 	// If this stepMovie call is frozen, drop the next enterFrame event
@@ -827,7 +828,7 @@ void Score::update() {
 
 	// then call the enterFrame hook (if one exists)
 	count = _window->frozenLingoStateCount();
-	if (!_vm->_playbackPaused) {
+	if (!_playbackPaused) {
 		_exitFrameCalled = false;
 		if (_version >= kFileVer400) {
 			_movie->processEvent(kEventEnterFrame);
@@ -848,7 +849,7 @@ void Score::update() {
 	if (!_nextFrame && _window->_nextMovie.movie.empty() && !processFrozenScripts())
 		return;
 
-	if (!_vm->_playbackPaused) {
+	if (!_playbackPaused) {
 		if (_movie->_timeOutPlay)
 			_movie->_lastTimeOut = _vm->getMacTicks();
 	}
@@ -869,7 +870,7 @@ void Score::renderFrame(uint16 frameId, RenderMode mode, bool sound1Changed, boo
 		incrementFilmLoops();
 		_window->render();
 		_skipTransition = false;
-	} else if (g_director->_playbackPaused) {
+	} else if (_playbackPaused) {
 		updateSprites(mode);
 		incrementFilmLoops();
 		_window->render();

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -2023,7 +2023,10 @@ void Score::loadFrames(Common::SeekableReadStreamEndian &stream, uint16 version,
 	debugC(1, kDebugLoading, "Score::loadFrames(): Calculated, total number of frames %d", _numFrames);
 
 	if (_version >= kFileVer600) {
-		for (uint i = 0; i < _spriteDetailAccessed.size() - 1; i++) {
+		// Note: use "i + 1 < size()" rather than "i < size() - 1" so that an
+		// empty detail list (size() == 0, e.g. an empty VWSC score) does not
+		// underflow the unsigned subtraction and run ~4 billion iterations.
+		for (uint i = 0; i + 1 < _spriteDetailAccessed.size(); i++) {
 			int size = _spriteDetailOffsets[i + 1] - _spriteDetailOffsets[i];
 			if (!_spriteDetailAccessed[i] && size > 0) {
 				int type = i % 3;

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -760,7 +760,23 @@ void Score::update() {
 			bool prevDis = _disableGoPlayUpdateStage;
 			_disableGoPlayUpdateStage = true;
 
-			_movie->broadcastEvent(kEventPrepareFrame);
+			// In Director 6, the event order per frame is:
+			//   beginSprite → prepareFrame → (render) → enterFrame → exitFrame
+			// createScriptInstances normally runs inside updateSprites (rendering),
+			// which is too late for prepareFrame. We run it here first so that
+			// the frame script channel instance (_scriptChannelScriptInstance) and
+			// the sprite behavior _scriptInstanceList entries are populated when
+			// prepareFrame fires.
+			// The second call from updateSprites is harmless (guarded by _scriptInstanceList.size()).
+			createScriptInstances(_curFrameNumber);
+
+			// prepareFrame must be dispatched like enterFrame/exitFrame via
+			// processEvent(), NOT broadcastEvent(). broadcastEvent() only walks
+			// sprite channels that have behaviors and never reaches the frame
+			// script channel (_scriptChannelScriptInstance). Many D6 titles (e.g.
+			// TKKG2's "SA" audio behavior) put their prepareFrame handler on the
+			// frame script channel, so it must go through the kFrameHandler path.
+			_movie->processEvent(kEventPrepareFrame);
 
 			_disableGoPlayUpdateStage = prevDis;
 		}

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -2515,8 +2515,19 @@ void Score::writeVWSCResource(Common::SeekableWriteStream *writeStream, uint32 o
 	} else if (_version >= kFileVer500 && _version < kFileVer600) {
 		channelSize = kSprChannelSizeD5;
 		mainChannelSize = kMainChannelSizeD5;
+	} else if (_version >= kFileVer600 && _version < kFileVer700) {
+		// D6 shares the sprite size with D5 (24) but has a larger main channel
+		// (144 vs 48). The version branches here must mirror Frame::readChannel()
+		// (readChannelD6), otherwise the frameSize prefix and sprite offsets are
+		// miscomputed and the saved score is unreadable. Without this branch the
+		// function bailed out for D6, writing nothing (TKKG2 savegame).
+		channelSize = kSprChannelSizeD6;
+		mainChannelSize = kMainChannelSizeD6;
+	} else if (_version >= kFileVer700 && _version < kFileVer1100) {
+		channelSize = kSprChannelSizeD7;
+		mainChannelSize = kMainChannelSizeD7;
 	} else {
-		warning("FilmLoopCastMember::writeSCVWResource: Writing Director Version 6+ not supported yet");
+		warning("Score::writeVWSCResource: Writing this Director version is not supported yet");
 		return;
 	}
 
@@ -2576,6 +2587,10 @@ void Score::writeFrame(Common::SeekableWriteStream *writeStream, Frame frame, ui
 			writeSpriteDataD4(writeStream, sprite);
 		} else if (_version >= kFileVer500 && _version < kFileVer600) {
 			writeSpriteDataD5(writeStream, sprite);
+		} else if (_version >= kFileVer600 && _version < kFileVer700) {
+			writeSpriteDataD6(writeStream, sprite);
+		} else if (_version >= kFileVer700 && _version < kFileVer1100) {
+			writeSpriteDataD7(writeStream, sprite);
 		}
 	}
 }
@@ -2586,11 +2601,18 @@ uint32 Score::getVWSCResourceSize() {
 	if (_version >= kFileVer400 && _version < kFileVer500) {
 		channelSize = kSprChannelSizeD4;
 		mainChannelSize = kMainChannelSizeD4;
-	} else if (_version >= kFileVer500) {
+	} else if (_version >= kFileVer500 && _version < kFileVer600) {
 		channelSize = kSprChannelSizeD5;
 		mainChannelSize = kMainChannelSizeD5;
+	} else if (_version >= kFileVer600 && _version < kFileVer700) {
+		// Must match writeVWSCResource()/Frame::readChannel() (D6: main channel 144).
+		channelSize = kSprChannelSizeD6;
+		mainChannelSize = kMainChannelSizeD6;
+	} else if (_version >= kFileVer700 && _version < kFileVer1100) {
+		channelSize = kSprChannelSizeD7;
+		mainChannelSize = kMainChannelSizeD7;
 	} else {
-		warning("FilmLoopCastMember::getSCVWResourceSize: Director version unsupported");
+		warning("Score::getVWSCResourceSize: Director version unsupported");
 	}
 
 	uint32 framesSize = 0;

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1946,11 +1946,29 @@ void Score::loadFrames(Common::SeekableReadStreamEndian &stream, uint16 version,
 			prevOff = off;
 		}
 
-		// now seek to the header, which is position 0 in the list
-		_framesStream->seek(_indexStart, SEEK_SET);
-		uint32 off = _framesStream->readUint32();
-		_framesStream->seek(_frameDataOffset + off, SEEK_SET);
-		_spriteDetailAccessed[0] = true;
+		// The on-disk index actually stores numEntries+1 offsets (== listSize/maxVar):
+		// the trailing one is an end-of-data sentinel. We only read numEntries above,
+		// so the final detail entry's length (offset[i+1] - offset[i]) was unknown and
+		// getSpriteDetailsStream() returned nullptr for it -- leaving e.g. the last
+		// sprite behavior's initializer params empty (TKKG2 non-persistent inventory).
+		// Read that trailing sentinel and append it so the last real entry is sizeable.
+		// The stream is positioned right after the numEntries offsets at this point.
+		if (numEntries > 0) {
+			uint32 endOff = _framesStream->readUint32();
+			_spriteDetailOffsets.push_back(_frameDataOffset + endOff);
+			_spriteDetailAccessed.push_back(true);
+		}
+
+		// now seek to the header, which is position 0 in the list.
+		// Guard against an empty detail list (numEntries == 0, e.g. an empty
+		// VWSC score): there is no entry 0 to seek to or mark, and indexing
+		// the empty _spriteDetailAccessed array would assert.
+		if (numEntries > 0) {
+			_framesStream->seek(_indexStart, SEEK_SET);
+			uint32 off = _framesStream->readUint32();
+			_framesStream->seek(_frameDataOffset + off, SEEK_SET);
+			_spriteDetailAccessed[0] = true;
+		}
 	}
 
 	if (version >= kFileVer400) {

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -227,6 +227,9 @@ public:
 	bool _activeFade;
 	bool _exitFrameCalled;
 	bool _stopPlayCalled;
+	// Whether this movie's playback head is paused (Lingo `pause`/`continue`).
+	// This is per-movie: pausing a MIAW must not freeze the stage and vice versa.
+	bool _playbackPaused;
 	Cursor _defaultCursor;
 	CursorRef _currentCursor;
 	bool _skipTransition;

--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -766,10 +766,16 @@ void DirectorSound::processCuePoints() {
 		const SoundID &lastPlayedSound = channel->lastPlayedSound;
 		if (lastPlayedSound.type == kSoundCast) {
 			CastMemberID memberID(lastPlayedSound.u.cast.member, lastPlayedSound.u.cast.castLib);
-			SoundCastMember *soundCast = (SoundCastMember *)_window->getCurrentMovie()->getCastMember(memberID);
+			CastMember *member = _window->getCurrentMovie()->getCastMember(memberID);
 
-			if (!soundCast)
+			// The sound channel can reference a cast member that is not (or no
+			// longer) a sound -- e.g. when the member ID resolves to a bitmap.
+			// Guard the downcast; otherwise we read _cuePoints off an unrelated
+			// object (here a BitmapCastMember) and crash in a release build.
+			if (!member || member->_type != kCastSound)
 				continue;
+
+			SoundCastMember *soundCast = (SoundCastMember *)member;
 
 			if (soundCast->_cuePoints.empty())
 				continue;

--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -83,17 +83,15 @@ void DirectorSound::playFile(Common::String filename, int soundChannel) {
 	AudioFileDecoder af(filename);
 	Audio::AudioStream *sound = af.getAudioStream(false, false, DisposeAfterUse::YES);
 
-	if (!sound) {
-		debugC(1, kDebugSound, "DirectorSound::playFile(): channel %d, '%s' -> no audio stream decoded", soundChannel, filename.c_str());
+	// The file may have failed to open or decode (e.g. an empty/relative path);
+	// don't hand a null stream to the mixer.
+	if (!sound)
 		return;
-	}
 
 	cancelFade(soundChannel);
 	stopSound(soundChannel);
 
 	setChannelDefaultVolume(soundChannel);
-	debugC(1, kDebugSound, "DirectorSound::playFile(): channel %d, '%s', enabled: %d, volume: %d (default %d)",
-		soundChannel, filename.c_str(), _enable, getChannelVolume(soundChannel), g_director->_defaultVolume);
 	_mixer->playStream(Audio::Mixer::kSFXSoundType, &_channels[soundChannel]->handle, sound, -1, getChannelVolume(soundChannel));
 	_channels[soundChannel]->originalRate = (int)_mixer->getChannelRate(_channels[soundChannel]->handle);
 	if (_channels[soundChannel]->pitchShiftPercent != 100) {

--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -83,10 +83,17 @@ void DirectorSound::playFile(Common::String filename, int soundChannel) {
 	AudioFileDecoder af(filename);
 	Audio::AudioStream *sound = af.getAudioStream(false, false, DisposeAfterUse::YES);
 
+	if (!sound) {
+		debugC(1, kDebugSound, "DirectorSound::playFile(): channel %d, '%s' -> no audio stream decoded", soundChannel, filename.c_str());
+		return;
+	}
+
 	cancelFade(soundChannel);
 	stopSound(soundChannel);
 
 	setChannelDefaultVolume(soundChannel);
+	debugC(1, kDebugSound, "DirectorSound::playFile(): channel %d, '%s', enabled: %d, volume: %d (default %d)",
+		soundChannel, filename.c_str(), _enable, getChannelVolume(soundChannel), g_director->_defaultVolume);
 	_mixer->playStream(Audio::Mixer::kSFXSoundType, &_channels[soundChannel]->handle, sound, -1, getChannelVolume(soundChannel));
 	_channels[soundChannel]->originalRate = (int)_mixer->getChannelRate(_channels[soundChannel]->handle);
 	if (_channels[soundChannel]->pitchShiftPercent != 100) {

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -368,6 +368,14 @@ bool Sprite::isActive() {
 	if (_cast && _cast->_type == kCastButton)
 		return true;
 
+	// D6+ sprites carry their scripts as behaviors rather than via _scriptId.
+	// respondsToMouse() already accounts for this; isActive() must too, otherwise
+	// `the clickOn` (which uses getActiveSpriteIDFromPos -> isActive) returns 0 for
+	// behavior-driven sprites even though they were clicked. TKKG2 relies on
+	// `the clickOn` to identify the clicked character sprite for character changes.
+	if (g_director->getVersion() >= 600 && _behaviors.size() > 0)
+		return true;
+
 	return (_movie->getScriptContext(kScoreScript, _scriptId) != nullptr)
 			|| (_movie->getScriptContext(kCastScript, _castId) != nullptr);
 }

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -640,11 +640,14 @@ void Sprite::replaceFrom(Sprite *nextSprite) {
 		return;
 	}
 
-	// If the cast member is the same, persist the editable flag
+	// The editable flag is read from the score every frame (colorcode bit
+	// 0x40), so it must follow the score even when the cast member does not
+	// change: a field that the score turns editable on the same member has to
+	// take effect (e.g. the login name fields in "Ein Fall fuer Muetze & Co",
+	// which become editable on the same member when "new member" is clicked).
+	// Lingo-controlled editability is handled separately via sprite puppeting,
+	// which returns above before reaching this point.
 	bool editable = nextSprite->_editable;
-	if (_castId == nextSprite->_castId) {
-		editable = _editable;
-	}
 
 	bool immediate = _immediate;
 


### PR DESCRIPTION
These commits make the following set of games crash less often.
Games that were used here include
- Löwenzahn 1,2, 2 version2.0, 3 and 4
- TKKG 1-6 
- "Ein Fall für Mütze & Co"

There is also a small fix to the detection table based on dutch Demos found on discs released by belgium publisher Lannoo.

TKKG1 can be completed and will now also have a proper intro scene without body parts looking distorted.

These were created with help of Anthropics Claude Opus and various cycles of instrumenting the engine , testing in game and refinement. This includes exrapolating from lingo samples and documentation found on the internet Therefore i will mark this as a draft for now.

Cap&Co or "Ein Fall für Mütze & Co" still needs refinement and a full playthrough, same for any TKKG game 2 and higher.