### PR TITLE
AGS: Detection, initial support for Gobliiins 5 from Gobliiins Collection (Switch)

### DIFF
--- a/engines/ags/detection_tables.h
+++ b/engines/ags/detection_tables.h
@@ -325,6 +325,7 @@ const PlainGameDescriptor GAME_NAMES[] = {
 	{ "ghostdream", "Ghostdream" },
 	{ "ghostman", "Ghostman: The Council Calamity" },
 	{ "gigant", "Gigant" },
+	{ "gobliiins5", "Gobliiins5 - L'Invasion des Morglotons" },
 	{ "gobliiins5-1", "Gobliiins5 - L'Invasion des Morglotons Part1/Demo" },
 	{ "gobliiins5-2", "Gobliiins5 - L'Invasion des Morglotons Part2" },
 	{ "gobliiins5-3", "Gobliiins5 - L'Invasion des Morglotons Part3" },
@@ -5012,6 +5013,9 @@ const AGSGameDescription GAME_DESCRIPTIONS[] = {
 	GAME_ENTRY_STEAM("gobliiins5-1", "Gobliiins5-Part1.ags", "41513db1bd8870e43426b9e94bb26ad1", 171800863),
 	// Steam release 2023-11-16
 	GAME_ENTRY_STEAM("gobliiins5-1", "Gobliiins5-Part1.ags", "41513db1bd8870e43426b9e94bb26ad1", 171800709),
+	// Gobliiins Collection release 2026-05-27
+	GAME_ENTRY_PLATFORM("gobliiins5", "Gobliiins5.ags", "58c44c065cbdbddf83e9535ef17ed51f", 281472880, "Switch"),
+
 
 	// Itch.io v? release 2026-02-10
 	GAME_ENTRY("gobliins6", "Gobliins6.exe", "t:aac0f0616ede4ec1d4300103b008f34b", 1287053862),

--- a/engines/ags/module.mk
+++ b/engines/ags/module.mk
@@ -318,6 +318,7 @@ MODULE_OBJS = \
 	plugins/ags_bm_font_renderer/ags_bm_font_renderer.o \
 	plugins/ags_clipboard/ags_clipboard.o \
 	plugins/ags_collision_detector/ags_collision_detector.o \
+	plugins/ags_console_sys_plugin/ags_console_sys_plugin.o \
 	plugins/ags_consoles/ags_consoles.o \
 	plugins/ags_controller/ags_controller.o \
 	plugins/ags_controller/ags_controller_arcnor.o \

--- a/engines/ags/plugins/ags_console_sys_plugin/ags_console_sys_plugin.cpp
+++ b/engines/ags/plugins/ags_console_sys_plugin/ags_console_sys_plugin.cpp
@@ -1,0 +1,146 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * of the License, or(at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "ags/plugins/ags_console_sys_plugin/ags_console_sys_plugin.h"
+// #include "ags/shared/core/platform.h"
+#include "common/config-manager.h"
+#include "common/language.h"
+
+namespace AGS3 {
+namespace Plugins {
+namespace AGSConsoleSysPlugin {
+
+const char *AGSConsoleSysPlugin::AGS_GetPluginName() {
+	return "AGS Console System Plugin";
+}
+
+void AGSConsoleSysPlugin::AGS_EngineStartup(IAGSEngine *engine) {
+	PluginBase::AGS_EngineStartup(engine);
+
+	SCRIPT_METHOD(AGSConsoleSysPlugin::GetSystemInputDeviceType^0, AGSConsoleSysPlugin::GetSystemInputDeviceType);
+	SCRIPT_METHOD(AGSConsoleSysPlugin::GetSystemLanguage^0, AGSConsoleSysPlugin::GetSystemLanguage);
+	SCRIPT_METHOD(AGSConsoleSysPlugin::GetSystemPlatform^0, AGSConsoleSysPlugin::GetSystemPlatform);
+	SCRIPT_METHOD(AGSConsoleSysPlugin::GetTextureFilteringType^0, AGSConsoleSysPlugin::GetTextureFilteringType);
+	SCRIPT_METHOD(AGSConsoleSysPlugin::IsSaveHandlerBusy^0, AGSConsoleSysPlugin::IsSaveHandlerBusy);
+	SCRIPT_METHOD(AGSConsoleSysPlugin::ResetControllerColor^0, AGSConsoleSysPlugin::ResetControllerColor);
+	SCRIPT_METHOD(AGSConsoleSysPlugin::SetBorder^1, AGSConsoleSysPlugin::SetBorder);
+	SCRIPT_METHOD(AGSConsoleSysPlugin::SetControllerColor^3, AGSConsoleSysPlugin::SetControllerColor);
+	SCRIPT_METHOD(AGSConsoleSysPlugin::SetPixelPerfect^1, AGSConsoleSysPlugin::SetPixelPerfect);
+	SCRIPT_METHOD(AGSConsoleSysPlugin::SetTextureFilteringType^1, AGSConsoleSysPlugin::SetTextureFilteringType);
+
+	SCRIPT_METHOD(Game_RAG::EnableCheats^0, AGSConsoleSysPlugin::EnableCheats);
+}
+
+void AGSConsoleSysPlugin::GetSystemInputDeviceType(ScriptMethodParams &params) {
+	warning("AGSConsoleSysPlugin::GetSystemInputDeviceType STUB: returning false");
+	params._result = 0;
+}
+
+void AGSConsoleSysPlugin::GetSystemLanguage(ScriptMethodParams &params) {
+	// PARAMS0();
+	// Returns the current system language as an integer
+	// 0   = German
+	// 1/2 = English (unknown which is UK/US)
+	// 3   = Spanish
+	// 4   = ?
+	// 5/6 = French (unknown which is France/Canada)
+	// 7   = Italian
+	if (!ConfMan.get("language").empty()) {
+		// Map the language defined in the command-line "language" option to its description
+		Common::Language lang = Common::parseLanguage(ConfMan.get("language"));
+
+		switch (lang) {
+		case Common::DE_DEU:
+			params._result = 0;
+			break;
+		case Common::EN_ANY:
+			params._result = 1;
+			break;
+		case Common::ES_ESP:
+			params._result = 3;
+			break;
+		case Common::FR_FRA:
+			params._result = 5;
+			break;
+		case Common::IT_ITA:
+			params._result = 7;
+			break;
+		default:
+			params._result = 1; // default to English
+			break;
+		}
+	} else
+		params._result = 1; // default to English
+}
+
+void AGSConsoleSysPlugin::GetSystemPlatform(ScriptMethodParams &params) {
+	warning("AGSConsoleSysPlugin::GetSystemPlatform STUB: returning 0");
+	params._result = 0;
+}
+
+void AGSConsoleSysPlugin::GetTextureFilteringType(ScriptMethodParams &params) {
+	warning("AGSConsoleSysPlugin::GetTextureFilteringType STUB: returning false");
+	params._result = false;
+}
+
+void AGSConsoleSysPlugin::IsSaveHandlerBusy(ScriptMethodParams &params) {
+	warning("AGSConsoleSysPlugin::IsSaveHandlerBusy STUB: returning false");
+	params._result = false;
+}
+
+void AGSConsoleSysPlugin::ResetControllerColor(ScriptMethodParams &params) {
+	warning("AGSConsoleSysPlugin::ResetControllerColor STUB: returning false");
+	params._result = false;
+}
+
+void AGSConsoleSysPlugin::SetBorder(ScriptMethodParams &params) {
+	// PARAMS1(char *, filename);
+	// Loads a BMP and uses it as a border. Result is ignored.
+	// If "none.bmp", border is removed.
+	params._result = 0;
+}
+
+void AGSConsoleSysPlugin::SetControllerColor(ScriptMethodParams &params) {
+	// PARAMS3(?);
+	warning("AGSConsoleSysPlugin::SetControllerColor STUB: returning false");
+	params._result = false;
+}
+
+void AGSConsoleSysPlugin::SetPixelPerfect(ScriptMethodParams &params) {
+	// PARAMS1(?);
+	warning("AGSConsoleSysPlugin::SetPixelPerfect STUB: returning false");
+	params._result = false;
+}
+
+void AGSConsoleSysPlugin::SetTextureFilteringType(ScriptMethodParams &params) {
+	// PARAMS1(?);
+	warning("AGSConsoleSysPlugin::SetTextureFilteringType STUB: returning false");
+	params._result = false;
+}
+
+void AGSConsoleSysPlugin::EnableCheats(ScriptMethodParams &params) {
+	params._result = false;
+}
+
+
+} // namespace AGSConsoleSysPlugin
+} // namespace Plugins
+} // namespace AGS3

--- a/engines/ags/plugins/ags_console_sys_plugin/ags_console_sys_plugin.h
+++ b/engines/ags/plugins/ags_console_sys_plugin/ags_console_sys_plugin.h
@@ -1,0 +1,60 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * of the License, or(at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef AGS_PLUGINS_AGS_CONSOLE_SYS_PLUGIN_H
+#define AGS_PLUGINS_AGS_CONSOLE_SYS_PLUGIN_H
+
+#include "ags/plugins/ags_plugin.h"
+
+namespace AGS3 {
+namespace Plugins {
+namespace AGSConsoleSysPlugin {
+
+class AGSConsoleSysPlugin : public PluginBase {
+	SCRIPT_HASH(AGSConsoleSysPlugin)
+
+private:
+	void GetSystemInputDeviceType(ScriptMethodParams &params);
+	void GetSystemLanguage(ScriptMethodParams &params);
+	void GetSystemPlatform(ScriptMethodParams &params);
+	void GetTextureFilteringType(ScriptMethodParams &params);
+	void IsSaveHandlerBusy(ScriptMethodParams &params);
+	void ResetControllerColor(ScriptMethodParams &params);
+	void SetBorder(ScriptMethodParams &params);
+	void SetControllerColor(ScriptMethodParams &params);
+	void SetPixelPerfect(ScriptMethodParams &params);
+	void SetTextureFilteringType(ScriptMethodParams &params);
+	void EnableCheats(ScriptMethodParams &params);
+
+public:
+	AGSConsoleSysPlugin() : PluginBase() {}
+	virtual ~AGSConsoleSysPlugin() {}
+
+	const char *AGS_GetPluginName() override;
+	void AGS_EngineStartup(IAGSEngine *engine) override;
+
+};
+
+} // namespace AGSConsoleSysPlugin
+} // namespace Plugins
+} // namespace AGS3
+
+#endif

--- a/engines/ags/plugins/plugin_base.cpp
+++ b/engines/ags/plugins/plugin_base.cpp
@@ -27,6 +27,7 @@
 #include "ags/plugins/ags_bm_font_renderer/ags_bm_font_renderer.h"
 #include "ags/plugins/ags_clipboard/ags_clipboard.h"
 #include "ags/plugins/ags_collision_detector/ags_collision_detector.h"
+#include "ags/plugins/ags_console_sys_plugin/ags_console_sys_plugin.h"
 #include "ags/plugins/ags_consoles/ags_consoles.h"
 #include "ags/plugins/ags_controller/ags_controller.h"
 #include "ags/plugins/ags_controller/ags_controller_arcnor.h"
@@ -95,6 +96,9 @@ Plugins::PluginBase *pluginOpen(const char *filename) {
 	if (fname.equalsIgnoreCase("AGSConsoles"))
 		return new AGSConsoles::AGSConsoles();
 
+	if (fname.equalsIgnoreCase("AGSConsoleSysPlugin") || fname.equalsIgnoreCase("ags_console_system_plugin"))
+		return new AGSConsoleSysPlugin::AGSConsoleSysPlugin();
+
 	if (fname.equalsIgnoreCase("AGSController") || fname.equalsIgnoreCase("agscontrollerpulp"))
 		return new AGSController::AGSController();
 
@@ -161,7 +165,7 @@ Plugins::PluginBase *pluginOpen(const char *filename) {
 		return new AGSGalaxySteam::AGSWadjetEyeSteam();
 
 	if (fname.equalsIgnoreCase("agsteam") || fname.equalsIgnoreCase("agsteam-unified") ||
-	        fname.equalsIgnoreCase("agsteam-disjoint"))
+	        fname.equalsIgnoreCase("agsteam-disjoint") || fname.equalsIgnoreCase("ags_achievements"))
 		return new AGSGalaxySteam::AGSSteam();
 
 	if (fname.equalsIgnoreCase("AGSTouch"))


### PR DESCRIPTION
TODO:
* SetBorder should *technically* set a border, though unsure how to go about it
* SetPixelPerfect should change the filtering between nearest-neighbour and bilinear(?)
* The 5 achievements (see: https://www.trueachievements.com/game/Gobliiins-Collection/achievements); achievements are unlocked by calls to `AchievementHandler.UnlockAchievement(ach)`, where `ach` is the numerical index of the achievement (35-46).

Achievement 42 ("Long Story Short...") is special in that they accidentally made the `CheckAllSchoolKidTalked` function unlock achievement 37 ("Good Dreams") instead.