### PR TITLE
MM: MM1: Fix classic combat target crashes

### DIFF
--- a/engines/mm/mm1/game/combat.cpp
+++ b/engines/mm/mm1/game/combat.cpp
@@ -673,7 +673,7 @@ void Combat::checkMonsterActions() {
 	_monsterP->_counterFlags--;
 
 	// Pick a random character to shoot at
-	int charNum = getRandomNumber(g_globals->_party.size()) - 1;
+	int charNum = CLIP<int>(getRandomNumber(g_globals->_party.size()) - 1, 0, (int)g_globals->_party.size() - 1);
 	Character &c = g_globals->_party[charNum];
 	g_globals->_currCharacter = &c;
 

--- a/engines/mm/mm1/views/combat.cpp
+++ b/engines/mm/mm1/views/combat.cpp
@@ -189,6 +189,9 @@ void Combat::draw() {
 }
 
 void Combat::timeout() {
+	if (!isFocused())
+		return;
+
 	switch (_mode) {
 	case NEXT_ROUND:
 		nextRound2();


### PR DESCRIPTION
Fixes two classic MM1 combat crash cases.

Monster shooting could choose a character index outside the active party range when the party had only one member, triggering an array assertion. Clamp the selected target to the valid party range.

Also ignore delayed combat timeout callbacks after the combat view has lost focus. This prevents stale combat processing from running after another view has taken over.
