### PR TITLE
BACKENDS: MORPHOS: rework backend

### DIFF
--- a/backends/platform/sdl/morphos/morphos-main.cpp
+++ b/backends/platform/sdl/morphos/morphos-main.cpp
@@ -28,10 +28,9 @@
 #include "backends/plugins/sdl/sdl-provider.h"
 #include "base/main.h"
 
-int main(int argc, char *argv[]) {
+extern "C" { long __stack = 4 * 1024 * 1024; }
 
-	// Set a stack cookie to avoid crashes from a too low stack.
-	static const char *stack_cookie __attribute__((used)) = "$STACK: 4096000";
+int main(int argc, char *argv[]) {
 
 	// Create our OSystem instance.
 	g_system = new OSystem_MorphOS();

--- a/backends/platform/sdl/morphos/morphos.cpp
+++ b/backends/platform/sdl/morphos/morphos.cpp
@@ -19,10 +19,13 @@
  *
  */
 
-#define FORBIDDEN_SYMBOL_EXCEPTION_printf
 #include "common/scummsys.h"
 
 #ifdef __MORPHOS__
+#include <proto/exec.h>
+#include <proto/dos.h>
+#include <exec/tasks.h>
+#include <dos/dosextens.h>
 
 #include "backends/platform/sdl/morphos/morphos.h"
 #include "backends/fs/morphos/morphos-fs-factory.h"
@@ -30,8 +33,33 @@
 
 static bool cleanupDone = false;
 
+static Common::Path getProcessDirectoryPath(const char *name, bool directory) {
+	char path[1024];
+
+	struct Process *process = (struct Process *)FindTask(NULL);
+
+	if (!process || !process->pr_HomeDir) {
+		Common::String fallback = Common::String::format("PROGDIR:%s", name);
+		if (directory && !fallback.hasSuffix("/"))
+			fallback += "/";
+		return Common::Path(fallback);
+	}
+
+	if (!NameFromLock(process->pr_HomeDir, path, sizeof(path)))
+		return Common::Path(Common::String::format("PROGDIR:%s", name));
+
+	if (!AddPart(path, name, sizeof(path)))
+		return Common::Path(Common::String::format("PROGDIR:%s", name));
+
+	Common::String result(path);
+	if (directory && !result.hasSuffix("/") && !result.hasSuffix(":"))
+		result += "/";
+
+	return Common::Path(result);
+}
+
 static void cleanup() {
-	if (!cleanupDone)
+	if (!cleanupDone && g_system)
 		g_system->destroy();
 }
 
@@ -65,32 +93,66 @@ bool OSystem_MorphOS::hasFeature(Feature f) {
 	return OSystem_SDL::hasFeature(f);
 }
 
-void OSystem_MorphOS::initBackend() {
+static Common::Path getProcessDirectoryFile(const char *file) {
+	return getProcessDirectoryPath(file, false);
+}
 
-	// First time user defaults
+Common::Path OSystem_MorphOS::getDefaultConfigFileName() {
+	return getProcessDirectoryFile("scummvm.ini");
+}
+
+static void assureDrawerExists(const Common::Path &path) {
+	Common::String nativePath = path.toString(Common::Path::kNativeSeparator);
+
+	if (nativePath.size() > 0 && nativePath.lastChar() == '/')
+		nativePath.deleteLastChar();
+
+	BPTR lock = Lock(nativePath.c_str(), ACCESS_READ);
+	if (lock) {
+		UnLock(lock);
+		return;
+	}
+
+	BPTR created = CreateDir(nativePath.c_str());
+	if (created)
+		UnLock(created);
+}
+
+void OSystem_MorphOS::initBackend() {
+	const Common::Path savePath = getProcessDirectoryPath("saves", true);
+	const Common::Path extraPath = getProcessDirectoryPath("extras", true);
+	const Common::Path themePath = getProcessDirectoryPath("themes", true);
+	const Common::Path iconPath = getProcessDirectoryPath("icons", true);
+
+	assureDrawerExists(savePath);
+
 	ConfMan.registerDefault("audio_buffer_size", "2048");
-	ConfMan.registerDefault("extrapath", Common::Path("PROGDIR:extras/"));
-	ConfMan.registerDefault("savepath", Common::Path("PROGDIR:saves/"));
-	ConfMan.registerDefault("themepath", Common::Path("PROGDIR:themes/"));
-	// First time .ini defaults
-	if (!ConfMan.hasKey("audio_buffer_size")) {
+	ConfMan.registerDefault("savepath", savePath);
+	ConfMan.registerDefault("extrapath", extraPath);
+	ConfMan.registerDefault("themepath", themePath);
+	ConfMan.registerDefault("iconspath", iconPath);
+
+	if (!ConfMan.hasKey("audio_buffer_size"))
 		ConfMan.set("audio_buffer_size", "2048");
-	}
-	if (!ConfMan.hasKey("extrapath")) {
-		ConfMan.setPath("extrapath", "PROGDIR:extras/");
-	}
-	if (!ConfMan.hasKey("savepath")) {
-		ConfMan.setPath("savepath", "PROGDIR:saves/");
-	}
-	if (!ConfMan.hasKey("themepath")) {
-		ConfMan.setPath("themepath", "PROGDIR:themes/");
-	}
+
+	if (!ConfMan.hasKey("savepath"))
+		ConfMan.setPath("savepath", savePath);
+
+	if (!ConfMan.hasKey("extrapath"))
+		ConfMan.setPath("extrapath", extraPath);
+
+	if (!ConfMan.hasKey("themepath"))
+		ConfMan.setPath("themepath", themePath);
+
+	if (!ConfMan.hasKey("iconspath"))
+		ConfMan.setPath("iconspath", iconPath);
+
 	OSystem_SDL::initBackend();
 }
 
 void OSystem_MorphOS::logMessage(LogMessageType::Type type, const char * message) {
 #ifdef DEBUG_BUILD
-	printf("%s\n", message);
+	OSystem_SDL::logMessage(type, message);
 #endif
 }
 #endif

--- a/backends/platform/sdl/morphos/morphos.h
+++ b/backends/platform/sdl/morphos/morphos.h
@@ -36,6 +36,10 @@ public:
 
 	void initBackend() override;
 	void logMessage(LogMessageType::Type type, const char *message) override;
+
+protected:
+	Common::Path getDefaultConfigFileName() override;
+
 };
 
 #endif


### PR DESCRIPTION
Some fixes and enhanced to MorphOS / SDL platform:

fix __stack
rework initBackend, do not use PROGDIR anymore and fix default values 
logMessage: use OSystem_SDL::logMessage
