### PR TITLE
DIRECTOR: fix empty cast slot error and immediate sprite drag in D4+

### DIFF
--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -500,7 +500,27 @@ void Movie::queueEvent(Common::Queue<LingoEvent> &queue, LEvent event, int targe
 		// In D2-3, specific objects handle each event, with no passing
 		switch(event) {
 		case kEventMouseUp:
+			if (_vm->getVersion() >= 300) {
+				uint16 spriteId = _score->getMouseSpriteIDFromPos(pos);
+				Sprite *sprite = _score->getSpriteById(spriteId);
+				if (sprite && sprite->_immediate)
+					break;
+			}
+			// fall through
 		case kEventMouseDown:
+			if (_vm->getVersion() >= 300) {
+				uint16 spriteId = _score->getMouseSpriteIDFromPos(pos);
+				Sprite *sprite = _score->getSpriteById(spriteId);
+				if (sprite && sprite->_immediate) {
+					queue.push(LingoEvent(kEventMouseDown, eventId, kSpriteHandler, false, pos));
+					queue.push(LingoEvent(kEventMouseDown, eventId, kCastHandler, false, pos));
+					_nextEventId++;
+					int mouseUpEventId = _nextEventId;
+					queue.push(LingoEvent(kEventMouseUp, mouseUpEventId, kSpriteHandler, false, pos));
+					queue.push(LingoEvent(kEventMouseUp, mouseUpEventId, kCastHandler, false, pos));
+					break;
+				}
+			}
 			queue.push(LingoEvent(event, eventId, kSpriteHandler, false, pos));
 			queue.push(LingoEvent(event, eventId, kCastHandler, false, pos));
 			break;
@@ -534,11 +554,28 @@ void Movie::queueEvent(Common::Queue<LingoEvent> &queue, LEvent event, int targe
 		 * Once one of these objects handles the event, any event handlers queued
 		 * for the same event will be ignored unless the pass command was called.
 		 */
+
+		uint16 spriteId = _score->getMouseSpriteIDFromPos(pos);
+		Sprite *sprite = _score->getSpriteById(spriteId);
+
 		switch (event) {
 		case kEventKeyUp:
 		case kEventKeyDown:
 		case kEventMouseUp:
+			if (sprite && sprite->_immediate) {
+				break;
+			}
+			// fall through
 		case kEventMouseDown:
+			if (sprite && sprite->_immediate) {
+				queue.push(LingoEvent(kEventMouseDown, eventId, kSpriteHandler, false, pos, spriteId));
+				queue.push(LingoEvent(kEventMouseDown, eventId, kCastHandler, false, pos, spriteId));
+				_nextEventId++;
+				int mouseUpEventId = _nextEventId;
+				queue.push(LingoEvent(kEventMouseUp, mouseUpEventId, kSpriteHandler, false, pos, spriteId));
+				queue.push(LingoEvent(kEventMouseUp, mouseUpEventId, kCastHandler, false, pos, spriteId));
+				break;
+			}
 		case kEventRightMouseUp:
 		case kEventRightMouseDown:
 		case kEventBeginSprite:

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -2192,21 +2192,10 @@ void Lingo::setTheCast(Datum &id1, int field, Datum &d) {
 	}
 
 	CastMemberID id = id1.asMemberID();
-	Cast *sharedCast = movie->getSharedCast();
-	Cast *cast = movie->getCast(id);
-	int maxID = 0;
-
-	if (sharedCast) {
-		maxID = MAX(maxID, sharedCast->getCastMaxID());
-	}
-	if (cast) {
-		maxID = MAX(maxID, cast->getCastMaxID());
-	}
-
 	CastMember *member = movie->getCastMember(id);
 
 	if (!member) {
-		if (id.member >= 1 && id.member <= maxID) {
+		if (id.member >= 1 && id.member <= movie->getMaxCastID()) {
 			debugC(1, kDebugLingoExec,
 				  "Lingo::setTheCast(): %s not found, ignoring (empty slot within cast bounds)",
 				  id.asString().c_str());
@@ -2222,6 +2211,7 @@ void Lingo::setTheCast(Datum &id1, int field, Datum &d) {
 			return;
 		}
 		CastMember *replacement = (CastMember *)d.u.obj;
+		Cast *cast = movie->getCast(id);
 		cast->duplicateCastMember(replacement, nullptr, id.member);
 		return;
 	}

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -2192,9 +2192,26 @@ void Lingo::setTheCast(Datum &id1, int field, Datum &d) {
 	}
 
 	CastMemberID id = id1.asMemberID();
+	Cast *sharedCast = movie->getSharedCast();
+	Cast *cast = movie->getCast(id);
+	int maxID = 0;
+
+	if (sharedCast) {
+		maxID = MAX(maxID, sharedCast->getCastMaxID());
+	}
+	if (cast) {
+		maxID = MAX(maxID, cast->getCastMaxID());
+	}
 
 	CastMember *member = movie->getCastMember(id);
+
 	if (!member) {
+		if (id.member >= 1 && id.member <= maxID) {
+			debugC(1, kDebugLingoExec,
+				  "Lingo::setTheCast(): %s not found, ignoring (empty slot within cast bounds)",
+				  id.asString().c_str());
+			return;
+		}
 		g_lingo->lingoError("Lingo::setTheCast(): %s not found", id.asString().c_str());
 		return;
 	}
@@ -2205,7 +2222,6 @@ void Lingo::setTheCast(Datum &id1, int field, Datum &d) {
 			return;
 		}
 		CastMember *replacement = (CastMember *)d.u.obj;
-		Cast *cast = movie->getCast(id);
 		cast->duplicateCastMember(replacement, nullptr, id.member);
 		return;
 	}

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -708,6 +708,17 @@ const Stxt *Movie::getStxt(CastMemberID memberID) {
 	return result;
 }
 
+int Movie::getMaxCastID() {
+	int max = 0;
+	for (auto &it : _casts) {
+		max = MAX(max, it._value->getCastMaxID());
+	}
+	if (_sharedCast) {
+		max = MAX(max, _sharedCast->getCastMaxID());
+	}
+	return max;
+}
+
 LingoArchive *Movie::getMainLingoArch() {
 	return _casts.getVal(DEFAULT_CAST_LIB)->_lingoArchive;
 }

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -127,6 +127,7 @@ public:
 	CastMemberInfo *getCastMemberInfo(CastMemberID memberID);
 	bool isValidCastMember(CastMemberID memberID, CastType type);
 	const Stxt *getStxt(CastMemberID memberID);
+	int getMaxCastID();
 
 
 	LingoArchive *getMainLingoArch();


### PR DESCRIPTION
Fix two behavioral differences from original Director 4:

  - Empty cast slots within a valid range now fail silently instead of throwing an error, matching original Director behavior where slots between 1 and the last populated member are valid but empty

  - Fix sprite dragging on immediate sprites in D4+: when immediate is set, both mouseDown and mouseUp should fire on press, which was not happening. Fixed by queuing both events on press and suppressing the physical mouseUp to prevent double-firing

This PR fixes 2 bugs in gustown (Gus Goes to Cybertown)