### PR TITLE
DIRECTOR: Fix Elroy Hits the Pavement Map Previews

### DIFF
--- a/engines/director/events.cpp
+++ b/engines/director/events.cpp
@@ -436,6 +436,11 @@ bool Window::processWMEvent(Graphics::WindowClick click, Common::Event &event) {
 }
 
 void Window::sendWindowEvent(LEvent event) {
+	// Built-in window events introduced in D5.
+	// Could fire if lower-version has a similarly named event.
+	if (_vm->getVersion() < 500)
+		return;
+
 	if (_currentMovie && _window->isVisible() && !_isStage) {
 		// We cannot call processEvent here directly because it might
 		// be called from within another event processing (like 'on startMovie'	)

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -1108,32 +1108,20 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 		d = _vm->getStage();
 		break;
 	case kTheStageBottom:
-		{
-			Window *window = _vm->getCurrentWindow();
-			d = window->_window->getInnerDimensions().bottom;
-		}
+		d = _vm->getStage()->_window->getInnerDimensions().bottom;
 		break;
 	case kTheStageColor:
 		// TODO: Provide proper reverse transform for non-indexed color
 		d = (int)g_director->transformColor(g_director->getCurrentWindow()->getStageColor());
 		break;
 	case kTheStageLeft:
-		{
-			Window *window = _vm->getCurrentWindow();
-			d = window->_window->getInnerDimensions().left;
-		}
+		d = _vm->getStage()->_window->getInnerDimensions().left;
 		break;
 	case kTheStageRight:
-		{
-			Window *window = _vm->getCurrentWindow();
-			d = window->_window->getInnerDimensions().right;
-		}
+		d = _vm->getStage()->_window->getInnerDimensions().right;
 		break;
 	case kTheStageTop:
-		{
-			Window *window = _vm->getCurrentWindow();
-			d = window->_window->getInnerDimensions().top;
-		}
+		d = _vm->getStage()->_window->getInnerDimensions().top;
 		break;
 	case kTheStillDown:
 		if (Director::DT::isMouseInputIgnored()) {

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -235,11 +235,15 @@ bool Movie::loadArchive() {
 	g_director->_lastPalette = CastMemberID();
 
 	bool recenter = false;
-	// If the stage dimensions are different, delete it and start again.
-	// Otherwise, do not clear it so there can be a nice transition.
-	if (_window->getSurface()->w != _movieRect.width() || _window->getSurface()->h != _movieRect.height()) {
-		_window->resizeInner(_movieRect.width(), _movieRect.height());
-		recenter = true;
+	// For the stage, always resize to the movie rect.
+	// For MIAWs, only resize if the window hasn't been explicitly sized by Lingo
+	// (i.e. still at the 1x1 default from createWindow).
+	bool windowSizeIsDefault = (_window->getSurface()->w <= 1 && _window->getSurface()->h <= 1);
+	if (_window == _vm->getStage() || windowSizeIsDefault) {
+		if (_window->getSurface()->w != _movieRect.width() || _window->getSurface()->h != _movieRect.height()) {
+			_window->resizeInner(_movieRect.width(), _movieRect.height());
+			recenter = true;
+		}
 	}
 
 	// TODO: Add more options for desktop dimensions


### PR DESCRIPTION
  **DIRECTOR: Fix MIAW window sizing and Elroy map preview**

  Three related fixes to Director window and event handling that resolve issues seen in Elroy Hits the Pavement and other D4-era titles.

  **Don't resize MIAW window to movie rect on load**

  When a Movie-in-a-Window (MIAW) has its rect explicitly set by Lingo before the movie loads, `loadArchive()` was overwriting that size with the movie's declared `movieRect`.

Claude Sonnet 4.6 was used to help with code tracing to uncover the resizing issue in this commit.

  **Fix Elroy map preview centering**

  `the stageLeft/Right/Top/Bottom` were being read from `getCurrentWindow()` (the currently-executing MIAW) instead of the actual stage window. 

  **Don't send window events for versions below 5.0**

  `sendWindowEvent` was firing `on activateWindow` / `on deactivateWindow` events for D4 and earlier titles, which don't support these events. This caused unexpected script execution in games that happen to define handlers with those names for other purposes.