### PR TITLE
I18N: Update Brazilian Portuguese translation

### DIFF
--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,18 +10,17 @@ msgstr ""
 "POT-Creation-Date: 2026-06-14 22:15+0000\n"
 "PO-Revision-Date: 2024-11-16 02:13+0000\n"
 "Last-Translator: Marcel Souza Lemes <marcosoutsider@gmail.com>\n"
-"Language-Team: Portuguese (Brazil) <https://translations.scummvm.org/"
-"projects/scummvm/scummvm/pt_BR/>\n"
+"Language-Team: Portuguese (Brazil) <https://translations.scummvm.org/projects/scummvm/scummvm/pt_BR/>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.7.2\n"
-"X-Poedit-Language: Portuguese\n"
-"X-Poedit-Country: BRAZIL\n"
-"X-Poedit-SourceCharset: iso-8859-1\n"
 "X-Language-name: Português (Brasil)\n"
+"X-Poedit-Country: BRAZIL\n"
+"X-Poedit-Language: Portuguese\n"
+"X-Poedit-SourceCharset: iso-8859-1\n"
 
 #: audio/mac_plugin.cpp:30
 msgid "Apple Macintosh Audio"
@@ -56,7 +55,8 @@ msgstr "desabilitado"
 msgid "enabled"
 msgstr "habilitado"
 
-#. I18N: CPU extensions are sets of extra processor instructions used to speed up operations. See Intel AVX2, ARM NEON, etc.
+#. I18N: CPU extensions are sets of extra processor instructions used to speed
+#. up operations. See Intel AVX2, ARM NEON, etc.
 #: gui/about.cpp:162
 msgid "CPU extensions support:"
 msgstr "Suporte a extensões de CPU:"
@@ -68,9 +68,9 @@ msgstr "Engines disponíveis:"
 #. I18N: Close dialog button
 #: gui/about.cpp:516 gui/about.cpp:648 gui/downloadpacksdialog.cpp:298
 #: gui/downloadpacksdialog.cpp:389 gui/integrity-dialog.cpp:354
-#: gui/gui-manager.cpp:168 gui/helpdialog.cpp:128 gui/imagealbum-dialog.cpp:133
-#: gui/textviewer.cpp:56 gui/unknown-game-dialog.cpp:53
-#: backends/platform/android/options.cpp:571
+#: gui/gui-manager.cpp:168 gui/helpdialog.cpp:128
+#: gui/imagealbum-dialog.cpp:133 gui/textviewer.cpp:56
+#: gui/unknown-game-dialog.cpp:53 backends/platform/android/options.cpp:571
 #: engines/drascula/metaengine.cpp:245 engines/queen/metaengine.cpp:264
 #: engines/saga/metaengine.cpp:374 engines/scumm/help.cpp:126
 #: engines/scumm/help.cpp:141 engines/scumm/help.cpp:166
@@ -81,8 +81,10 @@ msgid "Close"
 msgstr "Fechar"
 
 #. I18N: This keymap opens KIA's HELP tab.
-#. In Blade Runner's official localizations, there is a description of this keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
+#. In Blade Runner's official localizations, there is a description of this
+#. keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
+#. is
 #. ONLINE HELP
 #. I18N: Opens the help screen.
 #: gui/browser.cpp:64 gui/launcher.cpp:277 gui/launcher.cpp:959
@@ -338,8 +340,9 @@ msgstr "Outro Armazenamento está ativo no momento. Deseja interrompê-lo?"
 #: gui/fluidsynth-dialog.cpp:210 gui/launcher.cpp:428 gui/launcher.cpp:457
 #: gui/launcher.cpp:534 gui/launcher.cpp:1970 gui/options.cpp:3498
 #: gui/options.cpp:3872 base/main.cpp:608
-#: backends/events/default/default-events.cpp:193 engines/buried/buried.cpp:598
-#: engines/chamber/metaengine.cpp:91 engines/director/events.cpp:122
+#: backends/events/default/default-events.cpp:193
+#: engines/buried/buried.cpp:598 engines/chamber/metaengine.cpp:91
+#: engines/director/events.cpp:122
 #: engines/director/lingo/xlibs/j/jitdraw3.cpp:139
 #: engines/efh/metaengine.cpp:362 engines/grim/grim.cpp:366
 #: engines/hypno/metaengine.cpp:249 engines/kyra/gui/saveload_eob.cpp:611
@@ -374,9 +377,11 @@ msgstr "Não"
 #: gui/cloudconnectionwizard.cpp:539
 msgid "Wait until current Storage finishes and try again."
 msgstr ""
-"Aguarde até que o armazenamento atual conclua seu processo e tente outra vez."
+"Aguarde até que o armazenamento atual conclua seu processo e tente outra "
+"vez."
 
-#. I18N: JSON is name of the format, this message is displayed if user entered something incorrect to the text field
+#. I18N: JSON is name of the format, this message is displayed if user entered
+#. something incorrect to the text field
 #: gui/cloudconnectionwizard.cpp:564
 msgid "JSON code contents are malformed."
 msgstr "O conteúdo do código JSON está incorreto."
@@ -402,7 +407,9 @@ msgstr "OK"
 msgid "Incorrect JSON."
 msgstr "JSON incorreto."
 
-#. I18N: error message displayed on 'Manual Mode: Failure' step of 'Cloud Connection Wizard', describing that storage connection process was interrupted
+#. I18N: error message displayed on 'Manual Mode: Failure' step of 'Cloud
+#. Connection Wizard', describing that storage connection process was
+#. interrupted
 #: gui/cloudconnectionwizard.cpp:593
 msgid "Interrupted."
 msgstr "Interrompido."
@@ -446,7 +453,8 @@ msgid "Select directory where to download game data"
 msgstr "Selecione o diretório para baixar os dados do jogo"
 
 #: gui/downloaddialog.cpp:49 gui/dump-all-dialogs.cpp:117
-#: gui/dump-all-dialogs.cpp:142 gui/editgamedialog.cpp:586 gui/launcher.cpp:321
+#: gui/dump-all-dialogs.cpp:142 gui/editgamedialog.cpp:586
+#: gui/launcher.cpp:321
 msgid "Select directory with game data"
 msgstr "Selecione o diretório com os dados do jogo"
 
@@ -765,8 +773,8 @@ msgstr "ID:"
 #: gui/editgamedialog.cpp:347 gui/editgamedialog.cpp:349
 #: gui/editgamedialog.cpp:350
 msgid ""
-"Short game identifier used for referring to saved games and running the game "
-"from the command line"
+"Short game identifier used for referring to saved games and running the game"
+" from the command line"
 msgstr ""
 "Código identificador curto utilizado para se referir a jogos salvos e "
 "execução do jogo a partir da linha de comando"
@@ -886,7 +894,7 @@ msgstr "Executar Cliente de E-mail"
 
 #: gui/integrity-dialog.cpp:152
 msgid "This game includes add-ons, pick the part you want to be checked:"
-msgstr ""
+msgstr "Este jogo inclui complementos, escolha a parte que deseja verificar:"
 
 #: gui/integrity-dialog.cpp:258
 msgid "Calculation complete"
@@ -902,14 +910,12 @@ msgid ""
 "### Results\n"
 "Your set of game files seems to be unknown to us.\n"
 "\n"
-"If you are sure that this is a valid unknown variant, please send the "
-"following e-mail to integrity@scummvm.org"
+"If you are sure that this is a valid unknown variant, please send the following e-mail to integrity@scummvm.org"
 msgstr ""
 "### Resultados\n"
 "Seu conjunto de arquivos do jogo parece ser desconhecido para nós.\n"
 "\n"
-"Se você tiver certeza de que esta é uma variante desconhecida válida, envie "
-"o seguinte e-mail para integrity@scummvm.org"
+"Se você tiver certeza de que esta é uma variante desconhecida válida, envie o seguinte e-mail para integrity@scummvm.org"
 
 #: gui/integrity-dialog.cpp:692
 msgid ""
@@ -1143,8 +1149,11 @@ msgstr "Retroceder"
 msgid "Delete Character"
 msgstr "Apagar Caractere"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) This action is used to go to the end of the save file name input field
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) This action is used to go to the end of the password input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) This action is used to go to the end of the save file name input
+#. field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) This action is used to go to the end of the password input field
 #: gui/gui-manager.cpp:210 engines/sherlock/metaengine.cpp:1117
 #: engines/sherlock/metaengine.cpp:1222
 msgid "Go to end of line"
@@ -1158,8 +1167,11 @@ msgstr "Selecionar até o fim da linha"
 msgid "Select to start of line"
 msgstr "Selecionar até o início da linha"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) This action is used to go to the start of the save file name input field
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) This action is used to go to the start of the password input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) This action is used to go to the start of the save file name input
+#. field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) This action is used to go to the start of the password input field
 #: gui/gui-manager.cpp:240 engines/sherlock/metaengine.cpp:1110
 #: engines/sherlock/metaengine.cpp:1215
 msgid "Go to start of line"
@@ -1206,84 +1218,43 @@ msgstr "Geral"
 msgid ""
 "## ScummVM at a Glance\n"
 "\n"
-"ScummVM is a modern reimplementation of various game engines. Once you "
-"transfer the original game data to your device, it endeavors to use it to "
-"faithfully recreate the original gaming experience. \n"
+"ScummVM is a modern reimplementation of various game engines. Once you transfer the original game data to your device, it endeavors to use it to faithfully recreate the original gaming experience. \n"
 "\n"
-"ScummVM isn't your typical emulator of DOS, Windows, or some console. Rather "
-"than a one-size-fits-all approach, it takes a meticulous route, implementing "
-"the precise game logic for each specific title or engine it supports. "
-"ScummVM will not work with game engines it does not support.\n"
+"ScummVM isn't your typical emulator of DOS, Windows, or some console. Rather than a one-size-fits-all approach, it takes a meticulous route, implementing the precise game logic for each specific title or engine it supports. ScummVM will not work with game engines it does not support.\n"
 "\n"
-"ScummVM is developed by a team of volunteers and is free software. We lack "
-"an extensive testing team, possess only a limited range of devices, and "
-"cannot always address every request. We also do not run advertisements or "
-"sell you anything. Please be mindful of this when you submit a complaint or "
-"a bug report.\n"
+"ScummVM is developed by a team of volunteers and is free software. We lack an extensive testing team, possess only a limited range of devices, and cannot always address every request. We also do not run advertisements or sell you anything. Please be mindful of this when you submit a complaint or a bug report.\n"
 "\n"
 "## Where to get the games\n"
 "\n"
-"Visit [our Wiki](https://wiki.scummvm.org/index.php?"
-"title=Where_to_get_the_games) for a detailed list of supported games and "
-"where to purchase them.\n"
+"Visit [our Wiki](https://wiki.scummvm.org/index.php?title=Where_to_get_the_games) for a detailed list of supported games and where to purchase them.\n"
 "\n"
-"Alternatively, you can download a variety of [freeware games](https://"
-"scummvm.org/games) and [demos](https://www.scummvm.org/demos/) directly from "
-"our website.\n"
+"Alternatively, you can download a variety of [freeware games](https://scummvm.org/games) and [demos](https://www.scummvm.org/demos/) directly from our website.\n"
 "\n"
-"The ScummVM team does not endorse any specific game supplier. However, the "
-"project receives a commission from every purchase made on [ZOOM-Platform]"
-"(https://www.zoom-platform.com/?"
-"affiliate=c049516c-9c4c-42d6-8649-92ed870e8b53) through affiliate referral "
-"links.\n"
+"The ScummVM team does not endorse any specific game supplier. However, the project receives a commission from every purchase made on [ZOOM-Platform](https://www.zoom-platform.com/?affiliate=c049516c-9c4c-42d6-8649-92ed870e8b53) through affiliate referral links.\n"
 "\n"
-"Additionally, games not available on ZOOM-Platform can be found on other "
-"suppliers such as GOG.com and Steam.\n"
+"Additionally, games not available on ZOOM-Platform can be found on other suppliers such as GOG.com and Steam.\n"
 "\n"
-"For other (out-of-print) games, consider checking platforms like Amazon, "
-"eBay, Game Trading Zone, or other auction sites. Be cautious of faulty games "
-"and illegal game copies.\n"
+"For other (out-of-print) games, consider checking platforms like Amazon, eBay, Game Trading Zone, or other auction sites. Be cautious of faulty games and illegal game copies.\n"
 msgstr ""
 "## Visão geral do ScummVM\n"
 "\n"
-"ScummVM é uma reimplementação moderna de várias engines de jogo. Depois de "
-"transferir os dados originais do jogo para o seu dispositivo, ele se esforça "
-"para usá-los e recriar fielmente a experiência de jogo original.\n"
+"ScummVM é uma reimplementação moderna de várias engines de jogo. Depois de transferir os dados originais do jogo para o seu dispositivo, ele se esforça para usá-los e recriar fielmente a experiência de jogo original.\n"
 "\n"
-"ScummVM não é um emulador típico de DOS, Windows ou algum console. Em vez de "
-"uma abordagem única, ele segue um caminho meticuloso, implementando a lógica "
-"de jogo precisa para cada título ou engine específica compatível. ScummVM "
-"não funcionará com engines de jogos que não são compatíveis.\n"
+"ScummVM não é um emulador típico de DOS, Windows ou algum console. Em vez de uma abordagem única, ele segue um caminho meticuloso, implementando a lógica de jogo precisa para cada título ou engine específica compatível. ScummVM não funcionará com engines de jogos que não são compatíveis.\n"
 "\n"
-"ScummVM é desenvolvido por uma equipe de voluntários e é um software livre. "
-"Não temos uma equipe de testes extensa, possuímos apenas uma gama limitada "
-"de dispositivos e nem sempre podemos atender a todas as solicitações de "
-"forma imediata. Também não publicamos anúncios nem vendemos nada a você. Por "
-"favor, leve isso em consideração ao enviar uma reclamação ou um relatório de "
-"bug.\n"
+"ScummVM é desenvolvido por uma equipe de voluntários e é um software livre. Não temos uma equipe de testes extensa, possuímos apenas uma gama limitada de dispositivos e nem sempre podemos atender a todas as solicitações de forma imediata. Também não publicamos anúncios nem vendemos nada a você. Por favor, leve isso em consideração ao enviar uma reclamação ou um relatório de bug.\n"
 "\n"
 "## Onde conseguir os jogos\n"
 "\n"
-"Visite [nosso Wiki](https://wiki.scummvm.org/index.php?"
-"title=Where_to_get_the_games) para obter uma lista detalhada de jogos "
-"compatíveis e onde comprá-los.\n"
+"Visite [nosso Wiki](https://wiki.scummvm.org/index.php?title=Where_to_get_the_games) para obter uma lista detalhada de jogos compatíveis e onde comprá-los.\n"
 "\n"
-"Como alternativa, você pode baixar uma variedade de [jogos gratuitos]"
-"(https://scummvm.org/games) e [demonstrações](https://www.scummvm.org/"
-"demos/) diretamente de nosso site.\n"
+"Como alternativa, você pode baixar uma variedade de [jogos gratuitos](https://scummvm.org/games) e [demonstrações](https://www.scummvm.org/demos/) diretamente de nosso site.\n"
 "\n"
-"A equipe ScummVM não recomenda nenhum fornecedor específico de jogos. No "
-"entanto, o projeto recebe uma comissão por cada compra realizada na "
-"[Plataforma ZOOM](https://www.zoom-platform.com/?"
-"affiliate=c049516c-9c4c-42d6-8649-92ed870e8b53) por meio de links de "
-"referência de afiliados.\n"
+"A equipe ScummVM não recomenda nenhum fornecedor específico de jogos. No entanto, o projeto recebe uma comissão por cada compra realizada na [Plataforma ZOOM](https://www.zoom-platform.com/?affiliate=c049516c-9c4c-42d6-8649-92ed870e8b53) por meio de links de referência de afiliados.\n"
 "\n"
-"Além disso, jogos não disponíveis na plataforma ZOOM podem ser encontrados "
-"em outros fornecedores como GOG.com e Steam.\n"
+"Além disso, jogos não disponíveis na plataforma ZOOM podem ser encontrados em outros fornecedores como GOG.com e Steam.\n"
 "\n"
-"Para outros jogos (não mais disponíveis), considere verificar plataformas "
-"como Amazon, eBay, Game Trading Zone ou outros sites de leilão. Tenha "
-"cuidado com jogos defeituosos e cópias ilegais.\n"
+"Para outros jogos (não mais disponíveis), considere verificar plataformas como Amazon, eBay, Game Trading Zone ou outros sites de leilão. Tenha cuidado com jogos defeituosos e cópias ilegais.\n"
 
 #: gui/helpdialog.cpp:68 gui/options.cpp:2379
 msgid "Cloud"
@@ -1294,14 +1265,11 @@ msgstr "Nuvem"
 #| msgid ""
 #| "## Connecting a cloud service - Quick mode\n"
 #| "\n"
-#| "1. From the Launcher, select **Global Options** and then select the "
-#| "**Cloud** tab.\n"
+#| "1. From the Launcher, select **Global Options** and then select the **Cloud** tab.\n"
 #| "\n"
-#| "2. Select your preferred cloud storage service from the **Active "
-#| "storage** dropdown, then select **Connect**.\n"
+#| "2. Select your preferred cloud storage service from the **Active storage** dropdown, then select **Connect**.\n"
 #| "\n"
-#| "\t  ![Select cloud service](choose_storage.png \"Select cloud service\")"
-#| "{w=70%}\n"
+#| "\t  ![Select cloud service](choose_storage.png \"Select cloud service\"){w=70%}\n"
 #| "\n"
 #| "3. Select **Quick mode**.\n"
 #| "\n"
@@ -1317,14 +1285,11 @@ msgstr "Nuvem"
 #| "\n"
 #| "\t  ![Open the link](open_link.png \"Open the link\"){w=70%}\n"
 #| "\n"
-#| "6. In the browser window that opens, select the cloud service to "
-#| "connect. \n"
+#| "6. In the browser window that opens, select the cloud service to connect. \n"
 #| "\n"
-#| "\t  ![Choose the cloud service](cloud_browser.png \"Choose the cloud "
-#| "service\"){w=70%}\n"
+#| "\t  ![Choose the cloud service](cloud_browser.png \"Choose the cloud service\"){w=70%}\n"
 #| "\n"
-#| "7. Sign in to the chosen cloud service. Once completed, return to "
-#| "ScummVM.\n"
+#| "7. Sign in to the chosen cloud service. Once completed, return to ScummVM.\n"
 #| "\n"
 #| "8. On the success screen, select **Finish** to exit. \n"
 #| "\n"
@@ -1333,26 +1298,19 @@ msgstr "Nuvem"
 #| "\n"
 #| "\t  ![Enable storage](enable_storage.png \"Enable storage\"){w=70%}\n"
 #| "\n"
-#| "10. You're ready to go! Use the cloud functionality to sync saved games "
-#| "or game files between your devices.\n"
+#| "10. You're ready to go! Use the cloud functionality to sync saved games or game files between your devices.\n"
 #| "\n"
-#| "\t  ![Cloud functionality](cloud_functions.png \"Cloud functionality\")"
-#| "{w=70%}\n"
+#| "\t  ![Cloud functionality](cloud_functions.png \"Cloud functionality\"){w=70%}\n"
 #| "\n"
-#| "   For more information, including how to use the manual connection "
-#| "wizard, see our [Cloud documentation](https://docs.scummvm.org/en/latest/"
-#| "use_scummvm/connect_cloud.html) "
+#| "   For more information, including how to use the manual connection wizard, see our [Cloud documentation](https://docs.scummvm.org/en/latest/use_scummvm/connect_cloud.html) "
 msgid ""
 "## Connecting a cloud service - Quick mode\n"
 "\n"
-"1. From the Launcher, select **Global Options** and then select the "
-"**Cloud** tab.\n"
+"1. From the Launcher, select **Global Options** and then select the **Cloud** tab.\n"
 "\n"
-"2. Select your preferred cloud storage service from the **Active storage** "
-"dropdown, then select **Connect**.\n"
+"2. Select your preferred cloud storage service from the **Active storage** dropdown, then select **Connect**.\n"
 "\n"
-"\t  ![Select cloud service](choose_storage.png \"Select cloud service\")"
-"{w=70%,maxw=50em}\n"
+"\t  ![Select cloud service](choose_storage.png \"Select cloud service\"){w=70%,maxw=50em}\n"
 "\n"
 "3. Select **Quick mode**.\n"
 "\n"
@@ -1370,8 +1328,7 @@ msgid ""
 "\n"
 "6. In the browser window that opens, select the cloud service to connect. \n"
 "\n"
-"\t  ![Choose the cloud service](cloud_browser.png \"Choose the cloud "
-"service\"){w=70%,maxw=50em}\n"
+"\t  ![Choose the cloud service](cloud_browser.png \"Choose the cloud service\"){w=70%,maxw=50em}\n"
 "\n"
 "7. Sign in to the chosen cloud service. Once completed, return to ScummVM.\n"
 "\n"
@@ -1380,29 +1337,21 @@ msgid ""
 "\t  ![Success](cloud_success.png \"Success\"){w=70%,maxw=50em}\n"
 "9. Back on the main Cloud tab, select **Enable storage**.\n"
 "\n"
-"\t  ![Enable storage](enable_storage.png \"Enable storage\")"
-"{w=70%,maxw=50em}\n"
+"\t  ![Enable storage](enable_storage.png \"Enable storage\"){w=70%,maxw=50em}\n"
 "\n"
-"10. You're ready to go! Use the cloud functionality to sync saved games or "
-"game files between your devices.\n"
+"10. You're ready to go! Use the cloud functionality to sync saved games or game files between your devices.\n"
 "\n"
-"\t  ![Cloud functionality](cloud_functions.png \"Cloud functionality\")"
-"{w=70%,maxw=50em}\n"
+"\t  ![Cloud functionality](cloud_functions.png \"Cloud functionality\"){w=70%,maxw=50em}\n"
 "\n"
-"   For more information, including how to use the manual connection wizard, "
-"see our [Cloud documentation](https://docs.scummvm.org/en/latest/use_scummvm/"
-"connect_cloud.html) "
+"   For more information, including how to use the manual connection wizard, see our [Cloud documentation](https://docs.scummvm.org/en/latest/use_scummvm/connect_cloud.html) "
 msgstr ""
 "## Conectando um serviço em nuvem - Modo rápido\n"
 "\n"
-"1. No Inicializador, selecione **Opções globais** e depois selecione a aba "
-"**Nuvem**.\n"
+"1. No Inicializador, selecione **Opções globais** e depois selecione a aba **Nuvem**.\n"
 "\n"
-"2. Selecione seu serviço de armazenamento em nuvem preferido no menu "
-"suspenso **Armazenamento ativo** e selecione **Conectar**.\n"
+"2. Selecione seu serviço de armazenamento em nuvem preferido no menu suspenso **Armazenamento ativo** e selecione **Conectar**.\n"
 "\n"
-"\t  ![Selecionar serviço de nuvem](choose_storage.png \"Selecionar serviço "
-"de nuvem\"){w=70%}\n"
+"\t  ![Selecionar serviço de nuvem](choose_storage.png \"Selecionar serviço de nuvem\"){w=70%}\n"
 "\n"
 "3. Selecione **Modo rápido**.\n"
 "\n"
@@ -1418,32 +1367,24 @@ msgstr ""
 "\n"
 "\t  ![Abra o link](open_link.png \"Abra o link\"){w=70%}\n"
 "\n"
-"6. Na janela do navegador que é aberta, selecione o serviço de nuvem para "
-"conectar. \n"
+"6. Na janela do navegador que é aberta, selecione o serviço de nuvem para conectar. \n"
 "\n"
-"\t  ![Escolha o serviço de nuvem](cloud_browser.png \"Escolha o serviço de "
-"nuvem\"){w=70%}\n"
+"\t  ![Escolha o serviço de nuvem](cloud_browser.png \"Escolha o serviço de nuvem\"){w=70%}\n"
 "\n"
-"7. Faça login no serviço de nuvem escolhido. Depois de concluído, retorne ao "
-"ScummVM.\n"
+"7. Faça login no serviço de nuvem escolhido. Depois de concluído, retorne ao ScummVM.\n"
 "\n"
 "8. Na tela de sucesso, selecione **Concluir** para sair. \n"
 "\n"
 "\t  ![Sucesso](cloud_success.png \"Sucesso\"){w=70%}\n"
 "9. De volta à aba Nuvem principal, selecione **Ativar armazenamento**.\n"
 "\n"
-"\t  ![Ativar armazenamento](enable_storage.png \"Ativar armazenamento\")"
-"{w=70%}\n"
+"\t  ![Ativar armazenamento](enable_storage.png \"Ativar armazenamento\"){w=70%}\n"
 "\n"
-"10. Você está pronto para começar! Use a funcionalidade da nuvem para "
-"sincronizar jogos salvos ou arquivos de jogos entre seus dispositivos.\n"
+"10. Você está pronto para começar! Use a funcionalidade da nuvem para sincronizar jogos salvos ou arquivos de jogos entre seus dispositivos.\n"
 "\n"
-"\t  ![Funcionalidade da nuvem](cloud_functions.png \"Funcionalidade da "
-"nuvem\"){w=70%}\n"
+"\t  ![Funcionalidade da nuvem](cloud_functions.png \"Funcionalidade da nuvem\"){w=70%}\n"
 "\n"
-"   Para obter mais informações, incluindo como usar o assistente de conexão "
-"manual, consulte nossa [documentação sobre nuvem](https://docs.scummvm.org/"
-"en/latest/use_scummvm/connect_cloud.html) "
+"   Para obter mais informações, incluindo como usar o assistente de conexão manual, consulte nossa [documentação sobre nuvem](https://docs.scummvm.org/en/latest/use_scummvm/connect_cloud.html) "
 
 #: gui/imagealbum-dialog.cpp:103 gui/saveload-dialog.cpp:843
 msgid "Prev"
@@ -1468,7 +1409,8 @@ msgctxt "group"
 msgid "None"
 msgstr "Nenhum"
 
-#. I18N: Group name for the game list, grouped by the first letter of the game title
+#. I18N: Group name for the game list, grouped by the first letter of the game
+#. title
 #: gui/launcher.cpp:110
 msgctxt "group"
 msgid "First letter"
@@ -1531,7 +1473,8 @@ msgstr "Seleciona um critério para agrupar os registros"
 msgid "Click here to see Help"
 msgstr "Clique aqui para obter Ajuda"
 
-#. I18N: Button Quit ScummVM program. Q is the shortcut, Ctrl+Q, put it in parens for non-latin (~Q~)
+#. I18N: Button Quit ScummVM program. Q is the shortcut, Ctrl+Q, put it in
+#. parens for non-latin (~Q~)
 #: gui/launcher.cpp:269 engines/dialogs.cpp:94
 msgid "~Q~uit"
 msgstr "~S~air"
@@ -1540,7 +1483,8 @@ msgstr "~S~air"
 msgid "Quit ScummVM"
 msgstr "Sair do ScummVM"
 
-#. I18N: Button About ScummVM program. b is the shortcut, Ctrl+b, put it in parens for non-latin (~b~)
+#. I18N: Button About ScummVM program. b is the shortcut, Ctrl+b, put it in
+#. parens for non-latin (~b~)
 #: gui/launcher.cpp:273
 msgid "A~b~out"
 msgstr "So~b~re"
@@ -1555,7 +1499,8 @@ msgstr "Sobre o ScumnmVM"
 msgid "General help"
 msgstr "Teclas Gerais"
 
-#. I18N: Button caption. O is the shortcut, Ctrl+O, put it in parens for non-latin (~O~)
+#. I18N: Button caption. O is the shortcut, Ctrl+O, put it in parens for non-
+#. latin (~O~)
 #: gui/launcher.cpp:280
 msgid "Global ~O~ptions..."
 msgstr "~O~pções Globais..."
@@ -1577,7 +1522,8 @@ msgstr "Baixar Jogos"
 msgid "Download freeware games for ScummVM"
 msgstr "Baixa jogos freeware (gratuitos) para o ScummVM"
 
-#. I18N: Button caption. A is the shortcut, Ctrl+A, put it in parens for non-latin (~A~)
+#. I18N: Button caption. A is the shortcut, Ctrl+A, put it in parens for non-
+#. latin (~A~)
 #: gui/launcher.cpp:291
 msgid "~A~dd Game..."
 msgstr "~A~dicionar Jogo..."
@@ -1591,14 +1537,16 @@ msgctxt "lowres"
 msgid "~A~dd Game..."
 msgstr "~A~dicionar Jogo..."
 
-#. I18N: Button caption. R is the shortcut, Ctrl+R, put it in parens for non-latin (~R~)
+#. I18N: Button caption. R is the shortcut, Ctrl+R, put it in parens for non-
+#. latin (~R~)
 #: gui/launcher.cpp:295
 msgid "~R~emove Game"
 msgstr "~R~emover Jogo"
 
 #: gui/launcher.cpp:295
 msgid "Remove game from the list. The game data files stay intact"
-msgstr "Remove jogo da lista. Os arquivos de dados do jogo permanecem intactos"
+msgstr ""
+"Remove jogo da lista. Os arquivos de dados do jogo permanecem intactos"
 
 #: gui/launcher.cpp:295
 msgctxt "lowres"
@@ -1632,8 +1580,8 @@ msgstr "Este diretório não pode ser utilizado ainda, está sendo baixado!"
 
 #: gui/launcher.cpp:427
 msgid ""
-"Do you really want to run the mass game detector? This could potentially add "
-"a huge number of games."
+"Do you really want to run the mass game detector? This could potentially add"
+" a huge number of games."
 msgstr ""
 "Você realmente deseja adicionar vários jogos ao mesmo tempo? Isso poderá "
 "resultar em uma adição gigantesca de jogos."
@@ -1651,7 +1599,8 @@ msgid "This game does not support loading games from the launcher."
 msgstr "Este jogo não suporta abrir jogos a partir do inicializador."
 
 #: gui/launcher.cpp:594
-msgid "ScummVM could not find any engine capable of running the selected game!"
+msgid ""
+"ScummVM could not find any engine capable of running the selected game!"
 msgstr ""
 "ScummVM não conseguiu encontrar nenhuma engine capaz de rodar o jogo "
 "selecionado!"
@@ -1716,7 +1665,7 @@ msgstr "Opç. de Jo~g~o..."
 
 #: gui/launcher.cpp:1265
 msgid "Add-on"
-msgstr ""
+msgstr "Complemento"
 
 #. I18N: List grouping when no engine is specified
 #: gui/launcher.cpp:1335 gui/launcher.cpp:1580
@@ -2008,8 +1957,8 @@ msgstr "Sincronização Vertical"
 
 #: gui/options.cpp:1703
 msgid ""
-"Wait for the vertical sync to refresh the screen in order to prevent tearing "
-"artifacts"
+"Wait for the vertical sync to refresh the screen in order to prevent tearing"
+" artifacts"
 msgstr ""
 "Aguarda a sincronização vertical para atualizar a tela a fim de evitar o "
 "efeito de tela cortada"
@@ -2103,7 +2052,8 @@ msgstr "SoundFont:"
 
 #: gui/options.cpp:1838 gui/options.cpp:1840 gui/options.cpp:1848
 msgid "SoundFont is supported by some audio cards, FluidSynth and Timidity"
-msgstr "SoundFont é suportado por algumas placas de som, FluidSynth e Timidity"
+msgstr ""
+"SoundFont é suportado por algumas placas de som, FluidSynth e Timidity"
 
 #: gui/options.cpp:1840
 msgctxt "lowres"
@@ -2134,10 +2084,11 @@ msgid "MT-32 device:"
 msgstr "Dispositivo MT-32:"
 
 #: gui/options.cpp:1866
-msgid "Specifies default sound device for Roland MT-32/LAPC1/CM32l/CM64 output"
+msgid ""
+"Specifies default sound device for Roland MT-32/LAPC1/CM32l/CM64 output"
 msgstr ""
-"Especifica o dispositivo de som padrão para a saída Roland MT-32/LAPC1/CM32l/"
-"CM64"
+"Especifica o dispositivo de som padrão para a saída Roland "
+"MT-32/LAPC1/CM32l/CM64"
 
 #: gui/options.cpp:1871
 msgid "True Roland MT-32 (disable GM emulation)"
@@ -2303,8 +2254,8 @@ msgstr "Configurações do FluidSynth"
 
 #: gui/options.cpp:2524
 msgid ""
-"Specifies where your saved games are put. A red coloring indicates the value "
-"is temporary and will not get saved"
+"Specifies where your saved games are put. A red coloring indicates the value"
+" is temporary and will not get saved"
 msgstr ""
 "Especifica onde seus jogos salvos são colocados. Uma coloração vermelha "
 "indica que o valor é temporário e não será salvo"
@@ -2456,9 +2407,9 @@ msgid ""
 "That way, if a game uses the ScummVM save and load dialogs, they are in the "
 "same language as the game."
 msgstr ""
-"Ao iniciar um jogo, altera o idioma da interface do ScummVM para o idioma do "
-"jogo. Dessa forma, se um jogo usar as caixas de diálogo de salvar e carregar "
-"do ScummVM, eles ficarão no mesmo idioma do jogo."
+"Ao iniciar um jogo, altera o idioma da interface do ScummVM para o idioma do"
+" jogo. Dessa forma, se um jogo usar as caixas de diálogo de salvar e "
+"carregar do ScummVM, eles ficarão no mesmo idioma do jogo."
 
 #: gui/options.cpp:2719
 msgid "Use native system file browser"
@@ -2604,14 +2555,14 @@ msgstr "<nunca>"
 msgctxt "lowres"
 msgid "Saved games sync automatically on launch, after saving and on loading."
 msgstr ""
-"Os jogos salvos são sincronizados automaticamente no lançamento, após salvar "
-"e ao carregar."
+"Os jogos salvos são sincronizados automaticamente no lançamento, após salvar"
+" e ao carregar."
 
 #: gui/options.cpp:2822
 msgid "Saved games sync automatically on launch, after saving and on loading."
 msgstr ""
-"Os jogos salvos são sincronizados automaticamente no lançamento, após salvar "
-"e ao carregar."
+"Os jogos salvos são sincronizados automaticamente no lançamento, após salvar"
+" e ao carregar."
 
 #: gui/options.cpp:2823
 msgid "Sync now"
@@ -2734,17 +2685,10 @@ msgstr "Desabilitar autosave"
 
 #: gui/options.cpp:2965
 msgid ""
-"WARNING: Autosave was enabled. Some of your games have existing saved games "
-"on the autosave slot. You can either move the existing saves to new slots, "
-"disable autosave, or ignore (you will be prompted when autosave is about to "
-"overwrite a save).\n"
+"WARNING: Autosave was enabled. Some of your games have existing saved games on the autosave slot. You can either move the existing saves to new slots, disable autosave, or ignore (you will be prompted when autosave is about to overwrite a save).\n"
 "List of games:\n"
 msgstr ""
-"AVISO: O salvamento automático foi habilitado. Alguns de seus jogos possuem "
-"jogos salvos existentes no slot de salvamento automático. Você pode mover os "
-"salvamentos existentes para novos slots, desativar o salvamento automático "
-"ou ignorar (você será avisado quando o salvamento automático estiver prestes "
-"a substituir um salvamento).\n"
+"AVISO: O salvamento automático foi habilitado. Alguns de seus jogos possuem jogos salvos existentes no slot de salvamento automático. Você pode mover os salvamentos existentes para novos slots, desativar o salvamento automático ou ignorar (você será avisado quando o salvamento automático estiver prestes a substituir um salvamento).\n"
 "Lista de jogos:\n"
 
 #: gui/options.cpp:2974
@@ -2885,7 +2829,7 @@ msgstr "*  Abc"
 
 #: gui/printing-dialog.cpp:54
 msgid "Print"
-msgstr ""
+msgstr "Imprimir"
 
 #: gui/printing-dialog.cpp:56
 #, fuzzy
@@ -3162,47 +3106,29 @@ msgstr "Salvamentos"
 msgid "Bad config file format. overwrite?"
 msgstr "Formato de arquivo de configuração inválido. substituir?"
 
-#. I18N: <Add a new folder> must match the translation done in backends/fs/android/android-saf-fs.h
+#. I18N: <Add a new folder> must match the translation done in
+#. backends/fs/android/android-saf-fs.h
 #: base/main.cpp:657
 msgid ""
-"In this new version of ScummVM for Android, significant changes were made to "
-"the file access system to allow support for modern versions of the Android "
-"Operating System.\n"
-"If you find that your existing added games or custom paths no longer work, "
-"please edit those paths:\n"
-"  1. From the Launcher, go to **Game Options > Paths**. Select **Game Path** "
-"or **Extra Path**, as appropriate. \n"
-"  2. Inside the ScummVM file browser, select **Go Up** until you reach the "
-"root folder which has the **<Add a new folder>** option.\n"
-"  3. Double-tap **<Add a new folder>**. In your device's file browser, "
-"navigate to the folder containing all your game folders. For example, **SD "
-"Card > ScummVMgames** \n"
+"In this new version of ScummVM for Android, significant changes were made to the file access system to allow support for modern versions of the Android Operating System.\n"
+"If you find that your existing added games or custom paths no longer work, please edit those paths:\n"
+"  1. From the Launcher, go to **Game Options > Paths**. Select **Game Path** or **Extra Path**, as appropriate. \n"
+"  2. Inside the ScummVM file browser, select **Go Up** until you reach the root folder which has the **<Add a new folder>** option.\n"
+"  3. Double-tap **<Add a new folder>**. In your device's file browser, navigate to the folder containing all your game folders. For example, **SD Card > ScummVMgames** \n"
 "  4. Select **Use this folder**. \n"
 "  5. Select **Allow** to give ScummVM permission to access the folder. \n"
-"  6. In the ScummVM file browser, double-tap to browse through your added "
-"folder. Select the folder containing the game's files, then tap "
-"**Choose**. \n"
+"  6. In the ScummVM file browser, double-tap to browse through your added folder. Select the folder containing the game's files, then tap **Choose**. \n"
 "\n"
 "Repeat steps 1 and 6 for each game."
 msgstr ""
-"Nesta nova versão do ScummVM para Android, foram feitas mudanças "
-"significativas no sistema de acesso a arquivos para permitir o suporte a "
-"versões modernas do sistema operacional Android.\n"
-"Se você achar que seus jogos adicionados existentes ou caminhos "
-"personalizados não funcionam mais, altere os seguintes caminhos:\n"
-"  1. Pelo inicializador, entre em **Opções de jogo > Caminhos**. Selecione "
-"**Jogo** ou **Extras**, conforme apropriado.\n"
-"  2. Dentro do navegador de arquivos ScummVM, selecione **Subir** até chegar "
-"à pasta raiz que tem a opção **<Adicionar nova pasta>**.\n"
-"  3. Toque duas vezes em **<Adicionar nova pasta>**. No navegador de "
-"arquivos do seu dispositivo, navegue até a pasta que contém todas as pastas "
-"do jogo. Por exemplo, **Cartão SD > ScummVMjogos**\n"
+"Nesta nova versão do ScummVM para Android, foram feitas mudanças significativas no sistema de acesso a arquivos para permitir o suporte a versões modernas do sistema operacional Android.\n"
+"Se você achar que seus jogos adicionados existentes ou caminhos personalizados não funcionam mais, altere os seguintes caminhos:\n"
+"  1. Pelo inicializador, entre em **Opções de jogo > Caminhos**. Selecione **Jogo** ou **Extras**, conforme apropriado.\n"
+"  2. Dentro do navegador de arquivos ScummVM, selecione **Subir** até chegar à pasta raiz que tem a opção **<Adicionar nova pasta>**.\n"
+"  3. Toque duas vezes em **<Adicionar nova pasta>**. No navegador de arquivos do seu dispositivo, navegue até a pasta que contém todas as pastas do jogo. Por exemplo, **Cartão SD > ScummVMjogos**\n"
 "  4. Selecione **Utilizar esta pasta**.\n"
-"  5. Selecione **Permitir** para dar permissão ao ScummVM para acessar a "
-"pasta.\n"
-"  6. No navegador de arquivos ScummVM, toque duas vezes para navegar pela "
-"pasta adicionada. Selecione a pasta que contém os arquivos do jogo e toque "
-"em **Escolher**.\n"
+"  5. Selecione **Permitir** para dar permissão ao ScummVM para acessar a pasta.\n"
+"  6. No navegador de arquivos ScummVM, toque duas vezes para navegar pela pasta adicionada. Selecione a pasta que contém os arquivos do jogo e toque em **Escolher**.\n"
 "\n"
 "Repita as etapas 1 e 6 para cada jogo."
 
@@ -3211,44 +3137,30 @@ msgstr ""
 msgid "Read Later"
 msgstr "Ler mais Tarde"
 
-#. I18N: <Add a new folder> must match the translation done in backends/fs/android/android-saf-fs.h
+#. I18N: <Add a new folder> must match the translation done in
+#. backends/fs/android/android-saf-fs.h
 #: base/main.cpp:684
 msgid ""
-"In this new version of ScummVM for Android, significant changes were made to "
-"the file access system to allow support for modern versions of the Android "
-"Operating System.\n"
+"In this new version of ScummVM for Android, significant changes were made to the file access system to allow support for modern versions of the Android Operating System.\n"
 "To add a game:\n"
 "\n"
 "  1. Select **Add Game...** from the launcher. \n"
-"  2. Inside the ScummVM file browser, select **Go Up** until you reach the "
-"root folder which has the **<Add a new folder>** option.\n"
-"  3. Double-tap **<Add a new folder>**. In your device's file browser, "
-"navigate to the folder containing all your game folders. For example, **SD "
-"Card > ScummVMgames** \n"
+"  2. Inside the ScummVM file browser, select **Go Up** until you reach the root folder which has the **<Add a new folder>** option.\n"
+"  3. Double-tap **<Add a new folder>**. In your device's file browser, navigate to the folder containing all your game folders. For example, **SD Card > ScummVMgames** \n"
 "  4. Select **Use this folder**. \n"
 "  5. Select **Allow** to give ScummVM permission to access the folder. \n"
-"  6. In the ScummVM file browser, double-tap to browse through your added "
-"folder. Select the sub-folder containing the game's files, then tap "
-"**Choose**.\n"
+"  6. In the ScummVM file browser, double-tap to browse through your added folder. Select the sub-folder containing the game's files, then tap **Choose**.\n"
 "Repeat steps 1 and 6 for each game."
 msgstr ""
-"Nesta nova versão do ScummVM para Android, foram feitas mudanças "
-"significativas no sistema de acesso a arquivos para permitir o suporte a "
-"versões modernas do sistema operacional Android.\n"
+"Nesta nova versão do ScummVM para Android, foram feitas mudanças significativas no sistema de acesso a arquivos para permitir o suporte a versões modernas do sistema operacional Android.\n"
 "Para adicionar um jogo:\n"
 "\n"
 "  1. Selecione **Adicionar Jogo** pelo inicializador.\n"
-"  2. Dentro do navegador de arquivo do ScummVM, selecione **Subir** até "
-"chegar a pasta raiz onde há a opção **<Adicionar nova pasta>**\n"
-"  3. Dê um toque duplo em **<Adicionar nova pasta>**. No navegador de "
-"arquivo de seu dispositivo, navegue até chegar a pasta contendo todas as "
-"pastas de seu jogo. Por exemplo, **Cartão SD > ScummVMjogos**\n"
+"  2. Dentro do navegador de arquivo do ScummVM, selecione **Subir** até chegar a pasta raiz onde há a opção **<Adicionar nova pasta>**\n"
+"  3. Dê um toque duplo em **<Adicionar nova pasta>**. No navegador de arquivo de seu dispositivo, navegue até chegar a pasta contendo todas as pastas de seu jogo. Por exemplo, **Cartão SD > ScummVMjogos**\n"
 "  4. Selecione **Utilizar esta pasta**.\n"
-"  5. Selecione **Permitir** para dar ao ScummVM permissão de acesso a "
-"pasta.\n"
-"  6. No navegador de arquivo do ScummVM, dê um toque duplo para navegar pela "
-"pasta recém adicionada. Selecione a subpasta contendo os arquivos do jogo, e "
-"então dê um toque em **Escolher**.\n"
+"  5. Selecione **Permitir** para dar ao ScummVM permissão de acesso a pasta.\n"
+"  6. No navegador de arquivo do ScummVM, dê um toque duplo para navegar pela pasta recém adicionada. Selecione a subpasta contendo os arquivos do jogo, e então dê um toque em **Escolher**.\n"
 "Repita os passos 1 e 6 para cada jogo."
 
 #: base/main.cpp:866 base/main.cpp:915
@@ -3260,12 +3172,13 @@ msgstr "Erro ao executar o jogo:"
 msgid "Could not locate engine data %s"
 msgstr "Não foi possível localizar dados da engine %s"
 
-#: common/engine_data.cpp:295 engines/ultima/shared/engine/data_archive.cpp:106
+#: common/engine_data.cpp:295
+#: engines/ultima/shared/engine/data_archive.cpp:106
 #, c-format
 msgid "Out of date engine data. Expected %d.%d, but got version %d.%d"
 msgstr ""
-"Sem dados para a engine de dados. Esperava-se %d.%d, porém obteve versão %d."
-"%d"
+"Sem dados para a engine de dados. Esperava-se %d.%d, porém obteve versão "
+"%d.%d"
 
 #: common/error.cpp:37
 msgid "No error"
@@ -3587,8 +3500,8 @@ msgid ""
 "Please select the *root* of your external (physical) SD card. This is "
 "required for ScummVM to access this path: "
 msgstr ""
-"Selecione a *raiz* do seu cartão SD externo (físico). Isso é necessário para "
-"o ScummVM acessar este caminho: "
+"Selecione a *raiz* do seu cartão SD externo (físico). Isso é necessário para"
+" o ScummVM acessar este caminho: "
 
 #: dists/android.strings.xml.cpp:54
 msgid "Storage Access Framework Permissions for ScummVM were revoked!"
@@ -3639,22 +3552,22 @@ msgid ""
 "ScummVM is a program which allows you to run a wide variety of classic "
 "graphical point-and-click adventure games and role-playing games, provided "
 "you already have their data files. The clever part about this: ScummVM just "
-"replaces the executables shipped with the game, allowing you to play them on "
-"systems for which they were never designed!"
+"replaces the executables shipped with the game, allowing you to play them on"
+" systems for which they were never designed!"
 msgstr ""
 "ScummVM é um programa que permite que você execute uma ampla variedade de "
 "jogos clássicos de point-and-click (apontar e clicar) e RPG, desde que você "
-"já tenha seus arquivos de dados. A melhor parte: ScummVM apenas substitui os "
-"executáveis do jogo, permitindo que você os jogue em sistemas para os quais "
-"eles nunca foram projetados!"
+"já tenha seus arquivos de dados. A melhor parte: ScummVM apenas substitui os"
+" executáveis do jogo, permitindo que você os jogue em sistemas para os quais"
+" eles nunca foram projetados!"
 
 #. I18N: 2 of 3 paragraph of ScummVM description in *nix distributions
 #: dists/org.scummvm.scummvm.metainfo.xml.cpp:45
 msgid ""
 "Currently, ScummVM supports a huge library of adventures with over 4000 "
 "games in total. It supports many classics published by legendary studios "
-"like LucasArts, Sierra On-Line, Revolution Software, Cyan, Inc. and Westwood "
-"Studios."
+"like LucasArts, Sierra On-Line, Revolution Software, Cyan, Inc. and Westwood"
+" Studios."
 msgstr ""
 "Atualmente o ScummVM suporta uma enorme biblioteca de aventuras com mais de "
 "4000 jogos no total. Ele suporta muitos clássicos publicados por estúdios "
@@ -3752,7 +3665,8 @@ msgstr ""
 
 #: engines/dialogs.cpp:242 engines/ags/ags.cpp:344
 #: engines/glk/magnetic/magnetic.cpp:187 engines/scumm/saveload.cpp:116
-msgid "This game does not support loading from the menu. Use in-game interface"
+msgid ""
+"This game does not support loading from the menu. Use in-game interface"
 msgstr ""
 "Este jogo não suporta carregamento a partir do menu. Utilize a interface do "
 "jogo"
@@ -3847,24 +3761,17 @@ msgstr "Ignorar salvamento automático"
 #: engines/engine.cpp:644
 #, fuzzy, c-format
 #| msgid ""
-#| "WARNING: The autosave slot contains a saved game named %S, and an "
-#| "autosave is pending.\n"
-#| "Please move this saved game to a new slot, or delete it if it's no longer "
-#| "needed.\n"
+#| "WARNING: The autosave slot contains a saved game named %S, and an autosave is pending.\n"
+#| "Please move this saved game to a new slot, or delete it if it's no longer needed.\n"
 #| "Alternatively, you can skip the autosave (will prompt again in 5 minutes)."
 msgid ""
-"WARNING: The autosave slot contains a saved game named %s, and an autosave "
-"is pending.\n"
-"Please move this saved game to a new slot, or delete it if it's no longer "
-"needed.\n"
+"WARNING: The autosave slot contains a saved game named %s, and an autosave is pending.\n"
+"Please move this saved game to a new slot, or delete it if it's no longer needed.\n"
 "Alternatively, you can skip the autosave (will prompt again in 5 minutes)."
 msgstr ""
-"AVISO: O slot de salvamento automático contém um jogo salvo chamado %S e um "
-"salvamento automático está pendente.\n"
-"Mova este jogo salvo para um novo slot ou exclua-o se não for mais "
-"necessário.\n"
-"Como alternativa, você pode pular o salvamento automático (será solicitado "
-"novamente em 5 minutos)."
+"AVISO: O slot de salvamento automático contém um jogo salvo chamado %S e um salvamento automático está pendente.\n"
+"Mova este jogo salvo para um novo slot ou exclua-o se não for mais necessário.\n"
+"Como alternativa, você pode pular o salvamento automático (será solicitado novamente em 5 minutos)."
 
 #: engines/engine.cpp:654
 msgid "ERROR: Could not copy the savegame to a new slot"
@@ -3916,11 +3823,11 @@ msgstr "Iniciar"
 #, fuzzy, c-format
 #| msgid ""
 #| "WARNING: The game you are about to start is not yet fully supported by "
-#| "ScummVM. As such, it is likely to be unstable, and any saved game you "
-#| "make might not work in future versions of ScummVM."
+#| "ScummVM. As such, it is likely to be unstable, and any saved game you make "
+#| "might not work in future versions of ScummVM."
 msgid ""
-"WARNING: the game you are about to start contains the add-on \"%s\" which is "
-"not yet fully supported by ScummVM. As such, it is likely to be unstable, "
+"WARNING: the game you are about to start contains the add-on \"%s\" which is"
+" not yet fully supported by ScummVM. As such, it is likely to be unstable, "
 "and any saved game you make might not work in future versions of ScummVM."
 msgstr ""
 "AVISO: O jogo que você está prestes a começar ainda não é totalmente "
@@ -3929,18 +3836,23 @@ msgstr ""
 
 #: engines/engine.cpp:845
 msgid ""
-"WARNING: The game you are about to start is newly supported and is in "
-"testing mode.\n"
+"WARNING: The game you are about to start is newly supported and is in testing mode.\n"
 "If you encounter any bugs or oddities, please report them to our bugtracker."
 msgstr ""
+"AVISO: O jogo que você está prestes a iniciar tem suporte recente e está em modo de testes.\n"
+"Se encontrar quaisquer erros ou anomalias, por favor reporte-os ao nosso rastreador de erros."
 
 #: engines/engine.cpp:861
 #, c-format
 msgid ""
-"The game \"%s\" you are trying to add is an add-on for \"%s\" that cannot be "
-"run independently. Please copy the add-on contents into a subdirectory of "
+"The game \"%s\" you are trying to add is an add-on for \"%s\" that cannot be"
+" run independently. Please copy the add-on contents into a subdirectory of "
 "the base game, and start the base game itself."
 msgstr ""
+"O jogo \"%s\" que você está tentando adicionar é um complemento de \"%s\" "
+"que não pode ser executado de forma independente. Por favor, copie o "
+"conteúdo do complemento para um subdiretório do jogo base e inicie o próprio"
+" jogo base."
 
 #: engines/engine.cpp:878
 msgid "This game is not supported."
@@ -3965,27 +3877,28 @@ msgstr "Salvamento do jogo está atualmente indisponível"
 #: engines/engine.cpp:1222
 #, c-format
 msgid ""
-"The directory '%s' looks like an add-on for the game '%s', but ScummVM could "
-"not find any matching add-on in it."
+"The directory '%s' looks like an add-on for the game '%s', but ScummVM could"
+" not find any matching add-on in it."
 msgstr ""
+"O diretório '%s' parece ser um complemento do jogo '%s', mas o ScummVM não "
+"encontrou nenhum complemento correspondente nele."
 
 #: engines/engine.cpp:1250
 #, c-format
 msgid "Directory '%s' matches several add-ons, please pick one."
 msgstr ""
+"O diretório '%s' corresponde a vários complementos, por favor escolha um."
 
 #: engines/game.cpp:199
 #, c-format
 msgid ""
 "The game in '%s' seems to be an unknown game variant.\n"
 "\n"
-"Please report the following data to the ScummVM team at %s along with the "
-"name of the game you tried to add and its version, language, etc.:"
+"Please report the following data to the ScummVM team at %s along with the name of the game you tried to add and its version, language, etc.:"
 msgstr ""
 "O jogo em '%s' parece ser uma variante de jogo desconhecida.\n"
 "\n"
-"Por favor, relate os seguintes dados para o time do ScummVM em %s junto com "
-"o nome do jogo que você tentou adicionar e sua versão, idioma, etc.:"
+"Por favor, relate os seguintes dados para o time do ScummVM em %s junto com o nome do jogo que você tentou adicionar e sua versão, idioma, etc.:"
 
 #: engines/game.cpp:203
 #, c-format
@@ -4024,8 +3937,9 @@ msgstr "Mapeamento de tecla padrão do jogo"
 #: engines/ultima/ultima0/metaengine.cpp:180
 #: engines/ultima/ultima4/metaengine.cpp:227
 #: engines/ultima/nuvie/metaengine.cpp:238
-#: engines/ultima/ultima8/metaengine.cpp:138 engines/vcruise/metaengine.cpp:158
-#: engines/wintermute/keymapper_tables.h:42 engines/zvision/metaengine.cpp:203
+#: engines/ultima/ultima8/metaengine.cpp:138
+#: engines/vcruise/metaengine.cpp:158 engines/wintermute/keymapper_tables.h:42
+#: engines/zvision/metaengine.cpp:203
 msgid "Left click"
 msgstr "Clique esquerdo"
 
@@ -4114,8 +4028,10 @@ msgid "Predictive input dialog"
 msgstr "Caixa de diálogo de entrada preditivo"
 
 #. I18N: This keymap works within the KIA Save Game screen
-#. and allows confirming popup dialog prompts (eg. for save game deletion or overwriting)
-#. and also submitting a new save game name, or choosing an existing save game for overwriting.
+#. and allows confirming popup dialog prompts (eg. for save game deletion or
+#. overwriting)
+#. and also submitting a new save game name, or choosing an existing save game
+#. for overwriting.
 #: engines/metaengine.cpp:131 engines/bladerunner/metaengine.cpp:273
 #: engines/griffon/metaengine.cpp:115 engines/grim/grim.cpp:539
 #: engines/grim/grim.cpp:639 engines/sky/metaengine.cpp:101
@@ -4242,8 +4158,8 @@ msgid ""
 "FluidSynth requires a 'soundfont' setting. Please specify it in ScummVM GUI "
 "on MIDI tab. Music is off."
 msgstr ""
-"FluidSynth requer uma configuração de 'fonte de som'. Por favor, especifique-"
-"a na interface do ScummVM na aba MIDI. Música desligada."
+"FluidSynth requer uma configuração de 'fonte de som'. Por favor, "
+"especifique-a na interface do ScummVM na aba MIDI. Música desligada."
 
 #: audio/softsynth/fluidsynth.cpp:501
 #, c-format
@@ -4379,13 +4295,15 @@ msgstr "'Modo de Toque' do Touchscreen - Passar Sobre (Sem Clicar)"
 msgid "Touchscreen 'Tap Mode' - Hover (DPad Clicks)"
 msgstr "'Modo de Toque' do Touchscreen - Passar Sobre (Cliques do DPad)"
 
-#. I18N: This is displayed in the file browser to let the user choose a new folder for Android Storage Attached Framework
+#. I18N: This is displayed in the file browser to let the user choose a new
+#. folder for Android Storage Attached Framework
 #: backends/fs/android/android-saf-fs.cpp:804
 #: backends/fs/android/android-saf-fs.cpp:808
 msgid "Add a new folder"
 msgstr "Adicionar nova pasta"
 
-#. I18N: This may be displayed in the Android UI used to add a Storage Attach Framework authorization
+#. I18N: This may be displayed in the Android UI used to add a Storage Attach
+#. Framework authorization
 #: backends/fs/android/android-saf-fs.cpp:924
 msgid "Choose a new folder"
 msgstr "Escolher nova pasta"
@@ -4476,8 +4394,8 @@ msgstr "Não foi possível salvar captura de tela"
 msgid "Windowed mode"
 msgstr "Modo janela"
 
-#: backends/graphics/sdl/sdl-graphics.cpp:491 engines/colony/metaengine.cpp:173
-#: engines/scumm/help.cpp:88
+#: backends/graphics/sdl/sdl-graphics.cpp:491
+#: engines/colony/metaengine.cpp:173 engines/scumm/help.cpp:88
 msgid "Toggle fullscreen"
 msgstr "Alternar modo de tela cheia"
 
@@ -4488,7 +4406,7 @@ msgstr "Habilitar captura do mouse"
 
 #: backends/graphics/sdl/sdl-graphics.cpp:503
 msgid "Toggle resizable window"
-msgstr ""
+msgstr "Alternar janela redimensionável"
 
 #: backends/graphics/sdl/sdl-graphics.cpp:508 engines/stark/metaengine.cpp:240
 #: engines/wintermute/keymapper_tables.h:646
@@ -4611,13 +4529,15 @@ msgstr "Analógico Esquerdo"
 msgid "Right stick"
 msgstr "Analógico Direito"
 
-#: backends/keymapper/hardware-input.cpp:264 engines/dragons/metaengine.cpp:206
+#: backends/keymapper/hardware-input.cpp:264
+#: engines/dragons/metaengine.cpp:206
 #, fuzzy
 #| msgid "Left Shoulder"
 msgid "Left shoulder"
 msgstr "Botão LB"
 
-#: backends/keymapper/hardware-input.cpp:265 engines/dragons/metaengine.cpp:212
+#: backends/keymapper/hardware-input.cpp:265
+#: engines/dragons/metaengine.cpp:212
 #, fuzzy
 #| msgid "Right Shoulder"
 msgid "Right shoulder"
@@ -4831,8 +4751,8 @@ msgid ""
 "The page is not available without the resources. Make sure file wwwroot.zip "
 "from ScummVM distribution is available in 'themepath'."
 msgstr ""
-"A página não está disponível sem os recursos. Certifique-se de que o arquivo "
-"wwwroot.zip da distribuição do ScummVM está disponível em 'themepath'."
+"A página não está disponível sem os recursos. Certifique-se de que o arquivo"
+" wwwroot.zip da distribuição do ScummVM está disponível em 'themepath'."
 
 #: backends/networking/sdl_net/handlers/filesajaxpagehandler.cpp:66
 #: backends/networking/sdl_net/handlers/filesajaxpagehandler.cpp:67
@@ -4920,8 +4840,7 @@ msgid ""
 "Check whether selected port is not used by another application and try again."
 msgstr ""
 "Falha ao iniciar servidor web local.\n"
-"Verifique se a porta selecionada não está sendo utilizada por outra "
-"aplicação e tente novamente."
+"Verifique se a porta selecionada não está sendo utilizada por outra aplicação e tente novamente."
 
 #: backends/networking/sdl_net/uploadfileclienthandler.cpp:67
 #: backends/networking/sdl_net/uploadfileclienthandler.cpp:109
@@ -5156,42 +5075,19 @@ msgstr "Obtendo ajuda"
 msgid ""
 "## Help, I'm lost!\n"
 "\n"
-"First, make sure you have the games and necessary game files ready. Check "
-"the **Where to Get the Games** section under the **General** tab. Once "
-"obtained, follow the steps outlined in the **Adding Games** tab to finish "
-"adding them on this device. Take a moment to review this process carefully, "
-"as some users encountered challenges here owing to recent Android changes.\n"
+"First, make sure you have the games and necessary game files ready. Check the **Where to Get the Games** section under the **General** tab. Once obtained, follow the steps outlined in the **Adding Games** tab to finish adding them on this device. Take a moment to review this process carefully, as some users encountered challenges here owing to recent Android changes.\n"
 "\n"
-"Need more help? Refer to our [online documentation for Android](https://"
-"docs.scummvm.org/en/latest/other_platforms/android.html). Got questions? "
-"Swing by our [support forums](https://forums.scummvm.org/viewforum.php?f=17) "
-"or hop on our [Discord server](https://discord.gg/4cDsMNtcpG), which "
-"includes an [Android support channel](https://discord.com/channels/"
-"581224060529148060/1135579923185139862).\n"
+"Need more help? Refer to our [online documentation for Android](https://docs.scummvm.org/en/latest/other_platforms/android.html). Got questions? Swing by our [support forums](https://forums.scummvm.org/viewforum.php?f=17) or hop on our [Discord server](https://discord.gg/4cDsMNtcpG), which includes an [Android support channel](https://discord.com/channels/581224060529148060/1135579923185139862).\n"
 "\n"
-"Oh, and heads up, many of our supported games are intentionally tricky, "
-"sometimes mind-bogglingly so. If you're stuck in a game, think about "
-"checking out a game walkthrough. Good luck!\n"
+"Oh, and heads up, many of our supported games are intentionally tricky, sometimes mind-bogglingly so. If you're stuck in a game, think about checking out a game walkthrough. Good luck!\n"
 msgstr ""
 "## Socorro, estou perdido!\n"
 "\n"
-"Primeiro, certifique-se de ter os jogos e os arquivos de jogo necessários "
-"prontos. Verifique a seção **Onde obter os jogos** na guia **Geral**. Depois "
-"de obtido, siga as etapas descritas na guia **Adicionando jogos** para "
-"terminar de adicioná-los neste dispositivo. Reserve um momento para revisar "
-"esse processo com atenção, pois alguns usuários encontraram desafios aqui "
-"devido às mudanças recentes no Android.\n"
+"Primeiro, certifique-se de ter os jogos e os arquivos de jogo necessários prontos. Verifique a seção **Onde obter os jogos** na guia **Geral**. Depois de obtido, siga as etapas descritas na guia **Adicionando jogos** para terminar de adicioná-los neste dispositivo. Reserve um momento para revisar esse processo com atenção, pois alguns usuários encontraram desafios aqui devido às mudanças recentes no Android.\n"
 "\n"
-"Precisa de mais ajuda? Consulte nossa [documentação on-line para Android]"
-"(https://docs.scummvm.org/en/latest/other_platforms/android.html). Tem "
-"dúvidas? Visite nossos [fóruns de suporte](https://forums.scummvm.org/"
-"viewforum.php?f=17) ou acesse nosso [servidor Discord](https://discord.gg/"
-"4cDsMNtcpG), que inclui um [canal de suporte do Android](https://discord.com/"
-"channels/581224060529148060/1135579923185139862).\n"
+"Precisa de mais ajuda? Consulte nossa [documentação on-line para Android](https://docs.scummvm.org/en/latest/other_platforms/android.html). Tem dúvidas? Visite nossos [fóruns de suporte](https://forums.scummvm.org/viewforum.php?f=17) ou acesse nosso [servidor Discord](https://discord.gg/4cDsMNtcpG), que inclui um [canal de suporte do Android](https://discord.com/channels/581224060529148060/1135579923185139862).\n"
 "\n"
-"Ah, e atenção: muitos dos nossos jogos suportados são intencionalmente "
-"complicados, às vezes surpreendentemente. Se você estiver preso em um jogo, "
-"considere buscar um detonado dele. Boa sorte!\n"
+"Ah, e atenção: muitos dos nossos jogos suportados são intencionalmente complicados, às vezes surpreendentemente. Se você estiver preso em um jogo, considere buscar um detonado dele. Boa sorte!\n"
 
 #: backends/platform/android/android.cpp:942
 #: backends/platform/ios7/ios7_osys_misc.mm:258
@@ -5203,12 +5099,10 @@ msgstr "Controles de Toque"
 #, fuzzy
 #| msgid ""
 #| "## Touch control modes\n"
-#| "The touch control mode can be changed by tapping or clicking on the "
-#| "controller icon in the upper right corner\n"
+#| "The touch control mode can be changed by tapping or clicking on the controller icon in the upper right corner\n"
 #| "### Direct mouse \n"
 #| "\n"
-#| "The touch controls are direct. The pointer jumps to where the finger "
-#| "touches the screen (default for menus).\n"
+#| "The touch controls are direct. The pointer jumps to where the finger touches the screen (default for menus).\n"
 #| "\n"
 #| "  ![Direct mouse mode](mouse.png \"Direct mouse mode\"){w=10em}\n"
 #| "\n"
@@ -5220,13 +5114,11 @@ msgstr "Controles de Toque"
 #| "\n"
 #| "### Gamepad emulation \n"
 #| "\n"
-#| "Fingers must be placed on lower left and right of the screen to emulate a "
-#| "directional pad and action buttons.\n"
+#| "Fingers must be placed on lower left and right of the screen to emulate a directional pad and action buttons.\n"
 #| "\n"
 #| "  ![Gamepad mode](gamepad.png \"Gamepad mode\"){w=10em}\n"
 #| "\n"
-#| "To select the preferred touch mode for menus, 2D games, and 3D games, go "
-#| "to **Global Options > Backend > Choose the preferred touch mode**.\n"
+#| "To select the preferred touch mode for menus, 2D games, and 3D games, go to **Global Options > Backend > Choose the preferred touch mode**.\n"
 #| "\n"
 #| "## Touch actions \n"
 #| "\n"
@@ -5235,48 +5127,35 @@ msgstr "Controles de Toque"
 #| "To scroll, slide two fingers up or down the screen\n"
 #| "### Two finger tap\n"
 #| "\n"
-#| "To do a two finger tap, hold one finger down and then tap with a second "
-#| "finger.\n"
+#| "To do a two finger tap, hold one finger down and then tap with a second finger.\n"
 #| "\n"
 #| "### Three finger tap\n"
 #| "\n"
-#| "To do a three finger tap, start with holding down one finger and "
-#| "progressively touch down the other two fingers, one at a time, while "
-#| "still holding down the previous fingers. Imagine you are impatiently "
-#| "tapping your fingers on a surface, but then slow down that movement so it "
-#| "is rhythmic, but not too slow.\n"
+#| "To do a three finger tap, start with holding down one finger and progressively touch down the other two fingers, one at a time, while still holding down the previous fingers. Imagine you are impatiently tapping your fingers on a surface, but then slow down that movement so it is rhythmic, but not too slow.\n"
 #| "\n"
 #| "### Immersive Sticky fullscreen mode\n"
 #| "\n"
-#| "Swipe from the edge to reveal the system bars.  They remain semi-"
-#| "transparent and disappear after a few seconds unless you interact with "
-#| "them.\n"
+#| "Swipe from the edge to reveal the system bars.  They remain semi-transparent and disappear after a few seconds unless you interact with them.\n"
 #| "\n"
 #| "### Global Main Menu\n"
 #| "\n"
-#| "To open the Global Main Menu, tap on the menu icon at the top right of "
-#| "the screen.\n"
+#| "To open the Global Main Menu, tap on the menu icon at the top right of the screen.\n"
 #| "\n"
 #| "  ![Menu icon](menu.png \"Menu icon\"){w=10em}\n"
 #| "\n"
 #| "## Virtual keyboard\n"
 #| "\n"
-#| "To open the virtual keyboard, long press on the controller icon at the "
-#| "top right of the screen, or tap on any editable text field. To hide the "
-#| "virtual keyboard, tap the controller icon again, or tap outside the text "
-#| "field.\n"
+#| "To open the virtual keyboard, long press on the controller icon at the top right of the screen, or tap on any editable text field. To hide the virtual keyboard, tap the controller icon again, or tap outside the text field.\n"
 #| "\n"
 #| "\n"
 #| "  ![Keyboard icon](keyboard.png \"Keyboard icon\"){w=10em}\n"
 #| "\n"
 msgid ""
 "## Touch control modes\n"
-"The touch control mode can be changed by tapping or clicking on the "
-"controller icon in the upper right corner\n"
+"The touch control mode can be changed by tapping or clicking on the controller icon in the upper right corner\n"
 "### Direct mouse \n"
 "\n"
-"The touch controls are direct. The pointer jumps to where the finger touches "
-"the screen (default for menus).\n"
+"The touch controls are direct. The pointer jumps to where the finger touches the screen (default for menus).\n"
 "\n"
 "  ![Direct mouse mode](mouse.png \"Direct mouse mode\"){w=10em}\n"
 "\n"
@@ -5288,13 +5167,11 @@ msgid ""
 "\n"
 "### Gamepad emulation \n"
 "\n"
-"Fingers must be placed on lower left and right of the screen to emulate a "
-"directional pad and action buttons.\n"
+"Fingers must be placed on lower left and right of the screen to emulate a directional pad and action buttons.\n"
 "\n"
 "  ![Gamepad mode](gamepad.png \"Gamepad mode\"){w=10em}\n"
 "\n"
-"To select the preferred touch mode for menus, 2D games, and 3D games, go to "
-"**Global Options > Backend > Choose the preferred touch mode**.\n"
+"To select the preferred touch mode for menus, 2D games, and 3D games, go to **Global Options > Backend > Choose the preferred touch mode**.\n"
 "\n"
 "## Touch actions \n"
 "\n"
@@ -5303,46 +5180,35 @@ msgid ""
 "To scroll, slide two fingers up or down the screen\n"
 "### Two finger tap\n"
 "\n"
-"To do a two finger tap, hold one finger down and then tap with a second "
-"finger.\n"
+"To do a two finger tap, hold one finger down and then tap with a second finger.\n"
 "\n"
 "### Three finger tap\n"
 "\n"
-"To do a three finger tap, start with holding down one finger and "
-"progressively touch down the other two fingers, one at a time, while still "
-"holding down the previous fingers. Imagine you are impatiently tapping your "
-"fingers on a surface, but then slow down that movement so it is rhythmic, "
-"but not too slow.\n"
+"To do a three finger tap, start with holding down one finger and progressively touch down the other two fingers, one at a time, while still holding down the previous fingers. Imagine you are impatiently tapping your fingers on a surface, but then slow down that movement so it is rhythmic, but not too slow.\n"
 "\n"
 "### Immersive Sticky fullscreen mode\n"
 "\n"
-"Swipe from the edge to reveal the system bars.  They remain semi-transparent "
-"and disappear after a few seconds unless you interact with them.\n"
+"Swipe from the edge to reveal the system bars.  They remain semi-transparent and disappear after a few seconds unless you interact with them.\n"
 "\n"
 "### Global Main Menu\n"
 "\n"
-"To open the Global Main Menu, tap on the menu icon at the top right of the "
-"screen.\n"
+"To open the Global Main Menu, tap on the menu icon at the top right of the screen.\n"
 "\n"
 "  ![Menu icon](menu.png \"Menu icon\"){w=10em}\n"
 "\n"
 "## Virtual keyboard\n"
 "\n"
-"To open the virtual keyboard, long press on the controller icon at the top "
-"right of the screen, or tap on any editable text field. To hide the virtual "
-"keyboard, tap the controller icon again, or tap outside the text field.\n"
+"To open the virtual keyboard, long press on the controller icon at the top right of the screen, or tap on any editable text field. To hide the virtual keyboard, tap the controller icon again, or tap outside the text field.\n"
 "\n"
 "\n"
 "  ![Keyboard icon](keyboard.png \"Keyboard icon\"){w=10em}\n"
 "\n"
 msgstr ""
 "## Modos de controle de toque\n"
-"O modo de controle de toque pode ser alterado tocando ou clicando no ícone "
-"do controlador no canto superior direito\n"
+"O modo de controle de toque pode ser alterado tocando ou clicando no ícone do controlador no canto superior direito\n"
 "### Mouse direto\n"
 "\n"
-"Os controles de toque são diretos. O ponteiro salta para onde o dedo toca a "
-"tela (padrão para menus).\n"
+"Os controles de toque são diretos. O ponteiro salta para onde o dedo toca a tela (padrão para menus).\n"
 "\n"
 "  ![Modo de mouse direto](mouse.png \"Modo de mouse direto\"){w=10em}\n"
 "\n"
@@ -5354,13 +5220,11 @@ msgstr ""
 "\n"
 "### Emulação de gamepad\n"
 "\n"
-"Os dedos devem ser colocados na parte inferior esquerda e direita da tela "
-"para emular um teclado direcional e botões de ação.\n"
+"Os dedos devem ser colocados na parte inferior esquerda e direita da tela para emular um teclado direcional e botões de ação.\n"
 "\n"
 "  ![Modo gamepad](gamepad.png \"Modo gamepad\"){w=10em}\n"
 "\n"
-"Para selecionar o modo de toque preferido para menus, jogos 2D e jogos 3D, "
-"entre em **Opções globais > Back-end > Escolher modo de toque preferido**.\n"
+"Para selecionar o modo de toque preferido para menus, jogos 2D e jogos 3D, entre em **Opções globais > Back-end > Escolher modo de toque preferido**.\n"
 "\n"
 "## Ações de toque\n"
 "\n"
@@ -5369,36 +5233,25 @@ msgstr ""
 "Para rolar, deslize dois dedos para cima ou para baixo na tela\n"
 "### Toque com dois dedos\n"
 "\n"
-"Para tocar com dois dedos, mantenha um dedo pressionado e toque com o "
-"segundo dedo.\n"
+"Para tocar com dois dedos, mantenha um dedo pressionado e toque com o segundo dedo.\n"
 "\n"
 "### Toque com três dedos\n"
 "\n"
-"Para fazer um toque com três dedos, comece mantendo pressionado um dedo e "
-"toque progressivamente os outros dois dedos, um de cada vez, enquanto mantém "
-"pressionados os dedos anteriores. Imagine que você está batendo "
-"impacientemente os dedos em uma superfície, mas depois diminua a velocidade "
-"do movimento para que mantenha um rítmo, mas não muito lento.\n"
+"Para fazer um toque com três dedos, comece mantendo pressionado um dedo e toque progressivamente os outros dois dedos, um de cada vez, enquanto mantém pressionados os dedos anteriores. Imagine que você está batendo impacientemente os dedos em uma superfície, mas depois diminua a velocidade do movimento para que mantenha um rítmo, mas não muito lento.\n"
 "\n"
 "### Modo de tela cheia Imersivo Fixo\n"
 "\n"
-"Deslize da borda para revelar as barras do sistema. Eles permanecem "
-"semitransparentes e desaparecem após alguns segundos, a menos que você "
-"interaja com elas.\n"
+"Deslize da borda para revelar as barras do sistema. Eles permanecem semitransparentes e desaparecem após alguns segundos, a menos que você interaja com elas.\n"
 "\n"
 "### Menu Principal Global\n"
 "\n"
-"Para abrir o Menu Principal Global, toque no ícone do menu no canto superior "
-"direito da tela.\n"
+"Para abrir o Menu Principal Global, toque no ícone do menu no canto superior direito da tela.\n"
 "\n"
 "  ![Ícone de menu](menu.png \"Ícone de menu\"){w=10em}\n"
 "\n"
 "## Teclado virtual\n"
 "\n"
-"Para abrir o teclado virtual, mantenha pressionado o ícone do controlador no "
-"canto superior direito da tela ou toque em qualquer campo de texto editável. "
-"Para ocultar o teclado virtual, toque novamente no ícone do controlador ou "
-"toque fora do campo de texto.\n"
+"Para abrir o teclado virtual, mantenha pressionado o ícone do controlador no canto superior direito da tela ou toque em qualquer campo de texto editável. Para ocultar o teclado virtual, toque novamente no ícone do controlador ou toque fora do campo de texto.\n"
 "\n"
 "\n"
 "  ![Ícone do teclado](keyboard.png \"Ícone do teclado\"){w=10em}\n"
@@ -5417,15 +5270,11 @@ msgstr "Adicionando Jogos"
 #| "\n"
 #| "1. Select **Add Game...** from the launcher. \n"
 #| "\n"
-#| "2. Inside the ScummVM file browser, select **Go Up** until you reach the "
-#| "root folder which has the **<Add a new folder>** option. \n"
+#| "2. Inside the ScummVM file browser, select **Go Up** until you reach the root folder which has the **<Add a new folder>** option. \n"
 #| "\n"
-#| "  ![ScummVM file browser root](browser-root.png \"ScummVM file browser "
-#| "root\"){w=70%}\n"
+#| "  ![ScummVM file browser root](browser-root.png \"ScummVM file browser root\"){w=70%}\n"
 #| "\n"
-#| "3. Double-tap **<Add a new folder>**. In your device's file browser, "
-#| "navigate to the folder containing all your game folders. For example, "
-#| "**SD Card > ScummVMgames**. \n"
+#| "3. Double-tap **<Add a new folder>**. In your device's file browser, navigate to the folder containing all your game folders. For example, **SD Card > ScummVMgames**. \n"
 #| "\n"
 #| "4. Select **Use this folder**. \n"
 #| "\n"
@@ -5433,95 +5282,67 @@ msgstr "Adicionando Jogos"
 #| "\n"
 #| "5. Select **ALLOW** to give ScummVM permission to access the folder. \n"
 #| "\n"
-#| "  ![OS access permission dialog](fs-permission.png \"OS access "
-#| "permission\"){w=70%}\n"
+#| "  ![OS access permission dialog](fs-permission.png \"OS access permission\"){w=70%}\n"
 #| "\n"
-#| "6. In the ScummVM file browser, double-tap to browse through your added "
-#| "folder. Add a game by selecting the sub-folder containing the game files, "
-#| "then tap **Choose**. \n"
+#| "6. In the ScummVM file browser, double-tap to browse through your added folder. Add a game by selecting the sub-folder containing the game files, then tap **Choose**. \n"
 #| "\n"
-#| "  ![SAF folder added](browser-folder-in-list.png \"SAF folder added\")"
-#| "{w=70%}\n"
+#| "  ![SAF folder added](browser-folder-in-list.png \"SAF folder added\"){w=70%}\n"
 #| "\n"
-#| "Step 2 and 3 are done only once. To add more games, repeat Steps 1 and "
-#| "6. \n"
+#| "Step 2 and 3 are done only once. To add more games, repeat Steps 1 and 6. \n"
 #| "\n"
-#| "See our [Android documentation](https://docs.scummvm.org/en/latest/"
-#| "other_platforms/android.html) for more information.\n"
+#| "See our [Android documentation](https://docs.scummvm.org/en/latest/other_platforms/android.html) for more information.\n"
 msgid ""
 "## Adding Games \n"
 "\n"
 "1. Select **Add Game...** from the launcher. \n"
 "\n"
-"2. Inside the ScummVM file browser, select **Go Up** until you reach the "
-"root folder which has the **<Add a new folder>** option. \n"
+"2. Inside the ScummVM file browser, select **Go Up** until you reach the root folder which has the **<Add a new folder>** option. \n"
 "\n"
-"  ![ScummVM file browser root](browser-root.png \"ScummVM file browser "
-"root\"){w=70%,maxw=50em}\n"
+"  ![ScummVM file browser root](browser-root.png \"ScummVM file browser root\"){w=70%,maxw=50em}\n"
 "\n"
-"3. Double-tap **<Add a new folder>**. In your device's file browser, "
-"navigate to the folder containing all your game folders. For example, **SD "
-"Card > ScummVMgames**. \n"
+"3. Double-tap **<Add a new folder>**. In your device's file browser, navigate to the folder containing all your game folders. For example, **SD Card > ScummVMgames**. \n"
 "\n"
 "4. Select **Use this folder**. \n"
 "\n"
-"  ![OS selectable folder](fs-folder.png \"OS selectable folder\")"
-"{w=70%,maxw=50em}\n"
+"  ![OS selectable folder](fs-folder.png \"OS selectable folder\"){w=70%,maxw=50em}\n"
 "\n"
 "5. Select **ALLOW** to give ScummVM permission to access the folder. \n"
 "\n"
-"  ![OS access permission dialog](fs-permission.png \"OS access permission\")"
-"{w=70%,maxw=50em}\n"
+"  ![OS access permission dialog](fs-permission.png \"OS access permission\"){w=70%,maxw=50em}\n"
 "\n"
-"6. In the ScummVM file browser, double-tap to browse through your added "
-"folder. Add a game by selecting the sub-folder containing the game files, "
-"then tap **Choose**. \n"
+"6. In the ScummVM file browser, double-tap to browse through your added folder. Add a game by selecting the sub-folder containing the game files, then tap **Choose**. \n"
 "\n"
-"  ![SAF folder added](browser-folder-in-list.png \"SAF folder added\")"
-"{w=70%,maxw=50em}\n"
+"  ![SAF folder added](browser-folder-in-list.png \"SAF folder added\"){w=70%,maxw=50em}\n"
 "\n"
 "Step 2 and 3 are done only once. To add more games, repeat Steps 1 and 6. \n"
 "\n"
-"See our [Android documentation](https://docs.scummvm.org/en/latest/"
-"other_platforms/android.html) for more information.\n"
+"See our [Android documentation](https://docs.scummvm.org/en/latest/other_platforms/android.html) for more information.\n"
 msgstr ""
 "## Adicionando jogos\n"
 "\n"
 "1. Selecione **Adicionar jogo...** no inicializador.\n"
 "\n"
-"2. Dentro do navegador de arquivos ScummVM, selecione **Subir** até chegar à "
-"pasta raiz que tem a opção **<Adicionar nova pasta>**.\n"
+"2. Dentro do navegador de arquivos ScummVM, selecione **Subir** até chegar à pasta raiz que tem a opção **<Adicionar nova pasta>**.\n"
 "\n"
-"  ![Raiz do navegador de arquivos ScummVM](browser-root.png \"Raiz do "
-"navegador de arquivos ScummVM\"){w=70%}\n"
+"  ![Raiz do navegador de arquivos ScummVM](browser-root.png \"Raiz do navegador de arquivos ScummVM\"){w=70%}\n"
 "\n"
-"3. Toque duas vezes em **<Adicionar nova pasta>**. No navegador de arquivos "
-"do seu dispositivo, navegue até a pasta que contém todas as pastas do jogo. "
-"Por exemplo, **Cartão SD > ScummVMjogos**.\n"
+"3. Toque duas vezes em **<Adicionar nova pasta>**. No navegador de arquivos do seu dispositivo, navegue até a pasta que contém todas as pastas do jogo. Por exemplo, **Cartão SD > ScummVMjogos**.\n"
 "\n"
 "4. Selecione **Utilizar esta pasta**.\n"
 "\n"
-"  ![Pasta selecionável do SO](fs-folder.png \"Pasta selecionável do SO\")"
-"{w=70%}\n"
+"  ![Pasta selecionável do SO](fs-folder.png \"Pasta selecionável do SO\"){w=70%}\n"
 "\n"
-"5. Selecione **PERMITIR** para dar permissão ao ScummVM para acessar a "
-"pasta.\n"
+"5. Selecione **PERMITIR** para dar permissão ao ScummVM para acessar a pasta.\n"
 "\n"
-"  ![Caixa de diálogo de permissão de acesso ao SO](fs-permission.png "
-"\"Permissão de acesso ao SO\"){w=70%}\n"
+"  ![Caixa de diálogo de permissão de acesso ao SO](fs-permission.png \"Permissão de acesso ao SO\"){w=70%}\n"
 "\n"
-"6. No navegador de arquivos ScummVM, toque duas vezes para navegar pela "
-"pasta adicionada. Adicione um jogo selecionando a subpasta que contém os "
-"arquivos do jogo e toque em **Escolher**.\n"
+"6. No navegador de arquivos ScummVM, toque duas vezes para navegar pela pasta adicionada. Adicione um jogo selecionando a subpasta que contém os arquivos do jogo e toque em **Escolher**.\n"
 "\n"
-"  ![Pasta SAF adicionada](browser-folder-in-list.png \"Pasta SAF "
-"adicionada\"){w=70%}\n"
+"  ![Pasta SAF adicionada](browser-folder-in-list.png \"Pasta SAF adicionada\"){w=70%}\n"
 "\n"
-"As etapas 2 e 3 precisam ser realizadas apenas uma vez. Para adicionar mais "
-"jogos, repita as etapas 1 e 6.\n"
+"As etapas 2 e 3 precisam ser realizadas apenas uma vez. Para adicionar mais jogos, repita as etapas 1 e 6.\n"
 "\n"
-"Consulte nossa [documentação do Android](https://docs.scummvm.org/en/latest/"
-"other_platforms/android.html) para obter mais informações.\n"
+"Consulte nossa [documentação do Android](https://docs.scummvm.org/en/latest/other_platforms/android.html) para obter mais informações.\n"
 
 #: backends/platform/android/options.cpp:137
 #: backends/platform/ios7/ios7_options.mm:165
@@ -5530,7 +5351,7 @@ msgstr "Mostrar controle na tela"
 
 #: backends/platform/android/options.cpp:138
 msgid "Ignore safe areas in-game"
-msgstr ""
+msgstr "Ignorar áreas seguras no jogo"
 
 #: backends/platform/android/options.cpp:139
 #: backends/platform/ios7/ios7_options.mm:112
@@ -5613,21 +5434,22 @@ msgstr "Nos jogos"
 
 #: backends/platform/android/options.cpp:195
 msgid "Export backup"
-msgstr ""
+msgstr "Exportar backup"
 
 #: backends/platform/android/options.cpp:195
 msgid "Export a backup of the configuration and save files"
-msgstr ""
+msgstr "Exportar um backup das configurações e dos arquivos de salvamento"
 
 #: backends/platform/android/options.cpp:196
 msgid "Import backup"
-msgstr ""
+msgstr "Importar backup"
 
 #: backends/platform/android/options.cpp:196
 msgid "Import a previously exported backup file"
-msgstr ""
+msgstr "Importar um arquivo de backup exportado anteriormente"
 
-#. I18N: This button opens a list of all folders added for Android Storage Attached Framework
+#. I18N: This button opens a list of all folders added for Android Storage
+#. Attached Framework
 #: backends/platform/android/options.cpp:199
 msgid "Remove folder authorizations..."
 msgstr "Remover autorizações de pasta..."
@@ -5640,11 +5462,11 @@ msgstr "Selecionar orientação:"
 
 #: backends/platform/android/options.cpp:280
 msgid "The backup has been saved successfully."
-msgstr ""
+msgstr "O backup foi salvo com sucesso."
 
 #: backends/platform/android/options.cpp:282
 msgid "The backup has been saved successfully to the Downloads folder."
-msgstr ""
+msgstr "O backup foi salvo com sucesso na pasta Downloads."
 
 #: backends/platform/android/options.cpp:284
 #: backends/platform/android/options.cpp:317
@@ -5664,6 +5486,8 @@ msgid ""
 "Restoring a backup will erase the current configuration and overwrite "
 "existing saves. Do you want to proceed?"
 msgstr ""
+"Restaurar um backup apagará a configuração atual e substituirá os "
+"salvamentos existentes. Deseja continuar?"
 
 #: backends/platform/android/options.cpp:298
 #, fuzzy
@@ -5673,7 +5497,7 @@ msgstr "Selecione um Tema"
 
 #: backends/platform/android/options.cpp:315
 msgid "The backup has been restored successfully."
-msgstr ""
+msgstr "O backup foi restaurado com sucesso."
 
 #: backends/platform/android/options.cpp:319
 #, fuzzy
@@ -5730,53 +5554,28 @@ msgstr "Exibir barra de funções do teclado"
 msgid ""
 "## Help, I'm lost!\n"
 "\n"
-"First, make sure you have the games and necessary game files ready. Check "
-"the **Where to Get the Games** section under the **General** tab. Once "
-"obtained, follow the steps outlined in the **Adding Games** tab to finish "
-"adding them on this device.\n"
+"First, make sure you have the games and necessary game files ready. Check the **Where to Get the Games** section under the **General** tab. Once obtained, follow the steps outlined in the **Adding Games** tab to finish adding them on this device.\n"
 "\n"
-"Need more help? Refer to our [online documentation for iOS](https://"
-"docs.scummvm.org/en/latest/other_platforms/ios.html). Got questions? Swing "
-"by our [support forums](https://forums.scummvm.org/viewforum.php?f=15) or "
-"hop on our [Discord server](https://discord.gg/4cDsMNtcpG), which includes "
-"an [iOS support channel](https://discord.com/channels/"
-"581224060529148060/1149456560922316911).\n"
+"Need more help? Refer to our [online documentation for iOS](https://docs.scummvm.org/en/latest/other_platforms/ios.html). Got questions? Swing by our [support forums](https://forums.scummvm.org/viewforum.php?f=15) or hop on our [Discord server](https://discord.gg/4cDsMNtcpG), which includes an [iOS support channel](https://discord.com/channels/581224060529148060/1149456560922316911).\n"
 "\n"
-"Oh, and heads up, many of our supported games are intentionally tricky, "
-"sometimes mind-bogglingly so. If you're stuck in a game, think about "
-"checking out a game walkthrough. Good luck!\n"
+"Oh, and heads up, many of our supported games are intentionally tricky, sometimes mind-bogglingly so. If you're stuck in a game, think about checking out a game walkthrough. Good luck!\n"
 msgstr ""
 "## Socorro, estou perdido!\n"
 "\n"
-"Primeiro, certifique-se de ter os jogos e os arquivos de jogo necessários "
-"prontos. Verifique a seção **Onde obter os jogos** na guia **Geral**. Depois "
-"de obtido, siga as etapas descritas na guia **Adicionando jogos** para "
-"terminar de adicioná-los neste dispositivo.\n"
+"Primeiro, certifique-se de ter os jogos e os arquivos de jogo necessários prontos. Verifique a seção **Onde obter os jogos** na guia **Geral**. Depois de obtido, siga as etapas descritas na guia **Adicionando jogos** para terminar de adicioná-los neste dispositivo.\n"
 "\n"
-"Precisa de mais ajuda? Consulte nossa [documentação on-line para iOS]"
-"(https://docs.scummvm.org/en/latest/other_platforms/ios.html). Tem dúvidas? "
-"Visite nossos [fóruns de suporte](https://forums.scummvm.org/viewforum.php?"
-"f=15) ou acesse nosso [servidor Discord](https://discord.gg/4cDsMNtcpG), que "
-"inclui um [canal de suporte do iOS](https://discord.com/channels/"
-"581224060529148060/1149456560922316911).\n"
+"Precisa de mais ajuda? Consulte nossa [documentação on-line para iOS](https://docs.scummvm.org/en/latest/other_platforms/ios.html). Tem dúvidas? Visite nossos [fóruns de suporte](https://forums.scummvm.org/viewforum.php?f=15) ou acesse nosso [servidor Discord](https://discord.gg/4cDsMNtcpG), que inclui um [canal de suporte do iOS](https://discord.com/channels/581224060529148060/1149456560922316911).\n"
 "\n"
-"Ah, e atenção: muitos dos nossos jogos suportados são intencionalmente "
-"complicados, às vezes surpreendentemente. Se você estiver preso em um jogo, "
-"considere buscar por um detonado dele. Boa sorte!\n"
+"Ah, e atenção: muitos dos nossos jogos suportados são intencionalmente complicados, às vezes surpreendentemente. Se você estiver preso em um jogo, considere buscar por um detonado dele. Boa sorte!\n"
 
 #: backends/platform/ios7/ios7_osys_misc.mm:261
 msgid ""
 "## Touch control modes\n"
-"The touch control mode can be changed by tapping or clicking on the "
-"controller icon in the upper right corner, by swiping two fingers from left "
-"to right, or in the global settings from the Launcher go to **Global Options "
-"> Backend > Choose the preferred touch mode**. It's possible to configure "
-"the touch mode for three situations (ScummVM menus, 2D games and 3D games).\n"
+"The touch control mode can be changed by tapping or clicking on the controller icon in the upper right corner, by swiping two fingers from left to right, or in the global settings from the Launcher go to **Global Options > Backend > Choose the preferred touch mode**. It's possible to configure the touch mode for three situations (ScummVM menus, 2D games and 3D games).\n"
 "\n"
 "### Direct mouse \n"
 "\n"
-"The touch controls are direct. The pointer jumps to where the finger touches "
-"the screen (default for menus).\n"
+"The touch controls are direct. The pointer jumps to where the finger touches the screen (default for menus).\n"
 "\n"
 "  ![Direct mouse mode](mouse.png \"Direct mouse mode\"){w=10em}\n"
 "\n"
@@ -5786,8 +5585,7 @@ msgid ""
 "\n"
 "  ![Touchpad mode](touchpad.png \"Touchpad mode\"){w=10em}\n"
 "\n"
-"To select the preferred touch mode for menus, 2D games, and 3D games, go to "
-"**Global Options > Backend > Choose the preferred touch mode**.\n"
+"To select the preferred touch mode for menus, 2D games, and 3D games, go to **Global Options > Backend > Choose the preferred touch mode**.\n"
 "\n"
 "## Touch actions \n"
 "\n"
@@ -5796,59 +5594,38 @@ msgid ""
 "| `One finger tap`  | Left mouse click  \n"
 "| `Two fingers tap` | Right mouse click \n"
 "| `Two fingers double tap` | ESC \n"
-"| `One finger press & hold for >0.5s` | Left mouse button hold and drag, "
-"such as for selection from action wheel in Curse of Monkey Island \n"
-"| `Two fingers press & hold for >0.5s` | Right mouse button hold and drag, "
-"such as for selection from action wheel in Tony Tough \n"
+"| `One finger press & hold for >0.5s` | Left mouse button hold and drag, such as for selection from action wheel in Curse of Monkey Island \n"
+"| `Two fingers press & hold for >0.5s` | Right mouse button hold and drag, such as for selection from action wheel in Tony Tough \n"
 "| `Two fingers swipe (left to right)` | Toggles between the touch modes \n"
-"| `Two fingers swipe (right to left)` | Toggles virtual controller (>iOS "
-"15) \n"
+"| `Two fingers swipe (right to left)` | Toggles virtual controller (>iOS 15) \n"
 "| `Two fingers swipe (top to bottom)` | Access Global Main Menu in games \n"
 "| `Pinch (zoom in/out)` | Enables/disables keyboard \n"
 "\n"
 "### Virtual Gamepad \n"
 "\n"
-"Devices running iOS 15 or later can connect virtual gamepad controller by "
-"swiping two fingers from right to left or through **Global Options > "
-"Backend**. The directional button can be configured to either a thumbstick "
-"or a dpad.\n"
-"**Note** While the virtual controller is connected it is not possible to "
-"perform mouse clicks using tap gestures since they are disabled as long as "
-"the virtual controller is visible. Left mouse clicks are performed by "
-"pressing the A button. Tap gestures are enabled again when virtual "
-"controller is disconnected.\n"
+"Devices running iOS 15 or later can connect virtual gamepad controller by swiping two fingers from right to left or through **Global Options > Backend**. The directional button can be configured to either a thumbstick or a dpad.\n"
+"**Note** While the virtual controller is connected it is not possible to perform mouse clicks using tap gestures since they are disabled as long as the virtual controller is visible. Left mouse clicks are performed by pressing the A button. Tap gestures are enabled again when virtual controller is disconnected.\n"
 "\n"
 "### Global Main Menu\n"
 "\n"
-"To open the Global Main Menu, tap on the menu icon at the top right of the "
-"screen or swipe two fingers downwards.\n"
+"To open the Global Main Menu, tap on the menu icon at the top right of the screen or swipe two fingers downwards.\n"
 "\n"
 "  ![Menu icon](menu.png \"Menu icon\"){w=10em}\n"
 "\n"
 "## Virtual keyboard\n"
 "\n"
-"To open the virtual keyboard, long press on the controller icon at the top "
-"right of the screen, perform a pinch gesture (zoom out) or tap on any "
-"editable text field. To hide the virtual keyboard, tap the controller icon "
-"again, do an opposite pinch gesture (zoom in) or tap outside the text "
-"field.\n"
+"To open the virtual keyboard, long press on the controller icon at the top right of the screen, perform a pinch gesture (zoom out) or tap on any editable text field. To hide the virtual keyboard, tap the controller icon again, do an opposite pinch gesture (zoom in) or tap outside the text field.\n"
 "\n"
 "\n"
 "  ![Keyboard icon](keyboard.png \"Keyboard icon\"){w=10em}\n"
 "\n"
 msgstr ""
 "## Modos de controle de toque\n"
-"O modo de controle de toque pode ser alterado tocando ou clicando no ícone "
-"do controlador no canto superior direito, deslizando dois dedos da esquerda "
-"para a direita ou nas configurações globais do Inicializador entrando em "
-"**Opções globais > Backend > Escolher modo de toque favorito**. É possível "
-"configurar o modo de toque para três situações (menus do ScummVM, jogos 2D e "
-"jogos 3D).\n"
+"O modo de controle de toque pode ser alterado tocando ou clicando no ícone do controlador no canto superior direito, deslizando dois dedos da esquerda para a direita ou nas configurações globais do Inicializador entrando em **Opções globais > Backend > Escolher modo de toque favorito**. É possível configurar o modo de toque para três situações (menus do ScummVM, jogos 2D e jogos 3D).\n"
 "\n"
 "### Mouse direto\n"
 "\n"
-"Os controles de toque são diretos. O ponteiro salta para onde o dedo toca a "
-"tela (padrão para menus).\n"
+"Os controles de toque são diretos. O ponteiro salta para onde o dedo toca a tela (padrão para menus).\n"
 "\n"
 "  ![Modo mouse direto](mouse.png \"Modo mouse direto\"){w=10em}\n"
 "\n"
@@ -5858,8 +5635,7 @@ msgstr ""
 "\n"
 "  ![Modo Touchpad](touchpad.png \"Modo Touchpad\"){w=10em}\n"
 "\n"
-"Para selecionar o modo de toque preferido para menus, jogos 2D e jogos 3D, "
-"vá para **Opções globais > Back-end > Escolher modo de toque preferido**.\n"
+"Para selecionar o modo de toque preferido para menus, jogos 2D e jogos 3D, vá para **Opções globais > Back-end > Escolher modo de toque preferido**.\n"
 "\n"
 "## Ações de toque \n"
 "\n"
@@ -5868,47 +5644,27 @@ msgstr ""
 "| `Toque com um dedo`  | Clique com o botão esquerdo do mouse  \n"
 "| `Toque com dois dedos` | Clique com o botão direito do mouse \n"
 "| `Dois toques com dois dedos` | ESC \n"
-"| `Tocar e segurar com um dedo por mais de 0.5s` | Clicar e arrastar com o "
-"botão esquerdo do mouse, para selecionar a roda de ações em Curse of Monkey "
-"Island por exemplo\n"
-"| `Tocar e segurar com dois dedos por mais de 0.5s` | Clicar e arrastar com "
-"o botão direito do mouse, para selecionar a roda de ações em Tony Tough por "
-"exemplo \n"
-"| `Deslizar com dois dedos (da esquerda para direita)` | Alternar entre os "
-"modos de toque\n"
-"| `Deslizar com dois dedos (da direita para esquerda)` | Alternar controler "
-"virtual (iOS 15 ou superior) \n"
-"| `Deslizar com dois dedos (de cima para baixo)` | Acessar Menu Global "
-"durante o jogo \n"
-"| `Movimento de pinça com dois dedos (ampliar/reduzir zoom)` | Habilitar/"
-"desabilitar teclado \n"
+"| `Tocar e segurar com um dedo por mais de 0.5s` | Clicar e arrastar com o botão esquerdo do mouse, para selecionar a roda de ações em Curse of Monkey Island por exemplo\n"
+"| `Tocar e segurar com dois dedos por mais de 0.5s` | Clicar e arrastar com o botão direito do mouse, para selecionar a roda de ações em Tony Tough por exemplo \n"
+"| `Deslizar com dois dedos (da esquerda para direita)` | Alternar entre os modos de toque\n"
+"| `Deslizar com dois dedos (da direita para esquerda)` | Alternar controler virtual (iOS 15 ou superior) \n"
+"| `Deslizar com dois dedos (de cima para baixo)` | Acessar Menu Global durante o jogo \n"
+"| `Movimento de pinça com dois dedos (ampliar/reduzir zoom)` | Habilitar/desabilitar teclado \n"
 "\n"
 "### Gamepad virtual\n"
 "\n"
-"Dispositivos com iOS 15 ou posterior podem conectar um controlador de "
-"gamepad virtual deslizando dois dedos da direita para a esquerda ou em "
-"**Opções globais > Back-end**. O botão direcional pode ser configurado como "
-"um polegar ou botões direcionais.\n"
-"**Observação** Enquanto o controlador virtual estiver conectado, não é "
-"possível realizar cliques do mouse usando gestos de toque, pois eles estarão "
-"desativados enquanto o controlador virtual estiver visível. Os cliques com "
-"botão esquerdo do mouse são executados pressionando o botão A. Os gestos de "
-"toque são ativados novamente quando o controlador virtual é desconectado.\n"
+"Dispositivos com iOS 15 ou posterior podem conectar um controlador de gamepad virtual deslizando dois dedos da direita para a esquerda ou em **Opções globais > Back-end**. O botão direcional pode ser configurado como um polegar ou botões direcionais.\n"
+"**Observação** Enquanto o controlador virtual estiver conectado, não é possível realizar cliques do mouse usando gestos de toque, pois eles estarão desativados enquanto o controlador virtual estiver visível. Os cliques com botão esquerdo do mouse são executados pressionando o botão A. Os gestos de toque são ativados novamente quando o controlador virtual é desconectado.\n"
 "\n"
 "### Menu Principal Global\n"
 "\n"
-"Para abrir o Menu Principal Global, toque no ícone do menu no canto superior "
-"direito da tela ou deslize dois dedos para baixo.\n"
+"Para abrir o Menu Principal Global, toque no ícone do menu no canto superior direito da tela ou deslize dois dedos para baixo.\n"
 "\n"
 "  ![Ícone de menu](menu.png \"Ícone de menu\"){w=10em}\n"
 "\n"
 "## Teclado virtual\n"
 "\n"
-"Para abrir o teclado virtual, mantenha pressionado o ícone do controlador no "
-"canto superior direito da tela, faça um gesto de pinça (reduzir o zoom) ou "
-"toque em qualquer campo de texto editável. Para ocultar o teclado virtual, "
-"toque novamente no ícone do controlador, faça um gesto de pinça oposto "
-"(aumentar o zoom) ou toque fora do campo de texto.\n"
+"Para abrir o teclado virtual, mantenha pressionado o ícone do controlador no canto superior direito da tela, faça um gesto de pinça (reduzir o zoom) ou toque em qualquer campo de texto editável. Para ocultar o teclado virtual, toque novamente no ícone do controlador, faça um gesto de pinça oposto (aumentar o zoom) ou toque fora do campo de texto.\n"
 "\n"
 "\n"
 "  ![Ícone do teclado](keyboard.png \"Ícone do teclado\"){w=10em}\n"
@@ -5921,11 +5677,8 @@ msgstr "Teclado externo"
 #: backends/platform/ios7/ios7_osys_misc.mm:314
 msgid ""
 "## Use of keyboard\n"
-"External keyboards are supported and from iOS 13.4 most of the special keys, "
-"e.g. function keys, Home and End, are mapped. \n"
-"For external keyboards missing the special keys, e.g. the Apple Magic "
-"Keyboard for iPads, the special keys can be triggered using the following "
-"key combinations: \n"
+"External keyboards are supported and from iOS 13.4 most of the special keys, e.g. function keys, Home and End, are mapped. \n"
+"For external keyboards missing the special keys, e.g. the Apple Magic Keyboard for iPads, the special keys can be triggered using the following key combinations: \n"
 "\n"
 "\n"
 "| Key combination   | Action            \n"
@@ -5943,11 +5696,8 @@ msgid ""
 "\n"
 msgstr ""
 "## Uso do teclado\n"
-"Teclados externos são suportados e a partir do iOS 13.4 a maioria das teclas "
-"especiais, por ex. as teclas de função, Home e End, são mapeáveis.\n"
-"Para teclados externos faltam as teclas especiais, por ex. no Apple Magic "
-"Keyboard para iPads, as teclas especiais podem ser acionadas usando as "
-"seguintes combinações de teclas: \n"
+"Teclados externos são suportados e a partir do iOS 13.4 a maioria das teclas especiais, por ex. as teclas de função, Home e End, são mapeáveis.\n"
+"Para teclados externos faltam as teclas especiais, por ex. no Apple Magic Keyboard para iPads, as teclas especiais podem ser acionadas usando as seguintes combinações de teclas: \n"
 "\n"
 "\n"
 "| Combinação de teclas   | Ação            \n"
@@ -5968,40 +5718,27 @@ msgstr ""
 msgid ""
 "## Adding Games \n"
 "\n"
-"1. Copy the required game files to the ScummVM application. There are "
-"several ways to do that, see our [Transferring game files documentation]"
-"(https://docs.scummvm.org/en/latest/other_platforms/ios.html#transferring-"
-"game-files) for more information.\n"
+"1. Copy the required game files to the ScummVM application. There are several ways to do that, see our [Transferring game files documentation](https://docs.scummvm.org/en/latest/other_platforms/ios.html#transferring-game-files) for more information.\n"
 "\n"
 "2. Select **Add Game...** from the launcher. \n"
 "\n"
-"3. In the ScummVM file browser, double-tap to browse to your added folder. "
-"Add a game by selecting the sub-folder containing the game files, then tap "
-"**Choose**. \n"
+"3. In the ScummVM file browser, double-tap to browse to your added folder. Add a game by selecting the sub-folder containing the game files, then tap **Choose**. \n"
 "\n"
 "To add more games, repeat the steps above. \n"
 "\n"
-"See our [iOS documentation](https://docs.scummvm.org/en/latest/"
-"other_platforms/ios.html) for more information.\n"
+"See our [iOS documentation](https://docs.scummvm.org/en/latest/other_platforms/ios.html) for more information.\n"
 msgstr ""
 "## Adicionando jogos \n"
 "\n"
-"1. Copie os arquivos do jogo necessários para o aplicativo ScummVM. Existem "
-"várias maneiras de fazer isso, consulte nossa [documentação sobre "
-"transferência de arquivos de jogos](https://docs.scummvm.org/en/latest/"
-"other_platforms/ios.html#transferring-game-files) para obter mais "
-"informações.\n"
+"1. Copie os arquivos do jogo necessários para o aplicativo ScummVM. Existem várias maneiras de fazer isso, consulte nossa [documentação sobre transferência de arquivos de jogos](https://docs.scummvm.org/en/latest/other_platforms/ios.html#transferring-game-files) para obter mais informações.\n"
 "\n"
 "2. Selecione **Adicionar jogo...** no inicializador. \n"
 "\n"
-"3. No navegador de arquivos ScummVM, toque duas vezes para navegar até a "
-"pasta adicionada. Adicione um jogo selecionando a subpasta que contém os "
-"arquivos do jogo e toque em **Escolher**. \n"
+"3. No navegador de arquivos ScummVM, toque duas vezes para navegar até a pasta adicionada. Adicione um jogo selecionando a subpasta que contém os arquivos do jogo e toque em **Escolher**. \n"
 "\n"
 "Para adicionar mais jogos, repita os passos acima. \n"
 "\n"
-"Consulte nossa [documentação do iOS](https://docs.scummvm.org/en/latest/"
-"other_platforms/ios.html) para obter mais informações.\n"
+"Consulte nossa [documentação do iOS](https://docs.scummvm.org/en/latest/other_platforms/ios.html) para obter mais informações.\n"
 
 #: backends/platform/ios7/ios7_osys_misc.mm:357
 msgid ""
@@ -6020,8 +5757,7 @@ msgid ""
 "\n"
 "## Virtual keyboard\n"
 "\n"
-"To open the virtual keyboard, press and hold the Play/Pause button. To hide "
-"the virtual keyboard, press the Back/Menu button.\n"
+"To open the virtual keyboard, press and hold the Play/Pause button. To hide the virtual keyboard, press the Back/Menu button.\n"
 "\n"
 msgstr ""
 "## Ações de toque\n"
@@ -6039,48 +5775,34 @@ msgstr ""
 "\n"
 "## Teclado virtual\n"
 "\n"
-"Para abrir o teclado virtual, pressione e segure o botão Jogar/Pausar. Para "
-"ocultar o teclado virtual, pressione o botão Voltar/Menu.\n"
+"Para abrir o teclado virtual, pressione e segure o botão Jogar/Pausar. Para ocultar o teclado virtual, pressione o botão Voltar/Menu.\n"
 "\n"
 
 #: backends/platform/ios7/ios7_osys_misc.mm:380
 msgid ""
 "## Adding Games \n"
 "\n"
-"1. Copy the required game files to the ScummVM application. There are "
-"several ways to do that, see our [Transferring game files documentation]"
-"(https://docs.scummvm.org/en/latest/other_platforms/tvos.html#transferring-"
-"game-files) for more information.\n"
+"1. Copy the required game files to the ScummVM application. There are several ways to do that, see our [Transferring game files documentation](https://docs.scummvm.org/en/latest/other_platforms/tvos.html#transferring-game-files) for more information.\n"
 "\n"
 "2. Select **Add Game...** from the launcher. \n"
 "\n"
-"3. In the ScummVM file browser, double-tap to browse to your added folder. "
-"Add a game by selecting the sub-folder containing the game files, then tap "
-"**Choose**. \n"
+"3. In the ScummVM file browser, double-tap to browse to your added folder. Add a game by selecting the sub-folder containing the game files, then tap **Choose**. \n"
 "\n"
 "To add more games, repeat the steps above. \n"
 "\n"
-"See our [tvOS documentation](https://docs.scummvm.org/en/latest/"
-"other_platforms/tvos.html) for more information.\n"
+"See our [tvOS documentation](https://docs.scummvm.org/en/latest/other_platforms/tvos.html) for more information.\n"
 msgstr ""
 "## Adicionando jogos \n"
 "\n"
-"1. Copie os arquivos do jogo necessários para o aplicativo ScummVM. Existem "
-"várias maneiras de fazer isso, consulte nossa [documentação sobre "
-"transferência de arquivos de jogos](https://docs.scummvm.org/en/latest/"
-"other_platforms/tvos.html#transferring-game-files) para obter mais "
-"informações.\n"
+"1. Copie os arquivos do jogo necessários para o aplicativo ScummVM. Existem várias maneiras de fazer isso, consulte nossa [documentação sobre transferência de arquivos de jogos](https://docs.scummvm.org/en/latest/other_platforms/tvos.html#transferring-game-files) para obter mais informações.\n"
 "\n"
 "2. Selecione **Adicionar jogo...** no inicializador. \n"
 "\n"
-"3. No navegador de arquivos ScummVM, toque duas vezes para navegar até a "
-"pasta adicionada. Adicione um jogo selecionando a subpasta que contém os "
-"arquivos do jogo e toque em **Escolher**. \n"
+"3. No navegador de arquivos ScummVM, toque duas vezes para navegar até a pasta adicionada. Adicione um jogo selecionando a subpasta que contém os arquivos do jogo e toque em **Escolher**. \n"
 "\n"
 "Para adicionar mais jogos, repita os passos acima. \n"
 "\n"
-"Consulte nossa [documentação do tvOS](https://docs.scummvm.org/en/latest/"
-"other_platforms/tvos.html) para obter mais informações.\n"
+"Consulte nossa [documentação do tvOS](https://docs.scummvm.org/en/latest/other_platforms/tvos.html) para obter mais informações.\n"
 
 #: backends/platform/libretro/src/libretro-options-widget.cpp:46
 msgid "LIBRETRO PLAYLIST GENERATOR"
@@ -6150,46 +5872,25 @@ msgstr "Playlist do Libretro"
 #, fuzzy
 #| msgid ""
 #| "## Libretro playlists for ScummVM core\n"
-#| "Playlists used in Libretro frontends (e.g. Retroarch) are plain text "
-#| "lists used to directly launch a game with a specific core from the user "
-#| "interface. Those lists are structured to pass to the core the path of a "
-#| "specific content file to be loaded (e.g. ROM).\n"
+#| "Playlists used in Libretro frontends (e.g. Retroarch) are plain text lists used to directly launch a game with a specific core from the user interface. Those lists are structured to pass to the core the path of a specific content file to be loaded (e.g. ROM).\n"
 #| "\n"
-#| "ScummVM core can accept as content the path to any of the files inside a "
-#| "valid game folder, the detection system will try to autodetect the game "
-#| "from the content file parent folder and run the game with default ScummVM "
-#| "options.\n"
+#| "ScummVM core can accept as content the path to any of the files inside a valid game folder, the detection system will try to autodetect the game from the content file parent folder and run the game with default ScummVM options.\n"
 #| "\n"
-#| "The core also supports dedicated per game **hook** plain text files with "
-#| "**."
+#| "The core also supports dedicated per game **hook** plain text files with **."
 msgid ""
 "## Libretro playlists for ScummVM core\n"
-"Playlists used in Libretro frontends (e.g. Retroarch) are plain text lists "
-"used to directly launch a game with a specific core from the user interface. "
-"Those lists are structured to pass to the core the path of a specific "
-"content file to be loaded (e.g. ROM).\n"
+"Playlists used in Libretro frontends (e.g. Retroarch) are plain text lists used to directly launch a game with a specific core from the user interface. Those lists are structured to pass to the core the path of a specific content file to be loaded (e.g. ROM).\n"
 "\n"
-"ScummVM core can accept as content the playlist-provided path to any of the "
-"files inside a valid game folder, the detection system will try to "
-"autodetect the game from the content file parent folder and run the game "
-"with default ScummVM options.\n"
+"ScummVM core can accept as content the playlist-provided path to any of the files inside a valid game folder, the detection system will try to autodetect the game from the content file parent folder and run the game with default ScummVM options.\n"
 "\n"
 "The core also supports dedicated per game **hook** plain text files with **."
 msgstr ""
 "## Playlists do Libretro para o núcleo ScummVM\n"
-"As listas de reprodução usadas nos frontends do Libretro (por exemplo, "
-"Retroarch) são listas de texto simples usadas para iniciar diretamente um "
-"jogo com um núcleo específico a partir da interface do usuário. Essas listas "
-"são estruturadas para passar ao núcleo o caminho de um arquivo de conteúdo "
-"específico a ser carregado (por exemplo, ROM).\n"
+"As listas de reprodução usadas nos frontends do Libretro (por exemplo, Retroarch) são listas de texto simples usadas para iniciar diretamente um jogo com um núcleo específico a partir da interface do usuário. Essas listas são estruturadas para passar ao núcleo o caminho de um arquivo de conteúdo específico a ser carregado (por exemplo, ROM).\n"
 "\n"
-"O núcleo do ScummVM pode aceitar como conteúdo o caminho para qualquer um "
-"dos arquivos dentro de uma pasta de jogo válida, o sistema de detecção "
-"tentará detectar automaticamente o jogo a partir da pasta pai do arquivo de "
-"conteúdo e executar o jogo com as opções padrão do ScummVM.\n"
+"O núcleo do ScummVM pode aceitar como conteúdo o caminho para qualquer um dos arquivos dentro de uma pasta de jogo válida, o sistema de detecção tentará detectar automaticamente o jogo a partir da pasta pai do arquivo de conteúdo e executar o jogo com as opções padrão do ScummVM.\n"
 "\n"
-"O núcleo também é compatível com arquivos de texto simples **hook** "
-"dedicados para jogo com **."
+"O núcleo também é compatível com arquivos de texto simples **hook** dedicados para jogo com **."
 
 #: backends/platform/maemo/maemo.cpp:157
 msgid "Click Mode"
@@ -6203,12 +5904,9 @@ msgstr "Teclado"
 msgid ""
 "## Keyboard shortcuts\n"
 "\n"
-"ScummVM supports various in-game keyboard and mouse shortcuts, and since "
-"version 2.2.0 these can be manually configured in the **Keymaps tab**, or in "
-"the **configuration file**.\n"
+"ScummVM supports various in-game keyboard and mouse shortcuts, and since version 2.2.0 these can be manually configured in the **Keymaps tab**, or in the **configuration file**.\n"
 "\n"
-"For game-specific controls, see the [wiki entry](https://wiki.scummvm.org/"
-"index.php?title=Category:Supported_Games) for the game you are playing.\n"
+"For game-specific controls, see the [wiki entry](https://wiki.scummvm.org/index.php?title=Category:Supported_Games) for the game you are playing.\n"
 "\n"
 "Default shortcuts are shown in the table.\n"
 "\n"
@@ -6218,13 +5916,9 @@ msgid ""
 msgstr ""
 "## Atalhos do teclado\n"
 "\n"
-"ScummVM é compatível com vários atalhos de teclado e mouse no jogo e, desde "
-"a versão 2.2.0, eles podem ser configurados manualmente na **guia Mapeamento "
-"de Teclas** ou no **arquivo de configuração**.\n"
+"ScummVM é compatível com vários atalhos de teclado e mouse no jogo e, desde a versão 2.2.0, eles podem ser configurados manualmente na **guia Mapeamento de Teclas** ou no **arquivo de configuração**.\n"
 "\n"
-"Para controles específicos do jogo, consulte o [registro wiki](https://"
-"wiki.scummvm.org/index.php?title=Category:Supported_Games) do jogo que você "
-"está jogando.\n"
+"Para controles específicos do jogo, consulte o [registro wiki](https://wiki.scummvm.org/index.php?title=Category:Supported_Games) do jogo que você está jogando.\n"
 "\n"
 "Os atalhos padrão são exibidos na tabela.\n"
 "\n"
@@ -6252,33 +5946,26 @@ msgstr "| `Ctrl+z`  | Sair (outras plataformas)\n"
 msgid ""
 "| `Ctrl+u`  | Mutes all sounds\n"
 "| `Ctrl+m`  | Toggles mouse capture\n"
-"| `Ctrl+Alt` and `9` or `0` | Cycles forwards/backwards between graphics "
-"filters\n"
+"| `Ctrl+Alt` and `9` or `0` | Cycles forwards/backwards between graphics filters\n"
 "| `Ctrl+Alt` and `+` or `-` | Increases/decreases the scale factor\n"
 "| `Ctrl+Alt+a` | Toggles aspect ratio correction on/off\n"
-"| `Ctrl+Alt+f` | Toggles between nearest neighbor and bilinear interpolation "
-"(graphics filtering on/off)\n"
+"| `Ctrl+Alt+f` | Toggles between nearest neighbor and bilinear interpolation (graphics filtering on/off)\n"
 "| `Ctrl+Alt+s` | Cycles through stretch modes\n"
 "| `Alt+Enter`   | Toggles full screen/windowed mode\n"
 "| `Alt+s`          | Takes a screenshot\n"
-"| `Ctrl+F7`       | Opens virtual keyboard (if enabled). This can also be "
-"opened with a long press of the middle mouse button or wheel.\n"
+"| `Ctrl+F7`       | Opens virtual keyboard (if enabled). This can also be opened with a long press of the middle mouse button or wheel.\n"
 "| `Ctrl+Alt+d` | Opens the ScummVM debugger\n"
 msgstr ""
 "| `Ctrl+u`  | Silencia todos os sons\n"
 "| `Ctrl+m`  | Alterna captura do mouse\n"
-"| `Ctrl+Alt` e `9` ou `0` | Alterna para frente/para trás entre os filtros "
-"gráficos\n"
+"| `Ctrl+Alt` e `9` ou `0` | Alterna para frente/para trás entre os filtros gráficos\n"
 "| `Ctrl+Alt` e `+` ou `-` | Aumenta/reduz o fator de escala\n"
 "| `Ctrl+Alt+a` | Alterna a correção de aspecto ligado/desligado\n"
-"| `Ctrl+Alt+f` | Alterna entre escala sem filtro e interpolação bilinear "
-"(filtro de gráficos ligado/desligado)\n"
+"| `Ctrl+Alt+f` | Alterna entre escala sem filtro e interpolação bilinear (filtro de gráficos ligado/desligado)\n"
 "| `Ctrl+Alt+s` | Alterna entre os modos de redimensionamento\n"
 "| `Alt+Enter`   | Alterna entre o modo tela cheia/janela\n"
 "| `Alt+s`          | Captura um instantâneo\n"
-"| `Ctrl+F7`       | Abre o teclado virtual (se estiver habilitado). Este "
-"pode também ser aberto segurando por um tempo o toque com o botão do meio do "
-"mouse ou a roda.\n"
+"| `Ctrl+F7`       | Abre o teclado virtual (se estiver habilitado). Este pode também ser aberto segurando por um tempo o toque com o botão do meio do mouse ou a roda.\n"
 "| `Ctrl+Alt+d` | Abre o depurador do ScummVM\n"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:303
@@ -6690,7 +6377,8 @@ msgstr "Mover para baixo e esquerda"
 msgid "Move down-right"
 msgstr "Mover para baixo e direita"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) This action is used to look at an object or npc in the game
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) This action is used to look at an object or npc in the game
 #: engines/access/metaengine.cpp:285 engines/bbvs/metaengine.cpp:124
 #: engines/dgds/metaengine.cpp:83 engines/drascula/metaengine.cpp:230
 #: engines/petka/metaengine.cpp:130 engines/scumm/help.cpp:167
@@ -6740,7 +6428,7 @@ msgstr "Usar"
 
 #: engines/access/metaengine.cpp:313
 msgid "Goto"
-msgstr ""
+msgstr "Ir para"
 
 #: engines/access/metaengine.cpp:318 engines/access/metaengine.cpp:349
 #: engines/bbvs/metaengine.cpp:130 engines/drascula/metaengine.cpp:250
@@ -6786,7 +6474,7 @@ msgstr "Inventário"
 
 #: engines/access/metaengine.cpp:344 engines/ultima/ultima4/metaengine.cpp:51
 msgid "Climb"
-msgstr ""
+msgstr "Escalar"
 
 #: engines/access/metaengine.cpp:354 engines/bbvs/metaengine.cpp:142
 #: engines/freescape/games/castle/castle.cpp:511
@@ -6826,8 +6514,8 @@ msgstr "O arquivo de dados '%s' da engine está corrompido."
 #: engines/toon/toon.cpp:5449
 #, c-format
 msgid ""
-"Incorrect version of the '%s' engine data file found. Expected %d.%d but got "
-"%d.%d."
+"Incorrect version of the '%s' engine data file found. Expected %d.%d but got"
+" %d.%d."
 msgstr ""
 "Versão incorreta do arquivo de dados '%s\" da engine encontrada. Esperava "
 "por %d.%d mas obteve %d.%d."
@@ -6880,10 +6568,11 @@ msgstr "Utiliza o cursor quadriculado dos modelos posteriores do Apple II"
 #: engines/gob/metaengine.cpp:57 engines/got/metaengine.cpp:48
 #: engines/griffon/metaengine.cpp:40 engines/hugo/metaengine.cpp:56
 #: engines/made/metaengine.cpp:51 engines/mm/metaengine.cpp:91
-#: engines/mortevielle/metaengine.cpp:37 engines/parallaction/metaengine.cpp:52
-#: engines/sci/detection_options.h:221 engines/scumm/dialogs.cpp:1252
-#: engines/scumm/metaengine.cpp:872 engines/supernova/metaengine.cpp:53
-#: engines/wage/metaengine.cpp:51 engines/wintermute/metaengine.cpp:81
+#: engines/mortevielle/metaengine.cpp:37
+#: engines/parallaction/metaengine.cpp:52 engines/sci/detection_options.h:221
+#: engines/scumm/dialogs.cpp:1252 engines/scumm/metaengine.cpp:872
+#: engines/supernova/metaengine.cpp:53 engines/wage/metaengine.cpp:51
+#: engines/wintermute/metaengine.cpp:81
 msgid "Enable Text to Speech"
 msgstr "Habilitar Texto para Fala"
 
@@ -6907,13 +6596,10 @@ msgstr ""
 #: engines/agi/font.cpp:680
 msgid ""
 "Could not open/use file 'hgc_font' for Hercules hires font.\n"
-"If you have such file in other AGI (Sierra) game, you can copy it to the "
-"game directory"
+"If you have such file in other AGI (Sierra) game, you can copy it to the game directory"
 msgstr ""
-"Não foi possível abrir/utilizar o arquivo 'hgc_font' para a fonte Hercules "
-"hires.\n"
-"Se você tiver esse arquivo em outro jogo AGI (Sierra), você pode copiá-lo "
-"para o diretório do jogo"
+"Não foi possível abrir/utilizar o arquivo 'hgc_font' para a fonte Hercules hires.\n"
+"Se você tiver esse arquivo em outro jogo AGI (Sierra), você pode copiá-lo para o diretório do jogo"
 
 #: engines/agi/metaengine.cpp:111 engines/bagel/metaengine.cpp:105
 #: engines/chewy/metaengine.cpp:36 engines/cine/metaengine.cpp:46
@@ -6954,8 +6640,8 @@ msgid ""
 "Use an alternative palette, common for all Amiga games. This was the old "
 "behavior"
 msgstr ""
-"Utiliza uma paleta alternativa, comum para todos os jogos de Amiga. Este era "
-"o comportamento antigo"
+"Utiliza uma paleta alternativa, comum para todos os jogos de Amiga. Este era"
+" o comportamento antigo"
 
 #: engines/agi/metaengine.cpp:135
 msgid "Mouse support"
@@ -6974,15 +6660,11 @@ msgstr "Diálogo de Entrada Preditiva ao clicar o mouse"
 
 #: engines/agi/metaengine.cpp:148
 msgid ""
-"Enables the assistive Predictive Input Dialog specifically for when clicking "
-"the left mouse button within text input fields.\n"
-"The Predictive Input Dialog can still be activated on demand if there's a "
-"specified key mapping for it"
+"Enables the assistive Predictive Input Dialog specifically for when clicking the left mouse button within text input fields.\n"
+"The Predictive Input Dialog can still be activated on demand if there's a specified key mapping for it"
 msgstr ""
-"Habilita o Diálogo de Entrada Preditiva assistiva especificamente ao clicar "
-"com o botão esquerdo do mouse em campos de entrada de texto.\n"
-"O Diálogo de Entrada Preditiva também pode ser ativado sob demanda, caso "
-"exista um mapeamento de teclas configurado para essa função"
+"Habilita o Diálogo de Entrada Preditiva assistiva especificamente ao clicar com o botão esquerdo do mouse em campos de entrada de texto.\n"
+"O Diálogo de Entrada Preditiva também pode ser ativado sob demanda, caso exista um mapeamento de teclas configurado para essa função"
 
 #: engines/agi/metaengine.cpp:159
 msgid "Use Hercules hires font"
@@ -6999,8 +6681,8 @@ msgstr "Pausar quando estiver entrando com comandos"
 
 #: engines/agi/metaengine.cpp:172
 msgid ""
-"Shows a command prompt window and pauses the game (like in SCI) instead of a "
-"real-time prompt."
+"Shows a command prompt window and pauses the game (like in SCI) instead of a"
+" real-time prompt."
 msgstr ""
 "Exibe uma janela de linha de comando e pausa o jogo (como em SCI) em vez de "
 "linha em tempo real."
@@ -7027,22 +6709,27 @@ msgstr "Habilitar proteção contra cópia"
 #: engines/lure/metaengine.cpp:42 engines/mads/metaengine.cpp:57
 #: engines/mm/metaengine.cpp:47 engines/saga/metaengine.cpp:53
 #: engines/scumm/dialogs.cpp:1234 engines/scumm/metaengine.cpp:822
-msgid "Enable any copy protection that would otherwise be bypassed by default."
+msgid ""
+"Enable any copy protection that would otherwise be bypassed by default."
 msgstr ""
-"Ativa qualquer proteção contra cópia que, de outra forma, seria ignorada por "
-"padrão."
+"Ativa qualquer proteção contra cópia que, de outra forma, seria ignorada por"
+" padrão."
 
 #: engines/agi/metaengine.cpp:207
 msgid "Use PCjr's sound chip in 16-bit shift mode"
-msgstr ""
+msgstr "Usar o chip de som do PCjr no modo de deslocamento de 16 bits"
 
 #: engines/agi/metaengine.cpp:208
 msgid ""
 "In PCjr sound mode, emulate a non-standard SN76496 sound chip, similar to "
 "chips found in SEGA Master System consoles. Allows certain music effects, "
-"especially in fanmade games, but original Sierra music designed strictly for "
-"PCjr may sound wrong."
+"especially in fanmade games, but original Sierra music designed strictly for"
+" PCjr may sound wrong."
 msgstr ""
+"No modo de som PCjr, emula um chip de som SN76496 não padrão, semelhante aos"
+" chips encontrados nos consoles SEGA Master System. Permite certos efeitos "
+"musicais, especialmente em jogos feitos por fãs, mas a música original da "
+"Sierra projetada estritamente para PCjr pode soar incorreta."
 
 #: engines/agi/metaengine.cpp:447 engines/asylum/asylum.cpp:655
 #: engines/buried/saveload.cpp:53 engines/mohawk/riven.cpp:759
@@ -7113,7 +6800,7 @@ msgstr "Utilizar telas de salvar/carregar originais"
 
 #: engines/agos/dialogs.cpp:94
 msgid "Toggle between the system cursor and the default cursor."
-msgstr ""
+msgstr "Alternar entre o cursor do sistema e o cursor padrão."
 
 #: engines/agos/dialogs.cpp:107 engines/sci/detection_options.h:261
 msgid "MIDI mode:"
@@ -7121,8 +6808,8 @@ msgstr "Modo de MIDI:"
 
 #: engines/agos/dialogs.cpp:108 engines/sci/detection_options.h:262
 msgid ""
-"When using external MIDI devices (e.g. through USB-MIDI), select your device "
-"here"
+"When using external MIDI devices (e.g. through USB-MIDI), select your device"
+" here"
 msgstr ""
 "Quando utilizar dispositivos MIDI externos (ex: por interface USB-MIDI), "
 "selecione seu dispositivo aqui"
@@ -7408,30 +7095,26 @@ msgstr ""
 
 #: engines/ags/ags.cpp:165
 msgid ""
-"The selected game has a data file greater than 2Gb, which isn't supported by "
-"your version of ScummVM yet."
+"The selected game has a data file greater than 2Gb, which isn't supported by"
+" your version of ScummVM yet."
 msgstr ""
-"O jogo selecionado tem um arquivo de dados maior que 2 Gb, o que ainda não é "
-"compatível com a sua versão do ScummVM."
+"O jogo selecionado tem um arquivo de dados maior que 2 Gb, o que ainda não é"
+" compatível com a sua versão do ScummVM."
 
 #: engines/ags/ags.cpp:348
 msgid ""
-"To preserve the original experience, this game should be loaded using the in-"
-"game interface.\n"
+"To preserve the original experience, this game should be loaded using the in-game interface.\n"
 "You can, however, override this setting in Game Options."
 msgstr ""
-"Para preservar a experiência original, este jogo deve ser carregado "
-"utilizando a interface do jogo.\n"
+"Para preservar a experiência original, este jogo deve ser carregado utilizando a interface do jogo.\n"
 "Você pode, no entanto, substituir essa configuração nas Opções do Jogo."
 
 #: engines/ags/ags.cpp:363
 msgid ""
-"To preserve the original experience, this game should be saved using the in-"
-"game interface.\n"
+"To preserve the original experience, this game should be saved using the in-game interface.\n"
 "You can, however, override this setting in Game Options."
 msgstr ""
-"Para preservar a experiência original, este jogo deve ser salvo utilizando a "
-"interface do jogo.\n"
+"Para preservar a experiência original, este jogo deve ser salvo utilizando a interface do jogo.\n"
 "Você pode, no entanto, substituir essa configuração nas Opções do Jogo."
 
 #: engines/ags/dialogs.cpp:61
@@ -7451,8 +7134,7 @@ msgid ""
 "Never disable ScummVM save management and autosaves.\n"
 "NOTE: This could cause save duplication and other oddities"
 msgstr ""
-"Nunca desabilitar o gerenciamento de save e salvamento automático do "
-"ScummVM.\n"
+"Nunca desabilitar o gerenciamento de save e salvamento automático do ScummVM.\n"
 "NOTA: Isso pode causar duplicação de salvamento e outras esquisitices"
 
 #: engines/ags/dialogs.cpp:82
@@ -7475,21 +7157,17 @@ msgstr "Exibe a taxa de FPS atual, enquanto você joga."
 
 #: engines/ags/engine/ac/listbox.cpp:78
 msgid ""
-"The game will now list characters exported from the Sierra games that can be "
-"imported:\n"
-"1. Save files named qfg1*.sav or qfg1vga*.sav inside ScummVM save directory, "
-"or\n"
+"The game will now list characters exported from the Sierra games that can be imported:\n"
+"1. Save files named qfg1*.sav or qfg1vga*.sav inside ScummVM save directory, or\n"
 "2. Any .sav file inside the QfG2 Remake game directory"
 msgstr ""
-"O jogo agora listará personagens exportados dos jogos Sierra que podem ser "
-"importados:\n"
-"1. Salve os arquivos chamados qfg1*.sav ou qfg1vga*.sav dentro do diretório "
-"de salvamento do ScummVM, ou\n"
+"O jogo agora listará personagens exportados dos jogos Sierra que podem ser importados:\n"
+"1. Salve os arquivos chamados qfg1*.sav ou qfg1vga*.sav dentro do diretório de salvamento do ScummVM, ou\n"
 "2. Qualquer arquivo .sav dentro do diretório do jogo QfG2 Remake"
 
 #: engines/alcachofa/graphics-opengl.cpp:108
 msgid "Old OpenGL detected, some graphical errors will occur."
-msgstr ""
+msgstr "OpenGL antigo detectado, alguns erros gráficos ocorrerão."
 
 #: engines/alcachofa/metaengine.cpp:40
 #, fuzzy
@@ -7505,11 +7183,11 @@ msgstr "Ligar/desligar efeito sonoro"
 
 #: engines/alcachofa/metaengine.cpp:51
 msgid "32 Bits"
-msgstr ""
+msgstr "32 bits"
 
 #: engines/alcachofa/metaengine.cpp:52
 msgid "Whether to render the game in 16-bit color"
-msgstr ""
+msgstr "Define se o jogo deve ser renderizado em cores de 16 bits"
 
 #: engines/alcachofa/metaengine.cpp:62
 #, fuzzy
@@ -7519,7 +7197,7 @@ msgstr "Gráficos com filtro"
 
 #: engines/alcachofa/metaengine.cpp:63
 msgid "Whether textures should be linearly filtered"
-msgstr ""
+msgstr "Define se as texturas devem ser filtradas linearmente"
 
 #: engines/alcachofa/metaengine.cpp:98 engines/cine/metaengine.cpp:347
 #: engines/freescape/games/castle/castle.cpp:528
@@ -7541,13 +7219,15 @@ msgstr "Ativar/desativar legendas"
 
 #: engines/alg/metaengine.cpp:34
 msgid "Use lower quality single speed CD-ROM video"
-msgstr ""
+msgstr "Usar vídeo de CD-ROM de velocidade simples e qualidade inferior"
 
 #: engines/alg/metaengine.cpp:35
 msgid ""
 "These videos are of lower quality, the default version uses double speed CD-"
 "ROM videos which are of better quality"
 msgstr ""
+"Estes vídeos são de qualidade inferior; a versão padrão usa vídeos de CD-ROM"
+" de velocidade dupla, que são de melhor qualidade"
 
 #: engines/asylum/metaengine.cpp:115
 msgid "Show version"
@@ -7566,7 +7246,8 @@ msgstr "Carregamento rápido"
 #: engines/phoenixvr/metaengine.cpp:100 engines/queen/metaengine.cpp:247
 #: engines/sludge/keymapper_tables.h:64 engines/sludge/keymapper_tables.h:303
 #: engines/sludge/keymapper_tables.h:410 engines/sludge/keymapper_tables.h:465
-#: engines/sludge/keymapper_tables.h:496 engines/ultima/nuvie/metaengine.cpp:91
+#: engines/sludge/keymapper_tables.h:496
+#: engines/ultima/nuvie/metaengine.cpp:91
 #: engines/ultima/ultima8/metaengine.cpp:43
 #: engines/wintermute/keymapper_tables.h:930
 msgid "Quick save"
@@ -7638,7 +7319,7 @@ msgstr "Carregar mesmo assim"
 
 #: engines/awe/metaengine.cpp:35
 msgid "Enable title and copy protection screens (if present)"
-msgstr ""
+msgstr "Ativar telas de título e de proteção contra cópia (se presentes)"
 
 #: engines/awe/metaengine.cpp:36
 #, fuzzy
@@ -7648,8 +7329,8 @@ msgid ""
 "Displays title and copy protection screens that would otherwise be bypassed "
 "by default."
 msgstr ""
-"Ativa qualquer proteção contra cópia que, de outra forma, seria ignorada por "
-"padrão."
+"Ativa qualquer proteção contra cópia que, de outra forma, seria ignorada por"
+" padrão."
 
 #: engines/awe/metaengine.cpp:61
 #, fuzzy
@@ -7663,7 +7344,7 @@ msgstr "Pular"
 
 #: engines/awe/metaengine.cpp:63
 msgid "Enter level code"
-msgstr ""
+msgstr "Inserir código de fase"
 
 #: engines/awe/metaengine.cpp:88 engines/dgds/metaengine.cpp:87
 #: engines/got/metaengine.cpp:105
@@ -7712,7 +7393,7 @@ msgstr "Tecla anti-chefe"
 
 #: engines/bagel/metaengine.cpp:73
 msgid "End"
-msgstr ""
+msgstr "Fim"
 
 #: engines/bagel/metaengine.cpp:180
 msgid "General Keys"
@@ -7760,8 +7441,8 @@ msgid ""
 "mode for this session until you completely Quit the game."
 msgstr ""
 "AVISO: Este jogo foi salvo no modo de Conteúdo Original, mas você está "
-"jogando no modo Restauração de Conteúdo Cortado. O modo será ajustado para o "
-"modo de Conteúdo Original para esta sessão até que você Saia completamente "
+"jogando no modo Restauração de Conteúdo Cortado. O modo será ajustado para o"
+" modo de Conteúdo Original para esta sessão até que você Saia completamente "
 "do jogo."
 
 #: engines/bladerunner/bladerunner.cpp:2758
@@ -7776,9 +7457,11 @@ msgstr "Continuar"
 msgid ""
 "The fan translator does not wish his translation to be incorporated into "
 "ScummVM."
-msgstr "O tradutor fã deseja que sua tradução não seja incorporada ao ScummVM."
+msgstr ""
+"O tradutor fã deseja que sua tradução não seja incorporada ao ScummVM."
 
-#. I18N: Blade Runner Enhanced Edition is a trademark, so please keep the capitalization
+#. I18N: Blade Runner Enhanced Edition is a trademark, so please keep the
+#. capitalization
 #. for Enhanced Edition as is.
 #: engines/bladerunner/detection_tables.h:137
 msgid ""
@@ -7862,30 +7545,38 @@ msgstr ""
 "Atualiza os créditos finais com créditos corrigidos para os dubladores "
 "espanhóis"
 
-#. I18N: These are keymaps that work in the main gameplay and also when KIA (Knowledge Integration Assistant) is open.
+#. I18N: These are keymaps that work in the main gameplay and also when KIA
+#. (Knowledge Integration Assistant) is open.
 #: engines/bladerunner/metaengine.cpp:199
 msgid "common shortcuts"
 msgstr "atalhos comuns"
 
-#. I18N: These are keymaps which work only in the main gameplay and not within KIA's (Knowledge Integration Assistant) screens.
+#. I18N: These are keymaps which work only in the main gameplay and not within
+#. KIA's (Knowledge Integration Assistant) screens.
 #: engines/bladerunner/metaengine.cpp:201
 msgid "main game shortcuts"
 msgstr "atalhos do jogo principal"
 
-#. I18N: These are keymaps that work only within KIA's (Knowledge Integration Assistant) screens.
+#. I18N: These are keymaps that work only within KIA's (Knowledge Integration
+#. Assistant) screens.
 #: engines/bladerunner/metaengine.cpp:203
 msgid "KIA only shortcuts"
 msgstr "Atalhos do AIC"
 
 #. I18N: This keymap is the main way for the user interact with the game.
-#. It is used with the game's cursor to select, walk-to, run-to, look-at, talk-to, pick up, use, shoot (combat mode), open KIA (when clicking on McCoy).
+#. It is used with the game's cursor to select, walk-to, run-to, look-at,
+#. talk-to, pick up, use, shoot (combat mode), open KIA (when clicking on
+#. McCoy).
 #: engines/bladerunner/metaengine.cpp:210
 msgid "Walk / Look / Talk / Select / Shoot"
 msgstr "Andar / Olhar / Conversar / Selecionar / Atirar"
 
-#. I18N: This keymap toggles McCoy's status between combat mode (drawing his gun) and normal mode (holstering his gun)
-#. In Blade Runner's official localizations, there is a description of this keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
+#. I18N: This keymap toggles McCoy's status between combat mode (drawing his
+#. gun) and normal mode (holstering his gun)
+#. In Blade Runner's official localizations, there is a description of this
+#. keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
+#. is
 #. TOGGLE MCCOY'S COMBAT MODE
 #: engines/bladerunner/metaengine.cpp:220
 #: engines/ultima/nuvie/metaengine.cpp:73
@@ -7905,8 +7596,10 @@ msgid "Skip cutscene"
 msgstr "Pular cena"
 
 #. I18N: This keymap allows skipping the current line of dialog.
-#. In Blade Runner's official localizations, there is a description of this keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
+#. In Blade Runner's official localizations, there is a description of this
+#. keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
+#. is
 #. SKIP PAST CURRENT LINE OF DIALOG
 #: engines/bladerunner/metaengine.cpp:242 engines/sludge/keymapper_tables.h:89
 #: engines/sludge/keymapper_tables.h:138 engines/sludge/keymapper_tables.h:194
@@ -7920,9 +7613,12 @@ msgstr "Pular cena"
 msgid "Skip dialog"
 msgstr "Pular diálogo"
 
-#. I18N: This keymap toggles between opening the KIA in the Game Options tab, and closing the KIA.
-#. In Blade Runner's official localizations, there is a description of this keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
+#. I18N: This keymap toggles between opening the KIA in the Game Options tab,
+#. and closing the KIA.
+#. In Blade Runner's official localizations, there is a description of this
+#. keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
+#. is
 #. GAME OPTIONS
 #: engines/bladerunner/metaengine.cpp:253
 #, fuzzy
@@ -7932,8 +7628,10 @@ msgstr "Opções de Jogo"
 
 #. I18N: This keymap opens the KIA database on one of the investigation tabs,
 #. CRIME SCENE DATABASE, SUSPECT DATABASE and CLUES DATABASE.
-#. In Blade Runner's official localizations, there is a description of this keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
+#. In Blade Runner's official localizations, there is a description of this
+#. keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
+#. is
 #. ACTIVATE KIA CLUE DATABASE SYSTEM
 #: engines/bladerunner/metaengine.cpp:264
 #, fuzzy
@@ -7950,8 +7648,11 @@ msgid "Delete selected saved game"
 msgstr "Apagar Jogo Salvo Selecionado"
 
 #. I18N: This keymap allows scrolling texts and lists upwards
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a map, this action is used to scroll up in the map
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has multiple widgets for various purposes (eg. inventory, save files, etc.), this action is used to scroll up in the widget
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has a map, this action is used to scroll up in the map
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has multiple widgets for various purposes (eg. inventory,
+#. save files, etc.), this action is used to scroll up in the widget
 #: engines/bladerunner/metaengine.cpp:296 engines/efh/metaengine.cpp:415
 #: engines/sherlock/metaengine.cpp:368 engines/sherlock/metaengine.cpp:999
 #: engines/sherlock/metaengine.cpp:1025 engines/titanic/metaengine.cpp:218
@@ -7970,8 +7671,11 @@ msgid "Scroll up"
 msgstr "Rolar para cima"
 
 #. I18N: This keymap allows scrolling texts and lists downwards
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a map, this action is used to scroll down in the map
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has multiple widgets for various purposes (eg. inventory, save files, etc.), this action is used to scroll down in the widget
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has a map, this action is used to scroll down in the map
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has multiple widgets for various purposes (eg. inventory,
+#. save files, etc.), this action is used to scroll down in the widget
 #: engines/bladerunner/metaengine.cpp:303 engines/efh/metaengine.cpp:403
 #: engines/sherlock/metaengine.cpp:374 engines/sherlock/metaengine.cpp:1007
 #: engines/sherlock/metaengine.cpp:1033 engines/titanic/metaengine.cpp:225
@@ -7989,7 +7693,8 @@ msgstr "Rolar para cima"
 msgid "Scroll down"
 msgstr "Rolar para baixo"
 
-#. I18N: This keymap allows (in KIA only) for a clue to be set as private or public
+#. I18N: This keymap allows (in KIA only) for a clue to be set as private or
+#. public
 #. (only when the KIA is upgraded).
 #: engines/bladerunner/metaengine.cpp:311
 #, fuzzy
@@ -7998,8 +7703,10 @@ msgid "Toggle clue privacy"
 msgstr "Alternar Privacidade de Pistas"
 
 #. I18N: This keymap opens KIA's SAVE GAME tab.
-#. In Blade Runner's official localizations, there is a description of this keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
+#. In Blade Runner's official localizations, there is a description of this
+#. keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
+#. is
 #. SAVE GAME
 #: engines/bladerunner/metaengine.cpp:330 engines/buried/metaengine.cpp:179
 #: engines/cge/metaengine.cpp:221 engines/cge2/metaengine.cpp:235
@@ -8021,13 +7728,16 @@ msgstr "Alternar Privacidade de Pistas"
 #: engines/titanic/metaengine.cpp:199 engines/toltecs/metaengine.cpp:234
 #: engines/toon/metaengine.cpp:112 engines/trecision/metaengine.cpp:169
 #: engines/tsage/metaengine.cpp:242 engines/ultima/ultima8/metaengine.cpp:44
-#: engines/vcruise/metaengine.cpp:175 engines/wintermute/keymapper_tables.h:920
+#: engines/vcruise/metaengine.cpp:175
+#: engines/wintermute/keymapper_tables.h:920
 msgid "Save game"
 msgstr "Salvar jogo"
 
 #. I18N: This keymap opens KIA's LOAD GAME tab.
-#. In Blade Runner's official localizations, there is a description of this keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
+#. In Blade Runner's official localizations, there is a description of this
+#. keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
+#. is
 #. LOAD GAME
 #: engines/bladerunner/metaengine.cpp:339 engines/buried/metaengine.cpp:184
 #: engines/cge/metaengine.cpp:227 engines/cge2/metaengine.cpp:241
@@ -8053,8 +7763,10 @@ msgid "Load game"
 msgstr "Carregar jogo"
 
 #. I18N: This keymap opens KIA's CRIME SCENE DATABASE tab.
-#. In Blade Runner's official localizations, there is a description of this keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
+#. In Blade Runner's official localizations, there is a description of this
+#. keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
+#. is
 #. CRIME SCENE DATABASE
 #: engines/bladerunner/metaengine.cpp:348
 #, fuzzy
@@ -8063,8 +7775,10 @@ msgid "Crime scene database"
 msgstr "Base de Dados de Cena do Crime"
 
 #. I18N: This keymap opens KIA's SUSPECT DATABASE tab.
-#. In Blade Runner's official localizations, there is a description of this keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
+#. In Blade Runner's official localizations, there is a description of this
+#. keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
+#. is
 #. SUSPECT DATABASE
 #: engines/bladerunner/metaengine.cpp:357
 #, fuzzy
@@ -8073,8 +7787,10 @@ msgid "Suspect database"
 msgstr "Base de Dados de Suspeitos"
 
 #. I18N: This keymap opens KIA's CLUE DATABASE tab.
-#. In Blade Runner's official localizations, there is a description of this keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
+#. In Blade Runner's official localizations, there is a description of this
+#. keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
+#. is
 #. CLUE DATABASE
 #: engines/bladerunner/metaengine.cpp:366
 #, fuzzy
@@ -8083,8 +7799,10 @@ msgid "Clue database"
 msgstr "Base de Dados de Pistas"
 
 #. I18N: This keymap opens KIA's QUIT GAME tab.
-#. In Blade Runner's official localizations, there is a description of this keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
+#. In Blade Runner's official localizations, there is a description of this
+#. keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
+#. is
 #. QUIT GAME
 #: engines/bladerunner/metaengine.cpp:375 engines/cruise/metaengine.cpp:229
 #: engines/darkseed/metaengine.cpp:60 engines/dragons/metaengine.cpp:223
@@ -8113,6 +7831,8 @@ msgid ""
 "This option allows the game to play at a slightly extended resolution. This "
 "is what the Mac and CDi versions are supposed to play like."
 msgstr ""
+"Esta opção permite que o jogo seja executado em uma resolução ligeiramente "
+"estendida. É assim que as versões Mac e CDi deveriam ser exibidas."
 
 #: engines/buried/buried.cpp:598
 msgid "Are you sure you want to quit?"
@@ -8212,49 +7932,57 @@ msgstr "Mover para frente"
 #. I18N: AI is Artificial Intelligence
 #: engines/buried/metaengine.cpp:230
 msgid "Replay last AI comment"
-msgstr ""
+msgstr "Repetir o último comentário da IA"
 
-#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the Artificial Intelligence biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is
+#. used to switch the equipped biochip to the Artificial Intelligence biochip.
 #: engines/buried/metaengine.cpp:237
 msgid "Biochip AI"
-msgstr ""
+msgstr "Biochip IA"
 
-#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the blank biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is
+#. used to switch the equipped biochip to the blank biochip.
 #: engines/buried/metaengine.cpp:243
 msgid "Biochip blank"
-msgstr ""
+msgstr "Biochip em branco"
 
-#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the cloak biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is
+#. used to switch the equipped biochip to the cloak biochip.
 #: engines/buried/metaengine.cpp:249
 msgid "Biochip cloak"
-msgstr ""
+msgstr "Biochip de camuflagem"
 
-#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the evidence biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is
+#. used to switch the equipped biochip to the evidence biochip.
 #: engines/buried/metaengine.cpp:255
 msgid "Biochip evidence"
-msgstr ""
+msgstr "Biochip de evidências"
 
-#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the files biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is
+#. used to switch the equipped biochip to the files biochip.
 #: engines/buried/metaengine.cpp:261
 #, fuzzy
 #| msgid "Show hidden files"
 msgid "Biochip files"
 msgstr "Exibir arquivos ocultos"
 
-#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the interface biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is
+#. used to switch the equipped biochip to the interface biochip.
 #: engines/buried/metaengine.cpp:267
 msgid "Biochip interface"
-msgstr ""
+msgstr "Biochip de interface"
 
-#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the jump biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is
+#. used to switch the equipped biochip to the jump biochip.
 #: engines/buried/metaengine.cpp:273
 msgid "Biochip jump"
-msgstr ""
+msgstr "Biochip de salto"
 
-#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the translate biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is
+#. used to switch the equipped biochip to the translate biochip.
 #: engines/buried/metaengine.cpp:279
 msgid "Biochip translate"
-msgstr ""
+msgstr "Biochip de tradução"
 
 #. I18N: Shows a summary of collected points in the game.
 #: engines/buried/metaengine.cpp:285
@@ -8265,25 +7993,20 @@ msgstr "Exibir dicas"
 
 #: engines/buried/saveload.cpp:80
 msgid ""
-"ScummVM found that you have saved games that should be converted from the "
-"original saved game format.\n"
-"The original saved game format is no longer supported directly, so you will "
-"not be able to load your games if you don't convert them.\n"
+"ScummVM found that you have saved games that should be converted from the original saved game format.\n"
+"The original saved game format is no longer supported directly, so you will not be able to load your games if you don't convert them.\n"
 "\n"
-"Press OK to convert them now, otherwise you will be asked again the next "
-"time you start the game.\n"
+"Press OK to convert them now, otherwise you will be asked again the next time you start the game.\n"
 msgstr ""
-"ScummVM percebeu que você possui jogos salvos que precisam ser convertidos "
-"para um novo formato.\n"
-"O formato original do jogo salvo não é mais compatível, portanto, você não "
-"poderá carregar seus jogos se não convertê-los.\n"
+"ScummVM percebeu que você possui jogos salvos que precisam ser convertidos para um novo formato.\n"
+"O formato original do jogo salvo não é mais compatível, portanto, você não poderá carregar seus jogos se não convertê-los.\n"
 "\n"
-"Pressione OK para convertê-los agora, caso contrário, você será solicitado "
-"novamente na próxima vez que iniciar o jogo.\n"
+"Pressione OK para convertê-los agora, caso contrário, você será solicitado novamente na próxima vez que iniciar o jogo.\n"
 
 #: engines/buried/saveload.cpp:179 engines/mtropolis/saveload.cpp:158
 #: engines/tot/saveload.cpp:269 engines/vcruise/vcruise.cpp:356
-msgid "Saved game was created with a newer version of ScummVM. Unable to load."
+msgid ""
+"Saved game was created with a newer version of ScummVM. Unable to load."
 msgstr ""
 "O jogo salvo foi criado com uma versão mais recente do ScummVM. Não é "
 "possível carregar."
@@ -8647,11 +8370,11 @@ msgstr "Próxima ação"
 
 #: engines/colony/savegame.cpp:291
 msgid "Saving is only available in first-person view."
-msgstr ""
+msgstr "Salvar só está disponível na visão em primeira pessoa."
 
 #: engines/colony/savegame.cpp:300
 msgid "Loading is only available in first-person view."
-msgstr ""
+msgstr "Carregar só está disponível na visão em primeira pessoa."
 
 #: engines/crab/input/input.cpp:119
 #, fuzzy
@@ -8706,9 +8429,16 @@ msgstr "Resposta 5"
 msgid "Reply 6"
 msgstr "Resposta 6"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has an inventory, this action is go ahead a page (one page displays 6 items) in the inventory
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a journal, this action is used to go forward 1 page in the journal
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has multiple widgets for various purposes (eg. inventory, save files, etc.), this action is used to scroll down by a page in the widget
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
+#. Scalpel) The game has an inventory, this action is go ahead a page (one
+#. page displays 6 items) in the inventory
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has a journal, this action is used to go forward 1 page in
+#. the journal
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has multiple widgets for various purposes (eg. inventory,
+#. save files, etc.), this action is used to scroll down by a page in the
+#. widget
 #: engines/crab/input/input.cpp:221 engines/sherlock/metaengine.cpp:591
 #: engines/sherlock/metaengine.cpp:902 engines/sherlock/metaengine.cpp:1048
 #: engines/supernova/metaengine.cpp:291 engines/titanic/metaengine.cpp:271
@@ -8722,9 +8452,15 @@ msgstr "Resposta 6"
 msgid "Next page"
 msgstr "Próxima página"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has an inventory, this action is go back a page (one page displays 6 items) in the inventory
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a journal, this action is used to go back 1 page in the journal
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has multiple widgets for various purposes (eg. inventory, save files, etc.), this action is used to scroll up by a page in the widget
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
+#. Scalpel) The game has an inventory, this action is go back a page (one page
+#. displays 6 items) in the inventory
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has a journal, this action is used to go back 1 page in
+#. the journal
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has multiple widgets for various purposes (eg. inventory,
+#. save files, etc.), this action is used to scroll up by a page in the widget
 #: engines/crab/input/input.cpp:226 engines/sherlock/metaengine.cpp:572
 #: engines/sherlock/metaengine.cpp:917 engines/sherlock/metaengine.cpp:1041
 #: engines/supernova/metaengine.cpp:285 engines/titanic/metaengine.cpp:264
@@ -8786,9 +8522,11 @@ msgstr "Utilizar velocidade da música da versão DOS"
 
 #: engines/darkseed/dialogs.cpp:107
 msgid ""
-"Use the music from the floppy version. The floppy version's music files must "
-"be copied to the SOUND directory."
+"Use the music from the floppy version. The floppy version's music files must"
+" be copied to the SOUND directory."
 msgstr ""
+"Usar a música da versão em disquete. Os arquivos de música da versão em "
+"disquete devem ser copiados para o diretório SOUND."
 
 #: engines/darkseed/dialogs.cpp:121
 #, fuzzy
@@ -8802,18 +8540,22 @@ msgid ""
 "additional floppy SFX, or floppy SFX only. Floppy SFX are only available if "
 "floppy music is used."
 msgstr ""
+"Determina se o jogo deve usar apenas os efeitos sonoros da versão em CD, os "
+"efeitos sonoros do CD com efeitos adicionais da versão em disquete, ou "
+"apenas os efeitos sonoros da versão em disquete. Os efeitos sonoros do "
+"disquete só estão disponíveis se a música do disquete for usada."
 
 #: engines/darkseed/dialogs.cpp:127
 msgid "CD version SFX only"
-msgstr ""
+msgstr "Apenas efeitos sonoros da versão em CD"
 
 #: engines/darkseed/dialogs.cpp:131
 msgid "CD + extra floppy SFX"
-msgstr ""
+msgstr "CD + efeitos sonoros extras do disquete"
 
 #: engines/darkseed/dialogs.cpp:135
 msgid "Floppy version SFX only"
-msgstr ""
+msgstr "Apenas efeitos sonoros da versão em disquete"
 
 #. I18N: Perform action on object where cursor points
 #: engines/darkseed/metaengine.cpp:42 engines/dragons/metaengine.cpp:135
@@ -8883,15 +8625,16 @@ msgstr "Correção de proporção habilitada"
 
 #: engines/director/metaengine.cpp:71
 msgid "Brighten the graphics to simulate a Macintosh monitor"
-msgstr ""
+msgstr "Clarear os gráficos para simular um monitor Macintosh"
 
 #: engines/director/metaengine.cpp:81
 msgid "Force true color (32bpp) mode"
-msgstr ""
+msgstr "Forçar o modo de cores reais (32bpp)"
 
 #: engines/director/metaengine.cpp:82
 #, fuzzy
-#| msgid "Use antialiasing to draw text even if the game does not ask for it"
+#| msgid ""
+#| "Use antialiasing to draw text even if the game does not ask for it"
 msgid ""
 "Use true color graphics mode (32 bits per pixel), even if the game is not "
 "designed for it"
@@ -8904,40 +8647,52 @@ msgstr ""
 msgid "Dialog choice selection keymappings"
 msgstr "Mapeamento de teclas do menu Iniciar"
 
-#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters called "champions" which they choose themselves. One of them can be assigned the "leader". This action toggles the inventory screen of the leader champion.
+#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters
+#. called "champions" which they choose themselves. One of them can be
+#. assigned the "leader". This action toggles the inventory screen of the
+#. leader champion.
 #: engines/dm/metaengine.cpp:137
 #, fuzzy
 #| msgid "Toggle Inventory/IQ Points display"
 msgid "Toggle leader inventory"
 msgstr "Alternar exibição do Inventário/Pontos de QI"
 
-#. I18N: (Game name: Dungeon Master) The game has multi-choice dialogs. If there is only one choice, then this action can be used to select it.
+#. I18N: (Game name: Dungeon Master) The game has multi-choice dialogs. If
+#. there is only one choice, then this action can be used to select it.
 #: engines/dm/metaengine.cpp:144
 msgid "Select dialog choice (only works if there is a single choice)"
-msgstr ""
+msgstr "Selecionar a opção de diálogo (só funciona se houver uma única opção)"
 
-#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters called "champions" which they choose themselves. This action toggles the inventory screen of champion 1.
+#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters
+#. called "champions" which they choose themselves. This action toggles the
+#. inventory screen of champion 1.
 #: engines/dm/metaengine.cpp:151
 #, fuzzy
 #| msgid "Toggle Inventory/IQ Points display"
 msgid "Toggle champion 1 inventory"
 msgstr "Alternar exibição do Inventário/Pontos de QI"
 
-#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters called "champions" which they choose themselves. This action toggles the inventory screen of champion 2.
+#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters
+#. called "champions" which they choose themselves. This action toggles the
+#. inventory screen of champion 2.
 #: engines/dm/metaengine.cpp:157
 #, fuzzy
 #| msgid "Toggle Inventory/IQ Points display"
 msgid "Toggle champion 2 inventory"
 msgstr "Alternar exibição do Inventário/Pontos de QI"
 
-#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters called "champions" which they choose themselves. This action toggles the inventory screen of champion 3.
+#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters
+#. called "champions" which they choose themselves. This action toggles the
+#. inventory screen of champion 3.
 #: engines/dm/metaengine.cpp:163
 #, fuzzy
 #| msgid "Toggle Inventory/IQ Points display"
 msgid "Toggle champion 3 inventory"
 msgstr "Alternar exibição do Inventário/Pontos de QI"
 
-#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters called "champions" which they choose themselves. This action toggles the inventory screen of champion 4.
+#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters
+#. called "champions" which they choose themselves. This action toggles the
+#. inventory screen of champion 4.
 #: engines/dm/metaengine.cpp:169
 #, fuzzy
 #| msgid "Toggle Inventory/IQ Points display"
@@ -8955,10 +8710,12 @@ msgstr "Alternar exibição do Inventário/Pontos de QI"
 msgid "Move backwards"
 msgstr "Mover para trás"
 
-#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters called "champions" which they choose themselves. The champions can be put to sleep. This action wakes up the sleeping champion.
+#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters
+#. called "champions" which they choose themselves. The champions can be put
+#. to sleep. This action wakes up the sleeping champion.
 #: engines/dm/metaengine.cpp:247
 msgid "Wake up champion"
-msgstr ""
+msgstr "Acordar o campeão"
 
 #: engines/draci/metaengine.cpp:68 engines/prince/metaengine.cpp:64
 #, fuzzy
@@ -9014,29 +8771,24 @@ msgstr "Item seguinte do inventário"
 msgid ""
 "Error: The file '%s' hasn't been extracted properly.\n"
 "Please refer to the wiki page\n"
-"%s for details on how to properly extract the DTSPEECH.XA and *.STR files "
-"from your game disc."
+"%s for details on how to properly extract the DTSPEECH.XA and *.STR files from your game disc."
 msgstr ""
 "Erro: O arquivo '%s' não foi extraído corretamente.\n"
 "Por favor consulte a página wiki\n"
-"%s para detalhes de como extrair corretamente os arquivos DTSPEECH.XA e "
-"*.STR do seu disco de jogo."
+"%s para detalhes de como extrair corretamente os arquivos DTSPEECH.XA e *.STR do seu disco de jogo."
 
 #: engines/dragons/metaengine.cpp:120
 #, c-format
 msgid ""
 "Error: It appears that the game data files were extracted incorrectly.\n"
 "\n"
-"You should only extract STR and XA files using the special method. The rest "
-"should be copied normally from your game CD.\n"
+"You should only extract STR and XA files using the special method. The rest should be copied normally from your game CD.\n"
 "\n"
 " See %s"
 msgstr ""
-"Erro: Parece que os arquivos de dados do jogo foram extraídos "
-"incorretamente.\n"
+"Erro: Parece que os arquivos de dados do jogo foram extraídos incorretamente.\n"
 "\n"
-"Você só deve extrair arquivos STR e XA usando um método especial. O restante "
-"deve ser copiado normalmente do CD do jogo.\n"
+"Você só deve extrair arquivos STR e XA usando um método especial. O restante deve ser copiado normalmente do CD do jogo.\n"
 "\n"
 " Veja em %s"
 
@@ -9109,21 +8861,15 @@ msgstr "Confirmar"
 
 #: engines/drascula/saveload.cpp:49
 msgid ""
-"ScummVM found that you have old saved games for Drascula that should be "
-"converted.\n"
-"The old saved game format is no longer supported, so you will not be able to "
-"load your games if you don't convert them.\n"
+"ScummVM found that you have old saved games for Drascula that should be converted.\n"
+"The old saved game format is no longer supported, so you will not be able to load your games if you don't convert them.\n"
 "\n"
-"Press OK to convert them now, otherwise you will be asked again the next "
-"time you start the game.\n"
+"Press OK to convert them now, otherwise you will be asked again the next time you start the game.\n"
 msgstr ""
-"ScummVM percebeu que você possui antigos jogos salvos para Drascula que "
-"precisam ser convertidos.\n"
-"O antigo formato de jogo salvo não é mais suportado, portanto você não "
-"conseguirá carregar seus jogos se não os convertê-los.\n"
+"ScummVM percebeu que você possui antigos jogos salvos para Drascula que precisam ser convertidos.\n"
+"O antigo formato de jogo salvo não é mais suportado, portanto você não conseguirá carregar seus jogos se não os convertê-los.\n"
 "\n"
-"Pressione OK para convertê-los agora, caso contrário você será solicitado "
-"novamente da próxima vez que iniciar o jogo.\n"
+"Pressione OK para convertê-los agora, caso contrário você será solicitado novamente da próxima vez que iniciar o jogo.\n"
 
 #: engines/dreamweb/metaengine.cpp:60
 msgid "Use bright palette mode"
@@ -9341,7 +9087,7 @@ msgstr "Soltar"
 
 #: engines/efh/metaengine.cpp:437
 msgid "Equip"
-msgstr ""
+msgstr "Equipar"
 
 #: engines/efh/metaengine.cpp:442 engines/queen/metaengine.cpp:274
 #: engines/saga/metaengine.cpp:384 engines/scumm/help.cpp:124
@@ -9361,11 +9107,11 @@ msgstr "Menu de Informação"
 
 #: engines/efh/metaengine.cpp:452
 msgid "Passive skills"
-msgstr ""
+msgstr "Habilidades passivas"
 
 #: engines/efh/metaengine.cpp:457
 msgid "Trade"
-msgstr ""
+msgstr "Negociar"
 
 #: engines/efh/metaengine.cpp:467
 #, fuzzy
@@ -9381,7 +9127,7 @@ msgstr "Sair do jogo"
 
 #: engines/efh/metaengine.cpp:493
 msgid "Leave"
-msgstr ""
+msgstr "Sair"
 
 #: engines/efh/metaengine.cpp:500 engines/efh/metaengine.cpp:536
 #, fuzzy
@@ -9391,18 +9137,21 @@ msgstr "Status:"
 
 #: engines/efh/metaengine.cpp:518
 msgid "Defend"
-msgstr ""
+msgstr "Defender"
 
 #. I18N: Run is a movement type
 #. I18N: Action in In Cold Blood
-#: engines/efh/metaengine.cpp:530 engines/freescape/games/castle/castle.cpp:506
-#: engines/grim/grim.cpp:501 engines/grim/grim.cpp:596
-#: engines/hpl1/metaengine.cpp:82 engines/icb/icb.cpp:131
-#: engines/icb/icb.cpp:197 engines/ultima/ultima8/metaengine.cpp:56
+#: engines/efh/metaengine.cpp:530
+#: engines/freescape/games/castle/castle.cpp:506 engines/grim/grim.cpp:501
+#: engines/grim/grim.cpp:596 engines/hpl1/metaengine.cpp:82
+#: engines/icb/icb.cpp:131 engines/icb/icb.cpp:197
+#: engines/ultima/ultima8/metaengine.cpp:56
 msgid "Run"
 msgstr "Correr"
 
-#. I18N: (Game name: Escape from hell) This action is used to view the terrain during a fight so that the player can see where they can move if they decide to run.
+#. I18N: (Game name: Escape from hell) This action is used to view the terrain
+#. during a fight so that the player can see where they can move if they
+#. decide to run.
 #: engines/efh/metaengine.cpp:543
 #, fuzzy
 #| msgid "Exit conversation"
@@ -9509,7 +9258,7 @@ msgstr "Reproduzir nota 1: A"
 
 #: engines/efh/metaengine.cpp:657
 msgid "Play sound type 9"
-msgstr ""
+msgstr "Reproduzir som tipo 9"
 
 #: engines/efh/metaengine.cpp:662
 #, fuzzy
@@ -9593,11 +9342,11 @@ msgstr "Habilita viagem utilizando lançamento de pedra desde o início"
 
 #: engines/freescape/metaengine.cpp:140
 msgid "Smoother movement"
-msgstr ""
+msgstr "Movimento mais suave"
 
 #: engines/freescape/metaengine.cpp:141
 msgid "Use smoother movements instead of discrete steps"
-msgstr ""
+msgstr "Usar movimentos mais suaves em vez de passos discretos"
 
 #. I18N: Use modern FPS-style controls: WASD for movement, Shift to run
 #: engines/freescape/metaengine.cpp:152
@@ -9608,26 +9357,27 @@ msgstr "Controles de Toque"
 
 #: engines/freescape/metaengine.cpp:153
 msgid "Use WASD keys for movement and Shift to run"
-msgstr ""
+msgstr "Usar as teclas WASD para se mover e Shift para correr"
 
 #. I18N: Enable background music using AdLib/OPL2 FM synthesis
 #: engines/freescape/metaengine.cpp:164
 msgid "Backported music from C64 releases (AdLib)"
-msgstr ""
+msgstr "Música adaptada das versões do C64 (AdLib)"
 
 #: engines/freescape/metaengine.cpp:165
 msgid ""
 "Enable background music ported from the C64 version using AdLib FM synthesis"
 msgstr ""
+"Ativar a música de fundo adaptada da versão do C64 usando síntese FM AdLib"
 
 #. I18N: Enable background music using AY chip emulation
 #: engines/freescape/metaengine.cpp:176
 msgid "Backported music from C64 releases"
-msgstr ""
+msgstr "Música adaptada das versões do C64"
 
 #: engines/freescape/metaengine.cpp:177
 msgid "Enable background music ported from the C64 version"
-msgstr ""
+msgstr "Ativar a música de fundo adaptada da versão do C64"
 
 #. I18N: Combat command in Might & Magic 1
 #: engines/freescape/movement.cpp:69 engines/mm/mm1/metaengine.cpp:84
@@ -9648,7 +9398,8 @@ msgstr "Girar para baixo"
 msgid "Turn back"
 msgstr "Dar meia volta"
 
-#. I18N: Toggles between cursor lock modes, switching between free cursor movement and camera/head movement.
+#. I18N: Toggles between cursor lock modes, switching between free cursor
+#. movement and camera/head movement.
 #: engines/freescape/movement.cpp:101
 msgid "Change mode"
 msgstr "Alternar modo"
@@ -9692,7 +9443,7 @@ msgstr "Rastejar"
 
 #: engines/freescape/games/castle/castle.cpp:534
 msgid "Run (hold)"
-msgstr ""
+msgstr "Correr (segurar)"
 
 #: engines/freescape/games/dark/dark.cpp:262
 #: engines/freescape/games/driller/driller.cpp:182
@@ -9725,7 +9476,8 @@ msgstr "Aumentando Volume"
 msgid "Decrease turn angle"
 msgstr "Diminuindo Volume"
 
-#. I18N: STEP SIZE: Measures the size of one movement in the direction you are facing (1-250 standard distance units (SDUs))
+#. I18N: STEP SIZE: Measures the size of one movement in the direction you are
+#. facing (1-250 standard distance units (SDUs))
 #: engines/freescape/games/dark/dark.cpp:284
 #: engines/freescape/games/driller/driller.cpp:165
 #, fuzzy
@@ -9733,7 +9485,8 @@ msgstr "Diminuindo Volume"
 msgid "Increase step size"
 msgstr "Aumentar Tamanho do Passo"
 
-#. I18N: STEP SIZE: Measures the size of one movement in the direction you are facing (1-250 standard distance units (SDUs))
+#. I18N: STEP SIZE: Measures the size of one movement in the direction you are
+#. facing (1-250 standard distance units (SDUs))
 #: engines/freescape/games/dark/dark.cpp:290
 #: engines/freescape/games/driller/driller.cpp:171
 #, fuzzy
@@ -9778,7 +9531,8 @@ msgstr "Colete equipamento de perfuração"
 msgid "Change angle"
 msgstr "Mudar Ângulo"
 
-#. I18N: STEP SIZE: Measures the size of one movement in the direction you are facing (1-250 standard distance units (SDUs))
+#. I18N: STEP SIZE: Measures the size of one movement in the direction you are
+#. facing (1-250 standard distance units (SDUs))
 #: engines/freescape/games/eclipse/eclipse.cpp:370
 #, fuzzy
 #| msgid "Change Step Size"
@@ -9787,7 +9541,7 @@ msgstr "Mudar Tamanho do Passo"
 
 #: engines/freescape/games/eclipse/eclipse.cpp:376
 msgid "Sprint (hold)"
-msgstr ""
+msgstr "Disparada (segurar)"
 
 #: engines/freescape/games/eclipse/eclipse.cpp:384
 #, fuzzy
@@ -9876,11 +9630,11 @@ msgstr "Janela de imagem alternada\n"
 
 #: engines/glk/dialogs.cpp:141
 msgid "white"
-msgstr ""
+msgstr "branco"
 
 #: engines/glk/dialogs.cpp:142
 msgid "green"
-msgstr ""
+msgstr "verde"
 
 #: engines/glk/dialogs.cpp:143
 #, fuzzy
@@ -9890,47 +9644,47 @@ msgstr "Prosseguir"
 
 #: engines/glk/dialogs.cpp:144
 msgid "blue"
-msgstr ""
+msgstr "azul"
 
 #: engines/glk/dialogs.cpp:145
 msgid "black"
-msgstr ""
+msgstr "preto"
 
 #: engines/glk/dialogs.cpp:146
 msgid "grey"
-msgstr ""
+msgstr "cinza"
 
 #: engines/glk/dialogs.cpp:195
 msgid "Monospace Regular"
-msgstr ""
+msgstr "Monoespaçada Regular"
 
 #: engines/glk/dialogs.cpp:196
 msgid "Monospace Bold"
-msgstr ""
+msgstr "Monoespaçada Negrito"
 
 #: engines/glk/dialogs.cpp:197
 msgid "Monospace Italic"
-msgstr ""
+msgstr "Monoespaçada Itálico"
 
 #: engines/glk/dialogs.cpp:198
 msgid "Monospace Bold Italic"
-msgstr ""
+msgstr "Monoespaçada Negrito Itálico"
 
 #: engines/glk/dialogs.cpp:199
 msgid "Proportional Regular"
-msgstr ""
+msgstr "Proporcional Regular"
 
 #: engines/glk/dialogs.cpp:200
 msgid "Proportional Bold"
-msgstr ""
+msgstr "Proporcional Negrito"
 
 #: engines/glk/dialogs.cpp:201
 msgid "Proportional Italic"
-msgstr ""
+msgstr "Proporcional Itálico"
 
 #: engines/glk/dialogs.cpp:202
 msgid "Proportional Bold Italic"
-msgstr ""
+msgstr "Proporcional Negrito Itálico"
 
 #: engines/glk/dialogs.cpp:210
 #, fuzzy
@@ -9940,23 +9694,24 @@ msgstr "SoundFont:"
 
 #: engines/glk/dialogs.cpp:212 engines/glk/dialogs.cpp:222
 msgid "Text:"
-msgstr ""
+msgstr "Texto:"
 
 #: engines/glk/dialogs.cpp:212
 msgid "Font for the text"
-msgstr ""
+msgstr "Fonte para o texto"
 
 #: engines/glk/dialogs.cpp:216 engines/glk/dialogs.cpp:227
 msgid "Grid:"
-msgstr ""
+msgstr "Grade:"
 
 #: engines/glk/dialogs.cpp:216
 msgid "Font for drawn graphics like maps, diagrams, puzzles, etc"
 msgstr ""
+"Fonte para gráficos desenhados como mapas, diagramas, quebra-cabeças, etc."
 
 #: engines/glk/dialogs.cpp:220
 msgid "Color"
-msgstr ""
+msgstr "Cor"
 
 #: engines/glk/dialogs.cpp:222
 #, fuzzy
@@ -9969,11 +9724,12 @@ msgstr "Ir para próximo objeto"
 #: engines/glk/dialogs.cpp:254 engines/glk/dialogs.cpp:260
 #: engines/glk/dialogs.cpp:269
 msgid "<custom>"
-msgstr ""
+msgstr "<personalizado>"
 
 #: engines/glk/dialogs.cpp:227
 msgid "Color for drawn graphics such as maps, diagrams, puzzles, etc"
 msgstr ""
+"Cor para gráficos desenhados como mapas, diagramas, quebra-cabeças, etc."
 
 #: engines/glk/dialogs.cpp:232
 #, fuzzy
@@ -10034,7 +9790,7 @@ msgstr "Sub-escaneamento vertical:"
 
 #: engines/glk/dialogs.cpp:250
 msgid "Caret:"
-msgstr ""
+msgstr "Cursor:"
 
 #: engines/glk/dialogs.cpp:250
 #, fuzzy
@@ -10044,20 +9800,21 @@ msgstr "Cursor normal"
 
 #: engines/glk/dialogs.cpp:256
 msgid "Link:"
-msgstr ""
+msgstr "Link:"
 
 #: engines/glk/dialogs.cpp:256
 msgid "Color for URLs if they appear in-game"
-msgstr ""
+msgstr "Cor para URLs caso apareçam no jogo"
 
-#. I18N: "More..." is a prompt in text windows, which appears when the text exceeds the window size
+#. I18N: "More..." is a prompt in text windows, which appears when the text
+#. exceeds the window size
 #: engines/glk/dialogs.cpp:264
 msgid "More:"
-msgstr ""
+msgstr "Mais:"
 
 #: engines/glk/dialogs.cpp:265
 msgid "Color for the \"More...\" markers in the text"
-msgstr ""
+msgstr "Cor para os marcadores \"Mais...\" no texto"
 
 #: engines/glk/dialogs.cpp:272
 #, fuzzy
@@ -10067,11 +9824,11 @@ msgstr "Modo gráfico:"
 
 #: engines/glk/dialogs.cpp:274
 msgid "Link style:"
-msgstr ""
+msgstr "Estilo do link:"
 
 #: engines/glk/dialogs.cpp:274
 msgid "Style for URLs if they appear in-game"
-msgstr ""
+msgstr "Estilo para URLs caso apareçam no jogo"
 
 #: engines/glk/dialogs.cpp:279
 #, fuzzy
@@ -10093,9 +9850,11 @@ msgstr "Confirmar Saída"
 
 #: engines/glk/dialogs.cpp:286
 msgid ""
-"Custom marker in place of the \"More...\" marker for eg. \"continue\". Leave "
-"it blank to use the game's default"
+"Custom marker in place of the \"More...\" marker for eg. \"continue\". Leave"
+" it blank to use the game's default"
 msgstr ""
+"Marcador personalizado no lugar do marcador \"Mais...\", por exemplo "
+"\"continuar\". Deixe em branco para usar o padrão do jogo"
 
 #: engines/glk/dialogs.cpp:288
 #, fuzzy
@@ -10105,7 +9864,7 @@ msgstr "Ocultar dicas"
 
 #: engines/glk/dialogs.cpp:288
 msgid "Let the game suggest text styling options"
-msgstr ""
+msgstr "Permitir que o jogo sugira opções de estilo de texto"
 
 #: engines/glk/dialogs.cpp:289
 #, fuzzy
@@ -10115,7 +9874,7 @@ msgstr "Clique esquerdo"
 
 #: engines/glk/dialogs.cpp:289
 msgid "Safely apply clicks while input is pending"
-msgstr ""
+msgstr "Aplicar cliques com segurança enquanto há entrada pendente"
 
 #. I18N: This is setting for number of text columns
 #: engines/glk/dialogs.cpp:292
@@ -10126,24 +9885,24 @@ msgstr "Controles de Toque"
 
 #: engines/glk/dialogs.cpp:292
 msgid "Number of columns"
-msgstr ""
+msgstr "Número de colunas"
 
 #. I18N: This is setting for number of text rows
 #: engines/glk/dialogs.cpp:294
 msgid "Rows count:"
-msgstr ""
+msgstr "Número de linhas:"
 
 #: engines/glk/dialogs.cpp:294
 msgid "Number of rows"
-msgstr ""
+msgstr "Número de linhas"
 
 #: engines/glk/dialogs.cpp:296
 msgid "Lock columns:"
-msgstr ""
+msgstr "Travar colunas:"
 
 #: engines/glk/dialogs.cpp:296
 msgid "Check it to manually change the column count"
-msgstr ""
+msgstr "Marque para alterar manualmente o número de colunas"
 
 #: engines/glk/dialogs.cpp:297
 #, fuzzy
@@ -10153,12 +9912,12 @@ msgstr "Defender embaixo"
 
 #: engines/glk/dialogs.cpp:297
 msgid "Check it to manually change the row count"
-msgstr ""
+msgstr "Marque para alterar manualmente o número de linhas"
 
 #. I18N: This is a setting for enabling text justification
 #: engines/glk/dialogs.cpp:301
 msgid "Justify:"
-msgstr ""
+msgstr "Justificar:"
 
 #: engines/glk/dialogs.cpp:302
 #, fuzzy
@@ -10182,9 +9941,10 @@ msgstr "Gráficos coloridos"
 #: engines/glk/dialogs.cpp:307
 msgctxt "quotes"
 msgid "Off"
-msgstr ""
+msgstr "Desativado"
 
-#. I18N: This is a setting for using normal typographic quotes, which are like in most books, with the opening quote higher than the closing one
+#. I18N: This is a setting for using normal typographic quotes, which are like
+#. in most books, with the opening quote higher than the closing one
 #: engines/glk/dialogs.cpp:309
 #, fuzzy
 #| msgid "Normal"
@@ -10192,44 +9952,50 @@ msgctxt "quotes"
 msgid "Normal"
 msgstr "Normal"
 
-#. I18N: This is a setting for using "rabid" quotes, which are like normal typographic quotes but with the opening quote lower than the closing one, like in some comic books
+#. I18N: This is a setting for using "rabid" quotes, which are like normal
+#. typographic quotes but with the opening quote lower than the closing one,
+#. like in some comic books
 #: engines/glk/dialogs.cpp:311
 msgctxt "quotes"
 msgid "Rabid"
-msgstr ""
+msgstr "Raivosas"
 
 #. I18N: This is a setting for forcing all input to be in uppercase
 #: engines/glk/dialogs.cpp:314
 msgid "Caps:"
-msgstr ""
+msgstr "Maiúsculas:"
 
 #: engines/glk/dialogs.cpp:314
 msgid "Force uppercase input"
-msgstr ""
+msgstr "Forçar entrada em maiúsculas"
 
 #. I18N: This is a setting for type of text dash symbols
 #: engines/glk/dialogs.cpp:317
 msgid "Dashes:"
-msgstr ""
+msgstr "Travessões:"
 
 #. I18N: This is a setting for type of text dash symbols
 #: engines/glk/dialogs.cpp:319
 msgid "Types of dashes"
-msgstr ""
+msgstr "Tipos de travessões"
 
 #: engines/glk/dialogs.cpp:320 engines/glk/dialogs.cpp:332
 msgid "Off"
-msgstr ""
+msgstr "Desativado"
 
-#. I18N: This is a setting for using normal typographic dashes, which are like in most books, with the em dash being the longest and the en dash being half of it
+#. I18N: This is a setting for using normal typographic dashes, which are like
+#. in most books, with the em dash being the longest and the en dash being
+#. half of it
 #: engines/glk/dialogs.cpp:322
 msgid "Em dashes"
-msgstr ""
+msgstr "Travessões longos (em)"
 
-#. I18N: This is a setting for using "en+em" dashes, which are like normal typographic dashes but with the en dash being the same length as the em dash, like in some comic books
+#. I18N: This is a setting for using "en+em" dashes, which are like normal
+#. typographic dashes but with the en dash being the same length as the em
+#. dash, like in some comic books
 #: engines/glk/dialogs.cpp:324
 msgid "En+Em dashes"
-msgstr ""
+msgstr "Travessões en+em"
 
 #: engines/glk/dialogs.cpp:326
 #, fuzzy
@@ -10247,17 +10013,19 @@ msgstr "Espaço"
 #. I18N: This is a setting for type of spaces in the text
 #: engines/glk/dialogs.cpp:331
 msgid "Types of spaces"
-msgstr ""
+msgstr "Tipos de espaços"
 
-#. I18N: This is a setting for compressing double spaces into single ones in text
+#. I18N: This is a setting for compressing double spaces into single ones in
+#. text
 #: engines/glk/dialogs.cpp:334
 msgid "Compress double spaces"
-msgstr ""
+msgstr "Comprimir espaços duplos"
 
-#. I18N: This is a setting for expanding single spaces into double ones in text
+#. I18N: This is a setting for expanding single spaces into double ones in
+#. text
 #: engines/glk/dialogs.cpp:336
 msgid "Expand single spaces"
-msgstr ""
+msgstr "Expandir espaços simples"
 
 #: engines/glk/dialogs.cpp:338
 #, fuzzy
@@ -10267,7 +10035,7 @@ msgstr "Gráficos"
 
 #: engines/glk/dialogs.cpp:338
 msgid "Turn graphics on/off"
-msgstr ""
+msgstr "Ativar/desativar gráficos"
 
 #: engines/glk/dialogs.cpp:340
 #, fuzzy
@@ -10277,11 +10045,11 @@ msgstr "Janela"
 
 #: engines/glk/dialogs.cpp:341
 msgid "Horizontal margin for window"
-msgstr ""
+msgstr "Margem horizontal da janela"
 
 #: engines/glk/dialogs.cpp:342
 msgid "Vertical margin for window"
-msgstr ""
+msgstr "Margem vertical da janela"
 
 #: engines/glk/dialogs.cpp:344
 #, fuzzy
@@ -10291,11 +10059,11 @@ msgstr "Janela"
 
 #: engines/glk/dialogs.cpp:345
 msgid "Horizontal padding for window"
-msgstr ""
+msgstr "Preenchimento horizontal da janela"
 
 #: engines/glk/dialogs.cpp:346
 msgid "Vertical padding for window"
-msgstr ""
+msgstr "Preenchimento vertical da janela"
 
 #: engines/glk/dialogs.cpp:348
 #, fuzzy
@@ -10305,13 +10073,14 @@ msgstr "Próxima ação"
 
 #: engines/glk/dialogs.cpp:349
 msgid "Horizontal margin for text"
-msgstr ""
+msgstr "Margem horizontal do texto"
 
 #: engines/glk/dialogs.cpp:350
 msgid "Vertical margin for text"
-msgstr ""
+msgstr "Margem vertical do texto"
 
-#. I18N: This is a setting for leading, which is the vertical distance between text rows
+#. I18N: This is a setting for leading, which is the vertical distance between
+#. text rows
 #: engines/glk/dialogs.cpp:353
 #, fuzzy
 msgid "Leading:"
@@ -10320,49 +10089,56 @@ msgstr "Carregando jogo..."
 #: engines/glk/dialogs.cpp:354
 msgid "Vertical distance between text rows. Valid inputs - 12, 16, 22 etc."
 msgstr ""
+"Distância vertical entre as linhas de texto. Valores válidos - 12, 16, 22, "
+"etc."
 
-#. I18N: This is a setting for baseline, which is the invisible horizontal line on which text sits
+#. I18N: This is a setting for baseline, which is the invisible horizontal
+#. line on which text sits
 #: engines/glk/dialogs.cpp:356
 msgid "Baseline:"
-msgstr ""
+msgstr "Linha de base:"
 
 #: engines/glk/dialogs.cpp:357
 msgid ""
 "Invisible horizontal line on which text sits. Valid inputs - 8, 16 etc. as "
 "per your font size"
 msgstr ""
+"Linha horizontal invisível sobre a qual o texto se apoia. Valores válidos - "
+"8, 16, etc., de acordo com o tamanho da sua fonte"
 
 #. I18N: Font size scaling for the monospace text font
 #: engines/glk/dialogs.cpp:360
 msgid "Monosize:"
-msgstr ""
+msgstr "Tamanho mono:"
 
 #: engines/glk/dialogs.cpp:361
 msgid "Font size scaling for the monospace text font"
-msgstr ""
+msgstr "Escala do tamanho da fonte para o texto monoespaçado"
 
 #. I18N: Font size scaling for the proportional text font
 #: engines/glk/dialogs.cpp:363
 msgid "Propsize:"
-msgstr ""
+msgstr "Tamanho prop:"
 
 #: engines/glk/dialogs.cpp:364
 msgid "Font size scaling for the proportional text font"
-msgstr ""
+msgstr "Escala do tamanho da fonte para o texto proporcional"
 
-#. I18N: This is a section for settings related to the "More..." prompt in text windows
+#. I18N: This is a section for settings related to the "More..." prompt in
+#. text windows
 #: engines/glk/dialogs.cpp:367
 msgid "More"
-msgstr ""
+msgstr "Mais"
 
-#. I18N: This is a setting for alignment of the "More..." prompt in text windows
+#. I18N: This is a setting for alignment of the "More..." prompt in text
+#. windows
 #: engines/glk/dialogs.cpp:369
 msgid "Align:"
-msgstr ""
+msgstr "Alinhamento:"
 
 #: engines/glk/dialogs.cpp:370
 msgid "Alignment of the \"More...\" marker on the window"
-msgstr ""
+msgstr "Alinhamento do marcador \"Mais...\" na janela"
 
 #: engines/glk/dialogs.cpp:375
 #, fuzzy
@@ -10372,7 +10148,7 @@ msgstr "SoundFont:"
 
 #: engines/glk/dialogs.cpp:375
 msgid "Font for the \"More...\" marker"
-msgstr ""
+msgstr "Fonte para o marcador \"Mais...\""
 
 #: engines/glk/glulx/glulx.cpp:81
 msgid "This is too short to be a valid Glulx file."
@@ -10432,11 +10208,11 @@ msgstr "Disparar"
 
 #: engines/got/metaengine.cpp:75
 msgid "Magic"
-msgstr ""
+msgstr "Magia"
 
 #: engines/got/metaengine.cpp:79
 msgid "Thor dies"
-msgstr ""
+msgstr "Thor morre"
 
 #: engines/got/got.cpp:196 engines/got/got.cpp:206
 #, fuzzy
@@ -10519,15 +10295,11 @@ msgstr "Introduzir Texto"
 #, c-format
 msgid ""
 "The game data file %s may be corrupted.\n"
-"If you are sure it is not please provide the ScummVM team the following "
-"code, along with the file name, the language and a description of your game "
-"version (i.e. dvd-box or jewelcase):\n"
+"If you are sure it is not please provide the ScummVM team the following code, along with the file name, the language and a description of your game version (i.e. dvd-box or jewelcase):\n"
 "%s"
 msgstr ""
 "O arquivo de dados do jogo %s pode estar corrompido.\n"
-"Se você tiver certeza de que não está, forneça à equipe ScummVM o seguinte "
-"código, junto com o nome do arquivo, o idioma e uma descrição da versão do "
-"seu jogo (por exemplo, caixa de dvd ou caixa de colecionador):\n"
+"Se você tiver certeza de que não está, forneça à equipe ScummVM o seguinte código, junto com o nome do arquivo, o idioma e uma descrição da versão do seu jogo (por exemplo, caixa de dvd ou caixa de colecionador):\n"
 "%s"
 
 #: engines/grim/md5check.cpp:620
@@ -10543,13 +10315,11 @@ msgstr ""
 
 #: engines/grim/md5checkdialog.cpp:41
 msgid ""
-"ScummVM will now verify the game data files, to make sure you have the best "
-"gaming experience.\n"
+"ScummVM will now verify the game data files, to make sure you have the best gaming experience.\n"
 "This may take a while, please wait.\n"
 "Successive runs will not check them again."
 msgstr ""
-"O ScummVM agora verificará os arquivos de dados do jogo para garantir que "
-"você tenha a melhor experiência de jogo.\n"
+"O ScummVM agora verificará os arquivos de dados do jogo para garantir que você tenha a melhor experiência de jogo.\n"
 "Isso pode demorar um pouco, aguarde.\n"
 "As execuções sucessivas não os verificarão novamente."
 
@@ -10596,8 +10366,7 @@ msgid ""
 "The original patch of Escape from Monkey Island is missing. \n"
 "Please download it from %s\n"
 "and put it in the game data files directory.\n"
-"Pay attention to download the correct version according to the game's "
-"language!"
+"Pay attention to download the correct version according to the game's language!"
 msgstr ""
 "A atualização original de Escape from Monkey Island não está presente.\n"
 "Faça o download em %s\n"
@@ -10646,7 +10415,8 @@ msgstr "Música de Créditos Atualizada"
 
 #: engines/groovie/metaengine.cpp:90
 msgid ""
-"Play the song The Final Hour during the credits instead of reusing MIDI songs"
+"Play the song The Final Hour during the credits instead of reusing MIDI "
+"songs"
 msgstr ""
 "Reproduz a música The Final Hour durante os créditos em vez de reutilizar "
 "músicas MIDI"
@@ -10804,7 +10574,7 @@ msgstr "Interface fácil do mouse"
 
 #: engines/hugo/metaengine.cpp:46
 msgid "Use mouse and toolbar from Windows version"
-msgstr ""
+msgstr "Usar o mouse e a barra de ferramentas da versão Windows"
 
 #: engines/hugo/metaengine.cpp:148
 msgid "User help"
@@ -10919,7 +10689,8 @@ msgid "Enable restored content"
 msgstr "Habilitar conteúdo restaurado"
 
 #: engines/hypno/metaengine.cpp:82
-msgid "Add additional content that is not enabled the original implementation."
+msgid ""
+"Add additional content that is not enabled the original implementation."
 msgstr ""
 "Habilita conteúdo adicional que não está habilitado na implementação "
 "original."
@@ -10933,7 +10704,7 @@ msgstr "Mapeamentos de teclas de índice"
 
 #: engines/hypno/metaengine.cpp:134 engines/hypno/metaengine.cpp:144
 msgid "Primary shoot"
-msgstr ""
+msgstr "Disparo primário"
 
 #: engines/hypno/metaengine.cpp:139
 #, fuzzy
@@ -10967,7 +10738,7 @@ msgstr "Para Cima à Direita"
 
 #: engines/hypno/metaengine.cpp:170
 msgid "Aim up"
-msgstr ""
+msgstr "Mirar para cima"
 
 #: engines/hypno/metaengine.cpp:175 engines/scumm/metaengine.cpp:1202
 #: engines/scumm/metaengine.cpp:1279
@@ -11030,36 +10801,42 @@ msgid "Skip level (cheat)"
 msgstr "Pular fala"
 
 #. I18N: (Game name: Soldier Boyz) player refers to the users own character.
-#. I18N: (Game name: Marvel Comics Spider-Man: The Sinister Six) player refers to the users own character.
+#. I18N: (Game name: Marvel Comics Spider-Man: The Sinister Six) player refers
+#. to the users own character.
 #. I18N: (Game name: Wetlands) player refers to the users own character.
 #: engines/hypno/metaengine.cpp:238 engines/hypno/metaengine.cpp:334
 #: engines/hypno/metaengine.cpp:388
 msgid "Kill player"
-msgstr ""
+msgstr "Matar o jogador"
 
-#. I18N: (Game name: Soldier Boyz) the game has 3 difficulty levels: Chump, Punk and Badass. Chump is the easy mode.
+#. I18N: (Game name: Soldier Boyz) the game has 3 difficulty levels: Chump,
+#. Punk and Badass. Chump is the easy mode.
 #: engines/hypno/metaengine.cpp:262
 msgid "Chump"
-msgstr ""
+msgstr "Chump"
 
-#. I18N: (Game name: Soldier Boyz) the game has 3 difficulty levels: Chump, Punk and Badass. Punk is the medium mode.
+#. I18N: (Game name: Soldier Boyz) the game has 3 difficulty levels: Chump,
+#. Punk and Badass. Punk is the medium mode.
 #: engines/hypno/metaengine.cpp:269
 msgid "Punk"
-msgstr ""
+msgstr "Punk"
 
-#. I18N: (Game name: Soldier Boyz) the game has 3 difficulty levels: Chump, Punk and Badass. Badass is the hard mode.
+#. I18N: (Game name: Soldier Boyz) the game has 3 difficulty levels: Chump,
+#. Punk and Badass. Badass is the hard mode.
 #: engines/hypno/metaengine.cpp:276
 msgid "Badass"
-msgstr ""
+msgstr "Badass"
 
-#. I18N: (Game name: Soldier Boyz) This makes the player restart from the last checkpoint.
+#. I18N: (Game name: Soldier Boyz) This makes the player restart from the last
+#. checkpoint.
 #: engines/hypno/metaengine.cpp:289
 #, fuzzy
 #| msgid "Retreat"
 msgid "Retry sector"
 msgstr "Recuar"
 
-#. I18N: (Game name: Soldier Boyz) This makes the player restart the current mission / level.
+#. I18N: (Game name: Soldier Boyz) This makes the player restart the current
+#. mission / level.
 #: engines/hypno/metaengine.cpp:296
 #, fuzzy
 #| msgid "Restart animation"
@@ -11068,7 +10845,7 @@ msgstr "Reiniciar animação"
 
 #: engines/hypno/metaengine.cpp:302
 msgid "Begin new mission"
-msgstr ""
+msgstr "Iniciar nova missão"
 
 #: engines/hypno/metaengine.cpp:374
 #, fuzzy
@@ -11128,27 +10905,35 @@ msgstr "Rêmora"
 msgid "Side step"
 msgstr "Passo Lateral"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
 #: engines/illusions/metaengine.cpp:108 engines/sherlock/metaengine.cpp:1142
 msgid "Move cursor up"
 msgstr "Mover cursor para cima"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
 #: engines/illusions/metaengine.cpp:115 engines/sherlock/metaengine.cpp:1150
 msgid "Move cursor down"
 msgstr "Mover cursor para baixo"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the save file name input field
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the password input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) cursor refers to the text cursor in the save file name input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) cursor refers to the text cursor in the password input field
 #: engines/illusions/metaengine.cpp:122 engines/sherlock/metaengine.cpp:1094
 #: engines/sherlock/metaengine.cpp:1158 engines/sherlock/metaengine.cpp:1199
 msgid "Move cursor left"
 msgstr "Mover cursor para esquerda"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the save file name input field
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the password input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) cursor refers to the text cursor in the save file name input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) cursor refers to the text cursor in the password input field
 #: engines/illusions/metaengine.cpp:129 engines/sherlock/metaengine.cpp:1102
 #: engines/sherlock/metaengine.cpp:1166 engines/sherlock/metaengine.cpp:1207
 msgid "Move cursor right"
@@ -11168,15 +10953,17 @@ msgid ""
 "Missing language specific game code and/or resources for this fan "
 "translation."
 msgstr ""
-"Falta o código do jogo específico do idioma e/ou recursos para esta tradução "
-"de fã."
+"Falta o código do jogo específico do idioma e/ou recursos para esta tradução"
+" de fã."
 
 #: engines/kyra/detection_tables.h:78
 msgid "Demo plays simple animations without using Westwood's Engine."
-msgstr "Demonstração reproduz animações simples sem usar a engine de Westwood."
+msgstr ""
+"Demonstração reproduz animações simples sem usar a engine de Westwood."
 
 #: engines/kyra/detection_tables.h:1470
-msgid "You added the game incorrectly. Please add the root folder of the game."
+msgid ""
+"You added the game incorrectly. Please add the root folder of the game."
 msgstr "Você adicionou o jogo incorretamente. Adicione a pasta raiz do jogo."
 
 #. I18N: The file in the game directory needs to be extracted
@@ -11270,24 +11057,29 @@ msgid ""
 "- Correct projectile weapon damage (per AD&D 2nd Edition rules)\n"
 "- Elves get +1 to hit with swords and bows (per official game manual)"
 msgstr ""
+"- Eliminar erros de arredondamento no ganho de HP\n"
+"- Corrigir o dano de armas de projétil (conforme as regras da 2ª Edição de AD&D)\n"
+"- Elfos recebem +1 de acerto com espadas e arcos (conforme o manual oficial do jogo)"
 
 #: engines/kyra/metaengine.cpp:175
 msgid "Fix Ileria and Beohram NPCs"
-msgstr ""
+msgstr "Corrigir os NPCs Ileria e Beohram"
 
 #: engines/kyra/metaengine.cpp:176
 msgid "Make Ileria a female and Beohram a paladin"
-msgstr ""
+msgstr "Tornar Ileria uma mulher e Beohram um paladino"
 
 #: engines/kyra/metaengine.cpp:187
 msgid "Enhanced thrown weapon reload"
-msgstr ""
+msgstr "Recarga aprimorada de armas de arremesso"
 
 #: engines/kyra/metaengine.cpp:188
 msgid ""
 "Thrown weapons (daggers, darts, spears...) get replaced from belt and "
 "backpack inventory slots, with thrown weapons only"
 msgstr ""
+"Armas de arremesso (adagas, dardos, lanças...) são repostas a partir dos "
+"espaços de inventário do cinto e da mochila, apenas com armas de arremesso"
 
 #: engines/kyra/metaengine.cpp:275
 msgid "Lands of Lore support is not compiled in"
@@ -11410,8 +11202,7 @@ msgid ""
 "Do you wish to use this saved game file with ScummVM?\n"
 "\n"
 msgstr ""
-"O seguinte arquivo de jogo salvo original foi encontrado no caminho de seu "
-"jogo:\n"
+"O seguinte arquivo de jogo salvo original foi encontrado no caminho de seu jogo:\n"
 "\n"
 "%s %S\n"
 "\n"
@@ -11424,8 +11215,7 @@ msgid ""
 "A saved game file was found in the specified slot %d. Overwrite?\n"
 "\n"
 msgstr ""
-"Um arquivo de jogo salvo foi encontrado no slot %d especificado. "
-"Substituir?\n"
+"Um arquivo de jogo salvo foi encontrado no slot %d especificado. Substituir?\n"
 "\n"
 
 #: engines/kyra/gui/saveload_eob.cpp:677
@@ -11433,15 +11223,12 @@ msgstr ""
 msgid ""
 "%d original saved games have been successfully imported into\n"
 "ScummVM. If you want to manually import original saved game later you will\n"
-"need to open the ScummVM debug console and use the command "
-"'import_savefile'.\n"
+"need to open the ScummVM debug console and use the command 'import_savefile'.\n"
 "\n"
 msgstr ""
 "%d jogos salvos originais foram importados para o\n"
-"ScummVM. Se deseja importar manualmente o jogo salvo original mais tarde "
-"você\n"
-"precisará abrir o console de depuração do ScummVM e utilizar o comando "
-"'import_savefile'.\n"
+"ScummVM. Se deseja importar manualmente o jogo salvo original mais tarde você\n"
+"precisará abrir o console de depuração do ScummVM e utilizar o comando 'import_savefile'.\n"
 "\n"
 
 #: engines/kyra/graphics/screen_eob_amiga.cpp:279
@@ -11477,15 +11264,11 @@ msgid ""
 "EOBF8.FONT\n"
 "EOBF8/8\n"
 "\n"
-"This is a localized (non-English) version of EOB II which uses language "
-"specific characters\n"
-"contained only in the specific font files that came with your game. You "
-"cannot use the font\n"
-"files from the English version or from any EOB I game which seems to be what "
-"you are doing.\n"
+"This is a localized (non-English) version of EOB II which uses language specific characters\n"
+"contained only in the specific font files that came with your game. You cannot use the font\n"
+"files from the English version or from any EOB I game which seems to be what you are doing.\n"
 "\n"
-"The game will continue, but the language specific characters will not be "
-"displayed.\n"
+"The game will continue, but the language specific characters will not be displayed.\n"
 "Please copy the correct font files into your EOB II game data directory.\n"
 "\n"
 msgstr ""
@@ -11496,17 +11279,12 @@ msgstr ""
 "EOBF8.FONT\n"
 "EOBF8/8\n"
 "\n"
-"Esta é uma versão localizada (não-Inglês) do EOB II que utiliza caractere de "
-"idioma específicos\n"
-"contido apenas nos arquivos de fontes que vieram com seu jogo. Você não pode "
-"utilizar os arquivos\n"
-"de fonte da versão em Inglês ou de nenhum jogo EOB I que aparentemente é o "
-"que você está fazendo.\n"
+"Esta é uma versão localizada (não-Inglês) do EOB II que utiliza caractere de idioma específicos\n"
+"contido apenas nos arquivos de fontes que vieram com seu jogo. Você não pode utilizar os arquivos\n"
+"de fonte da versão em Inglês ou de nenhum jogo EOB I que aparentemente é o que você está fazendo.\n"
 "\n"
-"O jogo irá prosseguir, mas os caracteres específicos do idioma não serão "
-"exibidos.\n"
-"Por favor copie os arquivos de fonte corretos para o diretório de dados do "
-"seu jogo EOB II.\n"
+"O jogo irá prosseguir, mas os caracteres específicos do idioma não serão exibidos.\n"
+"Por favor copie os arquivos de fonte corretos para o diretório de dados do seu jogo EOB II.\n"
 "\n"
 
 #: engines/lab/engine.cpp:126
@@ -11558,11 +11336,11 @@ msgstr "Habilita o som do jogo"
 
 #: engines/lab/metaengine.cpp:185
 msgid "Lower the sound volume"
-msgstr ""
+msgstr "Diminuir o volume do som"
 
 #: engines/lab/metaengine.cpp:216
 msgid "Interact with object with chosen action"
-msgstr ""
+msgstr "Interagir com o objeto usando a ação escolhida"
 
 #: engines/lab/metaengine.cpp:221
 #, fuzzy
@@ -11584,11 +11362,11 @@ msgstr "Abrir Holomapa"
 
 #: engines/lab/metaengine.cpp:239
 msgid "Close door or object"
-msgstr ""
+msgstr "Fechar porta ou objeto"
 
 #: engines/lab/metaengine.cpp:245
 msgid "Look at object close-up"
-msgstr ""
+msgstr "Examinar o objeto de perto"
 
 #: engines/lab/metaengine.cpp:251
 #, fuzzy
@@ -11604,15 +11382,15 @@ msgstr "Ir para próximo objeto"
 
 #: engines/lab/metaengine.cpp:292 engines/lab/metaengine.cpp:352
 msgid "Start dropping virtual bread crumbs"
-msgstr ""
+msgstr "Começar a deixar migalhas de pão virtuais"
 
 #: engines/lab/metaengine.cpp:298 engines/lab/metaengine.cpp:359
 msgid "Follow virtual bread crumbs"
-msgstr ""
+msgstr "Seguir as migalhas de pão virtuais"
 
 #: engines/lab/metaengine.cpp:304 engines/lab/metaengine.cpp:366
 msgid "Run while following virtual bread crumbs"
-msgstr ""
+msgstr "Correr enquanto segue as migalhas de pão virtuais"
 
 #: engines/lab/metaengine.cpp:311
 #, fuzzy
@@ -11646,7 +11424,7 @@ msgstr "Inventário de itens animado"
 
 #: engines/lab/metaengine.cpp:373
 msgid "Exit map display"
-msgstr ""
+msgstr "Sair da exibição do mapa"
 
 #: engines/lab/metaengine.cpp:379
 #, fuzzy
@@ -11755,8 +11533,8 @@ msgstr "Reproduzir trilha sonora digital durante o vídeo de abertura"
 
 #: engines/made/metaengine.cpp:39
 msgid ""
-"If selected, the game will use a digital soundtrack during the introduction. "
-"Otherwise, it will play MIDI music."
+"If selected, the game will use a digital soundtrack during the introduction."
+" Otherwise, it will play MIDI music."
 msgstr ""
 "Se marcado, o jogo usará uma trilha sonora digital durante a introdução. "
 "Caso contrário, ele reproduzirá música MIDI."
@@ -11767,10 +11545,13 @@ msgstr "Utilizar cursores do Windows"
 
 #: engines/made/metaengine.cpp:64
 msgid ""
-"If selected, the game will use Windows mouse cursors bundled in the "
-"original .exe file. Otherwise, it will use lower resolution cursors from the "
-"data files."
+"If selected, the game will use Windows mouse cursors bundled in the original"
+" .exe file. Otherwise, it will use lower resolution cursors from the data "
+"files."
 msgstr ""
+"Se selecionado, o jogo usará os cursores de mouse do Windows incluídos no "
+"arquivo .exe original. Caso contrário, usará cursores de resolução inferior "
+"dos arquivos de dados."
 
 #: engines/made/metaengine.cpp:158
 msgid "Cursor up"
@@ -11865,7 +11646,8 @@ msgid "More durable armor"
 msgstr "Armadura mais durável"
 
 #: engines/mm/metaengine.cpp:69
-msgid "Armor won't break until character is at -80HP, rather than merely -10HP"
+msgid ""
+"Armor won't break until character is at -80HP, rather than merely -10HP"
 msgstr ""
 "A armadura não quebrará até que o personagem esteja com -80HP, em vez de "
 "meramente -10HP"
@@ -11983,9 +11765,11 @@ msgid "Reorder party"
 msgstr "Reorganizar Equipe"
 
 #. I18N: Action of hero party in Might & Magic 1
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a journal, this action is used to search the journal
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
+#. Scalpel) The game has a journal, this action is used to search the journal
 #: engines/mm/mm1/metaengine.cpp:116 engines/sherlock/metaengine.cpp:514
-#: engines/sherlock/metaengine.cpp:961 engines/ultima/ultima4/metaengine.cpp:71
+#: engines/sherlock/metaengine.cpp:961
+#: engines/ultima/ultima4/metaengine.cpp:71
 msgid "Search"
 msgstr "Pesquisar"
 
@@ -12027,22 +11811,20 @@ msgstr "Might and Magic 1 - Combate"
 
 #: engines/mm/mm1/mm1.cpp:57
 msgid ""
-"You cannot run the game directly from the Graphics Overhaul Mod. Instead, it "
-"will automatically be available if you detect the original game and select "
+"You cannot run the game directly from the Graphics Overhaul Mod. Instead, it"
+" will automatically be available if you detect the original game and select "
 "Enhanced mode."
 msgstr ""
 "Você não pode executar o jogo diretamente pelo Mod de Melhorias Gráficas "
-"(Graphics Overhaul Mod). Em vez disso, ele estará disponível automaticamente "
-"se você adicionar o jogo original e selecionar o modo Aprimorado."
+"(Graphics Overhaul Mod). Em vez disso, ele estará disponível automaticamente"
+" se você adicionar o jogo original e selecionar o modo Aprimorado."
 
 #: engines/mm/mm1/mm1.cpp:117
 msgid ""
-"In order to run in Enhanced mode,  please copy xeen.cc from a copy of World "
-"of Xeen\n"
+"In order to run in Enhanced mode,  please copy xeen.cc from a copy of World of Xeen\n"
 "or Clouds of Xeen to your Might and Magic 1 game folder"
 msgstr ""
-"Para executar no modo Aperfeiçoado, copie o arquivo xeen.cc do jogo World of "
-"Xeen\n"
+"Para executar no modo Aperfeiçoado, copie o arquivo xeen.cc do jogo World of Xeen\n"
 "ou Clouds of Xeen para a pasta do jogo Might and Magic 1"
 
 #: engines/mm/xeen/saves.cpp:294
@@ -12060,8 +11842,8 @@ msgid ""
 "takes you directly there, skipping intermediate screens. You can only 'Zip' "
 "to a precise area you've already been."
 msgstr ""
-"Quando ativado, clicar em um item ou área com o cursor em forma de raio leva "
-"você diretamente para lá, pulando as telas intermediárias. Você só pode "
+"Quando ativado, clicar em um item ou área com o cursor em forma de raio leva"
+" você diretamente para lá, pulando as telas intermediárias. Você só pode "
 "'Pular' para uma área específica em que você já esteve."
 
 #: engines/mohawk/dialogs.cpp:116
@@ -12090,7 +11872,6 @@ msgstr "O filme aéreo de Myst não foi reproduzido pela engine original."
 #. Normally game uses strict binary logic here.
 #. We change it to use fuzzy logic.
 #. By default the option is off.
-#.
 #: engines/mohawk/dialogs.cpp:133
 msgid "Improve Selenitic Age puzzle ~a~ccessibility"
 msgstr "Melhorar ~a~cessibilidade do enigma da Idade Selenítica"
@@ -12184,12 +11965,14 @@ msgstr "Melhor"
 
 #: engines/mohawk/dialogs.cpp:456
 msgid "Fix audio pops/clicks"
-msgstr ""
+msgstr "Corrigir estalos/cliques no áudio"
 
 #: engines/mohawk/dialogs.cpp:457
 msgid ""
 "Reduces audible pops at the end of some sound effects (Non Myst/Riven only)."
 msgstr ""
+"Reduz os estalos audíveis no final de alguns efeitos sonoros (apenas para "
+"jogos que não sejam Myst/Riven)."
 
 #: engines/mohawk/metaengine.cpp:291
 msgid "Myst ME support not compiled in"
@@ -12238,7 +12021,8 @@ msgstr ""
 #: engines/mohawk/myst_stacks/menu.cpp:299
 #: engines/mohawk/riven_stacks/aspit.cpp:370
 msgid ""
-"Are you sure you want to start a new game? All unsaved progress will be lost."
+"Are you sure you want to start a new game? All unsaved progress will be "
+"lost."
 msgstr ""
 "Você tem certeza de que deseja iniciar um novo jogo? Todo progresso não "
 "salvo será perdido."
@@ -12279,8 +12063,7 @@ msgstr ""
 
 #: engines/mohawk/riven.cpp:509
 msgid "You are missing the following required Riven data files:\n"
-msgstr ""
-"Você não possui os seguintes arquivos de dados necessários de Riven: \n"
+msgstr "Você não possui os seguintes arquivos de dados necessários de Riven: \n"
 
 #: engines/mohawk/riven.cpp:887
 msgid "Move forward left"
@@ -12299,8 +12082,7 @@ msgid ""
 "Exploration beyond this point available only within the full version of\n"
 "the game."
 msgstr ""
-"Exploração além deste ponto somente está disponível dentro da versão "
-"completa\n"
+"Exploração além deste ponto somente está disponível dentro da versão completa\n"
 "do jogo."
 
 #: engines/mohawk/riven_stacks/aspit.cpp:428
@@ -12347,7 +12129,8 @@ msgstr "Salvar automaticamente em pontos de progresso"
 
 #: engines/mtropolis/metaengine.cpp:76
 msgid "Automatically saves the game after completing puzzles and chapters."
-msgstr "Salva o jogo automaticamentem depois de completar puzzles e capítulos."
+msgstr ""
+"Salva o jogo automaticamentem depois de completar puzzles e capítulos."
 
 #: engines/mtropolis/metaengine.cpp:86
 msgid "Enable short transitions"
@@ -12414,7 +12197,8 @@ msgstr "Falha ao ler as informações da versão do arquivo salvo"
 
 #: engines/mtropolis/saveload.cpp:150 engines/vcruise/vcruise.cpp:351
 msgid ""
-"Failed to load save, the save file doesn't contain valid version information."
+"Failed to load save, the save file doesn't contain valid version "
+"information."
 msgstr ""
 "Falha ao carregar o salvamento, o arquivo salvo não contém informações de "
 "versão válidas."
@@ -12428,7 +12212,8 @@ msgstr ""
 "ScummVM. Não foi possível carregar."
 
 #: engines/mtropolis/saveload.cpp:174
-msgid "Failed to load save, an error occurred when reading the save game data."
+msgid ""
+"Failed to load save, an error occurred when reading the save game data."
 msgstr ""
 "Falha ao carregar o salvamento, ocorreu um erro ao ler os dados do jogo "
 "salvo."
@@ -12457,14 +12242,12 @@ msgstr "A versão para PS2 ainda não é suportada"
 #: engines/myst3/myst3.cpp:413
 #, c-format
 msgid ""
-"This version of Myst III has not been updated with the latest official "
-"patch.\n"
+"This version of Myst III has not been updated with the latest official patch.\n"
 "Please install the official update corresponding to your game's language.\n"
 "The updates can be downloaded from:\n"
 "%s"
 msgstr ""
-"Esta versão de Myst III não foi atualizada com a atualização oficial mais "
-"recente.\n"
+"Esta versão de Myst III não foi atualizada com a atualização oficial mais recente.\n"
 "Instale a atualização oficial correspondente ao idioma do seu jogo.\n"
 "As atualizações podem ser baixadas em:\n"
 "%s"
@@ -12552,8 +12335,8 @@ msgid ""
 "Get a little more time before failing the final puzzle. This is an official "
 "patch by HeR Interactive."
 msgstr ""
-"Recebe um pouco mais de tempo antes de falhar no quebra-cabeça final. Este é "
-"um patch oficial da HeR Interactive."
+"Recebe um pouco mais de tempo antes de falhar no quebra-cabeça final. Este é"
+" um patch oficial da HeR Interactive."
 
 #: engines/nancy/state/loadsave.cpp:108
 #, fuzzy
@@ -12626,19 +12409,22 @@ msgstr "Mover para esquerda"
 msgid "Pause / Exit menu"
 msgstr "Pular cena"
 
-#. I18N: (Game name: The Neverhood) The game has multiple cutscenes, and this action skips part of the scene.
+#. I18N: (Game name: The Neverhood) The game has multiple cutscenes, and this
+#. action skips part of the scene.
 #: engines/neverhood/metaengine.cpp:214
 #, fuzzy
 #| msgid "Skip cutscene"
 msgid "Skip section of cutscene"
 msgstr "Pular cena"
 
-#. I18N: (Game name: The Neverhood) The game has multiple cutscenes, and this action skips the entire scene.
+#. I18N: (Game name: The Neverhood) The game has multiple cutscenes, and this
+#. action skips the entire scene.
 #: engines/neverhood/metaengine.cpp:221
 msgid "Skip entire scene (works only in some scenes)"
-msgstr ""
+msgstr "Pular a cena inteira (funciona apenas em algumas cenas)"
 
-#. I18N: (Game name: The Neverhood) This action confirms the selected save or entered new save name in the save file management menus.
+#. I18N: (Game name: The Neverhood) This action confirms the selected save or
+#. entered new save name in the save file management menus.
 #: engines/neverhood/metaengine.cpp:228
 #, fuzzy
 #| msgid "Create a new saved game"
@@ -12715,20 +12501,15 @@ msgstr "Salvando jogo..."
 
 #: engines/parallaction/saveload.cpp:268
 msgid ""
-"ScummVM found that you have old saved games for Nippon Safes that should be "
-"renamed.\n"
-"The old names are no longer supported, so you will not be able to load your "
-"games if you don't convert them.\n"
+"ScummVM found that you have old saved games for Nippon Safes that should be renamed.\n"
+"The old names are no longer supported, so you will not be able to load your games if you don't convert them.\n"
 "\n"
 "Press OK to convert them now, otherwise you will be asked next time.\n"
 msgstr ""
-"ScummVM detectou que você possui antigos jogos salvos de Nippon Safes que "
-"devem ser renomeados.\n"
-"Os nomes antigos não são mais suportados, assim você não será capaz de "
-"carregar os seus jogos se você não convertê-los.\n"
+"ScummVM detectou que você possui antigos jogos salvos de Nippon Safes que devem ser renomeados.\n"
+"Os nomes antigos não são mais suportados, assim você não será capaz de carregar os seus jogos se você não convertê-los.\n"
 "\n"
-"Pressione OK para convertê-los agora, caso contrário você será solicitado na "
-"próxima vez.\n"
+"Pressione OK para convertê-los agora, caso contrário você será solicitado na próxima vez.\n"
 
 #: engines/parallaction/saveload.cpp:315
 msgid "ScummVM successfully converted all your saved games."
@@ -12736,13 +12517,11 @@ msgstr "ScummVM converteu com êxito todos os seus jogos salvos."
 
 #: engines/parallaction/saveload.cpp:317
 msgid ""
-"ScummVM printed some warnings in your console window and can't guarantee all "
-"your files have been converted.\n"
+"ScummVM printed some warnings in your console window and can't guarantee all your files have been converted.\n"
 "\n"
 "Please report to the team."
 msgstr ""
-"ScummVM exibiu alguns avisos em sua janela do console e não pode garantir "
-"que todos os seus arquivos foram convertidos.\n"
+"ScummVM exibiu alguns avisos em sua janela do console e não pode garantir que todos os seus arquivos foram convertidos.\n"
 "\n"
 "Por favor, relate para a equipe."
 
@@ -12807,6 +12586,8 @@ msgid ""
 "Use ScummVM's alternate animation timing instead of the original game's "
 "slower walking and talking speed"
 msgstr ""
+"Usar a temporização de animação alternativa do ScummVM em vez da velocidade "
+"mais lenta de caminhada e fala do jogo original"
 
 #: engines/pelrock/metaengine.cpp:57
 #, fuzzy
@@ -12819,6 +12600,8 @@ msgid ""
 "Play the game's intro sequence. Plays automatically the first time the game "
 "is launched."
 msgstr ""
+"Reproduzir a sequência de introdução do jogo. É reproduzida automaticamente "
+"na primeira vez que o jogo é iniciado."
 
 #: engines/pelrock/metaengine.cpp:68
 #, fuzzy
@@ -12829,6 +12612,8 @@ msgstr "Desabilitar sensores"
 #: engines/pelrock/metaengine.cpp:69
 msgid "Disable original screensaver slider mini-game every 60 seconds."
 msgstr ""
+"Desativar o minijogo deslizante de proteção de tela original que aparece a "
+"cada 60 segundos."
 
 #: engines/petka/metaengine.cpp:117
 #, fuzzy
@@ -12836,14 +12621,18 @@ msgstr ""
 msgid "Interact / Skip dialog"
 msgstr "Ir para próximo diálogo"
 
-#. I18N: (Game Name: Red Comrades 1: Save the Galaxy) The game has multiple actions that you can perform(take, use, etc.), the action menu allows you to select one of them.
+#. I18N: (Game Name: Red Comrades 1: Save the Galaxy) The game has multiple
+#. actions that you can perform(take, use, etc.), the action menu allows you
+#. to select one of them.
 #: engines/petka/metaengine.cpp:124
 #, fuzzy
 #| msgid "Open action menu / Close menu"
 msgid "Open action menu / Close current interface"
 msgstr "Abrir menu de ação / Fechar menu"
 
-#. I18N: (Game Name: Red Comrades 1: Save the Galaxy) The game features two characters, but all actions are normally performed by Petka. This action allows you to "use" an object specifically with Chapayev instead.
+#. I18N: (Game Name: Red Comrades 1: Save the Galaxy) The game features two
+#. characters, but all actions are normally performed by Petka. This action
+#. allows you to "use" an object specifically with Chapayev instead.
 #: engines/petka/metaengine.cpp:166
 #, fuzzy
 #| msgid "Chapayev's action"
@@ -12901,40 +12690,51 @@ msgstr "Este item do menu ainda não foi implementado"
 msgid "Interact / Select"
 msgstr "Mover para esquerda"
 
-#. I18N: (Game Name: Pink Panther) The player normally clicks on a target (character/object) to move toward it and interact (talk,use etc.) with it. This action makes the player still walk to the target but not start interacting when they arrive.
+#. I18N: (Game Name: Pink Panther) The player normally clicks on a target
+#. (character/object) to move toward it and interact (talk,use etc.) with it.
+#. This action makes the player still walk to the target but not start
+#. interacting when they arrive.
 #: engines/pink/metaengine.cpp:136
 #, fuzzy
 #| msgid "Change game options"
 msgid "Cancel interaction"
 msgstr "Altera opções do jogo"
 
-#. I18N: (Game Name: Pink Panther) The player normally clicks on a target (character/object) to move toward it and interact (talk,use etc.) with it. This action skips the walking animation and immediately start interacting.
+#. I18N: (Game Name: Pink Panther) The player normally clicks on a target
+#. (character/object) to move toward it and interact (talk,use etc.) with it.
+#. This action skips the walking animation and immediately start interacting.
 #: engines/pink/metaengine.cpp:144
 #, fuzzy
 #| msgid "Skip dialogue"
 msgid "Skip walk"
 msgstr "Pular diálogo"
 
-#. I18N: (Game Name: Pink Panther) The player normally clicks on a target (character/object) to move toward it and interact (talk,use etc.) with it. This action skips the walking animation and also prevents the interaction, instead instantly placing the player next to the target.
+#. I18N: (Game Name: Pink Panther) The player normally clicks on a target
+#. (character/object) to move toward it and interact (talk,use etc.) with it.
+#. This action skips the walking animation and also prevents the interaction,
+#. instead instantly placing the player next to the target.
 #: engines/pink/metaengine.cpp:151
 msgid "Skip walk and cancel interaction"
-msgstr ""
+msgstr "Pular a caminhada e cancelar a interação"
 
-#. I18N: (Game Name: Pink Panther) This action fully skips the current running sequence (cutscene, dialog, interaction, etc).
+#. I18N: (Game Name: Pink Panther) This action fully skips the current running
+#. sequence (cutscene, dialog, interaction, etc).
 #: engines/pink/metaengine.cpp:158
 #, fuzzy
 #| msgid "Skip cutscene"
 msgid "Skip sequence"
 msgstr "Pular cena"
 
-#. I18N: (Game Name: Pink Panther) This action skips part of the current running sequence (cutscene, dialog, interaction, etc).
+#. I18N: (Game Name: Pink Panther) This action skips part of the current
+#. running sequence (cutscene, dialog, interaction, etc).
 #: engines/pink/metaengine.cpp:165
 #, fuzzy
 #| msgid "Skip cutscene"
 msgid "Skip sub-sequence"
 msgstr "Pular cena"
 
-#. I18N: (Game Name: Pink Panther) This action restarts the current running sequence (cutscene, dialog, interaction, etc).
+#. I18N: (Game Name: Pink Panther) This action restarts the current running
+#. sequence (cutscene, dialog, interaction, etc).
 #: engines/pink/metaengine.cpp:173
 #, fuzzy
 #| msgid "Restart the Scene"
@@ -12981,15 +12781,16 @@ msgstr "Destacar próximo diálogo"
 
 #: engines/private/metaengine.cpp:51
 msgid "Highlight clickable areas in decision scenes."
-msgstr ""
+msgstr "Destacar áreas clicáveis nas cenas de decisão."
 
 #: engines/private/metaengine.cpp:61
 msgid "Increased contrast for small print"
-msgstr ""
+msgstr "Contraste aumentado para textos pequenos"
 
 #: engines/private/metaengine.cpp:62
 msgid "Enhance small printed paper close-ups for improved readability."
 msgstr ""
+"Aprimorar os close-ups de papéis com texto pequeno para melhor legibilidade."
 
 #: engines/private/metaengine.cpp:147 engines/trecision/metaengine.cpp:137
 msgid "Skip video"
@@ -13003,7 +12804,7 @@ msgstr "Habilita modo de depuração"
 
 #: engines/qdengine/dialogs.cpp:32
 msgid "Enable this if backend does not support 32bpp and/or to debug graphics"
-msgstr ""
+msgstr "Ative isto se o backend não suportar 32bpp e/ou para depurar gráficos"
 
 #: engines/queen/metaengine.cpp:41
 msgid "Alternative intro"
@@ -13023,7 +12824,7 @@ msgstr "Utiliza uma fonte personalizada mais fácil de ler"
 
 #: engines/queen/metaengine.cpp:186
 msgid "Move / Skip / Use default action with inventory item"
-msgstr ""
+msgstr "Mover / Pular / Usar ação padrão com item do inventário"
 
 #: engines/queen/metaengine.cpp:198 engines/twp/metaengine.cpp:175
 #, fuzzy
@@ -13103,17 +12904,20 @@ msgstr "Falar"
 msgid "Close journal"
 msgstr "Exibir diário"
 
-#. I18N: Inherit the Earth had a "trial" version which is a full game with a simple check
+#. I18N: Inherit the Earth had a "trial" version which is a full game with a
+#. simple check
 #: engines/saga/detection_tables.h:875
 msgid "Windows Trial version is not supported"
 msgstr "A versão de teste do Windows não é compatível"
 
-#. I18N: Inherit the Earth had a "trial" version which is a full game with a simple check
+#. I18N: Inherit the Earth had a "trial" version which is a full game with a
+#. simple check
 #: engines/saga/detection_tables.h:902
 msgid "macOS Trial version is not supported"
 msgstr "A versão de teste do macOS não é compatível"
 
-#. I18N: Inherit the Earth had a "trial" version which is a full game with a simple check
+#. I18N: Inherit the Earth had a "trial" version which is a full game with a
+#. simple check
 #: engines/saga/detection_tables.h:928
 msgid "Pocket PC Trial version is not supported"
 msgstr "A versão de teste do Pocket PC não é compatível"
@@ -13153,8 +12957,10 @@ msgid "Converse panel keymappings"
 msgstr "Mapeamento de tecla do painel de conversa"
 
 #. I18N: the boss key is a feature,
-#. that allows players to quickly switch to a fake screen that looks like a business application,
-#. typically to avoid detection if someone, like a boss, walks by while they are playing.
+#. that allows players to quickly switch to a fake screen that looks like a
+#. business application,
+#. typically to avoid detection if someone, like a boss, walks by while they
+#. are playing.
 #: engines/saga/metaengine.cpp:298
 msgid "Boss key"
 msgstr "Tecla anti-chefe"
@@ -13195,7 +13001,8 @@ msgstr "Exibir diálogo"
 #. I18N: Walk to where cursor points
 #: engines/saga/metaengine.cpp:349 engines/scumm/help.cpp:143
 #: engines/scumm/help.cpp:168 engines/scumm/help.cpp:197
-#: engines/tinsel/metaengine.cpp:288 engines/wintermute/keymapper_tables.h:1540
+#: engines/tinsel/metaengine.cpp:288
+#: engines/wintermute/keymapper_tables.h:1540
 msgid "Walk to"
 msgstr "Andar até"
 
@@ -13394,6 +13201,8 @@ msgid ""
 "Detect and attempt to repair overflows in DPCM8 audio, which cause "
 "noticeable pops and crackles."
 msgstr ""
+"Detectar e tentar reparar estouros no áudio DPCM8, que causam estalos e "
+"crepitações perceptíveis."
 
 #: engines/sci/detection_options.h:271
 msgid "Roland D-110 / D-10 / D-20"
@@ -13415,8 +13224,8 @@ msgstr "Esta demo utiliza uma versão não implementada de vídeos Robot"
 #: engines/sci/detection_tables.h:4926
 msgid "Incomplete game detected. You have to copy data from all the CDs."
 msgstr ""
-"Jogo incompleto detectado. Você precisa copiar os arquivos de dados de todos "
-"os CDs."
+"Jogo incompleto detectado. Você precisa copiar os arquivos de dados de todos"
+" os CDs."
 
 #: engines/sci/engine/kfile.cpp:491 engines/sci/metaengine.cpp:289
 msgid "(Autosave)"
@@ -13431,8 +13240,8 @@ msgstr ""
 
 #: engines/sci/engine/kmisc.cpp:928
 msgid ""
-"The Poker logic is hardcoded in an external DLL, and is not implemented yet. "
-"There exists some dummy logic for now, where opponent actions are chosen "
+"The Poker logic is hardcoded in an external DLL, and is not implemented yet."
+" There exists some dummy logic for now, where opponent actions are chosen "
 "randomly"
 msgstr ""
 "A lógica do Poker está embutida em uma DLL externa e ainda não foi "
@@ -13471,26 +13280,26 @@ msgstr "O suporte a SCI32 não está compilado"
 
 #: engines/sci/resource/resource.cpp:859
 msgid ""
-"Missing or corrupt game resources have been detected. Some game features may "
-"not work properly. Please check the console for more information, and verify "
-"that your game files are valid."
+"Missing or corrupt game resources have been detected. Some game features may"
+" not work properly. Please check the console for more information, and "
+"verify that your game files are valid."
 msgstr ""
 "Recursos de jogo ausentes ou corrompidos foram detectados. Alguns recursos "
-"do jogo podem não funcionar corretamente. Por favor verifique o console para "
-"mais informação, e verifique se seus arquivos de jogos são válidos."
+"do jogo podem não funcionar corretamente. Por favor verifique o console para"
+" mais informação, e verifique se seus arquivos de jogos são válidos."
 
 #: engines/sci/sci.cpp:415
 msgid ""
 "Subtitles are enabled, but subtitling in King's Quest 7 was unfinished and "
-"disabled in the release version of the game. ScummVM allows the subtitles to "
-"be re-enabled, but because they were removed from the original game, they do "
-"not always render properly or reflect the actual game speech. This is not a "
-"ScummVM bug -- it is a problem with the game's assets."
+"disabled in the release version of the game. ScummVM allows the subtitles to"
+" be re-enabled, but because they were removed from the original game, they "
+"do not always render properly or reflect the actual game speech. This is not"
+" a ScummVM bug -- it is a problem with the game's assets."
 msgstr ""
 "Legendas estão habilitadas, mas as legendas em King's Quest 7 estão "
-"inacabadas e desabilitadas na versão lançada do jogo. ScummVM permite que as "
-"legendas sejam reabilitadas, mas por terem sido removidas do jogo original, "
-"elas nem sempre renderizam corretamente ou refletem a fala atual no jogo. "
+"inacabadas e desabilitadas na versão lançada do jogo. ScummVM permite que as"
+" legendas sejam reabilitadas, mas por terem sido removidas do jogo original,"
+" elas nem sempre renderizam corretamente ou refletem a fala atual no jogo. "
 "Isto não é um bug do ScummVM -- é um problema com os ativos do jogo."
 
 #: engines/sci/sci.cpp:439
@@ -13507,8 +13316,8 @@ msgid ""
 msgstr ""
 "Você selecionou MIDI Geral como dispositivo de som. Sierra forneceu suporte "
 "pós-market para MIDI Geral para este jogo em seu \"Utilitário Geral de "
-"MIDI\". Por favor, aplique esta correção para poder aproveitar a música MIDI "
-"com este jogo. Assim que o obtiver, você poderá descompactar todos seus "
+"MIDI\". Por favor, aplique esta correção para poder aproveitar a música MIDI"
+" com este jogo. Assim que o obtiver, você poderá descompactar todos seus "
 "arquivos *.PAT inclusos na pasta de extras de seu ScummVM que irá adicionar "
 "a correção apropriada automaticamente. Alternativamente você pode seguir as "
 "instruções no arquivo READ.ME incluso na correção e renomear o arquivo "
@@ -13556,34 +13365,25 @@ msgstr ""
 "\n"
 "\n"
 "Alguns drivers de áudio (pelo menos para alguns jogos) foram\n"
-"disponibilizados pela Sierra como correções pós comercialização e portanto "
-"podem não\n"
+"disponibilizados pela Sierra como correções pós comercialização e portanto podem não\n"
 "terem sido instalados como parte do instalador original do jogo.\n"
 "\n"
 "Por favor copie estes arquivo(s) para dentro do diretório de seu jogo.\n"
 "\n"
-"De qualquer forma, por favor note que os arquivo(s) pode não estar "
-"disponíveis\n"
-"separadamente mas somente como conteúdo de um pacote de recursos "
-"(corrigido).\n"
+"De qualquer forma, por favor note que os arquivo(s) pode não estar disponíveis\n"
+"separadamente mas somente como conteúdo de um pacote de recursos (corrigido).\n"
 "Neste caso você pode precisar aplicar a correção original da Sierra.\n"
 "\n"
 
 #: engines/scumm/detection_internal.h:384
 msgid ""
-"This version of Monkey Island can't be played, because Limited Run Games "
-"provided corrupted DISK03.LEC, DISK04.LEC and 903.LFL files.\n"
+"This version of Monkey Island can't be played, because Limited Run Games provided corrupted DISK03.LEC, DISK04.LEC and 903.LFL files.\n"
 "\n"
-"Please contact their technical support for replacement files, or look online "
-"for some guides which can help you recover valid files from the KryoFlux "
-"dumps that Limited Run Games also provided."
+"Please contact their technical support for replacement files, or look online for some guides which can help you recover valid files from the KryoFlux dumps that Limited Run Games also provided."
 msgstr ""
-"Esta versão do Monkey Island não pode ser jogada, porque a Limited Run Games "
-"forneceram arquivos DISK03.LEC, DISK04.LEC e 903.LFL corrompidos.\n"
+"Esta versão do Monkey Island não pode ser jogada, porque a Limited Run Games forneceram arquivos DISK03.LEC, DISK04.LEC e 903.LFL corrompidos.\n"
 "\n"
-"Entre em contato com o suporte técnico para arquivos de substituição ou "
-"procure online alguns tutoriais que possam ajudá-lo a recuperar arquivos "
-"válidos extraídos de KryoFlux que a Limited Run Games também forneceu."
+"Entre em contato com o suporte técnico para arquivos de substituição ou procure online alguns tutoriais que possam ajudá-lo a recuperar arquivos válidos extraídos de KryoFlux que a Limited Run Games também forneceu."
 
 #. I18N: Creates new online session for multiplayer
 #: engines/scumm/dialog-createsession.cpp:37
@@ -13694,8 +13494,8 @@ msgid ""
 "Makes adjustments not related to bugs for certain audio and graphics "
 "elements (e.g. version consistency changes)."
 msgstr ""
-"Realiza ajustes não relacionados a bugs em determinados elementos de áudio e "
-"gráficos (por exemplo, alterações na consistência da versão)."
+"Realiza ajustes não relacionados a bugs em determinados elementos de áudio e"
+" gráficos (por exemplo, alterações na consistência da versão)."
 
 #: engines/scumm/dialogs.cpp:1176
 msgid "Restored content"
@@ -13715,8 +13515,8 @@ msgstr "Ajustes modernos de interface"
 
 #: engines/scumm/dialogs.cpp:1181
 msgid ""
-"Activates some modern comforts; e.g it removes the fake sound loading screen "
-"in Sam&Max, and makes early save menus snappier."
+"Activates some modern comforts; e.g it removes the fake sound loading screen"
+" in Sam&Max, and makes early save menus snappier."
 msgstr ""
 "Ativa alguns confortos modernos; por exemplo, remove a tela falsa de "
 "carregamento de som no Sam&Max e acelera a aparição dos menus de salvamento."
@@ -13731,33 +13531,39 @@ msgid ""
 "save/load menu. Use it together with the \"Ask for confirmation on exit\" "
 "for a more complete experience."
 msgstr ""
-"Permite que o jogo use a interface gráfica da engine e o menu salvar/"
-"carregar originais. Utilize em conjunto com \"Solicitar confirmação ao "
-"sair\" para uma experiência mais completa."
+"Permite que o jogo use a interface gráfica da engine e o menu "
+"salvar/carregar originais. Utilize em conjunto com \"Solicitar confirmação "
+"ao sair\" para uma experiência mais completa."
 
 #: engines/scumm/dialogs.cpp:1213 engines/scumm/metaengine.cpp:793
 msgid "Brighten the graphics to simulate a Macintosh monitor."
-msgstr ""
+msgstr "Clarear os gráficos para simular um monitor Macintosh."
 
 #: engines/scumm/dialogs.cpp:1219
 msgid "Simulate Sega colors"
-msgstr ""
+msgstr "Simular as cores do Sega"
 
 #: engines/scumm/dialogs.cpp:1220
 msgid ""
 "Instead of using the colors defined in the game, simulate colors used on "
-"actual Sega hardware. These are significantly darker, though it's unclear if "
-"that was intended or not."
+"actual Sega hardware. These are significantly darker, though it's unclear if"
+" that was intended or not."
 msgstr ""
+"Em vez de usar as cores definidas no jogo, simula as cores usadas no "
+"hardware real do Sega. Elas são significativamente mais escuras, embora não "
+"esteja claro se isso era intencional ou não."
 
 #: engines/scumm/dialogs.cpp:1226
 msgid "Show wait cursor when paused"
-msgstr ""
+msgstr "Mostrar o cursor de espera quando pausado"
 
 #: engines/scumm/dialogs.cpp:1227
 msgid ""
-"When paused, show the animated wait cursor from the original Sega CD version."
+"When paused, show the animated wait cursor from the original Sega CD "
+"version."
 msgstr ""
+"Quando pausado, mostra o cursor de espera animado da versão original do Sega"
+" CD."
 
 #: engines/scumm/dialogs.cpp:1364
 msgid "Overture Timing:"
@@ -13837,11 +13643,11 @@ msgstr "Ajustar Reprodução:"
 
 #: engines/scumm/dialogs.cpp:1601
 msgid ""
-"When playing sound from the CD audio track, adjust the start position of the "
-"sound by this much. Use this if you often hear bits of the wrong sound."
+"When playing sound from the CD audio track, adjust the start position of the"
+" sound by this much. Use this if you often hear bits of the wrong sound."
 msgstr ""
-"Ao reproduzir o som da faixa de áudio do CD, ajusta a posição inicial do som "
-"neste ponto. Use isso se você costuma ouvir trechos do som errado."
+"Ao reproduzir o som da faixa de áudio do CD, ajusta a posição inicial do som"
+" neste ponto. Use isso se você costuma ouvir trechos do som errado."
 
 #: engines/scumm/dialogs.cpp:1707
 msgid "Intro Adjust:"
@@ -13850,8 +13656,8 @@ msgstr "Ajustar Introdução:"
 #: engines/scumm/dialogs.cpp:1711
 msgid ""
 "When playing the intro track, play from this point in it. Use this if the "
-"music gets cut off prematurely, or if you are unhappy with the way the music "
-"syncs up with the intro."
+"music gets cut off prematurely, or if you are unhappy with the way the music"
+" syncs up with the intro."
 msgstr ""
 "Ao reproduzir a faixa de introdução, toca a partir deste ponto. Use isso se "
 "a música for cortada prematuramente ou se você não estiver satisfeito com a "
@@ -13880,8 +13686,8 @@ msgid ""
 "Replace music, sound effects, and speech clips with modded audio files, if "
 "available."
 msgstr ""
-"Substitui música, efeitos sonoros e falas por arquivos de áudio modificados, "
-"quando disponível."
+"Substitui música, efeitos sonoros e falas por arquivos de áudio modificados,"
+" quando disponível."
 
 #: engines/scumm/dialogs.cpp:1865 engines/scumm/dialogs.cpp:1878
 msgid "Multiplayer Server:"
@@ -13904,7 +13710,8 @@ msgid "Enable online competitive mods"
 msgstr "Habilitar mods competitivos online"
 
 #: engines/scumm/dialogs.cpp:1871
-msgid "Enables custom-made modifications intended for online competitive play."
+msgid ""
+"Enables custom-made modifications intended for online competitive play."
 msgstr ""
 "Permite modificações personalizadas destinadas a jogo online competitivo."
 
@@ -13925,7 +13732,8 @@ msgid "Host games over LAN"
 msgstr "Hospedar jogos por LAN"
 
 #: engines/scumm/dialogs.cpp:1882
-msgid "Allows the game sessions to be discovered over your local area network."
+msgid ""
+"Allows the game sessions to be discovered over your local area network."
 msgstr "Permite que as sessões de jogo sejam descobertas em sua rede local."
 
 #. I18N: Moonbase Console is a program name
@@ -14402,15 +14210,15 @@ msgid ""
 "This fan-made translation is not supported, because it is known to contain\n"
 "corrupted resources that might make it crash or seriously misbehave."
 msgstr ""
+"Esta tradução feita por fãs não é suportada, pois sabe-se que contém\n"
+"recursos corrompidos que podem fazê-la travar ou apresentar mau funcionamento grave."
 
 #: engines/scumm/metaengine.cpp:404
 msgid ""
-"The Lite version of Putt-Putt Saves the Zoo iOS is not supported to avoid "
-"piracy.\n"
+"The Lite version of Putt-Putt Saves the Zoo iOS is not supported to avoid piracy.\n"
 "The full version is available for purchase from the iTunes Store."
 msgstr ""
-"A versão Lite de Putt-Putt Saves the Zoo do iOS não é suportada para evitar "
-"pirataria.\n"
+"A versão Lite de Putt-Putt Saves the Zoo do iOS não é suportada para evitar pirataria.\n"
 "A versão completa está disponível para compra na Loja do iTunes."
 
 #: engines/scumm/metaengine.cpp:415
@@ -14451,11 +14259,12 @@ msgstr "Cortar jogos FM-TOWNS para 200 pixels de altura"
 
 #: engines/scumm/metaengine.cpp:721
 msgid ""
-"Cut the extra 40 pixels at the bottom of the screen, to make it standard 200 "
-"pixels height, allowing using 'aspect ratio correction'"
+"Cut the extra 40 pixels at the bottom of the screen, to make it standard 200"
+" pixels height, allowing using 'aspect ratio correction'"
 msgstr ""
-"Corta os 40 pixels extras na parte inferior da tela, para torná-la padrão de "
-"200 pixels de altura, permitindo o uso de 'correção de proporção de aspecto'"
+"Corta os 40 pixels extras na parte inferior da tela, para torná-la padrão de"
+" 200 pixels de altura, permitindo o uso de 'correção de proporção de "
+"aspecto'"
 
 #: engines/scumm/metaengine.cpp:729
 msgid "Run in original 640 x 480 resolution"
@@ -14475,7 +14284,8 @@ msgstr "Música simplificada"
 
 #: engines/scumm/metaengine.cpp:738
 msgid "This music was intended for low-end Macs, and uses only one channel."
-msgstr "Esta música era destinada a Macs de baixo custo e usa apenas um canal."
+msgstr ""
+"Esta música era destinada a Macs de baixo custo e usa apenas um canal."
 
 #: engines/scumm/metaengine.cpp:746
 msgid "Enable smooth scrolling"
@@ -14508,8 +14318,8 @@ msgid ""
 "issues during normal gameplay."
 msgstr ""
 "Permite que o jogo utilize áudio de baixa latência, sacrificando a precisão "
-"do som. É recomendável habilitar esse recurso apenas se você tiver problemas "
-"de atraso de áudio durante o jogo normal."
+"do som. É recomendável habilitar esse recurso apenas se você tiver problemas"
+" de atraso de áudio durante o jogo normal."
 
 #: engines/scumm/metaengine.cpp:811
 msgid "Enable the \"A Pirate I Was Meant To Be\" song"
@@ -14522,8 +14332,8 @@ msgid ""
 "subtitles may not be fully translated."
 msgstr ""
 "Habilita a música no início da Parte 3 do jogo, \"A Pirate I Was Meant To "
-"Be\", que foi cortada em lançamentos internacionais. Observe que as legendas "
-"podem não estar totalmente traduzidas."
+"Be\", que foi cortada em lançamentos internacionais. Observe que as legendas"
+" podem não estar totalmente traduzidas."
 
 #: engines/scumm/metaengine.cpp:830
 msgid "Enable demo/kiosk mode"
@@ -14545,6 +14355,9 @@ msgid ""
 "Disable the scripted part of the demo (dangerous!). This makes it "
 "interactive, but as this was never intended, expect frequent crashes!"
 msgstr ""
+"Desativar a parte programada da demonstração (perigoso!). Isso a torna "
+"interativa, mas como isso nunca foi planejado, espere travamentos "
+"frequentes!"
 
 #: engines/scumm/metaengine.cpp:848
 #, fuzzy
@@ -14554,7 +14367,7 @@ msgstr "Utilizar áudio de CD"
 
 #: engines/scumm/metaengine.cpp:849
 msgid "Use the remastered speech and sound effects."
-msgstr ""
+msgstr "Usar a fala e os efeitos sonoros remasterizados."
 
 #: engines/scumm/metaengine.cpp:861
 #, fuzzy
@@ -14577,7 +14390,7 @@ msgstr "Alta resolução ativada"
 
 #: engines/scumm/metaengine.cpp:883
 msgid "Run the game in 640x400 high resolution mode instead of 320x200"
-msgstr ""
+msgstr "Executar o jogo no modo de alta resolução 640x400 em vez de 320x200"
 
 #: engines/scumm/metaengine.cpp:892 engines/scumm/metaengine.cpp:919
 #, fuzzy
@@ -14604,8 +14417,11 @@ msgid "Yoda mode"
 msgstr "Modo rápido"
 
 #: engines/scumm/metaengine.cpp:910
-msgid "Enable original Yoda mode shortcuts, including movie mode and auto play"
+msgid ""
+"Enable original Yoda mode shortcuts, including movie mode and auto play"
 msgstr ""
+"Ativar os atalhos originais do modo Yoda, incluindo o modo filme e a "
+"reprodução automática"
 
 #: engines/scumm/metaengine.cpp:1085
 #, fuzzy
@@ -14642,23 +14458,23 @@ msgstr "Trapaça para vencer a briga de motos"
 
 #: engines/scumm/metaengine.cpp:1166
 msgid "Rebel Assault controls"
-msgstr ""
+msgstr "Controles de Rebel Assault"
 
 #: engines/scumm/metaengine.cpp:1168 engines/scumm/metaengine.cpp:1245
 msgid "Aim up / menu up"
-msgstr ""
+msgstr "Mirar para cima / menu para cima"
 
 #: engines/scumm/metaengine.cpp:1173 engines/scumm/metaengine.cpp:1250
 msgid "Aim down / menu down"
-msgstr ""
+msgstr "Mirar para baixo / menu para baixo"
 
 #: engines/scumm/metaengine.cpp:1178 engines/scumm/metaengine.cpp:1255
 msgid "Aim left / menu left"
-msgstr ""
+msgstr "Mirar para a esquerda / menu para a esquerda"
 
 #: engines/scumm/metaengine.cpp:1183 engines/scumm/metaengine.cpp:1260
 msgid "Aim right / menu right"
-msgstr ""
+msgstr "Mirar para a direita / menu para a direita"
 
 #: engines/scumm/metaengine.cpp:1216 engines/scumm/metaengine.cpp:1293
 #, fuzzy
@@ -14680,7 +14496,7 @@ msgstr "Omitir menu principal"
 
 #: engines/scumm/metaengine.cpp:1243
 msgid "Rebel Assault II controls"
-msgstr ""
+msgstr "Controles de Rebel Assault II"
 
 #: engines/scumm/metaengine.cpp:1298
 #, fuzzy
@@ -14703,51 +14519,42 @@ msgstr "Omitir menu principal"
 #: engines/scumm/saveload.cpp:1990
 #, c-format
 msgid ""
-"Warning: incompatible sound settings detected between the current "
-"configuration and this saved game.\n"
+"Warning: incompatible sound settings detected between the current configuration and this saved game.\n"
 "\n"
 "Current music device: %s (id %d)\n"
 "Save file music device: %s (id %d)\n"
 "\n"
 "Loading will be attempted, but the game may behave incorrectly or crash.\n"
-"Please change the audio configuration accordingly in order to properly load "
-"this save file."
+"Please change the audio configuration accordingly in order to properly load this save file."
 msgstr ""
-"Aviso: configurações de som incompatíveis detectadas entre a configuração "
-"atual e este jogo salvo.\n"
+"Aviso: configurações de som incompatíveis detectadas entre a configuração atual e este jogo salvo.\n"
 "\n"
 "Dispositivo de música atual: %s (id %d)\n"
 "Dispositivo de música do arquivo salvo: %s (id %d)\n"
 "\n"
-"Será feita uma tentativa de carregamento, mas o jogo pode se comportar "
-"incorretamente ou fechar.\n"
-"Por favor, altere a configuração de áudio adequadamente para carregar este "
-"arquivo salvo de forma correta."
+"Será feita uma tentativa de carregamento, mas o jogo pode se comportar incorretamente ou fechar.\n"
+"Por favor, altere a configuração de áudio adequadamente para carregar este arquivo salvo de forma correta."
 
 #: engines/scumm/scumm.cpp:320
 msgid ""
-"You have enabled 'aspect ratio correction'. However, FM-TOWNS' natural "
-"resolution is 320x240, which doesn't allow aspect ratio correction.\n"
-"Aspect ratio correction can be achieved by trimming the resolution to "
-"320x200, under 'engine' tab."
+"You have enabled 'aspect ratio correction'. However, FM-TOWNS' natural resolution is 320x240, which doesn't allow aspect ratio correction.\n"
+"Aspect ratio correction can be achieved by trimming the resolution to 320x200, under 'engine' tab."
 msgstr ""
-"Você habilitou a 'correção de proporção de aspecto'. No entanto, a resolução "
-"natural do FM-TOWNS é 320x240, o que não permite a correção da proporção de "
-"aspecto.\n"
-"A correção da proporção de aspecto pode ser obtida reduzindo a resolução "
-"para 320x200, na aba 'engine'."
+"Você habilitou a 'correção de proporção de aspecto'. No entanto, a resolução natural do FM-TOWNS é 320x240, o que não permite a correção da proporção de aspecto.\n"
+"A correção da proporção de aspecto pode ser obtida reduzindo a resolução para 320x200, na aba 'engine'."
 
 #: engines/scumm/scumm.cpp:1365
 #, fuzzy, c-format
-#| msgid "This game requires the 'Indy' Macintosh executable for its fonts."
+#| msgid ""
+#| "This game requires the 'Indy' Macintosh executable for its fonts."
 msgid "This game requires the '%s' Macintosh executable for its fonts."
-msgstr "Este jogo requer o executável de 'Indy' de Macintosh para suas fontes."
+msgstr ""
+"Este jogo requer o executável de 'Indy' de Macintosh para suas fontes."
 
 #: engines/scumm/scumm.cpp:1374
 #, fuzzy, c-format
 #| msgid ""
-#| "This game requires the 'Loom' Macintosh executable for its music and "
-#| "fonts."
+#| "This game requires the 'Loom' Macintosh executable for its music and fonts."
 msgid ""
 "This game requires the '%s' Macintosh executable for its music and fonts."
 msgstr ""
@@ -14757,24 +14564,22 @@ msgstr ""
 #: engines/scumm/scumm.cpp:1378
 #, fuzzy, c-format
 #| msgid ""
-#| "Could not find the 'Monkey Island' Macintosh executable to read "
-#| "resources\n"
+#| "Could not find the 'Monkey Island' Macintosh executable to read resources\n"
 #| "and instruments from. Music and Mac GUI will be disabled."
 msgid ""
-"Could not find the '%s' Macintosh executable to read resources from. %s will "
-"be disabled."
+"Could not find the '%s' Macintosh executable to read resources from. %s will"
+" be disabled."
 msgstr ""
-"Não foi possível encontrar o executável de 'Monkey Island' do Macintosh para "
-"ler recursos\n"
+"Não foi possível encontrar o executável de 'Monkey Island' do Macintosh para ler recursos\n"
 "e instrumentos. A música e a interface do Mac serão desabilitados."
 
 #: engines/scumm/scumm.cpp:1379
 msgid "The Mac GUI"
-msgstr ""
+msgstr "A interface gráfica do Mac"
 
 #: engines/scumm/scumm.cpp:1379
 msgid "The music and the Mac GUI"
-msgstr ""
+msgstr "A música e a interface gráfica do Mac"
 
 #: engines/scumm/scumm.cpp:1408
 #, c-format
@@ -14796,6 +14601,10 @@ msgid ""
 "dialog definitions. Look for a 'The Dig f' folder on your CD. Any one from "
 "its sub-folders should be what you need."
 msgstr ""
+"'%s' parece ser o executável errado de The Dig. Pode ser o inicializador "
+"encontrado na raiz do CD, que não contém nenhuma das definições de menu e "
+"diálogo necessárias. Procure por uma pasta 'The Dig f' no seu CD. Qualquer "
+"um de suas subpastas deve ser o que você precisa."
 
 #: engines/scumm/scumm.cpp:1584
 msgid ""
@@ -14804,6 +14613,10 @@ msgid ""
 "Since the One-Stop Fun Shop series makes extensive use of TTF fonts,\n"
 "some of the graphics on screen will be missing."
 msgstr ""
+"Parece que a sua versão do ScummVM não foi compilada com suporte a fontes TrueType.\n"
+"\n"
+"Como a série One-Stop Fun Shop faz uso extensivo de fontes TTF,\n"
+"alguns dos gráficos na tela estarão faltando."
 
 #: engines/scumm/scumm.cpp:1918
 msgid ""
@@ -14811,10 +14624,8 @@ msgid ""
 "compression is not supported anymore for this game, audio will be disabled.\n"
 "Please copy the game from the original media without compression."
 msgstr ""
-"Arquivos de áudio compactados com ScummVM Tools foram detectados; *.BUN/"
-"*.SOU\n"
-"a compactação não é mais suportada para este jogo, o áudio será "
-"desabilitado.\n"
+"Arquivos de áudio compactados com ScummVM Tools foram detectados; *.BUN/*.SOU\n"
+"a compactação não é mais suportada para este jogo, o áudio será desabilitado.\n"
 "Por favor, copie o jogo da mídia de origem sem a compactação."
 
 #: engines/scumm/scumm.cpp:2408
@@ -14823,8 +14634,7 @@ msgid ""
 "Native MIDI support requires the Roland Upgrade from LucasArts,\n"
 "but %s is missing. Using AdLib instead."
 msgstr ""
-"O suporte nativo MIDI requer a atualização do sistema Roland pela "
-"LucasArts,\n"
+"O suporte nativo MIDI requer a atualização do sistema Roland pela LucasArts,\n"
 "mas %s está faltando. Utilizando AdLib ao invés."
 
 #: engines/scumm/scumm.cpp:2423
@@ -14832,10 +14642,8 @@ msgid ""
 "This particular version of Monkey Island 1 is known to miss some\n"
 "required resources for MT-32. Using AdLib instead."
 msgstr ""
-"Esta versão em particular de Monkey Island 1 é conhecida por não possuir "
-"alguns\n"
-"recursos necessários para usar música MT-32. Será utilizado AdLib em seu "
-"lugar."
+"Esta versão em particular de Monkey Island 1 é conhecida por não possuir alguns\n"
+"recursos necessários para usar música MT-32. Será utilizado AdLib em seu lugar."
 
 #: engines/scumm/scumm.cpp:4372
 msgid ""
@@ -14985,8 +14793,7 @@ msgid ""
 "Unimplemented development codepath encountered within the sound engine,\n"
 "please file a ticket at https://bugs.scummvm.org."
 msgstr ""
-"Caminho de código de desenvolvimento não implementado encontrado na engine "
-"de som,\n"
+"Caminho de código de desenvolvimento não implementado encontrado na engine de som,\n"
 "por favor, registre um chamado em https://bugs.scummvm.org."
 
 #: engines/scumm/imuse/drivers/amiga.cpp:660
@@ -15013,7 +14820,8 @@ msgstr "Transições de cena quadriculadas"
 
 #: engines/sherlock/metaengine.cpp:60
 msgid "When changing scenes, a randomized pixel transition is done"
-msgstr "Quando há mudança de cenas, uma transição aleatória de pixel é exibida"
+msgstr ""
+"Quando há mudança de cenas, uma transição aleatória de pixel é exibida"
 
 #: engines/sherlock/metaengine.cpp:71
 msgid "Don't show hotspots when moving mouse"
@@ -15040,7 +14848,8 @@ msgid "Slide dialogs into view"
 msgstr "Deslizar diálogos para área visível"
 
 #: engines/sherlock/metaengine.cpp:96
-msgid "Slide UI dialogs into view, rather than simply showing them immediately"
+msgid ""
+"Slide UI dialogs into view, rather than simply showing them immediately"
 msgstr ""
 "Desliza os diálogos de interface para dentro do campo de visão, em vez de "
 "simplesmente exibi-los imediatamente"
@@ -15114,27 +14923,39 @@ msgstr "Configurações"
 msgid "Files"
 msgstr "Conjunto de peças"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a journal, this action is used to go back 10 pages in the journal
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a journal, this action is used to go back 10 pages in the journal
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
+#. Scalpel) The game has a journal, this action is used to go back 10 pages in
+#. the journal
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has a journal, this action is used to go back 10 pages in
+#. the journal
 #: engines/sherlock/metaengine.cpp:501 engines/sherlock/metaengine.cpp:910
 msgid "Go back 10 pages"
-msgstr ""
+msgstr "Voltar 10 páginas"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a journal, this action is used to go forward 10 pages in the journal
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a journal, this action is used to go forward 10 pages in the journal
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
+#. Scalpel) The game has a journal, this action is used to go forward 10 pages
+#. in the journal
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has a journal, this action is used to go forward 10 pages
+#. in the journal
 #: engines/sherlock/metaengine.cpp:507 engines/sherlock/metaengine.cpp:895
 #, fuzzy
 #| msgid "Show journal"
 msgid "Go forward 10 pages"
 msgstr "Exibir diário"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a journal, this action is used to go to the first page of the journal
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
+#. Scalpel) The game has a journal, this action is used to go to the first
+#. page of the journal
 #: engines/sherlock/metaengine.cpp:521 engines/sherlock/metaengine.cpp:924
 #: engines/wintermute/keymapper_tables.h:965
 msgid "First page"
 msgstr "Primeira página"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a journal, this action is used to go to the last page of the journal
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
+#. Scalpel) The game has a journal, this action is used to go to the last page
+#. of the journal
 #: engines/sherlock/metaengine.cpp:528 engines/sherlock/metaengine.cpp:931
 #: engines/wintermute/keymapper_tables.h:970
 msgid "Last page"
@@ -15176,7 +14997,9 @@ msgstr "Mudar tamanho da fonte"
 msgid "Toggle windows mode"
 msgstr "Alternar modo rápido"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has an auto-help feature, this action is used to change the auto-help location between left and right
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
+#. Scalpel) The game has an auto-help feature, this action is used to change
+#. the auto-help location between left and right
 #: engines/sherlock/metaengine.cpp:713
 #, fuzzy
 #| msgid "Change game options"
@@ -15189,19 +15012,25 @@ msgstr "Altera opções do jogo"
 msgid "Toggle voices"
 msgstr "Habilitar trapaças"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a fade animation when switching scenes, this action is used to change the fade mode to "Fade by pixel"
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
+#. Scalpel) The game has a fade animation when switching scenes, this action
+#. is used to change the fade mode to "Fade by pixel"
 #: engines/sherlock/metaengine.cpp:726
 msgid "Fade by pixel"
-msgstr ""
+msgstr "Desvanecer por pixel"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a fade animation when switching scenes, this action is used to change the fade mode to "Fade directly"
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
+#. Scalpel) The game has a fade animation when switching scenes, this action
+#. is used to change the fade mode to "Fade directly"
 #: engines/sherlock/metaengine.cpp:732
 #, fuzzy
 #| msgid "Create directory"
 msgid "Fade directly"
 msgstr "Criar diretório"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a fade animation when switching scenes, this action is used to change the fade mode
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
+#. Scalpel) The game has a fade animation when switching scenes, this action
+#. is used to change the fade mode
 #: engines/sherlock/metaengine.cpp:738
 #, fuzzy
 #| msgid "Change mode"
@@ -15262,7 +15091,9 @@ msgstr "Mapeamentos de teclas de índice"
 msgid "Move / Examine / Select"
 msgstr "Mover para esquerda"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) This action changes the speed of the game (walking, animations, etc.)
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) This action changes the speed of the game (walking, animations,
+#. etc.)
 #: engines/sherlock/metaengine.cpp:810
 #, fuzzy
 #| msgid "Change sound"
@@ -15287,11 +15118,11 @@ msgstr "Ajustar à janela"
 
 #: engines/sherlock/metaengine.cpp:882 engines/sherlock/metaengine.cpp:949
 msgid "Change selected option to the left"
-msgstr ""
+msgstr "Mudar a opção selecionada para a esquerda"
 
 #: engines/sherlock/metaengine.cpp:888 engines/sherlock/metaengine.cpp:955
 msgid "Change selected option to the right"
-msgstr ""
+msgstr "Mudar a opção selecionada para a direita"
 
 #: engines/sherlock/metaengine.cpp:972
 #, fuzzy
@@ -15299,28 +15130,36 @@ msgstr ""
 msgid "Skip darts minigame"
 msgstr "Pular minigame"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a map, this action is used to scroll to the top left of the map
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has a map, this action is used to scroll to the top left
+#. of the map
 #: engines/sherlock/metaengine.cpp:983
 #, fuzzy
 #| msgid "Scroll list up"
 msgid "Scroll to top left"
 msgstr "Subir na lista"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a map, this action is used to scroll to the bottom right of the map
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has a map, this action is used to scroll to the bottom
+#. right of the map
 #: engines/sherlock/metaengine.cpp:991
 #, fuzzy
 #| msgid "Move to bottom"
 msgid "Scroll to bottom right"
 msgstr "Mover para o final"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has multiple widgets for various purposes (eg. inventory, save files, etc.), this action is used to scroll to the end of the widget
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has multiple widgets for various purposes (eg. inventory,
+#. save files, etc.), this action is used to scroll to the end of the widget
 #: engines/sherlock/metaengine.cpp:1055
 #, fuzzy
 #| msgid "Scroll list up"
 msgid "Scroll to end"
 msgstr "Subir na lista"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has multiple widgets for various purposes (eg. inventory, save files, etc.), this action is used to scroll to the start of the widget
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has multiple widgets for various purposes (eg. inventory,
+#. save files, etc.), this action is used to scroll to the start of the widget
 #: engines/sherlock/metaengine.cpp:1062
 #, fuzzy
 #| msgid "Scroll list up"
@@ -15345,15 +15184,22 @@ msgstr "Ir para o início do menu de salvar/carregar"
 msgid "Select save file"
 msgstr "Selecione um Tema"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) save file name input field has 2 modes, insert and overwrite, this action toggles between them
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) save password input field has 2 modes, insert and overwrite, this action toggles between them
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) save file name input field has 2 modes, insert and overwrite, this
+#. action toggles between them
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) save password input field has 2 modes, insert and overwrite, this
+#. action toggles between them
 #: engines/sherlock/metaengine.cpp:1124 engines/sherlock/metaengine.cpp:1229
 #, fuzzy
 #| msgid "Toggle fast mode"
 msgid "Toggle insert mode"
 msgstr "Alternar modo rápido"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a foolscap puzzle, where the player has to decode a hidden message on a piece of paper called a foolscap. this action is used to exit the puzzle
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
+#. Tattoo) The game has a foolscap puzzle, where the player has to decode a
+#. hidden message on a piece of paper called a foolscap. this action is used
+#. to exit the puzzle
 #: engines/sherlock/metaengine.cpp:1135
 #, fuzzy
 #| msgid "Close popup"
@@ -15363,6 +15209,7 @@ msgstr "Fechar caixa de diálogo"
 #: engines/sherlock/metaengine.cpp:1177
 msgid "Exit inventory / Close verb menu / Cancel item use action"
 msgstr ""
+"Sair do inventário / Fechar menu de verbos / Cancelar ação de uso de item"
 
 #: engines/sherlock/metaengine.cpp:1239
 #, fuzzy
@@ -15410,13 +15257,14 @@ msgstr "Introdução de disquete"
 
 #: engines/sky/metaengine.cpp:157
 msgid "Use the floppy version's intro (CD version only)"
-msgstr "Utiliza a introdução da versão de disquete (somente para versão de CD)"
+msgstr ""
+"Utiliza a introdução da versão de disquete (somente para versão de CD)"
 
 #: engines/sky/metaengine.cpp:237
 msgid "WARNING: Deleting the autosave slot is not supported by this engine"
 msgstr ""
-"AVISO: a exclusão do slot de salvamento automático não é compatível com esta "
-"engine"
+"AVISO: a exclusão do slot de salvamento automático não é compatível com esta"
+" engine"
 
 #: engines/sludge/keymapper_tables.h:34
 #, fuzzy
@@ -15457,12 +15305,12 @@ msgstr "Salvamento automático sem título"
 #: engines/sludge/keymapper_tables.h:200 engines/sludge/keymapper_tables.h:435
 #: engines/sludge/keymapper_tables.h:552
 msgid "DEBUG: Show floor"
-msgstr ""
+msgstr "DEPURAÇÃO: Mostrar o chão"
 
 #: engines/sludge/keymapper_tables.h:205 engines/sludge/keymapper_tables.h:440
 #: engines/sludge/keymapper_tables.h:547
 msgid "DEBUG: Show boxes"
-msgstr ""
+msgstr "DEPURAÇÃO: Mostrar as caixas"
 
 #: engines/sludge/keymapper_tables.h:237
 #, fuzzy
@@ -15485,11 +15333,11 @@ msgstr "Pular cena"
 
 #: engines/sludge/keymapper_tables.h:328
 msgid "Smell"
-msgstr ""
+msgstr "Cheirar"
 
 #: engines/sludge/keymapper_tables.h:338
 msgid "Consume"
-msgstr ""
+msgstr "Consumir"
 
 #: engines/sludge/keymapper_tables.h:361
 #, fuzzy
@@ -15545,8 +15393,8 @@ msgid ""
 "When linear filtering is enabled the background graphics are smoother in "
 "full screen mode, at the cost of some details."
 msgstr ""
-"Quando a filtragem linear está ativada, os gráficos de fundo são mais suaves "
-"no modo de tela inteira, à custa de alguns detalhes."
+"Quando a filtragem linear está ativada, os gráficos de fundo são mais suaves"
+" no modo de tela inteira, à custa de alguns detalhes."
 
 #: engines/stark/metaengine.cpp:63 engines/ultima/metaengine.cpp:144
 msgid "Enable font anti-aliasing"
@@ -15644,8 +15492,8 @@ msgstr "Estão faltando os arquivos de dados recomendados:"
 #: engines/stark/stark.cpp:306
 msgid ""
 "The 'fonts' folder is required to experience the text style as it was "
-"designed. The Steam release is known to be missing it. You can get the fonts "
-"from the demo version of the game."
+"designed. The Steam release is known to be missing it. You can get the fonts"
+" from the demo version of the game."
 msgstr ""
 "A pasta 'fonts' é necessária para experimentar o estilo do texto conforme "
 "foi projetado. O lançamento no Steam é conhecido por estar faltando isso. "
@@ -15680,10 +15528,11 @@ msgstr ""
 #: engines/supernova/supernova.cpp:479 engines/teenagent/resources.cpp:338
 #, c-format
 msgid ""
-"Incorrect version of the '%s' engine data file found. Expected %d but got %d."
+"Incorrect version of the '%s' engine data file found. Expected %d but got "
+"%d."
 msgstr ""
-"Versão incorreta do arquivo '%s' de dados da engine encontrada. Esperava por "
-"%d mas obteve %d."
+"Versão incorreta do arquivo '%s' de dados da engine encontrada. Esperava por"
+" %d mas obteve %d."
 
 #: engines/supernova/supernova.cpp:489
 #, c-format
@@ -15703,7 +15552,8 @@ msgid ""
 "set in ScummVM and that you can write to it."
 msgstr ""
 "Falha ao salvar o estado temporário do jogo. Certifique-se de que o "
-"diretório do jogo salvo está definido no ScummVM e que você pode gravar nele."
+"diretório do jogo salvo está definido no ScummVM e que você pode gravar "
+"nele."
 
 #: engines/supernova/supernova.cpp:853
 msgid "Failed to load temporary game state."
@@ -15715,7 +15565,8 @@ msgstr "Modo aperfeiçoado"
 
 #: engines/supernova/metaengine.cpp:42
 msgid ""
-"Removes some repetitive actions, adds possibility to change verbs by keyboard"
+"Removes some repetitive actions, adds possibility to change verbs by "
+"keyboard"
 msgstr ""
 "Remove algumas ações repetitivas, adiciona a possibilidade de mudar verbos "
 "por teclado"
@@ -15776,15 +15627,15 @@ msgstr "Abrir gerenciador de Arquivos"
 
 #: engines/supernova/metaengine.cpp:385
 msgid "Phone"
-msgstr ""
+msgstr "Telefone"
 
 #: engines/supernova/metaengine.cpp:391
 msgid "ProText"
-msgstr ""
+msgstr "ProText"
 
 #: engines/supernova/metaengine.cpp:397
 msgid "Calculata"
-msgstr ""
+msgstr "Calculata"
 
 #: engines/sword1/animation.cpp:566 engines/sword2/animation.cpp:459
 msgid ""
@@ -15799,21 +15650,15 @@ msgstr "Vídeo '%s' não encontrado"
 
 #: engines/sword1/control.cpp:2814
 msgid ""
-"ScummVM found that you have old saved games for Broken Sword 1 that should "
-"be converted.\n"
-"The old saved game format is no longer supported, so you will not be able to "
-"load your games if you don't convert them.\n"
+"ScummVM found that you have old saved games for Broken Sword 1 that should be converted.\n"
+"The old saved game format is no longer supported, so you will not be able to load your games if you don't convert them.\n"
 "\n"
-"Press OK to convert them now, otherwise you will be asked again the next "
-"time you start the game.\n"
+"Press OK to convert them now, otherwise you will be asked again the next time you start the game.\n"
 msgstr ""
-"ScummVM percebeu que você possui jogos salvos antigos para Broken Sword 1 "
-"que precisam ser convertidos.\n"
-"O formato do jogo salvo antigo não é mais suportado, sendo assim você não "
-"conseguirá carregar seus jogos se não convertê-los.\n"
+"ScummVM percebeu que você possui jogos salvos antigos para Broken Sword 1 que precisam ser convertidos.\n"
+"O formato do jogo salvo antigo não é mais suportado, sendo assim você não conseguirá carregar seus jogos se não convertê-los.\n"
 "\n"
-"Pressione OK para convertê-los agora, caso contrário você será solicitado "
-"novamente da próxima vez em que iniciar o jogo.\n"
+"Pressione OK para convertê-los agora, caso contrário você será solicitado novamente da próxima vez em que iniciar o jogo.\n"
 
 #: engines/sword1/control.cpp:3000
 #, c-format
@@ -15884,7 +15729,8 @@ msgid ""
 msgstr ""
 "Faz o jogo usar curvas de áudio mais suaves (logarítmicas), mas remove o "
 "fade-in e o fade-out para efeitos sonoros, o fade-in para música e a "
-"atenuação automática do volume da música quando a fala está sendo reproduzida"
+"atenuação automática do volume da música quando a fala está sendo "
+"reproduzida"
 
 #: engines/sword1/metaengine.cpp:127
 msgid "Additional options:"
@@ -15899,7 +15745,8 @@ msgstr "Menu Principal"
 #: engines/sword2/detection_tables.h:431
 msgid "Remastered edition is not supported. Please, use the classic version"
 msgstr ""
-"A Versão Remasterizada não é compatível. Por favor, utilize a versão clássica"
+"A Versão Remasterizada não é compatível. Por favor, utilize a versão "
+"clássica"
 
 #: engines/sword2/metaengine.cpp:43
 msgid "Show object labels"
@@ -15917,12 +15764,12 @@ msgstr "Utilizar fala em Inglês"
 msgid ""
 "Use English speech instead of German for every language other than German"
 msgstr ""
-"Utiliza fala em Inglês em vez de Alemão para todos os outros idiomas que não "
-"sejam em Alemão"
+"Utiliza fala em Inglês em vez de Alemão para todos os outros idiomas que não"
+" sejam em Alemão"
 
 #: engines/sword25/metaengine.cpp:130
 msgid "Reveal all interactive hotspots (hold the key)"
-msgstr ""
+msgstr "Revelar todos os pontos interativos (segure a tecla)"
 
 #: engines/teenagent/metaengine.cpp:201
 #, fuzzy
@@ -16001,7 +15848,7 @@ msgstr "Ir para o fim do menu de salvar/carregar"
 
 #: engines/tinsel/tinsel.cpp:1061
 msgid "Discworld Noir needs ScummVM with TinyGL enabled"
-msgstr ""
+msgstr "Discworld Noir requer o ScummVM com o TinyGL ativado"
 
 #: engines/titanic/metaengine.cpp:173
 #, fuzzy
@@ -16077,7 +15924,7 @@ msgstr "Sala:"
 
 #: engines/titanic/metaengine.cpp:259
 msgid "Real life"
-msgstr ""
+msgstr "Vida real"
 
 #: engines/titanic/metaengine.cpp:278
 #, fuzzy
@@ -16099,19 +15946,19 @@ msgstr "Transições:"
 
 #: engines/titanic/metaengine.cpp:307
 msgid "Toggle between Star Map and photo of your home"
-msgstr ""
+msgstr "Alternar entre o Mapa Estelar e a foto da sua casa"
 
 #: engines/titanic/metaengine.cpp:350
 msgid "Stop moving"
-msgstr ""
+msgstr "Parar de se mover"
 
 #: engines/titanic/metaengine.cpp:356
 msgid "Lock coordinate"
-msgstr ""
+msgstr "Travar coordenada"
 
 #: engines/titanic/metaengine.cpp:362
 msgid "Unlock coordinate"
-msgstr ""
+msgstr "Destravar coordenada"
 
 #: engines/titanic/metaengine.cpp:368
 #, fuzzy
@@ -16121,7 +15968,7 @@ msgstr "Sair da conversa"
 
 #: engines/titanic/metaengine.cpp:373
 msgid "View boundaries"
-msgstr ""
+msgstr "Ver os limites"
 
 #: engines/toltecs/metaengine.cpp:216
 #, fuzzy
@@ -16131,7 +15978,7 @@ msgstr "Mover para esquerda"
 
 #: engines/toltecs/metaengine.cpp:222
 msgid "Move / Perform default action"
-msgstr ""
+msgstr "Mover / Executar ação padrão"
 
 #: engines/toltecs/metaengine.cpp:258
 #, fuzzy
@@ -16204,7 +16051,7 @@ msgstr "Transições de cena quadriculadas"
 
 #: engines/tot/metaengine.cpp:48
 msgid "Disable original transition effects between scenes"
-msgstr ""
+msgstr "Desativar os efeitos de transição originais entre cenas"
 
 #: engines/tot/metaengine.cpp:58
 #, fuzzy
@@ -16549,15 +16396,11 @@ msgstr "Piadas internas irritantes"
 
 #: engines/twp/dialogs.cpp:42
 msgid ""
-"The game will include in-jokes and references to past adventure games, in "
-"the form of both dialogues and objects.\n"
-"There is a game achievement that can be obtained only if the in-jokes option "
-"is switched on."
+"The game will include in-jokes and references to past adventure games, in the form of both dialogues and objects.\n"
+"There is a game achievement that can be obtained only if the in-jokes option is switched on."
 msgstr ""
-"O jogo incluirá piadas internas e referências a jogos de aventura "
-"anteriores, na forma de diálogos e objetos.\n"
-"Há uma conquista do jogo que só pode ser obtida se a opção de piadas "
-"internas estiver ativada."
+"O jogo incluirá piadas internas e referências a jogos de aventura anteriores, na forma de diálogos e objetos.\n"
+"Há uma conquista do jogo que só pode ser obtida se a opção de piadas internas estiver ativada."
 
 #: engines/twp/dialogs.cpp:44
 msgid "Controls:"
@@ -16714,9 +16557,11 @@ msgstr ""
 
 #: engines/twp/twp.cpp:1019
 #, fuzzy
-#| msgid "This game requires the FoxTail subengine, which is not compiled in."
+#| msgid ""
+#| "This game requires the FoxTail subengine, which is not compiled in."
 msgid ""
-"This game requires OpenGL with shaders, which is not supported on your system"
+"This game requires OpenGL with shaders, which is not supported on your "
+"system"
 msgstr "Este jogo requer a subengine FoxTail, que não está compilada."
 
 #: engines/twp/twp.cpp:1025
@@ -16724,6 +16569,8 @@ msgid ""
 "This game requires OpenGL Framebuffer Objects, which are not supported on "
 "your system"
 msgstr ""
+"Este jogo requer Objetos de Framebuffer do OpenGL, que não são suportados "
+"pelo seu sistema"
 
 #: engines/ultima/metaengine.cpp:67
 msgid "Enable frame skipping"
@@ -16748,7 +16595,8 @@ msgstr "Habilitar trapaças"
 
 #: engines/ultima/metaengine.cpp:90
 msgid "Allow cheats by commands and a menu when player is clicked."
-msgstr "Permite trapaças por comandos e abre um menu quando clicar no jogador."
+msgstr ""
+"Permite trapaças por comandos e abre um menu quando clicar no jogador."
 
 #: engines/ultima/metaengine.cpp:111
 msgid "Play foot step sounds"
@@ -16764,10 +16612,11 @@ msgstr "Habilitar pulo para a posição do mouse"
 
 #: engines/ultima/metaengine.cpp:123
 msgid ""
-"Jumping while not moving targets the mouse cursor rather than direction only."
+"Jumping while not moving targets the mouse cursor rather than direction "
+"only."
 msgstr ""
-"Pular quando não se está movendo causa um pulo na posição do cursor do mouse "
-"e não apenas a direção."
+"Pular quando não se está movendo causa um pulo na posição do cursor do mouse"
+" e não apenas a direção."
 
 #: engines/ultima/metaengine.cpp:133
 msgid "Enable font replacement"
@@ -16777,7 +16626,8 @@ msgstr "Habilitar substituição de fonte"
 msgid "Replaces game fonts with rendered fonts"
 msgstr "Substitui fontes do jogo por fontes renderizadas"
 
-#. I18N: Silencer is the player-character in Crusader games, known as the Avatar in Ultima series.
+#. I18N: Silencer is the player-character in Crusader games, known as the
+#. Avatar in Ultima series.
 #: engines/ultima/metaengine.cpp:156
 msgid "Camera moves with Silencer"
 msgstr "Câmera acompanha Jogador"
@@ -16786,7 +16636,8 @@ msgstr "Câmera acompanha Jogador"
 msgid ""
 "Camera tracks the player movement rather than snapping to defined positions."
 msgstr ""
-"A câmera segue o movimento do jogador em vez de travar em posições definidas."
+"A câmera segue o movimento do jogador em vez de travar em posições "
+"definidas."
 
 #: engines/ultima/metaengine.cpp:167
 msgid "Always enable Christmas easter-egg"
@@ -16802,35 +16653,35 @@ msgstr "Não foi possível encontrar o arquivo de dados ultima.dat correto"
 
 #: engines/ultima/ultima0/metaengine.cpp:49
 msgid "Swing"
-msgstr ""
+msgstr "Balançar"
 
 #: engines/ultima/ultima0/metaengine.cpp:50
 msgid "Throw"
-msgstr ""
+msgstr "Arremessar"
 
 #: engines/ultima/ultima0/metaengine.cpp:51
 msgid "Food"
-msgstr ""
+msgstr "Comida"
 
 #: engines/ultima/ultima0/metaengine.cpp:52
 msgid "Rapier"
-msgstr ""
+msgstr "Rapieira"
 
 #: engines/ultima/ultima0/metaengine.cpp:53
 msgid "Axe"
-msgstr ""
+msgstr "Machado"
 
 #: engines/ultima/ultima0/metaengine.cpp:54
 msgid "Shield"
-msgstr ""
+msgstr "Escudo"
 
 #: engines/ultima/ultima0/metaengine.cpp:55
 msgid "Bow & arrow"
-msgstr ""
+msgstr "Arco e flecha"
 
 #: engines/ultima/ultima0/metaengine.cpp:56
 msgid "Magic amulet"
-msgstr ""
+msgstr "Amuleto mágico"
 
 #: engines/ultima/ultima0/metaengine.cpp:57
 #, fuzzy
@@ -16930,7 +16781,7 @@ msgstr "Teclas Gerais"
 #: engines/ultima/ultima0/metaengine.cpp:101
 #: engines/ultima/ultima0/metaengine.cpp:124
 msgid "Dungeon keys"
-msgstr ""
+msgstr "Chaves da masmorra"
 
 #: engines/ultima/ultima4/metaengine.cpp:43
 #: engines/ultima/ultima4/metaengine.cpp:133
@@ -16950,7 +16801,7 @@ msgstr "Teclado"
 #: engines/ultima/ultima4/metaengine.cpp:52
 #: engines/ultima/ultima8/metaengine.cpp:107
 msgid "Descend"
-msgstr ""
+msgstr "Descer"
 
 #: engines/ultima/ultima4/metaengine.cpp:56
 #, fuzzy
@@ -16960,16 +16811,16 @@ msgstr "Trapaça de luta"
 
 #: engines/ultima/ultima4/metaengine.cpp:57
 msgid "Hole up & camp"
-msgstr ""
+msgstr "Abrigar-se e acampar"
 
 #. I18N: Jimmy is used to open locked doors
 #: engines/ultima/ultima4/metaengine.cpp:59
 msgid "Jimmy"
-msgstr ""
+msgstr "Forçar fechadura"
 
 #: engines/ultima/ultima4/metaengine.cpp:60
 msgid "Ignite"
-msgstr ""
+msgstr "Acender"
 
 #: engines/ultima/ultima4/metaengine.cpp:61
 #, fuzzy
@@ -16979,7 +16830,7 @@ msgstr "Olhar para"
 
 #: engines/ultima/ultima4/metaengine.cpp:62
 msgid "Mix reagents"
-msgstr ""
+msgstr "Misturar reagentes"
 
 #: engines/ultima/ultima4/metaengine.cpp:63
 #, fuzzy
@@ -17003,7 +16854,7 @@ msgstr "Senha:"
 #. I18N: Peer is used to look through keyholes or other small openings
 #: engines/ultima/ultima4/metaengine.cpp:68
 msgid "Peer"
-msgstr ""
+msgstr "Espiar"
 
 #: engines/ultima/ultima4/metaengine.cpp:69
 #, fuzzy
@@ -17025,11 +16876,11 @@ msgstr "Status:"
 
 #: engines/ultima/ultima4/metaengine.cpp:75
 msgid "Wear armor"
-msgstr ""
+msgstr "Vestir armadura"
 
 #: engines/ultima/ultima4/metaengine.cpp:76
 msgid "Yell"
-msgstr ""
+msgstr "Gritar"
 
 #: engines/ultima/ultima4/metaengine.cpp:82
 #, fuzzy
@@ -17051,7 +16902,7 @@ msgstr "Somente Fala"
 
 #: engines/ultima/ultima4/metaengine.cpp:85
 msgid "Combat speed up"
-msgstr ""
+msgstr "Acelerar combate"
 
 #: engines/ultima/ultima4/metaengine.cpp:86
 #, fuzzy
@@ -17061,11 +16912,11 @@ msgstr "Girar para baixo"
 
 #: engines/ultima/ultima4/metaengine.cpp:87
 msgid "Combat speed normal"
-msgstr ""
+msgstr "Velocidade de combate normal"
 
 #: engines/ultima/ultima4/metaengine.cpp:93
 msgid "Party - None"
-msgstr ""
+msgstr "Grupo - Nenhum"
 
 #: engines/ultima/ultima4/metaengine.cpp:94
 #, fuzzy
@@ -17117,7 +16968,7 @@ msgstr "Transferir Personagem"
 
 #: engines/ultima/ultima4/metaengine.cpp:107
 msgid "Destroy all creatures"
-msgstr ""
+msgstr "Destruir todas as criaturas"
 
 #: engines/ultima/ultima4/metaengine.cpp:108
 #, fuzzy
@@ -17134,7 +16985,7 @@ msgstr "Próximo objeto"
 
 #: engines/ultima/ultima4/metaengine.cpp:110
 msgid "Full equipment"
-msgstr ""
+msgstr "Equipamento completo"
 
 #: engines/ultima/ultima4/metaengine.cpp:111
 #, fuzzy
@@ -17144,15 +16995,15 @@ msgstr "Alternar Modo de Combate"
 
 #: engines/ultima/ultima4/metaengine.cpp:113
 msgid "Help - Teleport to Lord British"
-msgstr ""
+msgstr "Ajuda - Teleportar para Lord British"
 
 #: engines/ultima/ultima4/metaengine.cpp:114
 msgid "Give items"
-msgstr ""
+msgstr "Dar itens"
 
 #: engines/ultima/ultima4/metaengine.cpp:115
 msgid "List karma"
-msgstr ""
+msgstr "Listar karma"
 
 #: engines/ultima/ultima4/metaengine.cpp:116
 #, fuzzy
@@ -17162,11 +17013,11 @@ msgstr "Local seguinte"
 
 #: engines/ultima/ultima4/metaengine.cpp:117
 msgid "Give mixtures"
-msgstr ""
+msgstr "Dar misturas"
 
 #: engines/ultima/ultima4/metaengine.cpp:118
 msgid "Combat encounters"
-msgstr ""
+msgstr "Encontros de combate"
 
 #: engines/ultima/ultima4/metaengine.cpp:119
 #, fuzzy
@@ -17176,15 +17027,15 @@ msgstr "Alternar Modo de Arrastar"
 
 #: engines/ultima/ultima4/metaengine.cpp:120
 msgid "Full party"
-msgstr ""
+msgstr "Grupo completo"
 
 #: engines/ultima/ultima4/metaengine.cpp:121
 msgid "Give reagents"
-msgstr ""
+msgstr "Dar reagentes"
 
 #: engines/ultima/ultima4/metaengine.cpp:122
 msgid "Full stats"
-msgstr ""
+msgstr "Atributos completos"
 
 #: engines/ultima/ultima4/metaengine.cpp:123
 #, fuzzy
@@ -17206,7 +17057,7 @@ msgstr "Nível de Depuração:"
 
 #: engines/ultima/ultima4/metaengine.cpp:126
 msgid "Grant virtue"
-msgstr ""
+msgstr "Conceder virtude"
 
 #: engines/ultima/ultima4/metaengine.cpp:127
 #, fuzzy
@@ -17254,23 +17105,23 @@ msgstr "Andar até"
 
 #: engines/ultima/nuvie/metaengine.cpp:63
 msgid "Walk north-east"
-msgstr ""
+msgstr "Caminhar para nordeste"
 
 #: engines/ultima/nuvie/metaengine.cpp:64
 msgid "Walk south-east"
-msgstr ""
+msgstr "Caminhar para sudeste"
 
 #: engines/ultima/nuvie/metaengine.cpp:65
 msgid "Walk north-west"
-msgstr ""
+msgstr "Caminhar para noroeste"
 
 #: engines/ultima/nuvie/metaengine.cpp:66
 msgid "Walk south-west"
-msgstr ""
+msgstr "Caminhar para sudoeste"
 
 #: engines/ultima/nuvie/metaengine.cpp:75
 msgid "Multi-use"
-msgstr ""
+msgstr "Uso múltiplo"
 
 #. I18N: command bar is the bar of commands at the bottom of the screen
 #: engines/ultima/nuvie/metaengine.cpp:77
@@ -17313,7 +17164,7 @@ msgstr "Tecla anti-chefe"
 
 #: engines/ultima/nuvie/metaengine.cpp:85
 msgid "End key"
-msgstr ""
+msgstr "Tecla End"
 
 #: engines/ultima/nuvie/metaengine.cpp:86
 #, fuzzy
@@ -17348,6 +17199,7 @@ msgstr "Salvamento automático sem título"
 #: engines/ultima/nuvie/metaengine.cpp:95
 msgid "Show game menu; Cancel action if in middle of action"
 msgstr ""
+"Mostrar o menu do jogo; cancelar a ação se estiver no meio de uma ação"
 
 #: engines/ultima/nuvie/metaengine.cpp:97
 #, fuzzy
@@ -17382,7 +17234,7 @@ msgstr "Alternar som"
 #. I18N: command bar is the bar of commands at the bottom of the screen
 #: engines/ultima/nuvie/metaengine.cpp:104
 msgid "Toggle original style command bar"
-msgstr ""
+msgstr "Alternar a barra de comandos no estilo original"
 
 #: engines/ultima/nuvie/metaengine.cpp:105
 #, fuzzy
@@ -17435,51 +17287,51 @@ msgstr "Fechar caixa de diálogo"
 
 #: engines/ultima/nuvie/metaengine.cpp:115
 msgid "Enter ALT code (hold)"
-msgstr ""
+msgstr "Inserir código ALT (segurar)"
 
 #: engines/ultima/nuvie/metaengine.cpp:116
 msgid "ALT code 0"
-msgstr ""
+msgstr "Código ALT 0"
 
 #: engines/ultima/nuvie/metaengine.cpp:117
 msgid "ALT code 1"
-msgstr ""
+msgstr "Código ALT 1"
 
 #: engines/ultima/nuvie/metaengine.cpp:118
 msgid "ALT code 2"
-msgstr ""
+msgstr "Código ALT 2"
 
 #: engines/ultima/nuvie/metaengine.cpp:119
 msgid "ALT code 3"
-msgstr ""
+msgstr "Código ALT 3"
 
 #: engines/ultima/nuvie/metaengine.cpp:120
 msgid "ALT code 4"
-msgstr ""
+msgstr "Código ALT 4"
 
 #: engines/ultima/nuvie/metaengine.cpp:121
 msgid "ALT code 5"
-msgstr ""
+msgstr "Código ALT 5"
 
 #: engines/ultima/nuvie/metaengine.cpp:122
 msgid "ALT code 6"
-msgstr ""
+msgstr "Código ALT 6"
 
 #: engines/ultima/nuvie/metaengine.cpp:123
 msgid "ALT code 7"
-msgstr ""
+msgstr "Código ALT 7"
 
 #: engines/ultima/nuvie/metaengine.cpp:124
 msgid "ALT code 8"
-msgstr ""
+msgstr "Código ALT 8"
 
 #: engines/ultima/nuvie/metaengine.cpp:125
 msgid "ALT code 9"
-msgstr ""
+msgstr "Código ALT 9"
 
 #: engines/ultima/nuvie/metaengine.cpp:129
 msgid "Open the asset viewer"
-msgstr ""
+msgstr "Abrir o visualizador de recursos"
 
 #. I18N: Eggs are in-game hatchable objects that are normally invisible
 #: engines/ultima/nuvie/metaengine.cpp:131
@@ -17533,7 +17385,7 @@ msgstr "Alternar modo rápido"
 
 #: engines/ultima/nuvie/metaengine.cpp:140
 msgid "Heal party"
-msgstr ""
+msgstr "Curar o grupo"
 
 #: engines/ultima/nuvie/metaengine.cpp:141
 #, fuzzy
@@ -17549,7 +17401,7 @@ msgstr "Habilitar trapaças"
 
 #: engines/ultima/nuvie/metaengine.cpp:146
 msgid "Solo mode as Avatar"
-msgstr ""
+msgstr "Modo solo como o Avatar"
 
 #: engines/ultima/nuvie/metaengine.cpp:147
 #, fuzzy
@@ -17583,51 +17435,51 @@ msgstr "Ver Integrante 6"
 
 #: engines/ultima/nuvie/metaengine.cpp:152
 msgid "Solo mode as party member 7"
-msgstr ""
+msgstr "Modo solo como o membro do grupo 7"
 
 #: engines/ultima/nuvie/metaengine.cpp:153
 msgid "Solo mode as party member 8"
-msgstr ""
+msgstr "Modo solo como o membro do grupo 8"
 
 #: engines/ultima/nuvie/metaengine.cpp:154
 msgid "Solo mode as party member 9"
-msgstr ""
+msgstr "Modo solo como o membro do grupo 9"
 
 #: engines/ultima/nuvie/metaengine.cpp:155
 msgid "Show stats for Avatar"
-msgstr ""
+msgstr "Mostrar atributos do Avatar"
 
 #: engines/ultima/nuvie/metaengine.cpp:156
 msgid "Show stats for party member 2"
-msgstr ""
+msgstr "Mostrar atributos do membro do grupo 2"
 
 #: engines/ultima/nuvie/metaengine.cpp:157
 msgid "Show stats for party member 3"
-msgstr ""
+msgstr "Mostrar atributos do membro do grupo 3"
 
 #: engines/ultima/nuvie/metaengine.cpp:158
 msgid "Show stats for party member 4"
-msgstr ""
+msgstr "Mostrar atributos do membro do grupo 4"
 
 #: engines/ultima/nuvie/metaengine.cpp:159
 msgid "Show stats for party member 5"
-msgstr ""
+msgstr "Mostrar atributos do membro do grupo 5"
 
 #: engines/ultima/nuvie/metaengine.cpp:160
 msgid "Show stats for party member 6"
-msgstr ""
+msgstr "Mostrar atributos do membro do grupo 6"
 
 #: engines/ultima/nuvie/metaengine.cpp:161
 msgid "Show stats for party member 7"
-msgstr ""
+msgstr "Mostrar atributos do membro do grupo 7"
 
 #: engines/ultima/nuvie/metaengine.cpp:162
 msgid "Show stats for party member 8"
-msgstr ""
+msgstr "Mostrar atributos do membro do grupo 8"
 
 #: engines/ultima/nuvie/metaengine.cpp:163
 msgid "Show stats for party member 9"
-msgstr ""
+msgstr "Mostrar atributos do membro do grupo 9"
 
 #: engines/ultima/nuvie/metaengine.cpp:164
 #, fuzzy
@@ -17637,80 +17489,80 @@ msgstr "Exibir inventário"
 
 #: engines/ultima/nuvie/metaengine.cpp:165
 msgid "Show inventory for party member 2"
-msgstr ""
+msgstr "Mostrar inventário do membro do grupo 2"
 
 #: engines/ultima/nuvie/metaengine.cpp:166
 msgid "Show inventory for party member 3"
-msgstr ""
+msgstr "Mostrar inventário do membro do grupo 3"
 
 #: engines/ultima/nuvie/metaengine.cpp:167
 msgid "Show inventory for party member 4"
-msgstr ""
+msgstr "Mostrar inventário do membro do grupo 4"
 
 #: engines/ultima/nuvie/metaengine.cpp:168
 msgid "Show inventory for party member 5"
-msgstr ""
+msgstr "Mostrar inventário do membro do grupo 5"
 
 #: engines/ultima/nuvie/metaengine.cpp:169
 msgid "Show inventory for party member 6"
-msgstr ""
+msgstr "Mostrar inventário do membro do grupo 6"
 
 #: engines/ultima/nuvie/metaengine.cpp:170
 msgid "Show inventory for party member 7"
-msgstr ""
+msgstr "Mostrar inventário do membro do grupo 7"
 
 #: engines/ultima/nuvie/metaengine.cpp:171
 msgid "Show inventory for party member 8"
-msgstr ""
+msgstr "Mostrar inventário do membro do grupo 8"
 
 #: engines/ultima/nuvie/metaengine.cpp:172
 msgid "Show inventory for party member 9"
-msgstr ""
+msgstr "Mostrar inventário do membro do grupo 9"
 
 #. I18N: gump is Graphical User Menu Pop-up
 #: engines/ultima/nuvie/metaengine.cpp:174
 msgid "Show doll gump for Avatar"
-msgstr ""
+msgstr "Mostrar o boneco (gump) do Avatar"
 
 #. I18N: gump is Graphical User Menu Pop-up
 #: engines/ultima/nuvie/metaengine.cpp:176
 msgid "Show doll gump for party member 2"
-msgstr ""
+msgstr "Mostrar o boneco (gump) do membro do grupo 2"
 
 #. I18N: gump is Graphical User Menu Pop-up
 #: engines/ultima/nuvie/metaengine.cpp:178
 msgid "Show doll gump for party member 3"
-msgstr ""
+msgstr "Mostrar o boneco (gump) do membro do grupo 3"
 
 #. I18N: gump is Graphical User Menu Pop-up
 #: engines/ultima/nuvie/metaengine.cpp:180
 msgid "Show doll gump for party member 4"
-msgstr ""
+msgstr "Mostrar o boneco (gump) do membro do grupo 4"
 
 #. I18N: gump is Graphical User Menu Pop-up
 #: engines/ultima/nuvie/metaengine.cpp:182
 msgid "Show doll gump for party member 5"
-msgstr ""
+msgstr "Mostrar o boneco (gump) do membro do grupo 5"
 
 #. I18N: gump is Graphical User Menu Pop-up
 #: engines/ultima/nuvie/metaengine.cpp:184
 msgid "Show doll gump for party member 6"
-msgstr ""
+msgstr "Mostrar o boneco (gump) do membro do grupo 6"
 
 #. I18N: gump is Graphical User Menu Pop-up
 #: engines/ultima/nuvie/metaengine.cpp:186
 msgid "Show doll gump for party member 7"
-msgstr ""
+msgstr "Mostrar o boneco (gump) do membro do grupo 7"
 
 #. I18N: gump is Graphical User Menu Pop-up
 #: engines/ultima/nuvie/metaengine.cpp:188
 msgid "Show doll gump for party member 8"
-msgstr ""
+msgstr "Mostrar o boneco (gump) do membro do grupo 8"
 
 #. I18N: gump is Graphical User Menu Pop-up
 #: engines/ultima/nuvie/metaengine.cpp:190
 msgid "Show doll gump for party member 9"
-msgstr ""
+msgstr "Mostrar o boneco (gump) do membro do grupo 9"
 
 #: engines/ultima/nuvie/metaengine.cpp:196
 #: engines/ultima/nuvie/metaengine.cpp:201
@@ -17737,7 +17589,7 @@ msgstr "Transferir Personagem"
 
 #: engines/ultima/ultima8/metaengine.cpp:46
 msgid "Draw weapon / Combat"
-msgstr ""
+msgstr "Sacar arma / Combate"
 
 #: engines/ultima/ultima8/metaengine.cpp:51
 #, fuzzy
@@ -17753,7 +17605,7 @@ msgstr "Destacar próximo diálogo"
 
 #: engines/ultima/ultima8/metaengine.cpp:63
 msgid "Use bedroll"
-msgstr ""
+msgstr "Usar saco de dormir"
 
 #: engines/ultima/ultima8/metaengine.cpp:64
 #, fuzzy
@@ -17775,7 +17627,7 @@ msgstr "Abrir mapa"
 
 #: engines/ultima/ultima8/metaengine.cpp:67
 msgid "Use recall"
-msgstr ""
+msgstr "Usar Recall"
 
 #: engines/ultima/ultima8/metaengine.cpp:68
 #, fuzzy
@@ -17786,15 +17638,15 @@ msgstr "Abrir inventário"
 #. I18N: gump is Graphical User Menu Pop-up
 #: engines/ultima/ultima8/metaengine.cpp:70
 msgid "Close all displays"
-msgstr ""
+msgstr "Fechar todas as exibições"
 
 #: engines/ultima/ultima8/metaengine.cpp:71
 msgid "Jump (fake both-button-click)"
-msgstr ""
+msgstr "Saltar (simular clique de ambos os botões)"
 
 #: engines/ultima/ultima8/metaengine.cpp:72
 msgid "Careful step"
-msgstr ""
+msgstr "Passo cuidadoso"
 
 #: engines/ultima/ultima8/metaengine.cpp:78
 #, fuzzy
@@ -17816,7 +17668,7 @@ msgstr "Inventário"
 
 #: engines/ultima/ultima8/metaengine.cpp:81
 msgid "Use medikit"
-msgstr ""
+msgstr "Usar kit médico"
 
 #: engines/ultima/ultima8/metaengine.cpp:82
 #, fuzzy
@@ -17826,7 +17678,7 @@ msgstr "Inventário"
 
 #: engines/ultima/ultima8/metaengine.cpp:83
 msgid "Detonate bomb"
-msgstr ""
+msgstr "Detonar bomba"
 
 #: engines/ultima/ultima8/metaengine.cpp:85
 #, fuzzy
@@ -17848,7 +17700,7 @@ msgstr "Próxima ação"
 
 #: engines/ultima/ultima8/metaengine.cpp:88
 msgid "Grab items"
-msgstr ""
+msgstr "Pegar itens"
 
 #: engines/ultima/ultima8/metaengine.cpp:90
 #, fuzzy
@@ -17858,7 +17710,7 @@ msgstr "Câmera acompanha Jogador"
 
 #: engines/ultima/ultima8/metaengine.cpp:91
 msgid "Jump / Roll / Crouch"
-msgstr ""
+msgstr "Saltar / Rolar / Agachar"
 
 #: engines/ultima/ultima8/metaengine.cpp:92
 #, fuzzy
@@ -17892,7 +17744,7 @@ msgstr "Alternar Relógio"
 
 #: engines/ultima/ultima8/metaengine.cpp:100
 msgid "Side step / Advance / Retreat"
-msgstr ""
+msgstr "Passo lateral / Avançar / Recuar"
 
 #: engines/ultima/ultima8/metaengine.cpp:105
 #, fuzzy
@@ -17902,7 +17754,7 @@ msgstr "Alternar Relógio"
 
 #: engines/ultima/ultima8/metaengine.cpp:106
 msgid "Ascend"
-msgstr ""
+msgstr "Subir"
 
 #: engines/ultima/ultima8/metaengine.cpp:114
 #, fuzzy
@@ -17918,11 +17770,11 @@ msgstr "Exibir citações"
 
 #: engines/ultima/ultima8/metaengine.cpp:116
 msgid "Decrement map sort order"
-msgstr ""
+msgstr "Diminuir a ordem de classificação do mapa"
 
 #: engines/ultima/ultima8/metaengine.cpp:117
 msgid "Increment map sort order"
-msgstr ""
+msgstr "Aumentar a ordem de classificação do mapa"
 
 #: engines/ultima/ultima8/metaengine.cpp:118
 #, fuzzy
@@ -17932,11 +17784,11 @@ msgstr "Alternar estilo do painel"
 
 #: engines/ultima/ultima8/metaengine.cpp:119
 msgid "Advance frame"
-msgstr ""
+msgstr "Avançar quadro"
 
 #: engines/ultima/ultima8/metaengine.cpp:120
 msgid "Toggle Avatar in stasis"
-msgstr ""
+msgstr "Alternar o Avatar em estase"
 
 #: engines/ultima/ultima8/metaengine.cpp:121
 #, fuzzy
@@ -18031,7 +17883,8 @@ msgstr "Pré-carregar sons"
 
 #: engines/vcruise/metaengine.cpp:99
 msgid "Preload sounds. May improve performance on slow hard drives."
-msgstr "Pré-carrega sons. Pode melhorar o desempenho em discos rígidos lentos."
+msgstr ""
+"Pré-carrega sons. Pode melhorar o desempenho em discos rígidos lentos."
 
 #: engines/vcruise/metaengine.cpp:109
 msgid "Faster video decoder (lower quality)"
@@ -18075,8 +17928,7 @@ msgid ""
 "Music for this game requires Ogg Vorbis support, which was not compiled in.\n"
 "The game will still play, but will not have any music."
 msgstr ""
-"A música para este jogo requer suporte a Ogg Vorbis, o que não foi "
-"compilado.\n"
+"A música para este jogo requer suporte a Ogg Vorbis, o que não foi compilado.\n"
 "O jogo ainda pode ser jogado, mas não terá nenhuma música."
 
 #: engines/vcruise/vcruise.cpp:103
@@ -18129,11 +17981,11 @@ msgstr "Pular cena"
 
 #: engines/voyeur/metaengine.cpp:211
 msgid "View evidence"
-msgstr ""
+msgstr "Ver evidências"
 
 #: engines/voyeur/metaengine.cpp:217
 msgid "Exit / Put away evidence"
-msgstr ""
+msgstr "Sair / Guardar evidências"
 
 #: engines/voyeur/metaengine.cpp:223
 #, fuzzy
@@ -18147,7 +17999,8 @@ msgstr "Exibir contador de FPS"
 
 #: engines/wintermute/metaengine.cpp:43
 msgid "Show the current number of frames per second in the upper left corner"
-msgstr "Exibe o número atual de quadros por segundo no canto superior esquerdo"
+msgstr ""
+"Exibe o número atual de quadros por segundo no canto superior esquerdo"
 
 #: engines/wintermute/metaengine.cpp:54
 msgid "Sprite bilinear filtering (SLOW)"
@@ -18175,15 +18028,15 @@ msgstr "Utilizar fala em Inglês"
 
 #: engines/wintermute/metaengine.cpp:95
 msgid "Use Italian dubbing instead of the default English one"
-msgstr ""
+msgstr "Usar a dublagem italiana em vez da inglesa padrão"
 
 #: engines/wintermute/metaengine.cpp:106
 msgid "Run SD version (1280x800)"
-msgstr ""
+msgstr "Executar a versão SD (1280x800)"
 
 #: engines/wintermute/metaengine.cpp:107
 msgid "Run the legacy SD version, which is better for small screens"
-msgstr ""
+msgstr "Executar a versão SD legada, que é melhor para telas pequenas"
 
 #: engines/wintermute/metaengine.cpp:148
 msgid "FoxTail support is not compiled in"
@@ -18211,13 +18064,14 @@ msgstr "Este jogo requer a subengine HeroCraft, que não está compilada."
 
 #: engines/wintermute/wintermute.cpp:173
 msgid ""
-"This game requires 3D capabilities, which is not compiled in. As such, it is "
-"likely to be unplayable totally or partially."
+"This game requires 3D capabilities, which is not compiled in. As such, it is"
+" likely to be unplayable totally or partially."
 msgstr ""
 "Este jogo requer recursos 3D que não foram inclusos. Sendo assim, "
 "provavelmente não será possível jogar totalmente ou parcialmente."
 
-#. I18N: Debug feature to draw lines of scene geometry: walls, walking areas, etc
+#. I18N: Debug feature to draw lines of scene geometry: walls, walking areas,
+#. etc
 #: engines/wintermute/keymapper_tables.h:174
 #: engines/wintermute/keymapper_tables.h:685
 #: engines/wintermute/keymapper_tables.h:1855
@@ -18267,8 +18121,10 @@ msgstr "Botão para cima do telefone"
 msgid "Phone down button"
 msgstr "Botão para baixo do telefone"
 
-#. I18N: Some items are scripted to have alternative "Use" action, when MiddleClick is used
-#. It may result in actor saying different text or item being decomposed to it's parts
+#. I18N: Some items are scripted to have alternative "Use" action, when
+#. MiddleClick is used
+#. It may result in actor saying different text or item being decomposed to
+#. it's parts
 #: engines/wintermute/keymapper_tables.h:360
 msgid "Alternative action"
 msgstr "Ação alternativa"
@@ -18445,7 +18301,8 @@ msgstr "Velocidade de caminhada: Alta"
 msgid "Cancel waiting"
 msgstr "Cancelar espera"
 
-#. I18N: ultra_super_mega_fast_walk is the name of the variable used at game script for this speed
+#. I18N: ultra_super_mega_fast_walk is the name of the variable used at game
+#. script for this speed
 #: engines/wintermute/keymapper_tables.h:978
 msgid "Walking speed: Ultra Super Mega Fast"
 msgstr "Velocidade de caminhada: Ultra Super Mega Rápido"
@@ -18550,7 +18407,8 @@ msgstr "Cancelar entrada"
 msgid "Hide hints"
 msgstr "Ocultar dicas"
 
-#. I18N: At one of the puzzles game asks to press Up key / Shift key / Down key
+#. I18N: At one of the puzzles game asks to press Up key / Shift key / Down
+#. key
 #: engines/wintermute/keymapper_tables.h:1464
 msgid "Shift key"
 msgstr "Tecla Shift"
@@ -18585,12 +18443,14 @@ msgstr "Resposta ao diálogo 3"
 msgid "Dialog answer 4"
 msgstr "Resposta ao diálogo 4"
 
-#. I18N: This game is called "Pole Chudes" and it features a wheel similar to "Wheel of Fortune" TV show
+#. I18N: This game is called "Pole Chudes" and it features a wheel similar to
+#. "Wheel of Fortune" TV show
 #: engines/wintermute/keymapper_tables.h:1645
 msgid "Spin wheel slower"
 msgstr "Girar roda mais devagar"
 
-#. I18N: This game is called "Pole Chudes" and it features a wheel similar to "Wheel of Fortune" TV show
+#. I18N: This game is called "Pole Chudes" and it features a wheel similar to
+#. "Wheel of Fortune" TV show
 #: engines/wintermute/keymapper_tables.h:1653
 msgid "Spin wheel faster"
 msgstr "Girar roda mais rápido"
@@ -18671,8 +18531,8 @@ msgstr "Tecla i"
 #: engines/zvision/file/save_manager.cpp:207
 #, c-format
 msgid ""
-"This saved game uses version %u, but this engine only supports up to version "
-"%d. You will need an updated version of the engine to use this saved game."
+"This saved game uses version %u, but this engine only supports up to version"
+" %d. You will need an updated version of the engine to use this saved game."
 msgstr ""
 "Este jogo salvo utiliza a versão %u, mas esta engine suporta somente até a "
 "versão %d. Você precisará de uma versão atualizada da engine para utilizar "
@@ -18708,7 +18568,8 @@ msgstr "Usar vídeos MPEG de alta resolução"
 
 #: engines/zvision/metaengine.cpp:91
 msgid "Use MPEG video from the DVD version instead of lower resolution AVI"
-msgstr "Usar vídeo MPEG da versão em DVD em vez do AVI de resolução mais baixa"
+msgstr ""
+"Usar vídeo MPEG da versão em DVD em vez do AVI de resolução mais baixa"
 
 #: engines/zvision/metaengine.cpp:102
 #, fuzzy
@@ -18721,6 +18582,8 @@ msgid ""
 "Rearrange placement of menus & subtitles so as to make better use of modern "
 "wide aspect ratio displays"
 msgstr ""
+"Reorganizar a disposição de menus e legendas para aproveitar melhor as telas"
+" modernas de proporção ampla"
 
 #: engines/zvision/metaengine.cpp:114
 #, fuzzy
@@ -18758,13 +18621,13 @@ msgstr "Preferências"
 #, fuzzy
 #| msgid ""
 #| "Before playing this game, you'll need to copy the required fonts into "
-#| "ScummVM's extras directory, or into the game directory. On Windows, "
-#| "you'll need the following font files from the Windows font directory: "
-#| "Times New Roman, Century Schoolbook, Garamond, Courier New and Arial. "
-#| "Alternatively, you can download the Liberation Fonts or the GNU FreeFont "
-#| "package. You'll need all the fonts from the font package you choose, "
-#| "i.e., LiberationMono, LiberationSans and LiberationSerif, or FreeMono, "
-#| "FreeSans and FreeSerif respectively."
+#| "ScummVM's extras directory, or into the game directory. On Windows, you'll "
+#| "need the following font files from the Windows font directory: Times New "
+#| "Roman, Century Schoolbook, Garamond, Courier New and Arial. Alternatively, "
+#| "you can download the Liberation Fonts or the GNU FreeFont package. You'll "
+#| "need all the fonts from the font package you choose, i.e., LiberationMono, "
+#| "LiberationSans and LiberationSerif, or FreeMono, FreeSans and FreeSerif "
+#| "respectively."
 msgid ""
 "Before playing this game, you'll need to copy the required fonts into "
 "ScummVM's extras directory, or into the game directory. On Windows, you'll "
@@ -18774,13 +18637,13 @@ msgid ""
 "from the font package you choose, i.e., LiberationMono, LiberationSans and "
 "LiberationSerif."
 msgstr ""
-"Antes de jogar este jogo, você precisará copiar as fontes necessárias para o "
-"diretório de extras do ScummVM, ou para o diretório do jogo. No Windows, "
+"Antes de jogar este jogo, você precisará copiar as fontes necessárias para o"
+" diretório de extras do ScummVM, ou para o diretório do jogo. No Windows, "
 "você precisará dos seguintes arquivos de fonte do diretório de fontes do "
-"Windows: Times New Roman, Century Schoolbook, Garamond, Courier New e Arial. "
-"Alternativamente, você pode baixar as Fontes Liberation ou o pacote FreeFont "
-"do GNU. Você precisará de todas as fontes do pacote de fontes que você "
-"escolher, ex., LiberationMono, LiberationSans e LiberationSerif, ou "
+"Windows: Times New Roman, Century Schoolbook, Garamond, Courier New e Arial."
+" Alternativamente, você pode baixar as Fontes Liberation ou o pacote "
+"FreeFont do GNU. Você precisará de todas as fontes do pacote de fontes que "
+"você escolher, ex., LiberationMono, LiberationSans e LiberationSerif, ou "
 "FreeMono, FreeSans e FreeSerif respectivamente."
 
 #: engines/zvision/zvision.cpp:323
@@ -18790,19 +18653,21 @@ msgid ""
 "solved.  These puzzles may alternatively be solved using subtitles, if "
 "supported. Continue launching game?"
 msgstr ""
+"A reprodução de MIDI não está disponível, ou está configurada "
+"incorretamente. Zork Nemesis contém vários quebra-cabeças musicais que "
+"exigem áudio MIDI para serem resolvidos.  Esses quebra-cabeças podem, "
+"alternativamente, ser resolvidos usando legendas, se houver suporte. "
+"Continuar iniciando o jogo?"
 
 #, fuzzy
-#~| msgid "Move Back"
 #~ msgid "Menu back"
 #~ msgstr "Mover para Trás"
 
 #, fuzzy
-#~| msgid "Backspace"
 #~ msgid "Back / skip"
 #~ msgstr "Retroceder"
 
 #, fuzzy
-#~| msgid "No"
 #~ msgid "N"
 #~ msgstr "Não"
 
@@ -18822,22 +18687,18 @@ msgstr ""
 #~ msgstr "Salvar arquivo"
 
 #, fuzzy
-#~| msgid "Center"
 #~ msgid "Centre"
 #~ msgstr "Centralizado"
 
 #, fuzzy
-#~| msgid "L1"
 #~ msgid "1"
 #~ msgstr "L1"
 
 #, fuzzy
-#~| msgid "L2"
 #~ msgid "2"
 #~ msgstr "L2"
 
 #, fuzzy
-#~| msgid "L3"
 #~ msgid "3"
 #~ msgstr "L3"
 
@@ -18858,7 +18719,6 @@ msgstr ""
 #~ msgstr "Virar à Direita"
 
 #, fuzzy
-#~| msgid "Interact Mode"
 #~ msgid "Run in interactive mode"
 #~ msgstr "Modo de Interação"
 
@@ -18869,27 +18729,22 @@ msgstr ""
 #~ msgstr "Rolar inventário para baixo"
 
 #, fuzzy
-#~| msgid "Scroll up in your dialogues"
 #~ msgid "Scroll up in your dialogs"
 #~ msgstr "Rolar lista de diálogos para cima"
 
 #, fuzzy
-#~| msgid "Scroll down in your dialogues"
 #~ msgid "Scroll down in your dialogs"
 #~ msgstr "Rolar lista de diálogos para baixo"
 
 #, fuzzy
-#~| msgid "Switch to Game"
 #~ msgid "Switch test"
 #~ msgstr "Mudar para o Jogo"
 
 #, fuzzy
-#~| msgid "Enable/Disable Jetpack"
 #~ msgid "Enable/Disable fog"
 #~ msgstr "Habilitar/Desabilitar Jato Propulsor"
 
 #, fuzzy
-#~| msgid "Enable/Disable Jetpack"
 #~ msgid "Enable/Disable scissor"
 #~ msgstr "Habilitar/Desabilitar Jato Propulsor"
 
@@ -18930,12 +18785,10 @@ msgstr ""
 #~ msgstr "Mapeamento de tecla do jogo"
 
 #, fuzzy
-#~| msgid "C-Pad X"
 #~ msgid "C-pad X"
 #~ msgstr "C-Pad X"
 
 #, fuzzy
-#~| msgid "C-Pad Y"
 #~ msgid "C-pad Y"
 #~ msgstr "C-Pad Y"
 
@@ -18967,44 +18820,30 @@ msgstr ""
 #~ "(or click 'Download patch' button. But note - it only downloads, you will "
 #~ "have to continue from there)\n"
 #~ msgstr ""
-#~ "(ou clique no botão 'Baixar correção'. Mas observe - somente baixa, você "
-#~ "tem que dar continuidade a partir daí)\n"
+#~ "(ou clique no botão 'Baixar correção'. Mas observe - somente baixa, você tem"
+#~ " que dar continuidade a partir daí)\n"
 
 #, fuzzy
-#~| msgid ""
-#~| "GK2 has a fan made subtitles, available thanks to the good persons at "
-#~| "SierraHelp.\n"
-#~| "\n"
-#~| "Installation:\n"
-#~| "- download http://www.sierrahelp.com/Files/Patches/GabrielKnight/"
-#~| "GK2Subtitles.zip\n"
 #~ msgid ""
-#~ "GK2 has fan made subtitles, available thanks to the good people at "
-#~ "SierraHelp.\n"
+#~ "GK2 has fan made subtitles, available thanks to the good people at SierraHelp.\n"
 #~ "\n"
 #~ "Installation:\n"
-#~ "- download http://www.sierrahelp.com/Files/Patches/GabrielKnight/"
-#~ "GK2Subtitles.zip\n"
+#~ "- download http://www.sierrahelp.com/Files/Patches/GabrielKnight/GK2Subtitles.zip\n"
 #~ msgstr ""
-#~ "GK2 possui legendas feita por fãs, disponíveis graças às boas pessoas em "
-#~ "SierraHelp.\n"
+#~ "GK2 possui legendas feita por fãs, disponíveis graças às boas pessoas em SierraHelp.\n"
 #~ "\n"
 #~ "Instalação:\n"
-#~ "- baixe http://www.sierrahelp.com/Files/Patches/GabrielKnight/"
-#~ "GK2Subtitles.zip\n"
+#~ "- baixe http://www.sierrahelp.com/Files/Patches/GabrielKnight/GK2Subtitles.zip\n"
 
 #, fuzzy
-#~| msgid "Toggle music on/off"
 #~ msgid "Toggle music on / off"
 #~ msgstr "Ligar/desligar música"
 
 #, fuzzy
-#~| msgid "Toggle sound effects on/off"
 #~ msgid "Toggle sound effects on / off"
 #~ msgstr "Ligar/desligar efeitos sonoros"
 
 #, fuzzy
-#~| msgid "Toggle fast mode on/off"
 #~ msgid "Toggle fast mode on / off"
 #~ msgstr "Ativar/Desativar modo rápido"
 
@@ -19012,22 +18851,18 @@ msgstr ""
 #~ msgstr "Alterna entre correção do fator de proporção"
 
 #, fuzzy
-#~| msgid "Rotate up"
 #~ msgid "Page up"
 #~ msgstr "Girar para cima"
 
 #, fuzzy
-#~| msgid "Rotate down"
 #~ msgid "Page down"
 #~ msgstr "Girar para baixo"
 
 #, fuzzy
-#~| msgid "Scroll up"
 #~ msgid "Scroll up page"
 #~ msgstr "Rolar para cima"
 
 #, fuzzy
-#~| msgid "Scroll down"
 #~ msgid "Scroll down page"
 #~ msgstr "Rolar para baixo"
 
@@ -19038,57 +18873,46 @@ msgstr ""
 #~ msgstr "Salvar estado de jogo"
 
 #, fuzzy
-#~| msgid "Go to end of line"
 #~ msgid "Go to the line start"
 #~ msgstr "Ir para o fim da linha"
 
 #, fuzzy
-#~| msgid "Go to end of line"
 #~ msgid "Go to the line end"
 #~ msgstr "Ir para o fim da linha"
 
 #, fuzzy
-#~| msgid "Open action menu / Close menu"
 #~ msgid "Open verb menu / Close menu"
 #~ msgstr "Abrir menu de ação / Fechar menu"
 
 #, fuzzy
-#~| msgid "Open options menu"
 #~ msgid "Open options"
 #~ msgstr "Abrir menu de opções"
 
 #, fuzzy
-#~| msgid "Skip dialogue"
 #~ msgid "Skip prolog"
 #~ msgstr "Pular diálogo"
 
 #, fuzzy
-#~| msgid "Show journal"
 #~ msgid "Go forward 1 page"
 #~ msgstr "Exibir diário"
 
 #, fuzzy
-#~| msgid "Show journal"
 #~ msgid "Go back 1 page"
 #~ msgstr "Exibir diário"
 
 #, fuzzy
-#~| msgid "Go to start of line"
 #~ msgid "Go to start of journal"
 #~ msgstr "Ir para o início da linha"
 
 #, fuzzy
-#~| msgid "Go to end of line"
 #~ msgid "Go to end of journal"
 #~ msgstr "Ir para o fim da linha"
 
 #, fuzzy
-#~| msgid "Scroll bar up"
 #~ msgid "Scroll page up"
 #~ msgstr "Rolar barra para cima"
 
 #, fuzzy
-#~| msgid "Scroll bar down"
 #~ msgid "Scroll page down"
 #~ msgstr "Rolar barra para baixo"
 
@@ -19099,19 +18923,17 @@ msgstr ""
 #~ msgstr "Ok"
 
 #~ msgid ""
-#~ "Make implementation of AD&D rules more compliant with the AD&D 2nd "
-#~ "edition handbook"
+#~ "Make implementation of AD&D rules more compliant with the AD&D 2nd edition "
+#~ "handbook"
 #~ msgstr ""
 #~ "Torna a implementação das regras de AD&D mais conforme ao manual da 2ª "
 #~ "edição de AD&D"
 
 #, fuzzy
-#~| msgid "Show journal"
 #~ msgid "Go back a page"
 #~ msgstr "Exibir diário"
 
 #, fuzzy
-#~| msgid "Use Windows cursors"
 #~ msgid "Use Windows mouse cursors"
 #~ msgstr "Utilizar cursores do Windows"
 
@@ -19134,7 +18956,6 @@ msgstr ""
 #~ msgstr "Deslocar para Direita"
 
 #, fuzzy
-#~| msgid "Skip cutscene"
 #~ msgid "Skip Cutscene"
 #~ msgstr "Pular cena"
 
@@ -19142,17 +18963,14 @@ msgstr ""
 #~ msgstr "Licença Freefont"
 
 #, fuzzy
-#~| msgid "Toggle subtitles"
 #~ msgid "Display subtitles"
 #~ msgstr "Ativar/desativar legendas"
 
 #, fuzzy
-#~| msgid "Toggle subtitles"
 #~ msgid "Use subtitles."
 #~ msgstr "Ativar/desativar legendas"
 
 #, fuzzy
-#~| msgid "Toggle subtitles"
 #~ msgid "Use SFX subtitles."
 #~ msgstr "Ativar/desativar legendas"
 
@@ -19184,22 +19002,18 @@ msgstr ""
 #~ msgstr "Carregamento Rápido"
 
 #, fuzzy
-#~| msgid "Move up-left"
 #~ msgid "Move up left"
 #~ msgstr "Mover para cima e esquerda"
 
 #, fuzzy
-#~| msgid "Move up-right"
 #~ msgid "Move up right"
 #~ msgstr "Mover para cima e direita"
 
 #, fuzzy
-#~| msgid "Move down-left"
 #~ msgid "Move down left"
 #~ msgstr "Mover para baixo e esquerda"
 
 #, fuzzy
-#~| msgid "Move down-right"
 #~ msgid "Move down right"
 #~ msgstr "Mover para baixo e direita"
 
@@ -19255,27 +19069,22 @@ msgstr ""
 #~ msgstr "Pular Diálogo"
 
 #, fuzzy
-#~| msgid "Game menu"
 #~ msgid "Game Menu"
 #~ msgstr "Menu do jogo"
 
 #, fuzzy
-#~| msgid "Move up"
 #~ msgid "Move Up"
 #~ msgstr "Mover para cima"
 
 #, fuzzy
-#~| msgid "Move down"
 #~ msgid "Move Down"
 #~ msgstr "Mover para baixo"
 
 #, fuzzy
-#~| msgid "Step back"
 #~ msgid "Step Back"
 #~ msgstr "Passo para trás"
 
 #, fuzzy
-#~| msgid "Move left"
 #~ msgid "Roll Left"
 #~ msgstr "Mover para esquerda"
 
@@ -19286,19 +19095,16 @@ msgstr ""
 #~ msgstr "Olhar para Baixo"
 
 #, fuzzy
-#~| msgid "Toggle Combat"
 #~ msgid "Combat"
 #~ msgstr "Alternar Modo de Combate"
 
 #, fuzzy
-#~| msgid "Side Step"
 #~ msgid "Step"
 #~ msgstr "Passo Lateral"
 
 #~ msgid "Could not find any engine capable of running the selected game"
 #~ msgstr ""
-#~ "Não foi possível encontrar nenhuma engine capaz de rodar o jogo "
-#~ "selecionado"
+#~ "Não foi possível encontrar nenhuma engine capaz de rodar o jogo selecionado"
 
 #, c-format
 #~ msgid "PSX stream cutscene '%s' cannot be played in paletted mode"
@@ -19314,16 +19120,14 @@ msgstr ""
 #~ "Could not find the 'Fate of Atlantis' Macintosh executable.\n"
 #~ "Mac GUI will not be shown."
 #~ msgstr ""
-#~ "Não foi possível encontrar o executável de 'Fate of Atlantis' para "
-#~ "Macintosh.\n"
+#~ "Não foi possível encontrar o executável de 'Fate of Atlantis' para Macintosh.\n"
 #~ "A interface do Mac não será exibida."
 
 #~ msgid ""
 #~ "Could not find the 'LeChuck's Revenge' Macintosh executable.\n"
 #~ "Mac GUI will not be shown."
 #~ msgstr ""
-#~ "Não foi possível encontrar o executável de 'LeChuck's Revenge' para "
-#~ "Macintosh.\n"
+#~ "Não foi possível encontrar o executável de 'LeChuck's Revenge' para Macintosh.\n"
 #~ "A interface do Mac não será exibida."
 
 #~ msgid ""
@@ -19331,9 +19135,9 @@ msgstr ""
 #~ "save/load menu. \t\tUse it together with the \"Ask for confirmation on "
 #~ "exit\" for a more complete experience."
 #~ msgstr ""
-#~ "Permite que o jogo use a interface gráfica da engine e o menu salvar/"
-#~ "carregar originais. \t\tUtilize em conjunto com \"Solicitar confirmação "
-#~ "ao sair\" para uma experiência mais completa."
+#~ "Permite que o jogo use a interface gráfica da engine e o menu "
+#~ "salvar/carregar originais. \t\tUtilize em conjunto com \"Solicitar "
+#~ "confirmação ao sair\" para uma experiência mais completa."
 
 #~ msgid "Show memory consumption"
 #~ msgstr "Exibe o consumo de memória"
@@ -19399,8 +19203,8 @@ msgstr ""
 #~ msgid ""
 #~ "Allow the game to use the in-engine graphical interface and the original "
 #~ "save/load menu. \t\tUse it together with the \"Ask for confirmation on "
-#~ "exit\" for a more complete experience. \t\tAutosaving is disabled when "
-#~ "this mode is active."
+#~ "exit\" for a more complete experience. \t\tAutosaving is disabled when this "
+#~ "mode is active."
 #~ msgstr ""
 #~ "Permite que o jogo use a interface gráfica da engine e o menu original de "
 #~ "salvar/carregar. \t\tUtilize junto com \"Solicitar confirmação ao sair\" "
@@ -19426,32 +19230,26 @@ msgstr ""
 #~ msgstr "aceitar"
 
 #, fuzzy
-#~| msgid "The game in '%s' seems to be unknown."
 #~ msgid "Your set of game files seems to be unknown to us."
 #~ msgstr "O jogo em '% s' parece ser desconhecido."
 
 #, fuzzy
-#~| msgid "Next action"
 #~ msgid "Close action"
 #~ msgstr "Próxima ação"
 
 #, fuzzy
-#~| msgid "Next action"
 #~ msgid "Give action"
 #~ msgstr "Próxima ação"
 
 #, fuzzy
-#~| msgid "Talk to"
 #~ msgid "Talk to action"
 #~ msgstr "Falar"
 
 #, fuzzy
-#~| msgid "Previous action"
 #~ msgid "Push action"
 #~ msgstr "Ação anterior"
 
 #, fuzzy
-#~| msgid "Previous action"
 #~ msgid "Pull action"
 #~ msgstr "Ação anterior"
 
@@ -19459,23 +19257,21 @@ msgstr ""
 #~ msgstr "Abrir Configurações do 3DS"
 
 #, fuzzy
-#~| msgid "Very large"
 #~ msgid "Very very large"
 #~ msgstr "Muito grande"
 
 #~ msgid ""
 #~ "Your game is patched with a fan made script patch. Such patches have been "
 #~ "reported to cause issues, as they modify game scripts extensively. The "
-#~ "issues that these patches fix do not occur in ScummVM, so you are advised "
-#~ "to remove this patch from your game folder in order to avoid having "
-#~ "unexpected errors and/or issues later on."
+#~ "issues that these patches fix do not occur in ScummVM, so you are advised to"
+#~ " remove this patch from your game folder in order to avoid having unexpected"
+#~ " errors and/or issues later on."
 #~ msgstr ""
 #~ "Seu jogo foi corrigido com um script de correção feito por fãs. Tais "
 #~ "correções foram relatadas por causarem problemas, visto que modificam "
 #~ "scripts do jogo extensivamente. Os problemas que estas correções corrigem "
-#~ "não ocorrem com o ScummVM, assim você é aconselhado a remover essa "
-#~ "correção da pasta de seu jogo para evitar erros inesperados ou problemas "
-#~ "posteriores."
+#~ "não ocorrem com o ScummVM, assim você é aconselhado a remover essa correção "
+#~ "da pasta de seu jogo para evitar erros inesperados ou problemas posteriores."
 
 #~ msgid "Update Shaders"
 #~ msgstr "Atualizar Shaders"
@@ -19487,33 +19283,28 @@ msgstr ""
 #~ msgstr "Habilitar aprimoramentos específicos do jogo"
 
 #~ msgid ""
-#~ "Allow ScummVM to make small enhancements to the game, usually based on "
-#~ "other versions of the same game."
+#~ "Allow ScummVM to make small enhancements to the game, usually based on other"
+#~ " versions of the same game."
 #~ msgstr ""
-#~ "Permite que o ScummVM faça pequenas melhorias no jogo, geralmente "
-#~ "baseadas em outras versões do mesmo jogo."
+#~ "Permite que o ScummVM faça pequenas melhorias no jogo, geralmente baseadas "
+#~ "em outras versões do mesmo jogo."
 
 #~ msgid "New Line"
 #~ msgstr "Nova Linha"
 
 #~ msgid ""
-#~ "Could not find the 'Loom' Macintosh executable. Music and high-"
-#~ "resolution\n"
+#~ "Could not find the 'Loom' Macintosh executable. Music and high-resolution\n"
 #~ "versions of font and cursor will be disabled."
 #~ msgstr ""
-#~ "Não foi possível encontrar o executável de 'Loom' para Macintosh. Música "
-#~ "e versões\n"
+#~ "Não foi possível encontrar o executável de 'Loom' para Macintosh. Música e versões\n"
 #~ "de alta resolução da fonte e do cursor serão desativadas."
 
 #~ msgid ""
 #~ "## Keyboard shortcuts\n"
 #~ "\n"
-#~ "ScummVM supports various in-game keyboard and mouse shortcuts, and since "
-#~ "version 2.2.0 these can be manually configured in the **Keymaps tab**, or "
-#~ "in the **configuration file**.\n"
+#~ "ScummVM supports various in-game keyboard and mouse shortcuts, and since version 2.2.0 these can be manually configured in the **Keymaps tab**, or in the **configuration file**.\n"
 #~ "\n"
-#~ "For game-specific controls, see the [wiki entry](https://wiki.scummvm.org/"
-#~ "index.php?title=Category:Supported_Games) for the game you are playing.\n"
+#~ "For game-specific controls, see the [wiki entry](https://wiki.scummvm.org/index.php?title=Category:Supported_Games) for the game you are playing.\n"
 #~ "\n"
 #~ "Default shortcuts are shown in the table.\n"
 #~ "\n"
@@ -19523,13 +19314,9 @@ msgstr ""
 #~ msgstr ""
 #~ "## Atalhos do teclado\n"
 #~ "\n"
-#~ "ScummVM é compatível com vários atalhos de teclado e mouse no jogo e, "
-#~ "desde a versão 2.2.0, eles podem ser configurados manualmente na **guia "
-#~ "Mapeamento de Teclas** ou no **arquivo de configuração**.\n"
+#~ "ScummVM é compatível com vários atalhos de teclado e mouse no jogo e, desde a versão 2.2.0, eles podem ser configurados manualmente na **guia Mapeamento de Teclas** ou no **arquivo de configuração**.\n"
 #~ "\n"
-#~ "Para controles específicos do jogo, consulte o [registro wiki](https://"
-#~ "wiki.scummvm.org/index.php?title=Category:Supported_Games) do jogo que "
-#~ "você está jogando.\n"
+#~ "Para controles específicos do jogo, consulte o [registro wiki](https://wiki.scummvm.org/index.php?title=Category:Supported_Games) do jogo que você está jogando.\n"
 #~ "\n"
 #~ "Os atalhos padrão são exibidos na tabela.\n"
 #~ "\n"
@@ -19552,61 +19339,39 @@ msgstr ""
 #~ msgid ""
 #~ "| `Ctrl+u`  -- Mutes all sounds\n"
 #~ "| `Ctrl+m`  -- Toggles mouse capture\n"
-#~ "| `Ctrl+Alt` and `9` or `0` -- Cycles forwards/backwards between graphics "
-#~ "filters\n"
+#~ "| `Ctrl+Alt` and `9` or `0` -- Cycles forwards/backwards between graphics filters\n"
 #~ "| `Ctrl+Alt` and `+` or `-` -- Increases/decreases the scale factor\n"
 #~ "| `Ctrl+Alt+a` -- Toggles aspect ratio correction on/off\n"
-#~ "| `Ctrl+Alt+f` -- Toggles between nearest neighbor and bilinear "
-#~ "interpolation (graphics filtering on/off)\n"
+#~ "| `Ctrl+Alt+f` -- Toggles between nearest neighbor and bilinear interpolation (graphics filtering on/off)\n"
 #~ "| `Ctrl+Alt+s` -- Cycles through stretch modes\n"
 #~ "| `Alt+Enter`   -- Toggles full screen/windowed mode\n"
 #~ "| `Alt+s`          -- Takes a screenshot\n"
-#~ "| `Ctrl+F7`       -- Opens virtual keyboard (if enabled). This can also "
-#~ "be opened with a long press of the middle mouse button or wheel.\n"
+#~ "| `Ctrl+F7`       -- Opens virtual keyboard (if enabled). This can also be opened with a long press of the middle mouse button or wheel.\n"
 #~ "| `Ctrl+Alt+d` -- Opens the ScummVM debugger\n"
 #~ msgstr ""
 #~ "| `Ctrl+u`  -- Silencia todos os sons\n"
 #~ "| `Ctrl+m`  -- Alterna captura do mouse\n"
-#~ "| `Ctrl+Alt` e `9` ou `0` -- Alterna para frente/para trás entre os "
-#~ "filtros gráficos\n"
+#~ "| `Ctrl+Alt` e `9` ou `0` -- Alterna para frente/para trás entre os filtros gráficos\n"
 #~ "| `Ctrl+Alt` e `+` ou `-` -- Aumenta/reduz o fator de escala\n"
 #~ "| `Ctrl+Alt+a` -- Alterna a correção de aspecto ligado/desligado\n"
-#~ "| `Ctrl+Alt+f` -- Alterna entre escala sem filtro e interpolação bilinear "
-#~ "(filtro de gráficos ligado/desligado)\n"
+#~ "| `Ctrl+Alt+f` -- Alterna entre escala sem filtro e interpolação bilinear (filtro de gráficos ligado/desligado)\n"
 #~ "| `Ctrl+Alt+s` -- Alterna entre os modos de redimensionamento\n"
 #~ "| `Alt+Enter`   -- Alterna entre o modo tela cheia/janela\n"
 #~ "| `Alt+s`          -- Captura um instantâneo\n"
-#~ "| `Ctrl+F7`       -- Abre o teclado virtual (se estiver habilitado). Este "
-#~ "pode também ser aberto segurando por um tempo o toque com o botão do meio "
-#~ "do mouse ou a roda.\n"
+#~ "| `Ctrl+F7`       -- Abre o teclado virtual (se estiver habilitado). Este pode também ser aberto segurando por um tempo o toque com o botão do meio do mouse ou a roda.\n"
 #~ "| `Ctrl+Alt+d` -- Abre o depurador do ScummVM\n"
 
 #~ msgid "Controls Help"
 #~ msgstr "Ajuda sobre Controles"
 
 #, fuzzy
-#~| msgid ""
-#~| "Gestures and controls:\n"
-#~| "\n"
-#~| "One finger tap: Left mouse click\n"
-#~| "Two finger tap: Right mouse click\n"
-#~| "Two finger double tap: ESC\n"
-#~| "Two finger swipe (bottom to top): Toggles Click and drag mode\n"
-#~| "Two finger swipe (left to right): Toggles between touch direct mode and "
-#~| "touchpad mode\n"
-#~| "Two finger swipe (right to left): Shows/hides on-screen controls\n"
-#~| "Two finger swipe (top to bottom): Global Main Menu\n"
-#~| "Three finger swipe: Arrow keys\n"
-#~| "Pinch gesture: Enables/disables keyboard\n"
-#~| "Keyboard spacebar: Pause"
 #~ msgid ""
 #~ "Gestures and controls:\n"
 #~ "\n"
 #~ "One finger tap: Left mouse click\n"
 #~ "Two finger tap: Right mouse click\n"
 #~ "Two finger double tap: ESC\n"
-#~ "Two finger swipe (left to right): Toggles between touch direct mode and "
-#~ "touchpad mode\n"
+#~ "Two finger swipe (left to right): Toggles between touch direct mode and touchpad mode\n"
 #~ "Two finger swipe (right to left): Shows/hides on-screen controls\n"
 #~ "Two finger swipe (top to bottom): Global Main Menu\n"
 #~ "Three finger swipe: Arrow keys\n"
@@ -19618,12 +19383,9 @@ msgstr ""
 #~ "Toque com um dedo: Clique com o botão esquerdo do mouse\n"
 #~ "Toque com dois dedos: Clique com o botão direito do mouse\n"
 #~ "Toque duplo com dois dedos: ESC\n"
-#~ "Deslizar com dois dedos (de baixo para cima): Alterna o modo clicar e "
-#~ "arrastar\n"
-#~ "Deslizar com dois dedos (da esquerda para a direita): Alterna entre o "
-#~ "modo de toque direto e o modo de touchpad\n"
-#~ "Deslizar com dois dedos (da direita para a esquerda): Exibe/oculta os "
-#~ "controles na tela\n"
+#~ "Deslizar com dois dedos (de baixo para cima): Alterna o modo clicar e arrastar\n"
+#~ "Deslizar com dois dedos (da esquerda para a direita): Alterna entre o modo de toque direto e o modo de touchpad\n"
+#~ "Deslizar com dois dedos (da direita para a esquerda): Exibe/oculta os controles na tela\n"
 #~ "Deslizar com dois dedos (de cima para baixo): Menu Principal Global\n"
 #~ "Deslizar com três dedos: Teclas de seta\n"
 #~ "Gesto de pinça: Ativa/desativa o teclado\n"
@@ -19646,21 +19408,14 @@ msgstr ""
 #~ "Usando o controle remoto da Apple TV:\n"
 #~ "\n"
 #~ "Pressionar Área de toque: Clique com o botão esquerdo do mouse\n"
-#~ "Pressionar o botão Reproduzir/Pausar: Clique com o botão direito do "
-#~ "mouse\n"
+#~ "Pressionar o botão Reproduzir/Pausar: Clique com o botão direito do mouse\n"
 #~ "Pressionar o botão Voltar/Menu durante o jogo: Menu Principal Global\n"
-#~ "Pressionar o botão Voltar/Menu no inicializador: Tela Principal da Apple "
-#~ "TV\n"
-#~ "Pressionar e segurar o botão Reproduzir/Pausar: Mostrar teclado com "
-#~ "teclas adicionais\n"
-#~ "Toque (não pressionar) na parte superior da Área de toque: Tecla de seta "
-#~ "para cima\n"
-#~ "Toque (não pressionar) à esquerda da Área de toque: Tecla de seta para a "
-#~ "esquerda\n"
-#~ "Toque (não pressionar) à direita da Área de toque: Tecla de seta para a "
-#~ "direita\n"
-#~ "Toque (não pressionar) na parte inferior da Área de toque: Tecla de seta "
-#~ "para baixo\n"
+#~ "Pressionar o botão Voltar/Menu no inicializador: Tela Principal da Apple TV\n"
+#~ "Pressionar e segurar o botão Reproduzir/Pausar: Mostrar teclado com teclas adicionais\n"
+#~ "Toque (não pressionar) na parte superior da Área de toque: Tecla de seta para cima\n"
+#~ "Toque (não pressionar) à esquerda da Área de toque: Tecla de seta para a esquerda\n"
+#~ "Toque (não pressionar) à direita da Área de toque: Tecla de seta para a direita\n"
+#~ "Toque (não pressionar) na parte inferior da Área de toque: Tecla de seta para baixo\n"
 #~ "Barra de espaço do teclado: Pausa"
 
 #~ msgid "Mouse-click-and-drag mode"
@@ -19684,29 +19439,21 @@ msgstr ""
 #~ msgid ""
 #~ "## Adding SAF paths to ScummVM directory list\n"
 #~ "\n"
-#~ "Starting with version 2.7.0 of ScummVM for Android, significant changes "
-#~ "were made to the file access system to allow support for modern versions "
-#~ "of the Android Operating System.\n"
+#~ "Starting with version 2.7.0 of ScummVM for Android, significant changes were made to the file access system to allow support for modern versions of the Android Operating System.\n"
 #~ "\n"
-#~ "If you find that your existing added games or custom paths no longer "
-#~ "work, please edit those paths and this time use the SAF system to browse "
-#~ "to the desired locations.\n"
+#~ "If you find that your existing added games or custom paths no longer work, please edit those paths and this time use the SAF system to browse to the desired locations.\n"
 #~ "\n"
 #~ "To do that:\n"
 #~ "\n"
-#~ "  1. For each game whose data is not found, go to the \"Paths\" tab in "
-#~ "the \"Game Options\" and change the \"Game path\"\n"
+#~ "  1. For each game whose data is not found, go to the \"Paths\" tab in the \"Game Options\" and change the \"Game path\"\n"
 #~ "\n"
-#~ "  2. Inside the ScummVM file browser, use \"Go Up\" until you reach the "
-#~ "\"root\" folder where you will see the \"<Add a new folder>\" option.\n"
+#~ "  2. Inside the ScummVM file browser, use \"Go Up\" until you reach the \"root\" folder where you will see the \"<Add a new folder>\" option.\n"
 #~ "\n"
 #~ "  ![File browser](browser-root.png \"Android browser\")\n"
 #~ "\n"
 #~ "    File Browser root with <Add a new folder> item\n"
 #~ "\n"
-#~ "  3. Choose that, then browse and select the \"parent\" folder for your "
-#~ "games subfolders, e.g. \"SD Card > ScummVMgames\". Click on \"Use this "
-#~ "folder\".\n"
+#~ "  3. Choose that, then browse and select the \"parent\" folder for your games subfolders, e.g. \"SD Card > ScummVMgames\". Click on \"Use this folder\".\n"
 #~ "\n"
 #~ "  ![OS file browser root](fs-root.png \"OS file browser root\")\n"
 #~ "\n"
@@ -19716,13 +19463,11 @@ msgstr ""
 #~ "\n"
 #~ "    OS file browser selectable folder with \"Use this folder\" button\n"
 #~ "\n"
-#~ "  ![OS access permission dialog](fs-permission.png \"OS access "
-#~ "permission\")\n"
+#~ "  ![OS access permission dialog](fs-permission.png \"OS access permission\")\n"
 #~ "\n"
 #~ "    OS file browser ask to grant ScummVM directory access permission\n"
 #~ "\n"
-#~ "  4. Then, a new folder \"ScummVMgames\" will appear on the \"root\" "
-#~ "folder of the ScummVM browser.\n"
+#~ "  4. Then, a new folder \"ScummVMgames\" will appear on the \"root\" folder of the ScummVM browser.\n"
 #~ "\n"
 #~ "  ![SAF folder added](browser-folder-in-list.png \"SAF folder added\")\n"
 #~ "\n"
@@ -19735,105 +19480,76 @@ msgstr ""
 #~ "\n"
 #~ "## Removing SAF path authorizations\n"
 #~ "\n"
-#~ "In case you would like to revoke any of the granted SAF authorizations, "
-#~ "there is an option for this in the \"Global Options > Backend\" tab as "
-#~ "shown on the screenshot below:\n"
+#~ "In case you would like to revoke any of the granted SAF authorizations, there is an option for this in the \"Global Options > Backend\" tab as shown on the screenshot below:\n"
 #~ "\n"
-#~ "![\"Remove folder authorizations...\" button](gui-remove-permissions.png "
-#~ "\"'Remove folder authorizations...' button\")\n"
+#~ "![\"Remove folder authorizations...\" button](gui-remove-permissions.png \"'Remove folder authorizations...' button\")\n"
 #~ "\n"
 #~ "    GUI tab with \"Remove folder authorizations...\" button\n"
 #~ "\n"
-#~ "![List of authorizations to revoked](gui-remove-list.png \"List of "
-#~ "authorizations to revoke\")\n"
+#~ "![List of authorizations to revoked](gui-remove-list.png \"List of authorizations to revoke\")\n"
 #~ "\n"
 #~ "    GUI dialog with list of authorizations to revoke\n"
 #~ "\n"
-#~ "In case you revoke authorization to a path, still used for specific games/"
-#~ "titles, please follow the procedure of fixing them outlined in the "
-#~ "previous subheading.\n"
+#~ "In case you revoke authorization to a path, still used for specific games/titles, please follow the procedure of fixing them outlined in the previous subheading.\n"
 #~ msgstr ""
 #~ "## Adicionando caminhos SAF à lista de diretórios do ScummVM\n"
 #~ "\n"
-#~ "A partir da versão 2.7.0 do ScummVM para Android, foram feitas alterações "
-#~ "significativas no sistema de acesso a arquivos para permitir suporte a "
-#~ "versões modernas do sistema operacional Android.\n"
+#~ "A partir da versão 2.7.0 do ScummVM para Android, foram feitas alterações significativas no sistema de acesso a arquivos para permitir suporte a versões modernas do sistema operacional Android.\n"
 #~ "\n"
-#~ "Se você achar que seus jogos adicionados ou caminhos personalizados "
-#~ "existentes não funcionam mais, edite esses caminhos e desta vez use o "
-#~ "sistema SAF para navegar até os locais desejados.\n"
+#~ "Se você achar que seus jogos adicionados ou caminhos personalizados existentes não funcionam mais, edite esses caminhos e desta vez use o sistema SAF para navegar até os locais desejados.\n"
 #~ "\n"
 #~ "Para isso:\n"
 #~ "\n"
-#~ "  1. Para cada jogo cujos dados não forem encontrados, vá até a aba "
-#~ "“Caminhos” em “Opções de Jogo” e altere o “Caminho do Jogo”\n"
+#~ "  1. Para cada jogo cujos dados não forem encontrados, vá até a aba “Caminhos” em “Opções de Jogo” e altere o “Caminho do Jogo”\n"
 #~ "\n"
-#~ "  2. Dentro do navegador de arquivos do ScummVM, use \"Para cima\" até "
-#~ "chegar à pasta \"raiz\" onde você verá a opção \"<Adicionar uma nova "
-#~ "pasta>\".\n"
+#~ "  2. Dentro do navegador de arquivos do ScummVM, use \"Para cima\" até chegar à pasta \"raiz\" onde você verá a opção \"<Adicionar uma nova pasta>\".\n"
 #~ "\n"
 #~ "  ![Navegador de arquivos](browser-root.png \"Navegador Android\")\n"
 #~ "\n"
 #~ "    Raiz do navegador de arquivos com o item <Adicionar uma nova pasta>\n"
 #~ "\n"
-#~ "  3. Selecione isso, navegue e selecione a pasta \"pai\" para as "
-#~ "subpastas de seus jogos, por exemplo. \"Cartão SD > JogosScummVM\". "
-#~ "Clique em \"Utilizar esta pasta\".\n"
+#~ "  3. Selecione isso, navegue e selecione a pasta \"pai\" para as subpastas de seus jogos, por exemplo. \"Cartão SD > JogosScummVM\". Clique em \"Utilizar esta pasta\".\n"
 #~ "\n"
-#~ "  ![Raiz do navegador de arquivos do SO](fs-root.png \"Raiz do navegador "
-#~ "de arquivos do SO\")\n"
+#~ "  ![Raiz do navegador de arquivos do SO](fs-root.png \"Raiz do navegador de arquivos do SO\")\n"
 #~ "\n"
 #~ "    Raiz do navegador de arquivos do sistema operacional\n"
 #~ "\n"
-#~ "  ![Pasta selecionável do SO](fs-folder.png \"Pasta selecionável do "
-#~ "SO\")\n"
+#~ "  ![Pasta selecionável do SO](fs-folder.png \"Pasta selecionável do SO\")\n"
 #~ "\n"
-#~ "    Pasta selecionável pelo navegador de arquivos do sistema operacional "
-#~ "com o botão \"Utilizar esta pasta\"\n"
+#~ "    Pasta selecionável pelo navegador de arquivos do sistema operacional com o botão \"Utilizar esta pasta\"\n"
 #~ "\n"
-#~ "  ![Caixa de diálogo de permissão de acesso ao SO](fs-permission.png "
-#~ "\"Permissão de acesso ao SO\")\n"
+#~ "  ![Caixa de diálogo de permissão de acesso ao SO](fs-permission.png \"Permissão de acesso ao SO\")\n"
 #~ "\n"
-#~ "    O navegador de arquivos do sistema operacional solicita permissão de "
-#~ "acesso ao diretório ScummVM\n"
+#~ "    O navegador de arquivos do sistema operacional solicita permissão de acesso ao diretório ScummVM\n"
 #~ "\n"
-#~ "  4. Em seguida, uma nova pasta “JogosScummVM” aparecerá na pasta “raiz” "
-#~ "do navegador ScummVM.\n"
+#~ "  4. Em seguida, uma nova pasta “JogosScummVM” aparecerá na pasta “raiz” do navegador ScummVM.\n"
 #~ "\n"
-#~ "  ![Pasta SAF adicionada](browser-folder-in-list.png \"Pasta SAF "
-#~ "adicionada\")\n"
+#~ "  ![Pasta SAF adicionada](browser-folder-in-list.png \"Pasta SAF adicionada\")\n"
 #~ "\n"
 #~ "    Navegador de arquivos com pasta SAF adicionada na raiz\n"
 #~ "\n"
 #~ "  5. Navegue por esta pasta até chegar aos arquivos do jogo.\n"
 #~ "\n"
-#~ "As etapas 2 e 3 precisam ser executadas apenas uma vez para todos os seus "
-#~ "jogos.\n"
+#~ "As etapas 2 e 3 precisam ser executadas apenas uma vez para todos os seus jogos.\n"
 #~ "\n"
 #~ "\n"
 #~ "## Removendo autorizações de caminho SAF\n"
 #~ "\n"
-#~ "Caso você queira revogar alguma das autorizações SAF concedidas, existe "
-#~ "uma opção para isso na aba \"Opções Globais > Backend\" conforme mostrado "
-#~ "na imagem abaixo:\n"
+#~ "Caso você queira revogar alguma das autorizações SAF concedidas, existe uma opção para isso na aba \"Opções Globais > Backend\" conforme mostrado na imagem abaixo:\n"
 #~ "\n"
-#~ "![Botão \"Remover autorizações de pasta...\"](gui-remove-permissions.png "
-#~ "\"Botão 'Remover autorizações de pasta...'\")\n"
+#~ "![Botão \"Remover autorizações de pasta...\"](gui-remove-permissions.png \"Botão 'Remover autorizações de pasta...'\")\n"
 #~ "\n"
 #~ "    Guia da interface com botão \"Remover autorizações de pasta...\"\n"
 #~ "\n"
-#~ "![Lista de autorizações a serem revogadas](gui-remove-list.png \"Lista de "
-#~ "autorizações a serem revogadas\")\n"
+#~ "![Lista de autorizações a serem revogadas](gui-remove-list.png \"Lista de autorizações a serem revogadas\")\n"
 #~ "\n"
 #~ "    Diálogo da interface com lista de autorizações para revogar\n"
 #~ "\n"
-#~ "Caso você revogue a autorização de um caminho, ainda utilizado para jogos/"
-#~ "títulos específicos, siga o procedimento de correção descrito no "
-#~ "subtítulo anterior.\n"
+#~ "Caso você revogue a autorização de um caminho, ainda utilizado para jogos/títulos específicos, siga o procedimento de correção descrito no subtítulo anterior.\n"
 
 #~ msgid ""
-#~ "The teenagent.dat file is compressed and zlib hasn't been included in "
-#~ "this executable. Please decompress it"
+#~ "The teenagent.dat file is compressed and zlib hasn't been included in this "
+#~ "executable. Please decompress it"
 #~ msgstr ""
 #~ "O arquivo teenagent.dat está compactado e zlib não foi incluso neste "
 #~ "executável. Favor descompactá-lo"
@@ -19891,12 +19607,12 @@ msgstr ""
 #~ msgstr "Ir para tela do mapa"
 
 #~ msgid ""
-#~ "Use the original engine's main, save/load, and setup menus. ScummVM's "
-#~ "Global Main Menu can still be accessed through its keymap."
+#~ "Use the original engine's main, save/load, and setup menus. ScummVM's Global"
+#~ " Main Menu can still be accessed through its keymap."
 #~ msgstr ""
 #~ "Utiliza o menu principal, salvar/carregar e de configuração original da "
-#~ "engine. O Menu Principal Global do ScummVM ainda pode ser acessado por "
-#~ "meio de sua tecla de atalho mapeada."
+#~ "engine. O Menu Principal Global do ScummVM ainda pode ser acessado por meio "
+#~ "de sua tecla de atalho mapeada."
 
 #~ msgid "Enable Second Chance"
 #~ msgstr "Habilitar Segunda Chance"
@@ -19969,8 +19685,8 @@ msgstr ""
 #~ msgid ""
 #~ "Allows the game to use low latency audio, at the cost of sound accuracy."
 #~ msgstr ""
-#~ "Premite que o jogo utilize áudio de baixa latência, sacrificando a "
-#~ "precisão do som."
+#~ "Premite que o jogo utilize áudio de baixa latência, sacrificando a precisão "
+#~ "do som."
 
 #~ msgctxt "lowres"
 #~ msgid "Misc"
@@ -19980,8 +19696,8 @@ msgstr ""
 #~ "Compressed game detected. Please uncompress it as specified in the game "
 #~ "description on our Wiki"
 #~ msgstr ""
-#~ "Jogo compactado detectado. Por favor, descompacte-o conforme especificado "
-#~ "na descrição do jogo em nosso Wiki"
+#~ "Jogo compactado detectado. Por favor, descompacte-o conforme especificado na"
+#~ " descrição do jogo em nosso Wiki"
 
 #~ msgid "Group by: "
 #~ msgstr "Agrupar por: "
@@ -20086,11 +19802,11 @@ msgstr ""
 #~ "mais recente do ScummVM."
 
 #~ msgid ""
-#~ "WARNING: Existing save has longer gameplay duration than the current "
-#~ "state. Are you sure you want to overwrite it?"
+#~ "WARNING: Existing save has longer gameplay duration than the current state. "
+#~ "Are you sure you want to overwrite it?"
 #~ msgstr ""
-#~ "AVISO: O jogo salvo existente tem duração de jogo mais longa do que o "
-#~ "estado atual. Tem certeza de que deseja sobrescrever?"
+#~ "AVISO: O jogo salvo existente tem duração de jogo mais longa do que o estado"
+#~ " atual. Tem certeza de que deseja sobrescrever?"
 
 #~ msgid "I don't understand your command. "
 #~ msgstr "Eu não entendo seu comando. "
@@ -20243,8 +19959,8 @@ msgstr ""
 #~ msgstr "Utilizar espaçamento de fonte correto"
 
 #~ msgid ""
-#~ "Draw text with correct font spacing. This arguably looks better, but "
-#~ "doesn't match the original behavior."
+#~ "Draw text with correct font spacing. This arguably looks better, but doesn't"
+#~ " match the original behavior."
 #~ msgstr ""
 #~ "Desenha o texto com espaçamento de fonte correto. Isso sem dúvida fica "
 #~ "melhor, mas não corresponde ao comportamento original."
@@ -20257,12 +19973,11 @@ msgstr ""
 #~ msgstr "~E~ditar Jogo..."
 
 #~ msgid ""
-#~ "Adjusts the timing of the EGA Loom Overture when using enhanced music. "
-#~ "The lower the value, the earlier the Lucasfilm logo appears."
+#~ "Adjusts the timing of the EGA Loom Overture when using enhanced music. The "
+#~ "lower the value, the earlier the Lucasfilm logo appears."
 #~ msgstr ""
 #~ "Ajusta a sincronização da Abertura de Loom EGA ao utilizar música "
-#~ "aprimorada. Quanto menor o valor, mais cedo o logotipo da Lucasfilm "
-#~ "aparece."
+#~ "aprimorada. Quanto menor o valor, mais cedo o logotipo da Lucasfilm aparece."
 
 #~ msgid "Swap Menu and Back buttons"
 #~ msgstr "Inverter botões Menu e Voltar"
@@ -20392,8 +20107,7 @@ msgstr ""
 #~ msgstr "Usar controle de cursor estilo trackpad"
 
 #~ msgid "Tap for left click, double tap right click"
-#~ msgstr ""
-#~ "Um toque para o clique esquerdo, e toque duplo para o clique direito"
+#~ msgstr "Um toque para o clique esquerdo, e toque duplo para o clique direito"
 
 #~ msgid "Sensitivity"
 #~ msgstr "Sensibilidade"
@@ -20405,8 +20119,7 @@ msgstr ""
 #~ msgstr "Dimensão da tela principal:"
 
 #~ msgid "Unscaled (you must scroll left and right)"
-#~ msgstr ""
-#~ "Sem redimensionamento (você precisa rolar para a esquerda e direita)"
+#~ msgstr "Sem redimensionamento (você precisa rolar para a esquerda e direita)"
 
 #~ msgid "Brightness:"
 #~ msgstr "Brilho:"
@@ -20463,8 +20176,8 @@ msgstr ""
 #~ msgstr "Guarda média"
 
 #~ msgid ""
-#~ "The Russian version of Pajama Sam 2 is not supported yet due to "
-#~ "incomplete code."
+#~ "The Russian version of Pajama Sam 2 is not supported yet due to incomplete "
+#~ "code."
 #~ msgstr ""
 #~ "A versão Russa de Pajama Sam 2 ainda não é suportada devido ao código "
 #~ "incompleto."
@@ -20499,16 +20212,12 @@ msgstr ""
 #~ msgid ""
 #~ "Your game version appears to be unknown. If this is *NOT* a fan-modified\n"
 #~ "version (in particular, not a fan-made translation), please, report the\n"
-#~ "following data to the ScummVM team along with the name of the game you "
-#~ "tried\n"
+#~ "following data to the ScummVM team along with the name of the game you tried\n"
 #~ "to add and its version, language, etc.:\n"
 #~ msgstr ""
-#~ "A versão de seu jogo parece ser desconhecida. Se esta *NÃO É* uma versão "
-#~ "modificada\n"
-#~ "por fãs (particularmente, não é uma tradução feita por fãs), por favor, "
-#~ "relate\n"
-#~ "os seguintes dados para o time do ScummVM junto com o nome do jogo que "
-#~ "você tentou\n"
+#~ "A versão de seu jogo parece ser desconhecida. Se esta *NÃO É* uma versão modificada\n"
+#~ "por fãs (particularmente, não é uma tradução feita por fãs), por favor, relate\n"
+#~ "os seguintes dados para o time do ScummVM junto com o nome do jogo que você tentou\n"
 #~ "adicionar e sua versão, idioma, etc.:\n"
 
 #~ msgid ""
@@ -20530,8 +20239,8 @@ msgstr ""
 #~ "Use an IBM Music Feature card or a Yamaha FB-01 FM synth module for MIDI "
 #~ "output"
 #~ msgstr ""
-#~ "Utiliza uma placa IBM Music Feature ou um módulo sintetizador Yamaha "
-#~ "FB-01 para saída de MIDI"
+#~ "Utiliza uma placa IBM Music Feature ou um módulo sintetizador Yamaha FB-01 "
+#~ "para saída de MIDI"
 
 #~ msgid "Interact via Left Click)"
 #~ msgstr "Interagir com Clique Esquerdo)"
@@ -20627,13 +20336,12 @@ msgstr ""
 
 #~ msgid "You must map a key to the 'Right Click' action to play this game"
 #~ msgstr ""
-#~ "Você precisa mapear uma tecla para ação do \"Clique da Direita\" nesse "
-#~ "jogo"
+#~ "Você precisa mapear uma tecla para ação do \"Clique da Direita\" nesse jogo"
 
 #~ msgid "You must map a key to the 'Hide toolbar' action to play this game"
 #~ msgstr ""
-#~ "Você precisa mapear uma tecla para ação do \"Ocultar barra de "
-#~ "ferramentas\" nesse jogo"
+#~ "Você precisa mapear uma tecla para ação do \"Ocultar barra de ferramentas\" "
+#~ "nesse jogo"
 
 #~ msgid "Map Zoom Up action (optional)"
 #~ msgstr "Mapear Zoom para Cima (opcional)"
@@ -20645,8 +20353,8 @@ msgstr ""
 #~ "Don't forget to map a key to 'Hide Toolbar' action to see the whole "
 #~ "inventory"
 #~ msgstr ""
-#~ "Não se esqueça de mapear uma tecla para \"Ocultar a barra de "
-#~ "ferramentas\" para ver todo o seu inventário"
+#~ "Não se esqueça de mapear uma tecla para \"Ocultar a barra de ferramentas\" "
+#~ "para ver todo o seu inventário"
 
 #, fuzzy
 #~ msgid "Saved games sync complete."
@@ -20685,18 +20393,18 @@ msgstr ""
 #~ msgstr "Taxa de saída:"
 
 #~ msgid ""
-#~ "Higher value specifies better sound quality but may be not supported by "
-#~ "your soundcard"
+#~ "Higher value specifies better sound quality but may be not supported by your"
+#~ " soundcard"
 #~ msgstr ""
-#~ "Maior valor especifica melhor qualidade de som, mas pode não ser "
-#~ "suportado por sua placa de som"
+#~ "Maior valor especifica melhor qualidade de som, mas pode não ser suportado "
+#~ "por sua placa de som"
 
 #~ msgid ""
-#~ "The theme you selected does not support your current language. If you "
-#~ "want to use this theme you need to switch to another language first."
+#~ "The theme you selected does not support your current language. If you want "
+#~ "to use this theme you need to switch to another language first."
 #~ msgstr ""
-#~ "O tema que você selecionou não suporta seu idioma atual. Se você quiser "
-#~ "usar este tema você precisa mudar para outro idioma."
+#~ "O tema que você selecionou não suporta seu idioma atual. Se você quiser usar"
+#~ " este tema você precisa mudar para outro idioma."
 
 #, fuzzy
 #~ msgid "Speed multiplier for mouse emulation"
@@ -20716,11 +20424,9 @@ msgstr ""
 #~ "O arquivo \"sky.cpt\" possui um tamanho incorreto.\n"
 #~ "Por favor, refaça o download em www.scummvm.org"
 
-#~ msgid ""
-#~ "Please, report the following data to the ScummVM team along with name"
+#~ msgid "Please, report the following data to the ScummVM team along with name"
 #~ msgstr ""
-#~ "Por favor, informe os seguintes dados para a equipe ScummVM junto com o "
-#~ "nome"
+#~ "Por favor, informe os seguintes dados para a equipe ScummVM junto com o nome"
 
 #~ msgid "of the game you tried to add and its version/language/etc.:"
 #~ msgstr "do jogo que você tentou adicionar e sua versão/idioma/etc.:"
@@ -20745,11 +20451,9 @@ msgstr ""
 #~ "Vídeos no formato DXA foram encontrados, mas o ScummVM foi compilado sem "
 #~ "suporte a zlib"
 
-#~ msgid ""
-#~ "Turns off General MIDI mapping for games with Roland MT-32 soundtrack"
+#~ msgid "Turns off General MIDI mapping for games with Roland MT-32 soundtrack"
 #~ msgstr ""
-#~ "Desliga o mapeamento General MIDI para jogos com trilha sonora Roland "
-#~ "MT-32"
+#~ "Desliga o mapeamento General MIDI para jogos com trilha sonora Roland MT-32"
 
 #~ msgid "Standard (16bpp)"
 #~ msgstr "Padrão (16bpp)"

--- a/po/pt_BR.po
+++ b/po/pt_BR.po
@@ -10,17 +10,18 @@ msgstr ""
 "POT-Creation-Date: 2026-06-14 22:15+0000\n"
 "PO-Revision-Date: 2024-11-16 02:13+0000\n"
 "Last-Translator: Marcel Souza Lemes <marcosoutsider@gmail.com>\n"
-"Language-Team: Portuguese (Brazil) <https://translations.scummvm.org/projects/scummvm/scummvm/pt_BR/>\n"
+"Language-Team: Portuguese (Brazil) <https://translations.scummvm.org/"
+"projects/scummvm/scummvm/pt_BR/>\n"
 "Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=utf-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=n > 1;\n"
 "X-Generator: Weblate 5.7.2\n"
-"X-Language-name: Português (Brasil)\n"
-"X-Poedit-Country: BRAZIL\n"
 "X-Poedit-Language: Portuguese\n"
+"X-Poedit-Country: BRAZIL\n"
 "X-Poedit-SourceCharset: iso-8859-1\n"
+"X-Language-name: Português (Brasil)\n"
 
 #: audio/mac_plugin.cpp:30
 msgid "Apple Macintosh Audio"
@@ -55,8 +56,7 @@ msgstr "desabilitado"
 msgid "enabled"
 msgstr "habilitado"
 
-#. I18N: CPU extensions are sets of extra processor instructions used to speed
-#. up operations. See Intel AVX2, ARM NEON, etc.
+#. I18N: CPU extensions are sets of extra processor instructions used to speed up operations. See Intel AVX2, ARM NEON, etc.
 #: gui/about.cpp:162
 msgid "CPU extensions support:"
 msgstr "Suporte a extensões de CPU:"
@@ -68,9 +68,9 @@ msgstr "Engines disponíveis:"
 #. I18N: Close dialog button
 #: gui/about.cpp:516 gui/about.cpp:648 gui/downloadpacksdialog.cpp:298
 #: gui/downloadpacksdialog.cpp:389 gui/integrity-dialog.cpp:354
-#: gui/gui-manager.cpp:168 gui/helpdialog.cpp:128
-#: gui/imagealbum-dialog.cpp:133 gui/textviewer.cpp:56
-#: gui/unknown-game-dialog.cpp:53 backends/platform/android/options.cpp:571
+#: gui/gui-manager.cpp:168 gui/helpdialog.cpp:128 gui/imagealbum-dialog.cpp:133
+#: gui/textviewer.cpp:56 gui/unknown-game-dialog.cpp:53
+#: backends/platform/android/options.cpp:571
 #: engines/drascula/metaengine.cpp:245 engines/queen/metaengine.cpp:264
 #: engines/saga/metaengine.cpp:374 engines/scumm/help.cpp:126
 #: engines/scumm/help.cpp:141 engines/scumm/help.cpp:166
@@ -81,10 +81,8 @@ msgid "Close"
 msgstr "Fechar"
 
 #. I18N: This keymap opens KIA's HELP tab.
-#. In Blade Runner's official localizations, there is a description of this
-#. keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
-#. is
+#. In Blade Runner's official localizations, there is a description of this keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
 #. ONLINE HELP
 #. I18N: Opens the help screen.
 #: gui/browser.cpp:64 gui/launcher.cpp:277 gui/launcher.cpp:959
@@ -340,9 +338,8 @@ msgstr "Outro Armazenamento está ativo no momento. Deseja interrompê-lo?"
 #: gui/fluidsynth-dialog.cpp:210 gui/launcher.cpp:428 gui/launcher.cpp:457
 #: gui/launcher.cpp:534 gui/launcher.cpp:1970 gui/options.cpp:3498
 #: gui/options.cpp:3872 base/main.cpp:608
-#: backends/events/default/default-events.cpp:193
-#: engines/buried/buried.cpp:598 engines/chamber/metaengine.cpp:91
-#: engines/director/events.cpp:122
+#: backends/events/default/default-events.cpp:193 engines/buried/buried.cpp:598
+#: engines/chamber/metaengine.cpp:91 engines/director/events.cpp:122
 #: engines/director/lingo/xlibs/j/jitdraw3.cpp:139
 #: engines/efh/metaengine.cpp:362 engines/grim/grim.cpp:366
 #: engines/hypno/metaengine.cpp:249 engines/kyra/gui/saveload_eob.cpp:611
@@ -377,11 +374,9 @@ msgstr "Não"
 #: gui/cloudconnectionwizard.cpp:539
 msgid "Wait until current Storage finishes and try again."
 msgstr ""
-"Aguarde até que o armazenamento atual conclua seu processo e tente outra "
-"vez."
+"Aguarde até que o armazenamento atual conclua seu processo e tente outra vez."
 
-#. I18N: JSON is name of the format, this message is displayed if user entered
-#. something incorrect to the text field
+#. I18N: JSON is name of the format, this message is displayed if user entered something incorrect to the text field
 #: gui/cloudconnectionwizard.cpp:564
 msgid "JSON code contents are malformed."
 msgstr "O conteúdo do código JSON está incorreto."
@@ -407,9 +402,7 @@ msgstr "OK"
 msgid "Incorrect JSON."
 msgstr "JSON incorreto."
 
-#. I18N: error message displayed on 'Manual Mode: Failure' step of 'Cloud
-#. Connection Wizard', describing that storage connection process was
-#. interrupted
+#. I18N: error message displayed on 'Manual Mode: Failure' step of 'Cloud Connection Wizard', describing that storage connection process was interrupted
 #: gui/cloudconnectionwizard.cpp:593
 msgid "Interrupted."
 msgstr "Interrompido."
@@ -453,8 +446,7 @@ msgid "Select directory where to download game data"
 msgstr "Selecione o diretório para baixar os dados do jogo"
 
 #: gui/downloaddialog.cpp:49 gui/dump-all-dialogs.cpp:117
-#: gui/dump-all-dialogs.cpp:142 gui/editgamedialog.cpp:586
-#: gui/launcher.cpp:321
+#: gui/dump-all-dialogs.cpp:142 gui/editgamedialog.cpp:586 gui/launcher.cpp:321
 msgid "Select directory with game data"
 msgstr "Selecione o diretório com os dados do jogo"
 
@@ -773,8 +765,8 @@ msgstr "ID:"
 #: gui/editgamedialog.cpp:347 gui/editgamedialog.cpp:349
 #: gui/editgamedialog.cpp:350
 msgid ""
-"Short game identifier used for referring to saved games and running the game"
-" from the command line"
+"Short game identifier used for referring to saved games and running the game "
+"from the command line"
 msgstr ""
 "Código identificador curto utilizado para se referir a jogos salvos e "
 "execução do jogo a partir da linha de comando"
@@ -910,12 +902,14 @@ msgid ""
 "### Results\n"
 "Your set of game files seems to be unknown to us.\n"
 "\n"
-"If you are sure that this is a valid unknown variant, please send the following e-mail to integrity@scummvm.org"
+"If you are sure that this is a valid unknown variant, please send the "
+"following e-mail to integrity@scummvm.org"
 msgstr ""
 "### Resultados\n"
 "Seu conjunto de arquivos do jogo parece ser desconhecido para nós.\n"
 "\n"
-"Se você tiver certeza de que esta é uma variante desconhecida válida, envie o seguinte e-mail para integrity@scummvm.org"
+"Se você tiver certeza de que esta é uma variante desconhecida válida, envie "
+"o seguinte e-mail para integrity@scummvm.org"
 
 #: gui/integrity-dialog.cpp:692
 msgid ""
@@ -1149,11 +1143,8 @@ msgstr "Retroceder"
 msgid "Delete Character"
 msgstr "Apagar Caractere"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) This action is used to go to the end of the save file name input
-#. field
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) This action is used to go to the end of the password input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) This action is used to go to the end of the save file name input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) This action is used to go to the end of the password input field
 #: gui/gui-manager.cpp:210 engines/sherlock/metaengine.cpp:1117
 #: engines/sherlock/metaengine.cpp:1222
 msgid "Go to end of line"
@@ -1167,11 +1158,8 @@ msgstr "Selecionar até o fim da linha"
 msgid "Select to start of line"
 msgstr "Selecionar até o início da linha"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) This action is used to go to the start of the save file name input
-#. field
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) This action is used to go to the start of the password input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) This action is used to go to the start of the save file name input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) This action is used to go to the start of the password input field
 #: gui/gui-manager.cpp:240 engines/sherlock/metaengine.cpp:1110
 #: engines/sherlock/metaengine.cpp:1215
 msgid "Go to start of line"
@@ -1218,43 +1206,84 @@ msgstr "Geral"
 msgid ""
 "## ScummVM at a Glance\n"
 "\n"
-"ScummVM is a modern reimplementation of various game engines. Once you transfer the original game data to your device, it endeavors to use it to faithfully recreate the original gaming experience. \n"
+"ScummVM is a modern reimplementation of various game engines. Once you "
+"transfer the original game data to your device, it endeavors to use it to "
+"faithfully recreate the original gaming experience. \n"
 "\n"
-"ScummVM isn't your typical emulator of DOS, Windows, or some console. Rather than a one-size-fits-all approach, it takes a meticulous route, implementing the precise game logic for each specific title or engine it supports. ScummVM will not work with game engines it does not support.\n"
+"ScummVM isn't your typical emulator of DOS, Windows, or some console. Rather "
+"than a one-size-fits-all approach, it takes a meticulous route, implementing "
+"the precise game logic for each specific title or engine it supports. "
+"ScummVM will not work with game engines it does not support.\n"
 "\n"
-"ScummVM is developed by a team of volunteers and is free software. We lack an extensive testing team, possess only a limited range of devices, and cannot always address every request. We also do not run advertisements or sell you anything. Please be mindful of this when you submit a complaint or a bug report.\n"
+"ScummVM is developed by a team of volunteers and is free software. We lack "
+"an extensive testing team, possess only a limited range of devices, and "
+"cannot always address every request. We also do not run advertisements or "
+"sell you anything. Please be mindful of this when you submit a complaint or "
+"a bug report.\n"
 "\n"
 "## Where to get the games\n"
 "\n"
-"Visit [our Wiki](https://wiki.scummvm.org/index.php?title=Where_to_get_the_games) for a detailed list of supported games and where to purchase them.\n"
+"Visit [our Wiki](https://wiki.scummvm.org/index.php?"
+"title=Where_to_get_the_games) for a detailed list of supported games and "
+"where to purchase them.\n"
 "\n"
-"Alternatively, you can download a variety of [freeware games](https://scummvm.org/games) and [demos](https://www.scummvm.org/demos/) directly from our website.\n"
+"Alternatively, you can download a variety of [freeware games](https://"
+"scummvm.org/games) and [demos](https://www.scummvm.org/demos/) directly from "
+"our website.\n"
 "\n"
-"The ScummVM team does not endorse any specific game supplier. However, the project receives a commission from every purchase made on [ZOOM-Platform](https://www.zoom-platform.com/?affiliate=c049516c-9c4c-42d6-8649-92ed870e8b53) through affiliate referral links.\n"
+"The ScummVM team does not endorse any specific game supplier. However, the "
+"project receives a commission from every purchase made on [ZOOM-Platform]"
+"(https://www.zoom-platform.com/?"
+"affiliate=c049516c-9c4c-42d6-8649-92ed870e8b53) through affiliate referral "
+"links.\n"
 "\n"
-"Additionally, games not available on ZOOM-Platform can be found on other suppliers such as GOG.com and Steam.\n"
+"Additionally, games not available on ZOOM-Platform can be found on other "
+"suppliers such as GOG.com and Steam.\n"
 "\n"
-"For other (out-of-print) games, consider checking platforms like Amazon, eBay, Game Trading Zone, or other auction sites. Be cautious of faulty games and illegal game copies.\n"
+"For other (out-of-print) games, consider checking platforms like Amazon, "
+"eBay, Game Trading Zone, or other auction sites. Be cautious of faulty games "
+"and illegal game copies.\n"
 msgstr ""
 "## Visão geral do ScummVM\n"
 "\n"
-"ScummVM é uma reimplementação moderna de várias engines de jogo. Depois de transferir os dados originais do jogo para o seu dispositivo, ele se esforça para usá-los e recriar fielmente a experiência de jogo original.\n"
+"ScummVM é uma reimplementação moderna de várias engines de jogo. Depois de "
+"transferir os dados originais do jogo para o seu dispositivo, ele se esforça "
+"para usá-los e recriar fielmente a experiência de jogo original.\n"
 "\n"
-"ScummVM não é um emulador típico de DOS, Windows ou algum console. Em vez de uma abordagem única, ele segue um caminho meticuloso, implementando a lógica de jogo precisa para cada título ou engine específica compatível. ScummVM não funcionará com engines de jogos que não são compatíveis.\n"
+"ScummVM não é um emulador típico de DOS, Windows ou algum console. Em vez de "
+"uma abordagem única, ele segue um caminho meticuloso, implementando a lógica "
+"de jogo precisa para cada título ou engine específica compatível. ScummVM "
+"não funcionará com engines de jogos que não são compatíveis.\n"
 "\n"
-"ScummVM é desenvolvido por uma equipe de voluntários e é um software livre. Não temos uma equipe de testes extensa, possuímos apenas uma gama limitada de dispositivos e nem sempre podemos atender a todas as solicitações de forma imediata. Também não publicamos anúncios nem vendemos nada a você. Por favor, leve isso em consideração ao enviar uma reclamação ou um relatório de bug.\n"
+"ScummVM é desenvolvido por uma equipe de voluntários e é um software livre. "
+"Não temos uma equipe de testes extensa, possuímos apenas uma gama limitada "
+"de dispositivos e nem sempre podemos atender a todas as solicitações de "
+"forma imediata. Também não publicamos anúncios nem vendemos nada a você. Por "
+"favor, leve isso em consideração ao enviar uma reclamação ou um relatório de "
+"bug.\n"
 "\n"
 "## Onde conseguir os jogos\n"
 "\n"
-"Visite [nosso Wiki](https://wiki.scummvm.org/index.php?title=Where_to_get_the_games) para obter uma lista detalhada de jogos compatíveis e onde comprá-los.\n"
+"Visite [nosso Wiki](https://wiki.scummvm.org/index.php?"
+"title=Where_to_get_the_games) para obter uma lista detalhada de jogos "
+"compatíveis e onde comprá-los.\n"
 "\n"
-"Como alternativa, você pode baixar uma variedade de [jogos gratuitos](https://scummvm.org/games) e [demonstrações](https://www.scummvm.org/demos/) diretamente de nosso site.\n"
+"Como alternativa, você pode baixar uma variedade de [jogos gratuitos]"
+"(https://scummvm.org/games) e [demonstrações](https://www.scummvm.org/"
+"demos/) diretamente de nosso site.\n"
 "\n"
-"A equipe ScummVM não recomenda nenhum fornecedor específico de jogos. No entanto, o projeto recebe uma comissão por cada compra realizada na [Plataforma ZOOM](https://www.zoom-platform.com/?affiliate=c049516c-9c4c-42d6-8649-92ed870e8b53) por meio de links de referência de afiliados.\n"
+"A equipe ScummVM não recomenda nenhum fornecedor específico de jogos. No "
+"entanto, o projeto recebe uma comissão por cada compra realizada na "
+"[Plataforma ZOOM](https://www.zoom-platform.com/?"
+"affiliate=c049516c-9c4c-42d6-8649-92ed870e8b53) por meio de links de "
+"referência de afiliados.\n"
 "\n"
-"Além disso, jogos não disponíveis na plataforma ZOOM podem ser encontrados em outros fornecedores como GOG.com e Steam.\n"
+"Além disso, jogos não disponíveis na plataforma ZOOM podem ser encontrados "
+"em outros fornecedores como GOG.com e Steam.\n"
 "\n"
-"Para outros jogos (não mais disponíveis), considere verificar plataformas como Amazon, eBay, Game Trading Zone ou outros sites de leilão. Tenha cuidado com jogos defeituosos e cópias ilegais.\n"
+"Para outros jogos (não mais disponíveis), considere verificar plataformas "
+"como Amazon, eBay, Game Trading Zone ou outros sites de leilão. Tenha "
+"cuidado com jogos defeituosos e cópias ilegais.\n"
 
 #: gui/helpdialog.cpp:68 gui/options.cpp:2379
 msgid "Cloud"
@@ -1265,11 +1294,14 @@ msgstr "Nuvem"
 #| msgid ""
 #| "## Connecting a cloud service - Quick mode\n"
 #| "\n"
-#| "1. From the Launcher, select **Global Options** and then select the **Cloud** tab.\n"
+#| "1. From the Launcher, select **Global Options** and then select the "
+#| "**Cloud** tab.\n"
 #| "\n"
-#| "2. Select your preferred cloud storage service from the **Active storage** dropdown, then select **Connect**.\n"
+#| "2. Select your preferred cloud storage service from the **Active "
+#| "storage** dropdown, then select **Connect**.\n"
 #| "\n"
-#| "\t  ![Select cloud service](choose_storage.png \"Select cloud service\"){w=70%}\n"
+#| "\t  ![Select cloud service](choose_storage.png \"Select cloud service\")"
+#| "{w=70%}\n"
 #| "\n"
 #| "3. Select **Quick mode**.\n"
 #| "\n"
@@ -1285,11 +1317,14 @@ msgstr "Nuvem"
 #| "\n"
 #| "\t  ![Open the link](open_link.png \"Open the link\"){w=70%}\n"
 #| "\n"
-#| "6. In the browser window that opens, select the cloud service to connect. \n"
+#| "6. In the browser window that opens, select the cloud service to "
+#| "connect. \n"
 #| "\n"
-#| "\t  ![Choose the cloud service](cloud_browser.png \"Choose the cloud service\"){w=70%}\n"
+#| "\t  ![Choose the cloud service](cloud_browser.png \"Choose the cloud "
+#| "service\"){w=70%}\n"
 #| "\n"
-#| "7. Sign in to the chosen cloud service. Once completed, return to ScummVM.\n"
+#| "7. Sign in to the chosen cloud service. Once completed, return to "
+#| "ScummVM.\n"
 #| "\n"
 #| "8. On the success screen, select **Finish** to exit. \n"
 #| "\n"
@@ -1298,19 +1333,26 @@ msgstr "Nuvem"
 #| "\n"
 #| "\t  ![Enable storage](enable_storage.png \"Enable storage\"){w=70%}\n"
 #| "\n"
-#| "10. You're ready to go! Use the cloud functionality to sync saved games or game files between your devices.\n"
+#| "10. You're ready to go! Use the cloud functionality to sync saved games "
+#| "or game files between your devices.\n"
 #| "\n"
-#| "\t  ![Cloud functionality](cloud_functions.png \"Cloud functionality\"){w=70%}\n"
+#| "\t  ![Cloud functionality](cloud_functions.png \"Cloud functionality\")"
+#| "{w=70%}\n"
 #| "\n"
-#| "   For more information, including how to use the manual connection wizard, see our [Cloud documentation](https://docs.scummvm.org/en/latest/use_scummvm/connect_cloud.html) "
+#| "   For more information, including how to use the manual connection "
+#| "wizard, see our [Cloud documentation](https://docs.scummvm.org/en/latest/"
+#| "use_scummvm/connect_cloud.html) "
 msgid ""
 "## Connecting a cloud service - Quick mode\n"
 "\n"
-"1. From the Launcher, select **Global Options** and then select the **Cloud** tab.\n"
+"1. From the Launcher, select **Global Options** and then select the "
+"**Cloud** tab.\n"
 "\n"
-"2. Select your preferred cloud storage service from the **Active storage** dropdown, then select **Connect**.\n"
+"2. Select your preferred cloud storage service from the **Active storage** "
+"dropdown, then select **Connect**.\n"
 "\n"
-"\t  ![Select cloud service](choose_storage.png \"Select cloud service\"){w=70%,maxw=50em}\n"
+"\t  ![Select cloud service](choose_storage.png \"Select cloud service\")"
+"{w=70%,maxw=50em}\n"
 "\n"
 "3. Select **Quick mode**.\n"
 "\n"
@@ -1328,7 +1370,8 @@ msgid ""
 "\n"
 "6. In the browser window that opens, select the cloud service to connect. \n"
 "\n"
-"\t  ![Choose the cloud service](cloud_browser.png \"Choose the cloud service\"){w=70%,maxw=50em}\n"
+"\t  ![Choose the cloud service](cloud_browser.png \"Choose the cloud "
+"service\"){w=70%,maxw=50em}\n"
 "\n"
 "7. Sign in to the chosen cloud service. Once completed, return to ScummVM.\n"
 "\n"
@@ -1337,21 +1380,29 @@ msgid ""
 "\t  ![Success](cloud_success.png \"Success\"){w=70%,maxw=50em}\n"
 "9. Back on the main Cloud tab, select **Enable storage**.\n"
 "\n"
-"\t  ![Enable storage](enable_storage.png \"Enable storage\"){w=70%,maxw=50em}\n"
+"\t  ![Enable storage](enable_storage.png \"Enable storage\")"
+"{w=70%,maxw=50em}\n"
 "\n"
-"10. You're ready to go! Use the cloud functionality to sync saved games or game files between your devices.\n"
+"10. You're ready to go! Use the cloud functionality to sync saved games or "
+"game files between your devices.\n"
 "\n"
-"\t  ![Cloud functionality](cloud_functions.png \"Cloud functionality\"){w=70%,maxw=50em}\n"
+"\t  ![Cloud functionality](cloud_functions.png \"Cloud functionality\")"
+"{w=70%,maxw=50em}\n"
 "\n"
-"   For more information, including how to use the manual connection wizard, see our [Cloud documentation](https://docs.scummvm.org/en/latest/use_scummvm/connect_cloud.html) "
+"   For more information, including how to use the manual connection wizard, "
+"see our [Cloud documentation](https://docs.scummvm.org/en/latest/use_scummvm/"
+"connect_cloud.html) "
 msgstr ""
 "## Conectando um serviço em nuvem - Modo rápido\n"
 "\n"
-"1. No Inicializador, selecione **Opções globais** e depois selecione a aba **Nuvem**.\n"
+"1. No Inicializador, selecione **Opções globais** e depois selecione a aba "
+"**Nuvem**.\n"
 "\n"
-"2. Selecione seu serviço de armazenamento em nuvem preferido no menu suspenso **Armazenamento ativo** e selecione **Conectar**.\n"
+"2. Selecione seu serviço de armazenamento em nuvem preferido no menu "
+"suspenso **Armazenamento ativo** e selecione **Conectar**.\n"
 "\n"
-"\t  ![Selecionar serviço de nuvem](choose_storage.png \"Selecionar serviço de nuvem\"){w=70%}\n"
+"\t  ![Selecionar serviço de nuvem](choose_storage.png \"Selecionar serviço "
+"de nuvem\"){w=70%}\n"
 "\n"
 "3. Selecione **Modo rápido**.\n"
 "\n"
@@ -1367,24 +1418,32 @@ msgstr ""
 "\n"
 "\t  ![Abra o link](open_link.png \"Abra o link\"){w=70%}\n"
 "\n"
-"6. Na janela do navegador que é aberta, selecione o serviço de nuvem para conectar. \n"
+"6. Na janela do navegador que é aberta, selecione o serviço de nuvem para "
+"conectar. \n"
 "\n"
-"\t  ![Escolha o serviço de nuvem](cloud_browser.png \"Escolha o serviço de nuvem\"){w=70%}\n"
+"\t  ![Escolha o serviço de nuvem](cloud_browser.png \"Escolha o serviço de "
+"nuvem\"){w=70%}\n"
 "\n"
-"7. Faça login no serviço de nuvem escolhido. Depois de concluído, retorne ao ScummVM.\n"
+"7. Faça login no serviço de nuvem escolhido. Depois de concluído, retorne ao "
+"ScummVM.\n"
 "\n"
 "8. Na tela de sucesso, selecione **Concluir** para sair. \n"
 "\n"
 "\t  ![Sucesso](cloud_success.png \"Sucesso\"){w=70%}\n"
 "9. De volta à aba Nuvem principal, selecione **Ativar armazenamento**.\n"
 "\n"
-"\t  ![Ativar armazenamento](enable_storage.png \"Ativar armazenamento\"){w=70%}\n"
+"\t  ![Ativar armazenamento](enable_storage.png \"Ativar armazenamento\")"
+"{w=70%}\n"
 "\n"
-"10. Você está pronto para começar! Use a funcionalidade da nuvem para sincronizar jogos salvos ou arquivos de jogos entre seus dispositivos.\n"
+"10. Você está pronto para começar! Use a funcionalidade da nuvem para "
+"sincronizar jogos salvos ou arquivos de jogos entre seus dispositivos.\n"
 "\n"
-"\t  ![Funcionalidade da nuvem](cloud_functions.png \"Funcionalidade da nuvem\"){w=70%}\n"
+"\t  ![Funcionalidade da nuvem](cloud_functions.png \"Funcionalidade da "
+"nuvem\"){w=70%}\n"
 "\n"
-"   Para obter mais informações, incluindo como usar o assistente de conexão manual, consulte nossa [documentação sobre nuvem](https://docs.scummvm.org/en/latest/use_scummvm/connect_cloud.html) "
+"   Para obter mais informações, incluindo como usar o assistente de conexão "
+"manual, consulte nossa [documentação sobre nuvem](https://docs.scummvm.org/"
+"en/latest/use_scummvm/connect_cloud.html) "
 
 #: gui/imagealbum-dialog.cpp:103 gui/saveload-dialog.cpp:843
 msgid "Prev"
@@ -1409,8 +1468,7 @@ msgctxt "group"
 msgid "None"
 msgstr "Nenhum"
 
-#. I18N: Group name for the game list, grouped by the first letter of the game
-#. title
+#. I18N: Group name for the game list, grouped by the first letter of the game title
 #: gui/launcher.cpp:110
 msgctxt "group"
 msgid "First letter"
@@ -1473,8 +1531,7 @@ msgstr "Seleciona um critério para agrupar os registros"
 msgid "Click here to see Help"
 msgstr "Clique aqui para obter Ajuda"
 
-#. I18N: Button Quit ScummVM program. Q is the shortcut, Ctrl+Q, put it in
-#. parens for non-latin (~Q~)
+#. I18N: Button Quit ScummVM program. Q is the shortcut, Ctrl+Q, put it in parens for non-latin (~Q~)
 #: gui/launcher.cpp:269 engines/dialogs.cpp:94
 msgid "~Q~uit"
 msgstr "~S~air"
@@ -1483,8 +1540,7 @@ msgstr "~S~air"
 msgid "Quit ScummVM"
 msgstr "Sair do ScummVM"
 
-#. I18N: Button About ScummVM program. b is the shortcut, Ctrl+b, put it in
-#. parens for non-latin (~b~)
+#. I18N: Button About ScummVM program. b is the shortcut, Ctrl+b, put it in parens for non-latin (~b~)
 #: gui/launcher.cpp:273
 msgid "A~b~out"
 msgstr "So~b~re"
@@ -1499,8 +1555,7 @@ msgstr "Sobre o ScumnmVM"
 msgid "General help"
 msgstr "Teclas Gerais"
 
-#. I18N: Button caption. O is the shortcut, Ctrl+O, put it in parens for non-
-#. latin (~O~)
+#. I18N: Button caption. O is the shortcut, Ctrl+O, put it in parens for non-latin (~O~)
 #: gui/launcher.cpp:280
 msgid "Global ~O~ptions..."
 msgstr "~O~pções Globais..."
@@ -1522,8 +1577,7 @@ msgstr "Baixar Jogos"
 msgid "Download freeware games for ScummVM"
 msgstr "Baixa jogos freeware (gratuitos) para o ScummVM"
 
-#. I18N: Button caption. A is the shortcut, Ctrl+A, put it in parens for non-
-#. latin (~A~)
+#. I18N: Button caption. A is the shortcut, Ctrl+A, put it in parens for non-latin (~A~)
 #: gui/launcher.cpp:291
 msgid "~A~dd Game..."
 msgstr "~A~dicionar Jogo..."
@@ -1537,16 +1591,14 @@ msgctxt "lowres"
 msgid "~A~dd Game..."
 msgstr "~A~dicionar Jogo..."
 
-#. I18N: Button caption. R is the shortcut, Ctrl+R, put it in parens for non-
-#. latin (~R~)
+#. I18N: Button caption. R is the shortcut, Ctrl+R, put it in parens for non-latin (~R~)
 #: gui/launcher.cpp:295
 msgid "~R~emove Game"
 msgstr "~R~emover Jogo"
 
 #: gui/launcher.cpp:295
 msgid "Remove game from the list. The game data files stay intact"
-msgstr ""
-"Remove jogo da lista. Os arquivos de dados do jogo permanecem intactos"
+msgstr "Remove jogo da lista. Os arquivos de dados do jogo permanecem intactos"
 
 #: gui/launcher.cpp:295
 msgctxt "lowres"
@@ -1580,8 +1632,8 @@ msgstr "Este diretório não pode ser utilizado ainda, está sendo baixado!"
 
 #: gui/launcher.cpp:427
 msgid ""
-"Do you really want to run the mass game detector? This could potentially add"
-" a huge number of games."
+"Do you really want to run the mass game detector? This could potentially add "
+"a huge number of games."
 msgstr ""
 "Você realmente deseja adicionar vários jogos ao mesmo tempo? Isso poderá "
 "resultar em uma adição gigantesca de jogos."
@@ -1599,8 +1651,7 @@ msgid "This game does not support loading games from the launcher."
 msgstr "Este jogo não suporta abrir jogos a partir do inicializador."
 
 #: gui/launcher.cpp:594
-msgid ""
-"ScummVM could not find any engine capable of running the selected game!"
+msgid "ScummVM could not find any engine capable of running the selected game!"
 msgstr ""
 "ScummVM não conseguiu encontrar nenhuma engine capaz de rodar o jogo "
 "selecionado!"
@@ -1957,8 +2008,8 @@ msgstr "Sincronização Vertical"
 
 #: gui/options.cpp:1703
 msgid ""
-"Wait for the vertical sync to refresh the screen in order to prevent tearing"
-" artifacts"
+"Wait for the vertical sync to refresh the screen in order to prevent tearing "
+"artifacts"
 msgstr ""
 "Aguarda a sincronização vertical para atualizar a tela a fim de evitar o "
 "efeito de tela cortada"
@@ -2052,8 +2103,7 @@ msgstr "SoundFont:"
 
 #: gui/options.cpp:1838 gui/options.cpp:1840 gui/options.cpp:1848
 msgid "SoundFont is supported by some audio cards, FluidSynth and Timidity"
-msgstr ""
-"SoundFont é suportado por algumas placas de som, FluidSynth e Timidity"
+msgstr "SoundFont é suportado por algumas placas de som, FluidSynth e Timidity"
 
 #: gui/options.cpp:1840
 msgctxt "lowres"
@@ -2084,11 +2134,10 @@ msgid "MT-32 device:"
 msgstr "Dispositivo MT-32:"
 
 #: gui/options.cpp:1866
-msgid ""
-"Specifies default sound device for Roland MT-32/LAPC1/CM32l/CM64 output"
+msgid "Specifies default sound device for Roland MT-32/LAPC1/CM32l/CM64 output"
 msgstr ""
-"Especifica o dispositivo de som padrão para a saída Roland "
-"MT-32/LAPC1/CM32l/CM64"
+"Especifica o dispositivo de som padrão para a saída Roland MT-32/LAPC1/CM32l/"
+"CM64"
 
 #: gui/options.cpp:1871
 msgid "True Roland MT-32 (disable GM emulation)"
@@ -2254,8 +2303,8 @@ msgstr "Configurações do FluidSynth"
 
 #: gui/options.cpp:2524
 msgid ""
-"Specifies where your saved games are put. A red coloring indicates the value"
-" is temporary and will not get saved"
+"Specifies where your saved games are put. A red coloring indicates the value "
+"is temporary and will not get saved"
 msgstr ""
 "Especifica onde seus jogos salvos são colocados. Uma coloração vermelha "
 "indica que o valor é temporário e não será salvo"
@@ -2407,9 +2456,9 @@ msgid ""
 "That way, if a game uses the ScummVM save and load dialogs, they are in the "
 "same language as the game."
 msgstr ""
-"Ao iniciar um jogo, altera o idioma da interface do ScummVM para o idioma do"
-" jogo. Dessa forma, se um jogo usar as caixas de diálogo de salvar e "
-"carregar do ScummVM, eles ficarão no mesmo idioma do jogo."
+"Ao iniciar um jogo, altera o idioma da interface do ScummVM para o idioma do "
+"jogo. Dessa forma, se um jogo usar as caixas de diálogo de salvar e carregar "
+"do ScummVM, eles ficarão no mesmo idioma do jogo."
 
 #: gui/options.cpp:2719
 msgid "Use native system file browser"
@@ -2555,14 +2604,14 @@ msgstr "<nunca>"
 msgctxt "lowres"
 msgid "Saved games sync automatically on launch, after saving and on loading."
 msgstr ""
-"Os jogos salvos são sincronizados automaticamente no lançamento, após salvar"
-" e ao carregar."
+"Os jogos salvos são sincronizados automaticamente no lançamento, após salvar "
+"e ao carregar."
 
 #: gui/options.cpp:2822
 msgid "Saved games sync automatically on launch, after saving and on loading."
 msgstr ""
-"Os jogos salvos são sincronizados automaticamente no lançamento, após salvar"
-" e ao carregar."
+"Os jogos salvos são sincronizados automaticamente no lançamento, após salvar "
+"e ao carregar."
 
 #: gui/options.cpp:2823
 msgid "Sync now"
@@ -2685,10 +2734,17 @@ msgstr "Desabilitar autosave"
 
 #: gui/options.cpp:2965
 msgid ""
-"WARNING: Autosave was enabled. Some of your games have existing saved games on the autosave slot. You can either move the existing saves to new slots, disable autosave, or ignore (you will be prompted when autosave is about to overwrite a save).\n"
+"WARNING: Autosave was enabled. Some of your games have existing saved games "
+"on the autosave slot. You can either move the existing saves to new slots, "
+"disable autosave, or ignore (you will be prompted when autosave is about to "
+"overwrite a save).\n"
 "List of games:\n"
 msgstr ""
-"AVISO: O salvamento automático foi habilitado. Alguns de seus jogos possuem jogos salvos existentes no slot de salvamento automático. Você pode mover os salvamentos existentes para novos slots, desativar o salvamento automático ou ignorar (você será avisado quando o salvamento automático estiver prestes a substituir um salvamento).\n"
+"AVISO: O salvamento automático foi habilitado. Alguns de seus jogos possuem "
+"jogos salvos existentes no slot de salvamento automático. Você pode mover os "
+"salvamentos existentes para novos slots, desativar o salvamento automático "
+"ou ignorar (você será avisado quando o salvamento automático estiver prestes "
+"a substituir um salvamento).\n"
 "Lista de jogos:\n"
 
 #: gui/options.cpp:2974
@@ -3106,29 +3162,47 @@ msgstr "Salvamentos"
 msgid "Bad config file format. overwrite?"
 msgstr "Formato de arquivo de configuração inválido. substituir?"
 
-#. I18N: <Add a new folder> must match the translation done in
-#. backends/fs/android/android-saf-fs.h
+#. I18N: <Add a new folder> must match the translation done in backends/fs/android/android-saf-fs.h
 #: base/main.cpp:657
 msgid ""
-"In this new version of ScummVM for Android, significant changes were made to the file access system to allow support for modern versions of the Android Operating System.\n"
-"If you find that your existing added games or custom paths no longer work, please edit those paths:\n"
-"  1. From the Launcher, go to **Game Options > Paths**. Select **Game Path** or **Extra Path**, as appropriate. \n"
-"  2. Inside the ScummVM file browser, select **Go Up** until you reach the root folder which has the **<Add a new folder>** option.\n"
-"  3. Double-tap **<Add a new folder>**. In your device's file browser, navigate to the folder containing all your game folders. For example, **SD Card > ScummVMgames** \n"
+"In this new version of ScummVM for Android, significant changes were made to "
+"the file access system to allow support for modern versions of the Android "
+"Operating System.\n"
+"If you find that your existing added games or custom paths no longer work, "
+"please edit those paths:\n"
+"  1. From the Launcher, go to **Game Options > Paths**. Select **Game Path** "
+"or **Extra Path**, as appropriate. \n"
+"  2. Inside the ScummVM file browser, select **Go Up** until you reach the "
+"root folder which has the **<Add a new folder>** option.\n"
+"  3. Double-tap **<Add a new folder>**. In your device's file browser, "
+"navigate to the folder containing all your game folders. For example, **SD "
+"Card > ScummVMgames** \n"
 "  4. Select **Use this folder**. \n"
 "  5. Select **Allow** to give ScummVM permission to access the folder. \n"
-"  6. In the ScummVM file browser, double-tap to browse through your added folder. Select the folder containing the game's files, then tap **Choose**. \n"
+"  6. In the ScummVM file browser, double-tap to browse through your added "
+"folder. Select the folder containing the game's files, then tap "
+"**Choose**. \n"
 "\n"
 "Repeat steps 1 and 6 for each game."
 msgstr ""
-"Nesta nova versão do ScummVM para Android, foram feitas mudanças significativas no sistema de acesso a arquivos para permitir o suporte a versões modernas do sistema operacional Android.\n"
-"Se você achar que seus jogos adicionados existentes ou caminhos personalizados não funcionam mais, altere os seguintes caminhos:\n"
-"  1. Pelo inicializador, entre em **Opções de jogo > Caminhos**. Selecione **Jogo** ou **Extras**, conforme apropriado.\n"
-"  2. Dentro do navegador de arquivos ScummVM, selecione **Subir** até chegar à pasta raiz que tem a opção **<Adicionar nova pasta>**.\n"
-"  3. Toque duas vezes em **<Adicionar nova pasta>**. No navegador de arquivos do seu dispositivo, navegue até a pasta que contém todas as pastas do jogo. Por exemplo, **Cartão SD > ScummVMjogos**\n"
+"Nesta nova versão do ScummVM para Android, foram feitas mudanças "
+"significativas no sistema de acesso a arquivos para permitir o suporte a "
+"versões modernas do sistema operacional Android.\n"
+"Se você achar que seus jogos adicionados existentes ou caminhos "
+"personalizados não funcionam mais, altere os seguintes caminhos:\n"
+"  1. Pelo inicializador, entre em **Opções de jogo > Caminhos**. Selecione "
+"**Jogo** ou **Extras**, conforme apropriado.\n"
+"  2. Dentro do navegador de arquivos ScummVM, selecione **Subir** até chegar "
+"à pasta raiz que tem a opção **<Adicionar nova pasta>**.\n"
+"  3. Toque duas vezes em **<Adicionar nova pasta>**. No navegador de "
+"arquivos do seu dispositivo, navegue até a pasta que contém todas as pastas "
+"do jogo. Por exemplo, **Cartão SD > ScummVMjogos**\n"
 "  4. Selecione **Utilizar esta pasta**.\n"
-"  5. Selecione **Permitir** para dar permissão ao ScummVM para acessar a pasta.\n"
-"  6. No navegador de arquivos ScummVM, toque duas vezes para navegar pela pasta adicionada. Selecione a pasta que contém os arquivos do jogo e toque em **Escolher**.\n"
+"  5. Selecione **Permitir** para dar permissão ao ScummVM para acessar a "
+"pasta.\n"
+"  6. No navegador de arquivos ScummVM, toque duas vezes para navegar pela "
+"pasta adicionada. Selecione a pasta que contém os arquivos do jogo e toque "
+"em **Escolher**.\n"
 "\n"
 "Repita as etapas 1 e 6 para cada jogo."
 
@@ -3137,30 +3211,44 @@ msgstr ""
 msgid "Read Later"
 msgstr "Ler mais Tarde"
 
-#. I18N: <Add a new folder> must match the translation done in
-#. backends/fs/android/android-saf-fs.h
+#. I18N: <Add a new folder> must match the translation done in backends/fs/android/android-saf-fs.h
 #: base/main.cpp:684
 msgid ""
-"In this new version of ScummVM for Android, significant changes were made to the file access system to allow support for modern versions of the Android Operating System.\n"
+"In this new version of ScummVM for Android, significant changes were made to "
+"the file access system to allow support for modern versions of the Android "
+"Operating System.\n"
 "To add a game:\n"
 "\n"
 "  1. Select **Add Game...** from the launcher. \n"
-"  2. Inside the ScummVM file browser, select **Go Up** until you reach the root folder which has the **<Add a new folder>** option.\n"
-"  3. Double-tap **<Add a new folder>**. In your device's file browser, navigate to the folder containing all your game folders. For example, **SD Card > ScummVMgames** \n"
+"  2. Inside the ScummVM file browser, select **Go Up** until you reach the "
+"root folder which has the **<Add a new folder>** option.\n"
+"  3. Double-tap **<Add a new folder>**. In your device's file browser, "
+"navigate to the folder containing all your game folders. For example, **SD "
+"Card > ScummVMgames** \n"
 "  4. Select **Use this folder**. \n"
 "  5. Select **Allow** to give ScummVM permission to access the folder. \n"
-"  6. In the ScummVM file browser, double-tap to browse through your added folder. Select the sub-folder containing the game's files, then tap **Choose**.\n"
+"  6. In the ScummVM file browser, double-tap to browse through your added "
+"folder. Select the sub-folder containing the game's files, then tap "
+"**Choose**.\n"
 "Repeat steps 1 and 6 for each game."
 msgstr ""
-"Nesta nova versão do ScummVM para Android, foram feitas mudanças significativas no sistema de acesso a arquivos para permitir o suporte a versões modernas do sistema operacional Android.\n"
+"Nesta nova versão do ScummVM para Android, foram feitas mudanças "
+"significativas no sistema de acesso a arquivos para permitir o suporte a "
+"versões modernas do sistema operacional Android.\n"
 "Para adicionar um jogo:\n"
 "\n"
 "  1. Selecione **Adicionar Jogo** pelo inicializador.\n"
-"  2. Dentro do navegador de arquivo do ScummVM, selecione **Subir** até chegar a pasta raiz onde há a opção **<Adicionar nova pasta>**\n"
-"  3. Dê um toque duplo em **<Adicionar nova pasta>**. No navegador de arquivo de seu dispositivo, navegue até chegar a pasta contendo todas as pastas de seu jogo. Por exemplo, **Cartão SD > ScummVMjogos**\n"
+"  2. Dentro do navegador de arquivo do ScummVM, selecione **Subir** até "
+"chegar a pasta raiz onde há a opção **<Adicionar nova pasta>**\n"
+"  3. Dê um toque duplo em **<Adicionar nova pasta>**. No navegador de "
+"arquivo de seu dispositivo, navegue até chegar a pasta contendo todas as "
+"pastas de seu jogo. Por exemplo, **Cartão SD > ScummVMjogos**\n"
 "  4. Selecione **Utilizar esta pasta**.\n"
-"  5. Selecione **Permitir** para dar ao ScummVM permissão de acesso a pasta.\n"
-"  6. No navegador de arquivo do ScummVM, dê um toque duplo para navegar pela pasta recém adicionada. Selecione a subpasta contendo os arquivos do jogo, e então dê um toque em **Escolher**.\n"
+"  5. Selecione **Permitir** para dar ao ScummVM permissão de acesso a "
+"pasta.\n"
+"  6. No navegador de arquivo do ScummVM, dê um toque duplo para navegar pela "
+"pasta recém adicionada. Selecione a subpasta contendo os arquivos do jogo, e "
+"então dê um toque em **Escolher**.\n"
 "Repita os passos 1 e 6 para cada jogo."
 
 #: base/main.cpp:866 base/main.cpp:915
@@ -3172,13 +3260,12 @@ msgstr "Erro ao executar o jogo:"
 msgid "Could not locate engine data %s"
 msgstr "Não foi possível localizar dados da engine %s"
 
-#: common/engine_data.cpp:295
-#: engines/ultima/shared/engine/data_archive.cpp:106
+#: common/engine_data.cpp:295 engines/ultima/shared/engine/data_archive.cpp:106
 #, c-format
 msgid "Out of date engine data. Expected %d.%d, but got version %d.%d"
 msgstr ""
-"Sem dados para a engine de dados. Esperava-se %d.%d, porém obteve versão "
-"%d.%d"
+"Sem dados para a engine de dados. Esperava-se %d.%d, porém obteve versão %d."
+"%d"
 
 #: common/error.cpp:37
 msgid "No error"
@@ -3500,8 +3587,8 @@ msgid ""
 "Please select the *root* of your external (physical) SD card. This is "
 "required for ScummVM to access this path: "
 msgstr ""
-"Selecione a *raiz* do seu cartão SD externo (físico). Isso é necessário para"
-" o ScummVM acessar este caminho: "
+"Selecione a *raiz* do seu cartão SD externo (físico). Isso é necessário para "
+"o ScummVM acessar este caminho: "
 
 #: dists/android.strings.xml.cpp:54
 msgid "Storage Access Framework Permissions for ScummVM were revoked!"
@@ -3552,22 +3639,22 @@ msgid ""
 "ScummVM is a program which allows you to run a wide variety of classic "
 "graphical point-and-click adventure games and role-playing games, provided "
 "you already have their data files. The clever part about this: ScummVM just "
-"replaces the executables shipped with the game, allowing you to play them on"
-" systems for which they were never designed!"
+"replaces the executables shipped with the game, allowing you to play them on "
+"systems for which they were never designed!"
 msgstr ""
 "ScummVM é um programa que permite que você execute uma ampla variedade de "
 "jogos clássicos de point-and-click (apontar e clicar) e RPG, desde que você "
-"já tenha seus arquivos de dados. A melhor parte: ScummVM apenas substitui os"
-" executáveis do jogo, permitindo que você os jogue em sistemas para os quais"
-" eles nunca foram projetados!"
+"já tenha seus arquivos de dados. A melhor parte: ScummVM apenas substitui os "
+"executáveis do jogo, permitindo que você os jogue em sistemas para os quais "
+"eles nunca foram projetados!"
 
 #. I18N: 2 of 3 paragraph of ScummVM description in *nix distributions
 #: dists/org.scummvm.scummvm.metainfo.xml.cpp:45
 msgid ""
 "Currently, ScummVM supports a huge library of adventures with over 4000 "
 "games in total. It supports many classics published by legendary studios "
-"like LucasArts, Sierra On-Line, Revolution Software, Cyan, Inc. and Westwood"
-" Studios."
+"like LucasArts, Sierra On-Line, Revolution Software, Cyan, Inc. and Westwood "
+"Studios."
 msgstr ""
 "Atualmente o ScummVM suporta uma enorme biblioteca de aventuras com mais de "
 "4000 jogos no total. Ele suporta muitos clássicos publicados por estúdios "
@@ -3665,8 +3752,7 @@ msgstr ""
 
 #: engines/dialogs.cpp:242 engines/ags/ags.cpp:344
 #: engines/glk/magnetic/magnetic.cpp:187 engines/scumm/saveload.cpp:116
-msgid ""
-"This game does not support loading from the menu. Use in-game interface"
+msgid "This game does not support loading from the menu. Use in-game interface"
 msgstr ""
 "Este jogo não suporta carregamento a partir do menu. Utilize a interface do "
 "jogo"
@@ -3761,17 +3847,24 @@ msgstr "Ignorar salvamento automático"
 #: engines/engine.cpp:644
 #, fuzzy, c-format
 #| msgid ""
-#| "WARNING: The autosave slot contains a saved game named %S, and an autosave is pending.\n"
-#| "Please move this saved game to a new slot, or delete it if it's no longer needed.\n"
+#| "WARNING: The autosave slot contains a saved game named %S, and an "
+#| "autosave is pending.\n"
+#| "Please move this saved game to a new slot, or delete it if it's no longer "
+#| "needed.\n"
 #| "Alternatively, you can skip the autosave (will prompt again in 5 minutes)."
 msgid ""
-"WARNING: The autosave slot contains a saved game named %s, and an autosave is pending.\n"
-"Please move this saved game to a new slot, or delete it if it's no longer needed.\n"
+"WARNING: The autosave slot contains a saved game named %s, and an autosave "
+"is pending.\n"
+"Please move this saved game to a new slot, or delete it if it's no longer "
+"needed.\n"
 "Alternatively, you can skip the autosave (will prompt again in 5 minutes)."
 msgstr ""
-"AVISO: O slot de salvamento automático contém um jogo salvo chamado %S e um salvamento automático está pendente.\n"
-"Mova este jogo salvo para um novo slot ou exclua-o se não for mais necessário.\n"
-"Como alternativa, você pode pular o salvamento automático (será solicitado novamente em 5 minutos)."
+"AVISO: O slot de salvamento automático contém um jogo salvo chamado %S e um "
+"salvamento automático está pendente.\n"
+"Mova este jogo salvo para um novo slot ou exclua-o se não for mais "
+"necessário.\n"
+"Como alternativa, você pode pular o salvamento automático (será solicitado "
+"novamente em 5 minutos)."
 
 #: engines/engine.cpp:654
 msgid "ERROR: Could not copy the savegame to a new slot"
@@ -3823,11 +3916,11 @@ msgstr "Iniciar"
 #, fuzzy, c-format
 #| msgid ""
 #| "WARNING: The game you are about to start is not yet fully supported by "
-#| "ScummVM. As such, it is likely to be unstable, and any saved game you make "
-#| "might not work in future versions of ScummVM."
+#| "ScummVM. As such, it is likely to be unstable, and any saved game you "
+#| "make might not work in future versions of ScummVM."
 msgid ""
-"WARNING: the game you are about to start contains the add-on \"%s\" which is"
-" not yet fully supported by ScummVM. As such, it is likely to be unstable, "
+"WARNING: the game you are about to start contains the add-on \"%s\" which is "
+"not yet fully supported by ScummVM. As such, it is likely to be unstable, "
 "and any saved game you make might not work in future versions of ScummVM."
 msgstr ""
 "AVISO: O jogo que você está prestes a começar ainda não é totalmente "
@@ -3836,7 +3929,8 @@ msgstr ""
 
 #: engines/engine.cpp:845
 msgid ""
-"WARNING: The game you are about to start is newly supported and is in testing mode.\n"
+"WARNING: The game you are about to start is newly supported and is in "
+"testing mode.\n"
 "If you encounter any bugs or oddities, please report them to our bugtracker."
 msgstr ""
 "AVISO: O jogo que você está prestes a iniciar tem suporte recente e está em modo de testes.\n"
@@ -3845,8 +3939,8 @@ msgstr ""
 #: engines/engine.cpp:861
 #, c-format
 msgid ""
-"The game \"%s\" you are trying to add is an add-on for \"%s\" that cannot be"
-" run independently. Please copy the add-on contents into a subdirectory of "
+"The game \"%s\" you are trying to add is an add-on for \"%s\" that cannot be "
+"run independently. Please copy the add-on contents into a subdirectory of "
 "the base game, and start the base game itself."
 msgstr ""
 "O jogo \"%s\" que você está tentando adicionar é um complemento de \"%s\" "
@@ -3877,8 +3971,8 @@ msgstr "Salvamento do jogo está atualmente indisponível"
 #: engines/engine.cpp:1222
 #, c-format
 msgid ""
-"The directory '%s' looks like an add-on for the game '%s', but ScummVM could"
-" not find any matching add-on in it."
+"The directory '%s' looks like an add-on for the game '%s', but ScummVM could "
+"not find any matching add-on in it."
 msgstr ""
 "O diretório '%s' parece ser um complemento do jogo '%s', mas o ScummVM não "
 "encontrou nenhum complemento correspondente nele."
@@ -3894,11 +3988,13 @@ msgstr ""
 msgid ""
 "The game in '%s' seems to be an unknown game variant.\n"
 "\n"
-"Please report the following data to the ScummVM team at %s along with the name of the game you tried to add and its version, language, etc.:"
+"Please report the following data to the ScummVM team at %s along with the "
+"name of the game you tried to add and its version, language, etc.:"
 msgstr ""
 "O jogo em '%s' parece ser uma variante de jogo desconhecida.\n"
 "\n"
-"Por favor, relate os seguintes dados para o time do ScummVM em %s junto com o nome do jogo que você tentou adicionar e sua versão, idioma, etc.:"
+"Por favor, relate os seguintes dados para o time do ScummVM em %s junto com "
+"o nome do jogo que você tentou adicionar e sua versão, idioma, etc.:"
 
 #: engines/game.cpp:203
 #, c-format
@@ -3937,9 +4033,8 @@ msgstr "Mapeamento de tecla padrão do jogo"
 #: engines/ultima/ultima0/metaengine.cpp:180
 #: engines/ultima/ultima4/metaengine.cpp:227
 #: engines/ultima/nuvie/metaengine.cpp:238
-#: engines/ultima/ultima8/metaengine.cpp:138
-#: engines/vcruise/metaengine.cpp:158 engines/wintermute/keymapper_tables.h:42
-#: engines/zvision/metaengine.cpp:203
+#: engines/ultima/ultima8/metaengine.cpp:138 engines/vcruise/metaengine.cpp:158
+#: engines/wintermute/keymapper_tables.h:42 engines/zvision/metaengine.cpp:203
 msgid "Left click"
 msgstr "Clique esquerdo"
 
@@ -4028,10 +4123,8 @@ msgid "Predictive input dialog"
 msgstr "Caixa de diálogo de entrada preditivo"
 
 #. I18N: This keymap works within the KIA Save Game screen
-#. and allows confirming popup dialog prompts (eg. for save game deletion or
-#. overwriting)
-#. and also submitting a new save game name, or choosing an existing save game
-#. for overwriting.
+#. and allows confirming popup dialog prompts (eg. for save game deletion or overwriting)
+#. and also submitting a new save game name, or choosing an existing save game for overwriting.
 #: engines/metaengine.cpp:131 engines/bladerunner/metaengine.cpp:273
 #: engines/griffon/metaengine.cpp:115 engines/grim/grim.cpp:539
 #: engines/grim/grim.cpp:639 engines/sky/metaengine.cpp:101
@@ -4158,8 +4251,8 @@ msgid ""
 "FluidSynth requires a 'soundfont' setting. Please specify it in ScummVM GUI "
 "on MIDI tab. Music is off."
 msgstr ""
-"FluidSynth requer uma configuração de 'fonte de som'. Por favor, "
-"especifique-a na interface do ScummVM na aba MIDI. Música desligada."
+"FluidSynth requer uma configuração de 'fonte de som'. Por favor, especifique-"
+"a na interface do ScummVM na aba MIDI. Música desligada."
 
 #: audio/softsynth/fluidsynth.cpp:501
 #, c-format
@@ -4295,15 +4388,13 @@ msgstr "'Modo de Toque' do Touchscreen - Passar Sobre (Sem Clicar)"
 msgid "Touchscreen 'Tap Mode' - Hover (DPad Clicks)"
 msgstr "'Modo de Toque' do Touchscreen - Passar Sobre (Cliques do DPad)"
 
-#. I18N: This is displayed in the file browser to let the user choose a new
-#. folder for Android Storage Attached Framework
+#. I18N: This is displayed in the file browser to let the user choose a new folder for Android Storage Attached Framework
 #: backends/fs/android/android-saf-fs.cpp:804
 #: backends/fs/android/android-saf-fs.cpp:808
 msgid "Add a new folder"
 msgstr "Adicionar nova pasta"
 
-#. I18N: This may be displayed in the Android UI used to add a Storage Attach
-#. Framework authorization
+#. I18N: This may be displayed in the Android UI used to add a Storage Attach Framework authorization
 #: backends/fs/android/android-saf-fs.cpp:924
 msgid "Choose a new folder"
 msgstr "Escolher nova pasta"
@@ -4394,8 +4485,8 @@ msgstr "Não foi possível salvar captura de tela"
 msgid "Windowed mode"
 msgstr "Modo janela"
 
-#: backends/graphics/sdl/sdl-graphics.cpp:491
-#: engines/colony/metaengine.cpp:173 engines/scumm/help.cpp:88
+#: backends/graphics/sdl/sdl-graphics.cpp:491 engines/colony/metaengine.cpp:173
+#: engines/scumm/help.cpp:88
 msgid "Toggle fullscreen"
 msgstr "Alternar modo de tela cheia"
 
@@ -4529,15 +4620,13 @@ msgstr "Analógico Esquerdo"
 msgid "Right stick"
 msgstr "Analógico Direito"
 
-#: backends/keymapper/hardware-input.cpp:264
-#: engines/dragons/metaengine.cpp:206
+#: backends/keymapper/hardware-input.cpp:264 engines/dragons/metaengine.cpp:206
 #, fuzzy
 #| msgid "Left Shoulder"
 msgid "Left shoulder"
 msgstr "Botão LB"
 
-#: backends/keymapper/hardware-input.cpp:265
-#: engines/dragons/metaengine.cpp:212
+#: backends/keymapper/hardware-input.cpp:265 engines/dragons/metaengine.cpp:212
 #, fuzzy
 #| msgid "Right Shoulder"
 msgid "Right shoulder"
@@ -4751,8 +4840,8 @@ msgid ""
 "The page is not available without the resources. Make sure file wwwroot.zip "
 "from ScummVM distribution is available in 'themepath'."
 msgstr ""
-"A página não está disponível sem os recursos. Certifique-se de que o arquivo"
-" wwwroot.zip da distribuição do ScummVM está disponível em 'themepath'."
+"A página não está disponível sem os recursos. Certifique-se de que o arquivo "
+"wwwroot.zip da distribuição do ScummVM está disponível em 'themepath'."
 
 #: backends/networking/sdl_net/handlers/filesajaxpagehandler.cpp:66
 #: backends/networking/sdl_net/handlers/filesajaxpagehandler.cpp:67
@@ -4840,7 +4929,8 @@ msgid ""
 "Check whether selected port is not used by another application and try again."
 msgstr ""
 "Falha ao iniciar servidor web local.\n"
-"Verifique se a porta selecionada não está sendo utilizada por outra aplicação e tente novamente."
+"Verifique se a porta selecionada não está sendo utilizada por outra "
+"aplicação e tente novamente."
 
 #: backends/networking/sdl_net/uploadfileclienthandler.cpp:67
 #: backends/networking/sdl_net/uploadfileclienthandler.cpp:109
@@ -5075,19 +5165,42 @@ msgstr "Obtendo ajuda"
 msgid ""
 "## Help, I'm lost!\n"
 "\n"
-"First, make sure you have the games and necessary game files ready. Check the **Where to Get the Games** section under the **General** tab. Once obtained, follow the steps outlined in the **Adding Games** tab to finish adding them on this device. Take a moment to review this process carefully, as some users encountered challenges here owing to recent Android changes.\n"
+"First, make sure you have the games and necessary game files ready. Check "
+"the **Where to Get the Games** section under the **General** tab. Once "
+"obtained, follow the steps outlined in the **Adding Games** tab to finish "
+"adding them on this device. Take a moment to review this process carefully, "
+"as some users encountered challenges here owing to recent Android changes.\n"
 "\n"
-"Need more help? Refer to our [online documentation for Android](https://docs.scummvm.org/en/latest/other_platforms/android.html). Got questions? Swing by our [support forums](https://forums.scummvm.org/viewforum.php?f=17) or hop on our [Discord server](https://discord.gg/4cDsMNtcpG), which includes an [Android support channel](https://discord.com/channels/581224060529148060/1135579923185139862).\n"
+"Need more help? Refer to our [online documentation for Android](https://"
+"docs.scummvm.org/en/latest/other_platforms/android.html). Got questions? "
+"Swing by our [support forums](https://forums.scummvm.org/viewforum.php?f=17) "
+"or hop on our [Discord server](https://discord.gg/4cDsMNtcpG), which "
+"includes an [Android support channel](https://discord.com/channels/"
+"581224060529148060/1135579923185139862).\n"
 "\n"
-"Oh, and heads up, many of our supported games are intentionally tricky, sometimes mind-bogglingly so. If you're stuck in a game, think about checking out a game walkthrough. Good luck!\n"
+"Oh, and heads up, many of our supported games are intentionally tricky, "
+"sometimes mind-bogglingly so. If you're stuck in a game, think about "
+"checking out a game walkthrough. Good luck!\n"
 msgstr ""
 "## Socorro, estou perdido!\n"
 "\n"
-"Primeiro, certifique-se de ter os jogos e os arquivos de jogo necessários prontos. Verifique a seção **Onde obter os jogos** na guia **Geral**. Depois de obtido, siga as etapas descritas na guia **Adicionando jogos** para terminar de adicioná-los neste dispositivo. Reserve um momento para revisar esse processo com atenção, pois alguns usuários encontraram desafios aqui devido às mudanças recentes no Android.\n"
+"Primeiro, certifique-se de ter os jogos e os arquivos de jogo necessários "
+"prontos. Verifique a seção **Onde obter os jogos** na guia **Geral**. Depois "
+"de obtido, siga as etapas descritas na guia **Adicionando jogos** para "
+"terminar de adicioná-los neste dispositivo. Reserve um momento para revisar "
+"esse processo com atenção, pois alguns usuários encontraram desafios aqui "
+"devido às mudanças recentes no Android.\n"
 "\n"
-"Precisa de mais ajuda? Consulte nossa [documentação on-line para Android](https://docs.scummvm.org/en/latest/other_platforms/android.html). Tem dúvidas? Visite nossos [fóruns de suporte](https://forums.scummvm.org/viewforum.php?f=17) ou acesse nosso [servidor Discord](https://discord.gg/4cDsMNtcpG), que inclui um [canal de suporte do Android](https://discord.com/channels/581224060529148060/1135579923185139862).\n"
+"Precisa de mais ajuda? Consulte nossa [documentação on-line para Android]"
+"(https://docs.scummvm.org/en/latest/other_platforms/android.html). Tem "
+"dúvidas? Visite nossos [fóruns de suporte](https://forums.scummvm.org/"
+"viewforum.php?f=17) ou acesse nosso [servidor Discord](https://discord.gg/"
+"4cDsMNtcpG), que inclui um [canal de suporte do Android](https://discord.com/"
+"channels/581224060529148060/1135579923185139862).\n"
 "\n"
-"Ah, e atenção: muitos dos nossos jogos suportados são intencionalmente complicados, às vezes surpreendentemente. Se você estiver preso em um jogo, considere buscar um detonado dele. Boa sorte!\n"
+"Ah, e atenção: muitos dos nossos jogos suportados são intencionalmente "
+"complicados, às vezes surpreendentemente. Se você estiver preso em um jogo, "
+"considere buscar um detonado dele. Boa sorte!\n"
 
 #: backends/platform/android/android.cpp:942
 #: backends/platform/ios7/ios7_osys_misc.mm:258
@@ -5099,10 +5212,12 @@ msgstr "Controles de Toque"
 #, fuzzy
 #| msgid ""
 #| "## Touch control modes\n"
-#| "The touch control mode can be changed by tapping or clicking on the controller icon in the upper right corner\n"
+#| "The touch control mode can be changed by tapping or clicking on the "
+#| "controller icon in the upper right corner\n"
 #| "### Direct mouse \n"
 #| "\n"
-#| "The touch controls are direct. The pointer jumps to where the finger touches the screen (default for menus).\n"
+#| "The touch controls are direct. The pointer jumps to where the finger "
+#| "touches the screen (default for menus).\n"
 #| "\n"
 #| "  ![Direct mouse mode](mouse.png \"Direct mouse mode\"){w=10em}\n"
 #| "\n"
@@ -5114,11 +5229,13 @@ msgstr "Controles de Toque"
 #| "\n"
 #| "### Gamepad emulation \n"
 #| "\n"
-#| "Fingers must be placed on lower left and right of the screen to emulate a directional pad and action buttons.\n"
+#| "Fingers must be placed on lower left and right of the screen to emulate a "
+#| "directional pad and action buttons.\n"
 #| "\n"
 #| "  ![Gamepad mode](gamepad.png \"Gamepad mode\"){w=10em}\n"
 #| "\n"
-#| "To select the preferred touch mode for menus, 2D games, and 3D games, go to **Global Options > Backend > Choose the preferred touch mode**.\n"
+#| "To select the preferred touch mode for menus, 2D games, and 3D games, go "
+#| "to **Global Options > Backend > Choose the preferred touch mode**.\n"
 #| "\n"
 #| "## Touch actions \n"
 #| "\n"
@@ -5127,35 +5244,48 @@ msgstr "Controles de Toque"
 #| "To scroll, slide two fingers up or down the screen\n"
 #| "### Two finger tap\n"
 #| "\n"
-#| "To do a two finger tap, hold one finger down and then tap with a second finger.\n"
+#| "To do a two finger tap, hold one finger down and then tap with a second "
+#| "finger.\n"
 #| "\n"
 #| "### Three finger tap\n"
 #| "\n"
-#| "To do a three finger tap, start with holding down one finger and progressively touch down the other two fingers, one at a time, while still holding down the previous fingers. Imagine you are impatiently tapping your fingers on a surface, but then slow down that movement so it is rhythmic, but not too slow.\n"
+#| "To do a three finger tap, start with holding down one finger and "
+#| "progressively touch down the other two fingers, one at a time, while "
+#| "still holding down the previous fingers. Imagine you are impatiently "
+#| "tapping your fingers on a surface, but then slow down that movement so it "
+#| "is rhythmic, but not too slow.\n"
 #| "\n"
 #| "### Immersive Sticky fullscreen mode\n"
 #| "\n"
-#| "Swipe from the edge to reveal the system bars.  They remain semi-transparent and disappear after a few seconds unless you interact with them.\n"
+#| "Swipe from the edge to reveal the system bars.  They remain semi-"
+#| "transparent and disappear after a few seconds unless you interact with "
+#| "them.\n"
 #| "\n"
 #| "### Global Main Menu\n"
 #| "\n"
-#| "To open the Global Main Menu, tap on the menu icon at the top right of the screen.\n"
+#| "To open the Global Main Menu, tap on the menu icon at the top right of "
+#| "the screen.\n"
 #| "\n"
 #| "  ![Menu icon](menu.png \"Menu icon\"){w=10em}\n"
 #| "\n"
 #| "## Virtual keyboard\n"
 #| "\n"
-#| "To open the virtual keyboard, long press on the controller icon at the top right of the screen, or tap on any editable text field. To hide the virtual keyboard, tap the controller icon again, or tap outside the text field.\n"
+#| "To open the virtual keyboard, long press on the controller icon at the "
+#| "top right of the screen, or tap on any editable text field. To hide the "
+#| "virtual keyboard, tap the controller icon again, or tap outside the text "
+#| "field.\n"
 #| "\n"
 #| "\n"
 #| "  ![Keyboard icon](keyboard.png \"Keyboard icon\"){w=10em}\n"
 #| "\n"
 msgid ""
 "## Touch control modes\n"
-"The touch control mode can be changed by tapping or clicking on the controller icon in the upper right corner\n"
+"The touch control mode can be changed by tapping or clicking on the "
+"controller icon in the upper right corner\n"
 "### Direct mouse \n"
 "\n"
-"The touch controls are direct. The pointer jumps to where the finger touches the screen (default for menus).\n"
+"The touch controls are direct. The pointer jumps to where the finger touches "
+"the screen (default for menus).\n"
 "\n"
 "  ![Direct mouse mode](mouse.png \"Direct mouse mode\"){w=10em}\n"
 "\n"
@@ -5167,11 +5297,13 @@ msgid ""
 "\n"
 "### Gamepad emulation \n"
 "\n"
-"Fingers must be placed on lower left and right of the screen to emulate a directional pad and action buttons.\n"
+"Fingers must be placed on lower left and right of the screen to emulate a "
+"directional pad and action buttons.\n"
 "\n"
 "  ![Gamepad mode](gamepad.png \"Gamepad mode\"){w=10em}\n"
 "\n"
-"To select the preferred touch mode for menus, 2D games, and 3D games, go to **Global Options > Backend > Choose the preferred touch mode**.\n"
+"To select the preferred touch mode for menus, 2D games, and 3D games, go to "
+"**Global Options > Backend > Choose the preferred touch mode**.\n"
 "\n"
 "## Touch actions \n"
 "\n"
@@ -5180,35 +5312,46 @@ msgid ""
 "To scroll, slide two fingers up or down the screen\n"
 "### Two finger tap\n"
 "\n"
-"To do a two finger tap, hold one finger down and then tap with a second finger.\n"
+"To do a two finger tap, hold one finger down and then tap with a second "
+"finger.\n"
 "\n"
 "### Three finger tap\n"
 "\n"
-"To do a three finger tap, start with holding down one finger and progressively touch down the other two fingers, one at a time, while still holding down the previous fingers. Imagine you are impatiently tapping your fingers on a surface, but then slow down that movement so it is rhythmic, but not too slow.\n"
+"To do a three finger tap, start with holding down one finger and "
+"progressively touch down the other two fingers, one at a time, while still "
+"holding down the previous fingers. Imagine you are impatiently tapping your "
+"fingers on a surface, but then slow down that movement so it is rhythmic, "
+"but not too slow.\n"
 "\n"
 "### Immersive Sticky fullscreen mode\n"
 "\n"
-"Swipe from the edge to reveal the system bars.  They remain semi-transparent and disappear after a few seconds unless you interact with them.\n"
+"Swipe from the edge to reveal the system bars.  They remain semi-transparent "
+"and disappear after a few seconds unless you interact with them.\n"
 "\n"
 "### Global Main Menu\n"
 "\n"
-"To open the Global Main Menu, tap on the menu icon at the top right of the screen.\n"
+"To open the Global Main Menu, tap on the menu icon at the top right of the "
+"screen.\n"
 "\n"
 "  ![Menu icon](menu.png \"Menu icon\"){w=10em}\n"
 "\n"
 "## Virtual keyboard\n"
 "\n"
-"To open the virtual keyboard, long press on the controller icon at the top right of the screen, or tap on any editable text field. To hide the virtual keyboard, tap the controller icon again, or tap outside the text field.\n"
+"To open the virtual keyboard, long press on the controller icon at the top "
+"right of the screen, or tap on any editable text field. To hide the virtual "
+"keyboard, tap the controller icon again, or tap outside the text field.\n"
 "\n"
 "\n"
 "  ![Keyboard icon](keyboard.png \"Keyboard icon\"){w=10em}\n"
 "\n"
 msgstr ""
 "## Modos de controle de toque\n"
-"O modo de controle de toque pode ser alterado tocando ou clicando no ícone do controlador no canto superior direito\n"
+"O modo de controle de toque pode ser alterado tocando ou clicando no ícone "
+"do controlador no canto superior direito\n"
 "### Mouse direto\n"
 "\n"
-"Os controles de toque são diretos. O ponteiro salta para onde o dedo toca a tela (padrão para menus).\n"
+"Os controles de toque são diretos. O ponteiro salta para onde o dedo toca a "
+"tela (padrão para menus).\n"
 "\n"
 "  ![Modo de mouse direto](mouse.png \"Modo de mouse direto\"){w=10em}\n"
 "\n"
@@ -5220,11 +5363,13 @@ msgstr ""
 "\n"
 "### Emulação de gamepad\n"
 "\n"
-"Os dedos devem ser colocados na parte inferior esquerda e direita da tela para emular um teclado direcional e botões de ação.\n"
+"Os dedos devem ser colocados na parte inferior esquerda e direita da tela "
+"para emular um teclado direcional e botões de ação.\n"
 "\n"
 "  ![Modo gamepad](gamepad.png \"Modo gamepad\"){w=10em}\n"
 "\n"
-"Para selecionar o modo de toque preferido para menus, jogos 2D e jogos 3D, entre em **Opções globais > Back-end > Escolher modo de toque preferido**.\n"
+"Para selecionar o modo de toque preferido para menus, jogos 2D e jogos 3D, "
+"entre em **Opções globais > Back-end > Escolher modo de toque preferido**.\n"
 "\n"
 "## Ações de toque\n"
 "\n"
@@ -5233,25 +5378,36 @@ msgstr ""
 "Para rolar, deslize dois dedos para cima ou para baixo na tela\n"
 "### Toque com dois dedos\n"
 "\n"
-"Para tocar com dois dedos, mantenha um dedo pressionado e toque com o segundo dedo.\n"
+"Para tocar com dois dedos, mantenha um dedo pressionado e toque com o "
+"segundo dedo.\n"
 "\n"
 "### Toque com três dedos\n"
 "\n"
-"Para fazer um toque com três dedos, comece mantendo pressionado um dedo e toque progressivamente os outros dois dedos, um de cada vez, enquanto mantém pressionados os dedos anteriores. Imagine que você está batendo impacientemente os dedos em uma superfície, mas depois diminua a velocidade do movimento para que mantenha um rítmo, mas não muito lento.\n"
+"Para fazer um toque com três dedos, comece mantendo pressionado um dedo e "
+"toque progressivamente os outros dois dedos, um de cada vez, enquanto mantém "
+"pressionados os dedos anteriores. Imagine que você está batendo "
+"impacientemente os dedos em uma superfície, mas depois diminua a velocidade "
+"do movimento para que mantenha um rítmo, mas não muito lento.\n"
 "\n"
 "### Modo de tela cheia Imersivo Fixo\n"
 "\n"
-"Deslize da borda para revelar as barras do sistema. Eles permanecem semitransparentes e desaparecem após alguns segundos, a menos que você interaja com elas.\n"
+"Deslize da borda para revelar as barras do sistema. Eles permanecem "
+"semitransparentes e desaparecem após alguns segundos, a menos que você "
+"interaja com elas.\n"
 "\n"
 "### Menu Principal Global\n"
 "\n"
-"Para abrir o Menu Principal Global, toque no ícone do menu no canto superior direito da tela.\n"
+"Para abrir o Menu Principal Global, toque no ícone do menu no canto superior "
+"direito da tela.\n"
 "\n"
 "  ![Ícone de menu](menu.png \"Ícone de menu\"){w=10em}\n"
 "\n"
 "## Teclado virtual\n"
 "\n"
-"Para abrir o teclado virtual, mantenha pressionado o ícone do controlador no canto superior direito da tela ou toque em qualquer campo de texto editável. Para ocultar o teclado virtual, toque novamente no ícone do controlador ou toque fora do campo de texto.\n"
+"Para abrir o teclado virtual, mantenha pressionado o ícone do controlador no "
+"canto superior direito da tela ou toque em qualquer campo de texto editável. "
+"Para ocultar o teclado virtual, toque novamente no ícone do controlador ou "
+"toque fora do campo de texto.\n"
 "\n"
 "\n"
 "  ![Ícone do teclado](keyboard.png \"Ícone do teclado\"){w=10em}\n"
@@ -5270,11 +5426,15 @@ msgstr "Adicionando Jogos"
 #| "\n"
 #| "1. Select **Add Game...** from the launcher. \n"
 #| "\n"
-#| "2. Inside the ScummVM file browser, select **Go Up** until you reach the root folder which has the **<Add a new folder>** option. \n"
+#| "2. Inside the ScummVM file browser, select **Go Up** until you reach the "
+#| "root folder which has the **<Add a new folder>** option. \n"
 #| "\n"
-#| "  ![ScummVM file browser root](browser-root.png \"ScummVM file browser root\"){w=70%}\n"
+#| "  ![ScummVM file browser root](browser-root.png \"ScummVM file browser "
+#| "root\"){w=70%}\n"
 #| "\n"
-#| "3. Double-tap **<Add a new folder>**. In your device's file browser, navigate to the folder containing all your game folders. For example, **SD Card > ScummVMgames**. \n"
+#| "3. Double-tap **<Add a new folder>**. In your device's file browser, "
+#| "navigate to the folder containing all your game folders. For example, "
+#| "**SD Card > ScummVMgames**. \n"
 #| "\n"
 #| "4. Select **Use this folder**. \n"
 #| "\n"
@@ -5282,67 +5442,95 @@ msgstr "Adicionando Jogos"
 #| "\n"
 #| "5. Select **ALLOW** to give ScummVM permission to access the folder. \n"
 #| "\n"
-#| "  ![OS access permission dialog](fs-permission.png \"OS access permission\"){w=70%}\n"
+#| "  ![OS access permission dialog](fs-permission.png \"OS access "
+#| "permission\"){w=70%}\n"
 #| "\n"
-#| "6. In the ScummVM file browser, double-tap to browse through your added folder. Add a game by selecting the sub-folder containing the game files, then tap **Choose**. \n"
+#| "6. In the ScummVM file browser, double-tap to browse through your added "
+#| "folder. Add a game by selecting the sub-folder containing the game files, "
+#| "then tap **Choose**. \n"
 #| "\n"
-#| "  ![SAF folder added](browser-folder-in-list.png \"SAF folder added\"){w=70%}\n"
+#| "  ![SAF folder added](browser-folder-in-list.png \"SAF folder added\")"
+#| "{w=70%}\n"
 #| "\n"
-#| "Step 2 and 3 are done only once. To add more games, repeat Steps 1 and 6. \n"
+#| "Step 2 and 3 are done only once. To add more games, repeat Steps 1 and "
+#| "6. \n"
 #| "\n"
-#| "See our [Android documentation](https://docs.scummvm.org/en/latest/other_platforms/android.html) for more information.\n"
+#| "See our [Android documentation](https://docs.scummvm.org/en/latest/"
+#| "other_platforms/android.html) for more information.\n"
 msgid ""
 "## Adding Games \n"
 "\n"
 "1. Select **Add Game...** from the launcher. \n"
 "\n"
-"2. Inside the ScummVM file browser, select **Go Up** until you reach the root folder which has the **<Add a new folder>** option. \n"
+"2. Inside the ScummVM file browser, select **Go Up** until you reach the "
+"root folder which has the **<Add a new folder>** option. \n"
 "\n"
-"  ![ScummVM file browser root](browser-root.png \"ScummVM file browser root\"){w=70%,maxw=50em}\n"
+"  ![ScummVM file browser root](browser-root.png \"ScummVM file browser "
+"root\"){w=70%,maxw=50em}\n"
 "\n"
-"3. Double-tap **<Add a new folder>**. In your device's file browser, navigate to the folder containing all your game folders. For example, **SD Card > ScummVMgames**. \n"
+"3. Double-tap **<Add a new folder>**. In your device's file browser, "
+"navigate to the folder containing all your game folders. For example, **SD "
+"Card > ScummVMgames**. \n"
 "\n"
 "4. Select **Use this folder**. \n"
 "\n"
-"  ![OS selectable folder](fs-folder.png \"OS selectable folder\"){w=70%,maxw=50em}\n"
+"  ![OS selectable folder](fs-folder.png \"OS selectable folder\")"
+"{w=70%,maxw=50em}\n"
 "\n"
 "5. Select **ALLOW** to give ScummVM permission to access the folder. \n"
 "\n"
-"  ![OS access permission dialog](fs-permission.png \"OS access permission\"){w=70%,maxw=50em}\n"
+"  ![OS access permission dialog](fs-permission.png \"OS access permission\")"
+"{w=70%,maxw=50em}\n"
 "\n"
-"6. In the ScummVM file browser, double-tap to browse through your added folder. Add a game by selecting the sub-folder containing the game files, then tap **Choose**. \n"
+"6. In the ScummVM file browser, double-tap to browse through your added "
+"folder. Add a game by selecting the sub-folder containing the game files, "
+"then tap **Choose**. \n"
 "\n"
-"  ![SAF folder added](browser-folder-in-list.png \"SAF folder added\"){w=70%,maxw=50em}\n"
+"  ![SAF folder added](browser-folder-in-list.png \"SAF folder added\")"
+"{w=70%,maxw=50em}\n"
 "\n"
 "Step 2 and 3 are done only once. To add more games, repeat Steps 1 and 6. \n"
 "\n"
-"See our [Android documentation](https://docs.scummvm.org/en/latest/other_platforms/android.html) for more information.\n"
+"See our [Android documentation](https://docs.scummvm.org/en/latest/"
+"other_platforms/android.html) for more information.\n"
 msgstr ""
 "## Adicionando jogos\n"
 "\n"
 "1. Selecione **Adicionar jogo...** no inicializador.\n"
 "\n"
-"2. Dentro do navegador de arquivos ScummVM, selecione **Subir** até chegar à pasta raiz que tem a opção **<Adicionar nova pasta>**.\n"
+"2. Dentro do navegador de arquivos ScummVM, selecione **Subir** até chegar à "
+"pasta raiz que tem a opção **<Adicionar nova pasta>**.\n"
 "\n"
-"  ![Raiz do navegador de arquivos ScummVM](browser-root.png \"Raiz do navegador de arquivos ScummVM\"){w=70%}\n"
+"  ![Raiz do navegador de arquivos ScummVM](browser-root.png \"Raiz do "
+"navegador de arquivos ScummVM\"){w=70%}\n"
 "\n"
-"3. Toque duas vezes em **<Adicionar nova pasta>**. No navegador de arquivos do seu dispositivo, navegue até a pasta que contém todas as pastas do jogo. Por exemplo, **Cartão SD > ScummVMjogos**.\n"
+"3. Toque duas vezes em **<Adicionar nova pasta>**. No navegador de arquivos "
+"do seu dispositivo, navegue até a pasta que contém todas as pastas do jogo. "
+"Por exemplo, **Cartão SD > ScummVMjogos**.\n"
 "\n"
 "4. Selecione **Utilizar esta pasta**.\n"
 "\n"
-"  ![Pasta selecionável do SO](fs-folder.png \"Pasta selecionável do SO\"){w=70%}\n"
+"  ![Pasta selecionável do SO](fs-folder.png \"Pasta selecionável do SO\")"
+"{w=70%}\n"
 "\n"
-"5. Selecione **PERMITIR** para dar permissão ao ScummVM para acessar a pasta.\n"
+"5. Selecione **PERMITIR** para dar permissão ao ScummVM para acessar a "
+"pasta.\n"
 "\n"
-"  ![Caixa de diálogo de permissão de acesso ao SO](fs-permission.png \"Permissão de acesso ao SO\"){w=70%}\n"
+"  ![Caixa de diálogo de permissão de acesso ao SO](fs-permission.png "
+"\"Permissão de acesso ao SO\"){w=70%}\n"
 "\n"
-"6. No navegador de arquivos ScummVM, toque duas vezes para navegar pela pasta adicionada. Adicione um jogo selecionando a subpasta que contém os arquivos do jogo e toque em **Escolher**.\n"
+"6. No navegador de arquivos ScummVM, toque duas vezes para navegar pela "
+"pasta adicionada. Adicione um jogo selecionando a subpasta que contém os "
+"arquivos do jogo e toque em **Escolher**.\n"
 "\n"
-"  ![Pasta SAF adicionada](browser-folder-in-list.png \"Pasta SAF adicionada\"){w=70%}\n"
+"  ![Pasta SAF adicionada](browser-folder-in-list.png \"Pasta SAF "
+"adicionada\"){w=70%}\n"
 "\n"
-"As etapas 2 e 3 precisam ser realizadas apenas uma vez. Para adicionar mais jogos, repita as etapas 1 e 6.\n"
+"As etapas 2 e 3 precisam ser realizadas apenas uma vez. Para adicionar mais "
+"jogos, repita as etapas 1 e 6.\n"
 "\n"
-"Consulte nossa [documentação do Android](https://docs.scummvm.org/en/latest/other_platforms/android.html) para obter mais informações.\n"
+"Consulte nossa [documentação do Android](https://docs.scummvm.org/en/latest/"
+"other_platforms/android.html) para obter mais informações.\n"
 
 #: backends/platform/android/options.cpp:137
 #: backends/platform/ios7/ios7_options.mm:165
@@ -5448,8 +5636,7 @@ msgstr "Importar backup"
 msgid "Import a previously exported backup file"
 msgstr "Importar um arquivo de backup exportado anteriormente"
 
-#. I18N: This button opens a list of all folders added for Android Storage
-#. Attached Framework
+#. I18N: This button opens a list of all folders added for Android Storage Attached Framework
 #: backends/platform/android/options.cpp:199
 msgid "Remove folder authorizations..."
 msgstr "Remover autorizações de pasta..."
@@ -5554,28 +5741,53 @@ msgstr "Exibir barra de funções do teclado"
 msgid ""
 "## Help, I'm lost!\n"
 "\n"
-"First, make sure you have the games and necessary game files ready. Check the **Where to Get the Games** section under the **General** tab. Once obtained, follow the steps outlined in the **Adding Games** tab to finish adding them on this device.\n"
+"First, make sure you have the games and necessary game files ready. Check "
+"the **Where to Get the Games** section under the **General** tab. Once "
+"obtained, follow the steps outlined in the **Adding Games** tab to finish "
+"adding them on this device.\n"
 "\n"
-"Need more help? Refer to our [online documentation for iOS](https://docs.scummvm.org/en/latest/other_platforms/ios.html). Got questions? Swing by our [support forums](https://forums.scummvm.org/viewforum.php?f=15) or hop on our [Discord server](https://discord.gg/4cDsMNtcpG), which includes an [iOS support channel](https://discord.com/channels/581224060529148060/1149456560922316911).\n"
+"Need more help? Refer to our [online documentation for iOS](https://"
+"docs.scummvm.org/en/latest/other_platforms/ios.html). Got questions? Swing "
+"by our [support forums](https://forums.scummvm.org/viewforum.php?f=15) or "
+"hop on our [Discord server](https://discord.gg/4cDsMNtcpG), which includes "
+"an [iOS support channel](https://discord.com/channels/"
+"581224060529148060/1149456560922316911).\n"
 "\n"
-"Oh, and heads up, many of our supported games are intentionally tricky, sometimes mind-bogglingly so. If you're stuck in a game, think about checking out a game walkthrough. Good luck!\n"
+"Oh, and heads up, many of our supported games are intentionally tricky, "
+"sometimes mind-bogglingly so. If you're stuck in a game, think about "
+"checking out a game walkthrough. Good luck!\n"
 msgstr ""
 "## Socorro, estou perdido!\n"
 "\n"
-"Primeiro, certifique-se de ter os jogos e os arquivos de jogo necessários prontos. Verifique a seção **Onde obter os jogos** na guia **Geral**. Depois de obtido, siga as etapas descritas na guia **Adicionando jogos** para terminar de adicioná-los neste dispositivo.\n"
+"Primeiro, certifique-se de ter os jogos e os arquivos de jogo necessários "
+"prontos. Verifique a seção **Onde obter os jogos** na guia **Geral**. Depois "
+"de obtido, siga as etapas descritas na guia **Adicionando jogos** para "
+"terminar de adicioná-los neste dispositivo.\n"
 "\n"
-"Precisa de mais ajuda? Consulte nossa [documentação on-line para iOS](https://docs.scummvm.org/en/latest/other_platforms/ios.html). Tem dúvidas? Visite nossos [fóruns de suporte](https://forums.scummvm.org/viewforum.php?f=15) ou acesse nosso [servidor Discord](https://discord.gg/4cDsMNtcpG), que inclui um [canal de suporte do iOS](https://discord.com/channels/581224060529148060/1149456560922316911).\n"
+"Precisa de mais ajuda? Consulte nossa [documentação on-line para iOS]"
+"(https://docs.scummvm.org/en/latest/other_platforms/ios.html). Tem dúvidas? "
+"Visite nossos [fóruns de suporte](https://forums.scummvm.org/viewforum.php?"
+"f=15) ou acesse nosso [servidor Discord](https://discord.gg/4cDsMNtcpG), que "
+"inclui um [canal de suporte do iOS](https://discord.com/channels/"
+"581224060529148060/1149456560922316911).\n"
 "\n"
-"Ah, e atenção: muitos dos nossos jogos suportados são intencionalmente complicados, às vezes surpreendentemente. Se você estiver preso em um jogo, considere buscar por um detonado dele. Boa sorte!\n"
+"Ah, e atenção: muitos dos nossos jogos suportados são intencionalmente "
+"complicados, às vezes surpreendentemente. Se você estiver preso em um jogo, "
+"considere buscar por um detonado dele. Boa sorte!\n"
 
 #: backends/platform/ios7/ios7_osys_misc.mm:261
 msgid ""
 "## Touch control modes\n"
-"The touch control mode can be changed by tapping or clicking on the controller icon in the upper right corner, by swiping two fingers from left to right, or in the global settings from the Launcher go to **Global Options > Backend > Choose the preferred touch mode**. It's possible to configure the touch mode for three situations (ScummVM menus, 2D games and 3D games).\n"
+"The touch control mode can be changed by tapping or clicking on the "
+"controller icon in the upper right corner, by swiping two fingers from left "
+"to right, or in the global settings from the Launcher go to **Global Options "
+"> Backend > Choose the preferred touch mode**. It's possible to configure "
+"the touch mode for three situations (ScummVM menus, 2D games and 3D games).\n"
 "\n"
 "### Direct mouse \n"
 "\n"
-"The touch controls are direct. The pointer jumps to where the finger touches the screen (default for menus).\n"
+"The touch controls are direct. The pointer jumps to where the finger touches "
+"the screen (default for menus).\n"
 "\n"
 "  ![Direct mouse mode](mouse.png \"Direct mouse mode\"){w=10em}\n"
 "\n"
@@ -5585,7 +5797,8 @@ msgid ""
 "\n"
 "  ![Touchpad mode](touchpad.png \"Touchpad mode\"){w=10em}\n"
 "\n"
-"To select the preferred touch mode for menus, 2D games, and 3D games, go to **Global Options > Backend > Choose the preferred touch mode**.\n"
+"To select the preferred touch mode for menus, 2D games, and 3D games, go to "
+"**Global Options > Backend > Choose the preferred touch mode**.\n"
 "\n"
 "## Touch actions \n"
 "\n"
@@ -5594,38 +5807,59 @@ msgid ""
 "| `One finger tap`  | Left mouse click  \n"
 "| `Two fingers tap` | Right mouse click \n"
 "| `Two fingers double tap` | ESC \n"
-"| `One finger press & hold for >0.5s` | Left mouse button hold and drag, such as for selection from action wheel in Curse of Monkey Island \n"
-"| `Two fingers press & hold for >0.5s` | Right mouse button hold and drag, such as for selection from action wheel in Tony Tough \n"
+"| `One finger press & hold for >0.5s` | Left mouse button hold and drag, "
+"such as for selection from action wheel in Curse of Monkey Island \n"
+"| `Two fingers press & hold for >0.5s` | Right mouse button hold and drag, "
+"such as for selection from action wheel in Tony Tough \n"
 "| `Two fingers swipe (left to right)` | Toggles between the touch modes \n"
-"| `Two fingers swipe (right to left)` | Toggles virtual controller (>iOS 15) \n"
+"| `Two fingers swipe (right to left)` | Toggles virtual controller (>iOS "
+"15) \n"
 "| `Two fingers swipe (top to bottom)` | Access Global Main Menu in games \n"
 "| `Pinch (zoom in/out)` | Enables/disables keyboard \n"
 "\n"
 "### Virtual Gamepad \n"
 "\n"
-"Devices running iOS 15 or later can connect virtual gamepad controller by swiping two fingers from right to left or through **Global Options > Backend**. The directional button can be configured to either a thumbstick or a dpad.\n"
-"**Note** While the virtual controller is connected it is not possible to perform mouse clicks using tap gestures since they are disabled as long as the virtual controller is visible. Left mouse clicks are performed by pressing the A button. Tap gestures are enabled again when virtual controller is disconnected.\n"
+"Devices running iOS 15 or later can connect virtual gamepad controller by "
+"swiping two fingers from right to left or through **Global Options > "
+"Backend**. The directional button can be configured to either a thumbstick "
+"or a dpad.\n"
+"**Note** While the virtual controller is connected it is not possible to "
+"perform mouse clicks using tap gestures since they are disabled as long as "
+"the virtual controller is visible. Left mouse clicks are performed by "
+"pressing the A button. Tap gestures are enabled again when virtual "
+"controller is disconnected.\n"
 "\n"
 "### Global Main Menu\n"
 "\n"
-"To open the Global Main Menu, tap on the menu icon at the top right of the screen or swipe two fingers downwards.\n"
+"To open the Global Main Menu, tap on the menu icon at the top right of the "
+"screen or swipe two fingers downwards.\n"
 "\n"
 "  ![Menu icon](menu.png \"Menu icon\"){w=10em}\n"
 "\n"
 "## Virtual keyboard\n"
 "\n"
-"To open the virtual keyboard, long press on the controller icon at the top right of the screen, perform a pinch gesture (zoom out) or tap on any editable text field. To hide the virtual keyboard, tap the controller icon again, do an opposite pinch gesture (zoom in) or tap outside the text field.\n"
+"To open the virtual keyboard, long press on the controller icon at the top "
+"right of the screen, perform a pinch gesture (zoom out) or tap on any "
+"editable text field. To hide the virtual keyboard, tap the controller icon "
+"again, do an opposite pinch gesture (zoom in) or tap outside the text "
+"field.\n"
 "\n"
 "\n"
 "  ![Keyboard icon](keyboard.png \"Keyboard icon\"){w=10em}\n"
 "\n"
 msgstr ""
 "## Modos de controle de toque\n"
-"O modo de controle de toque pode ser alterado tocando ou clicando no ícone do controlador no canto superior direito, deslizando dois dedos da esquerda para a direita ou nas configurações globais do Inicializador entrando em **Opções globais > Backend > Escolher modo de toque favorito**. É possível configurar o modo de toque para três situações (menus do ScummVM, jogos 2D e jogos 3D).\n"
+"O modo de controle de toque pode ser alterado tocando ou clicando no ícone "
+"do controlador no canto superior direito, deslizando dois dedos da esquerda "
+"para a direita ou nas configurações globais do Inicializador entrando em "
+"**Opções globais > Backend > Escolher modo de toque favorito**. É possível "
+"configurar o modo de toque para três situações (menus do ScummVM, jogos 2D e "
+"jogos 3D).\n"
 "\n"
 "### Mouse direto\n"
 "\n"
-"Os controles de toque são diretos. O ponteiro salta para onde o dedo toca a tela (padrão para menus).\n"
+"Os controles de toque são diretos. O ponteiro salta para onde o dedo toca a "
+"tela (padrão para menus).\n"
 "\n"
 "  ![Modo mouse direto](mouse.png \"Modo mouse direto\"){w=10em}\n"
 "\n"
@@ -5635,7 +5869,8 @@ msgstr ""
 "\n"
 "  ![Modo Touchpad](touchpad.png \"Modo Touchpad\"){w=10em}\n"
 "\n"
-"Para selecionar o modo de toque preferido para menus, jogos 2D e jogos 3D, vá para **Opções globais > Back-end > Escolher modo de toque preferido**.\n"
+"Para selecionar o modo de toque preferido para menus, jogos 2D e jogos 3D, "
+"vá para **Opções globais > Back-end > Escolher modo de toque preferido**.\n"
 "\n"
 "## Ações de toque \n"
 "\n"
@@ -5644,27 +5879,47 @@ msgstr ""
 "| `Toque com um dedo`  | Clique com o botão esquerdo do mouse  \n"
 "| `Toque com dois dedos` | Clique com o botão direito do mouse \n"
 "| `Dois toques com dois dedos` | ESC \n"
-"| `Tocar e segurar com um dedo por mais de 0.5s` | Clicar e arrastar com o botão esquerdo do mouse, para selecionar a roda de ações em Curse of Monkey Island por exemplo\n"
-"| `Tocar e segurar com dois dedos por mais de 0.5s` | Clicar e arrastar com o botão direito do mouse, para selecionar a roda de ações em Tony Tough por exemplo \n"
-"| `Deslizar com dois dedos (da esquerda para direita)` | Alternar entre os modos de toque\n"
-"| `Deslizar com dois dedos (da direita para esquerda)` | Alternar controler virtual (iOS 15 ou superior) \n"
-"| `Deslizar com dois dedos (de cima para baixo)` | Acessar Menu Global durante o jogo \n"
-"| `Movimento de pinça com dois dedos (ampliar/reduzir zoom)` | Habilitar/desabilitar teclado \n"
+"| `Tocar e segurar com um dedo por mais de 0.5s` | Clicar e arrastar com o "
+"botão esquerdo do mouse, para selecionar a roda de ações em Curse of Monkey "
+"Island por exemplo\n"
+"| `Tocar e segurar com dois dedos por mais de 0.5s` | Clicar e arrastar com "
+"o botão direito do mouse, para selecionar a roda de ações em Tony Tough por "
+"exemplo \n"
+"| `Deslizar com dois dedos (da esquerda para direita)` | Alternar entre os "
+"modos de toque\n"
+"| `Deslizar com dois dedos (da direita para esquerda)` | Alternar controler "
+"virtual (iOS 15 ou superior) \n"
+"| `Deslizar com dois dedos (de cima para baixo)` | Acessar Menu Global "
+"durante o jogo \n"
+"| `Movimento de pinça com dois dedos (ampliar/reduzir zoom)` | Habilitar/"
+"desabilitar teclado \n"
 "\n"
 "### Gamepad virtual\n"
 "\n"
-"Dispositivos com iOS 15 ou posterior podem conectar um controlador de gamepad virtual deslizando dois dedos da direita para a esquerda ou em **Opções globais > Back-end**. O botão direcional pode ser configurado como um polegar ou botões direcionais.\n"
-"**Observação** Enquanto o controlador virtual estiver conectado, não é possível realizar cliques do mouse usando gestos de toque, pois eles estarão desativados enquanto o controlador virtual estiver visível. Os cliques com botão esquerdo do mouse são executados pressionando o botão A. Os gestos de toque são ativados novamente quando o controlador virtual é desconectado.\n"
+"Dispositivos com iOS 15 ou posterior podem conectar um controlador de "
+"gamepad virtual deslizando dois dedos da direita para a esquerda ou em "
+"**Opções globais > Back-end**. O botão direcional pode ser configurado como "
+"um polegar ou botões direcionais.\n"
+"**Observação** Enquanto o controlador virtual estiver conectado, não é "
+"possível realizar cliques do mouse usando gestos de toque, pois eles estarão "
+"desativados enquanto o controlador virtual estiver visível. Os cliques com "
+"botão esquerdo do mouse são executados pressionando o botão A. Os gestos de "
+"toque são ativados novamente quando o controlador virtual é desconectado.\n"
 "\n"
 "### Menu Principal Global\n"
 "\n"
-"Para abrir o Menu Principal Global, toque no ícone do menu no canto superior direito da tela ou deslize dois dedos para baixo.\n"
+"Para abrir o Menu Principal Global, toque no ícone do menu no canto superior "
+"direito da tela ou deslize dois dedos para baixo.\n"
 "\n"
 "  ![Ícone de menu](menu.png \"Ícone de menu\"){w=10em}\n"
 "\n"
 "## Teclado virtual\n"
 "\n"
-"Para abrir o teclado virtual, mantenha pressionado o ícone do controlador no canto superior direito da tela, faça um gesto de pinça (reduzir o zoom) ou toque em qualquer campo de texto editável. Para ocultar o teclado virtual, toque novamente no ícone do controlador, faça um gesto de pinça oposto (aumentar o zoom) ou toque fora do campo de texto.\n"
+"Para abrir o teclado virtual, mantenha pressionado o ícone do controlador no "
+"canto superior direito da tela, faça um gesto de pinça (reduzir o zoom) ou "
+"toque em qualquer campo de texto editável. Para ocultar o teclado virtual, "
+"toque novamente no ícone do controlador, faça um gesto de pinça oposto "
+"(aumentar o zoom) ou toque fora do campo de texto.\n"
 "\n"
 "\n"
 "  ![Ícone do teclado](keyboard.png \"Ícone do teclado\"){w=10em}\n"
@@ -5677,8 +5932,11 @@ msgstr "Teclado externo"
 #: backends/platform/ios7/ios7_osys_misc.mm:314
 msgid ""
 "## Use of keyboard\n"
-"External keyboards are supported and from iOS 13.4 most of the special keys, e.g. function keys, Home and End, are mapped. \n"
-"For external keyboards missing the special keys, e.g. the Apple Magic Keyboard for iPads, the special keys can be triggered using the following key combinations: \n"
+"External keyboards are supported and from iOS 13.4 most of the special keys, "
+"e.g. function keys, Home and End, are mapped. \n"
+"For external keyboards missing the special keys, e.g. the Apple Magic "
+"Keyboard for iPads, the special keys can be triggered using the following "
+"key combinations: \n"
 "\n"
 "\n"
 "| Key combination   | Action            \n"
@@ -5696,8 +5954,11 @@ msgid ""
 "\n"
 msgstr ""
 "## Uso do teclado\n"
-"Teclados externos são suportados e a partir do iOS 13.4 a maioria das teclas especiais, por ex. as teclas de função, Home e End, são mapeáveis.\n"
-"Para teclados externos faltam as teclas especiais, por ex. no Apple Magic Keyboard para iPads, as teclas especiais podem ser acionadas usando as seguintes combinações de teclas: \n"
+"Teclados externos são suportados e a partir do iOS 13.4 a maioria das teclas "
+"especiais, por ex. as teclas de função, Home e End, são mapeáveis.\n"
+"Para teclados externos faltam as teclas especiais, por ex. no Apple Magic "
+"Keyboard para iPads, as teclas especiais podem ser acionadas usando as "
+"seguintes combinações de teclas: \n"
 "\n"
 "\n"
 "| Combinação de teclas   | Ação            \n"
@@ -5718,27 +5979,40 @@ msgstr ""
 msgid ""
 "## Adding Games \n"
 "\n"
-"1. Copy the required game files to the ScummVM application. There are several ways to do that, see our [Transferring game files documentation](https://docs.scummvm.org/en/latest/other_platforms/ios.html#transferring-game-files) for more information.\n"
+"1. Copy the required game files to the ScummVM application. There are "
+"several ways to do that, see our [Transferring game files documentation]"
+"(https://docs.scummvm.org/en/latest/other_platforms/ios.html#transferring-"
+"game-files) for more information.\n"
 "\n"
 "2. Select **Add Game...** from the launcher. \n"
 "\n"
-"3. In the ScummVM file browser, double-tap to browse to your added folder. Add a game by selecting the sub-folder containing the game files, then tap **Choose**. \n"
+"3. In the ScummVM file browser, double-tap to browse to your added folder. "
+"Add a game by selecting the sub-folder containing the game files, then tap "
+"**Choose**. \n"
 "\n"
 "To add more games, repeat the steps above. \n"
 "\n"
-"See our [iOS documentation](https://docs.scummvm.org/en/latest/other_platforms/ios.html) for more information.\n"
+"See our [iOS documentation](https://docs.scummvm.org/en/latest/"
+"other_platforms/ios.html) for more information.\n"
 msgstr ""
 "## Adicionando jogos \n"
 "\n"
-"1. Copie os arquivos do jogo necessários para o aplicativo ScummVM. Existem várias maneiras de fazer isso, consulte nossa [documentação sobre transferência de arquivos de jogos](https://docs.scummvm.org/en/latest/other_platforms/ios.html#transferring-game-files) para obter mais informações.\n"
+"1. Copie os arquivos do jogo necessários para o aplicativo ScummVM. Existem "
+"várias maneiras de fazer isso, consulte nossa [documentação sobre "
+"transferência de arquivos de jogos](https://docs.scummvm.org/en/latest/"
+"other_platforms/ios.html#transferring-game-files) para obter mais "
+"informações.\n"
 "\n"
 "2. Selecione **Adicionar jogo...** no inicializador. \n"
 "\n"
-"3. No navegador de arquivos ScummVM, toque duas vezes para navegar até a pasta adicionada. Adicione um jogo selecionando a subpasta que contém os arquivos do jogo e toque em **Escolher**. \n"
+"3. No navegador de arquivos ScummVM, toque duas vezes para navegar até a "
+"pasta adicionada. Adicione um jogo selecionando a subpasta que contém os "
+"arquivos do jogo e toque em **Escolher**. \n"
 "\n"
 "Para adicionar mais jogos, repita os passos acima. \n"
 "\n"
-"Consulte nossa [documentação do iOS](https://docs.scummvm.org/en/latest/other_platforms/ios.html) para obter mais informações.\n"
+"Consulte nossa [documentação do iOS](https://docs.scummvm.org/en/latest/"
+"other_platforms/ios.html) para obter mais informações.\n"
 
 #: backends/platform/ios7/ios7_osys_misc.mm:357
 msgid ""
@@ -5757,7 +6031,8 @@ msgid ""
 "\n"
 "## Virtual keyboard\n"
 "\n"
-"To open the virtual keyboard, press and hold the Play/Pause button. To hide the virtual keyboard, press the Back/Menu button.\n"
+"To open the virtual keyboard, press and hold the Play/Pause button. To hide "
+"the virtual keyboard, press the Back/Menu button.\n"
 "\n"
 msgstr ""
 "## Ações de toque\n"
@@ -5775,34 +6050,48 @@ msgstr ""
 "\n"
 "## Teclado virtual\n"
 "\n"
-"Para abrir o teclado virtual, pressione e segure o botão Jogar/Pausar. Para ocultar o teclado virtual, pressione o botão Voltar/Menu.\n"
+"Para abrir o teclado virtual, pressione e segure o botão Jogar/Pausar. Para "
+"ocultar o teclado virtual, pressione o botão Voltar/Menu.\n"
 "\n"
 
 #: backends/platform/ios7/ios7_osys_misc.mm:380
 msgid ""
 "## Adding Games \n"
 "\n"
-"1. Copy the required game files to the ScummVM application. There are several ways to do that, see our [Transferring game files documentation](https://docs.scummvm.org/en/latest/other_platforms/tvos.html#transferring-game-files) for more information.\n"
+"1. Copy the required game files to the ScummVM application. There are "
+"several ways to do that, see our [Transferring game files documentation]"
+"(https://docs.scummvm.org/en/latest/other_platforms/tvos.html#transferring-"
+"game-files) for more information.\n"
 "\n"
 "2. Select **Add Game...** from the launcher. \n"
 "\n"
-"3. In the ScummVM file browser, double-tap to browse to your added folder. Add a game by selecting the sub-folder containing the game files, then tap **Choose**. \n"
+"3. In the ScummVM file browser, double-tap to browse to your added folder. "
+"Add a game by selecting the sub-folder containing the game files, then tap "
+"**Choose**. \n"
 "\n"
 "To add more games, repeat the steps above. \n"
 "\n"
-"See our [tvOS documentation](https://docs.scummvm.org/en/latest/other_platforms/tvos.html) for more information.\n"
+"See our [tvOS documentation](https://docs.scummvm.org/en/latest/"
+"other_platforms/tvos.html) for more information.\n"
 msgstr ""
 "## Adicionando jogos \n"
 "\n"
-"1. Copie os arquivos do jogo necessários para o aplicativo ScummVM. Existem várias maneiras de fazer isso, consulte nossa [documentação sobre transferência de arquivos de jogos](https://docs.scummvm.org/en/latest/other_platforms/tvos.html#transferring-game-files) para obter mais informações.\n"
+"1. Copie os arquivos do jogo necessários para o aplicativo ScummVM. Existem "
+"várias maneiras de fazer isso, consulte nossa [documentação sobre "
+"transferência de arquivos de jogos](https://docs.scummvm.org/en/latest/"
+"other_platforms/tvos.html#transferring-game-files) para obter mais "
+"informações.\n"
 "\n"
 "2. Selecione **Adicionar jogo...** no inicializador. \n"
 "\n"
-"3. No navegador de arquivos ScummVM, toque duas vezes para navegar até a pasta adicionada. Adicione um jogo selecionando a subpasta que contém os arquivos do jogo e toque em **Escolher**. \n"
+"3. No navegador de arquivos ScummVM, toque duas vezes para navegar até a "
+"pasta adicionada. Adicione um jogo selecionando a subpasta que contém os "
+"arquivos do jogo e toque em **Escolher**. \n"
 "\n"
 "Para adicionar mais jogos, repita os passos acima. \n"
 "\n"
-"Consulte nossa [documentação do tvOS](https://docs.scummvm.org/en/latest/other_platforms/tvos.html) para obter mais informações.\n"
+"Consulte nossa [documentação do tvOS](https://docs.scummvm.org/en/latest/"
+"other_platforms/tvos.html) para obter mais informações.\n"
 
 #: backends/platform/libretro/src/libretro-options-widget.cpp:46
 msgid "LIBRETRO PLAYLIST GENERATOR"
@@ -5872,25 +6161,46 @@ msgstr "Playlist do Libretro"
 #, fuzzy
 #| msgid ""
 #| "## Libretro playlists for ScummVM core\n"
-#| "Playlists used in Libretro frontends (e.g. Retroarch) are plain text lists used to directly launch a game with a specific core from the user interface. Those lists are structured to pass to the core the path of a specific content file to be loaded (e.g. ROM).\n"
+#| "Playlists used in Libretro frontends (e.g. Retroarch) are plain text "
+#| "lists used to directly launch a game with a specific core from the user "
+#| "interface. Those lists are structured to pass to the core the path of a "
+#| "specific content file to be loaded (e.g. ROM).\n"
 #| "\n"
-#| "ScummVM core can accept as content the path to any of the files inside a valid game folder, the detection system will try to autodetect the game from the content file parent folder and run the game with default ScummVM options.\n"
+#| "ScummVM core can accept as content the path to any of the files inside a "
+#| "valid game folder, the detection system will try to autodetect the game "
+#| "from the content file parent folder and run the game with default ScummVM "
+#| "options.\n"
 #| "\n"
-#| "The core also supports dedicated per game **hook** plain text files with **."
+#| "The core also supports dedicated per game **hook** plain text files with "
+#| "**."
 msgid ""
 "## Libretro playlists for ScummVM core\n"
-"Playlists used in Libretro frontends (e.g. Retroarch) are plain text lists used to directly launch a game with a specific core from the user interface. Those lists are structured to pass to the core the path of a specific content file to be loaded (e.g. ROM).\n"
+"Playlists used in Libretro frontends (e.g. Retroarch) are plain text lists "
+"used to directly launch a game with a specific core from the user interface. "
+"Those lists are structured to pass to the core the path of a specific "
+"content file to be loaded (e.g. ROM).\n"
 "\n"
-"ScummVM core can accept as content the playlist-provided path to any of the files inside a valid game folder, the detection system will try to autodetect the game from the content file parent folder and run the game with default ScummVM options.\n"
+"ScummVM core can accept as content the playlist-provided path to any of the "
+"files inside a valid game folder, the detection system will try to "
+"autodetect the game from the content file parent folder and run the game "
+"with default ScummVM options.\n"
 "\n"
 "The core also supports dedicated per game **hook** plain text files with **."
 msgstr ""
 "## Playlists do Libretro para o núcleo ScummVM\n"
-"As listas de reprodução usadas nos frontends do Libretro (por exemplo, Retroarch) são listas de texto simples usadas para iniciar diretamente um jogo com um núcleo específico a partir da interface do usuário. Essas listas são estruturadas para passar ao núcleo o caminho de um arquivo de conteúdo específico a ser carregado (por exemplo, ROM).\n"
+"As listas de reprodução usadas nos frontends do Libretro (por exemplo, "
+"Retroarch) são listas de texto simples usadas para iniciar diretamente um "
+"jogo com um núcleo específico a partir da interface do usuário. Essas listas "
+"são estruturadas para passar ao núcleo o caminho de um arquivo de conteúdo "
+"específico a ser carregado (por exemplo, ROM).\n"
 "\n"
-"O núcleo do ScummVM pode aceitar como conteúdo o caminho para qualquer um dos arquivos dentro de uma pasta de jogo válida, o sistema de detecção tentará detectar automaticamente o jogo a partir da pasta pai do arquivo de conteúdo e executar o jogo com as opções padrão do ScummVM.\n"
+"O núcleo do ScummVM pode aceitar como conteúdo o caminho para qualquer um "
+"dos arquivos dentro de uma pasta de jogo válida, o sistema de detecção "
+"tentará detectar automaticamente o jogo a partir da pasta pai do arquivo de "
+"conteúdo e executar o jogo com as opções padrão do ScummVM.\n"
 "\n"
-"O núcleo também é compatível com arquivos de texto simples **hook** dedicados para jogo com **."
+"O núcleo também é compatível com arquivos de texto simples **hook** "
+"dedicados para jogo com **."
 
 #: backends/platform/maemo/maemo.cpp:157
 msgid "Click Mode"
@@ -5904,9 +6214,12 @@ msgstr "Teclado"
 msgid ""
 "## Keyboard shortcuts\n"
 "\n"
-"ScummVM supports various in-game keyboard and mouse shortcuts, and since version 2.2.0 these can be manually configured in the **Keymaps tab**, or in the **configuration file**.\n"
+"ScummVM supports various in-game keyboard and mouse shortcuts, and since "
+"version 2.2.0 these can be manually configured in the **Keymaps tab**, or in "
+"the **configuration file**.\n"
 "\n"
-"For game-specific controls, see the [wiki entry](https://wiki.scummvm.org/index.php?title=Category:Supported_Games) for the game you are playing.\n"
+"For game-specific controls, see the [wiki entry](https://wiki.scummvm.org/"
+"index.php?title=Category:Supported_Games) for the game you are playing.\n"
 "\n"
 "Default shortcuts are shown in the table.\n"
 "\n"
@@ -5916,9 +6229,13 @@ msgid ""
 msgstr ""
 "## Atalhos do teclado\n"
 "\n"
-"ScummVM é compatível com vários atalhos de teclado e mouse no jogo e, desde a versão 2.2.0, eles podem ser configurados manualmente na **guia Mapeamento de Teclas** ou no **arquivo de configuração**.\n"
+"ScummVM é compatível com vários atalhos de teclado e mouse no jogo e, desde "
+"a versão 2.2.0, eles podem ser configurados manualmente na **guia Mapeamento "
+"de Teclas** ou no **arquivo de configuração**.\n"
 "\n"
-"Para controles específicos do jogo, consulte o [registro wiki](https://wiki.scummvm.org/index.php?title=Category:Supported_Games) do jogo que você está jogando.\n"
+"Para controles específicos do jogo, consulte o [registro wiki](https://"
+"wiki.scummvm.org/index.php?title=Category:Supported_Games) do jogo que você "
+"está jogando.\n"
 "\n"
 "Os atalhos padrão são exibidos na tabela.\n"
 "\n"
@@ -5946,26 +6263,33 @@ msgstr "| `Ctrl+z`  | Sair (outras plataformas)\n"
 msgid ""
 "| `Ctrl+u`  | Mutes all sounds\n"
 "| `Ctrl+m`  | Toggles mouse capture\n"
-"| `Ctrl+Alt` and `9` or `0` | Cycles forwards/backwards between graphics filters\n"
+"| `Ctrl+Alt` and `9` or `0` | Cycles forwards/backwards between graphics "
+"filters\n"
 "| `Ctrl+Alt` and `+` or `-` | Increases/decreases the scale factor\n"
 "| `Ctrl+Alt+a` | Toggles aspect ratio correction on/off\n"
-"| `Ctrl+Alt+f` | Toggles between nearest neighbor and bilinear interpolation (graphics filtering on/off)\n"
+"| `Ctrl+Alt+f` | Toggles between nearest neighbor and bilinear interpolation "
+"(graphics filtering on/off)\n"
 "| `Ctrl+Alt+s` | Cycles through stretch modes\n"
 "| `Alt+Enter`   | Toggles full screen/windowed mode\n"
 "| `Alt+s`          | Takes a screenshot\n"
-"| `Ctrl+F7`       | Opens virtual keyboard (if enabled). This can also be opened with a long press of the middle mouse button or wheel.\n"
+"| `Ctrl+F7`       | Opens virtual keyboard (if enabled). This can also be "
+"opened with a long press of the middle mouse button or wheel.\n"
 "| `Ctrl+Alt+d` | Opens the ScummVM debugger\n"
 msgstr ""
 "| `Ctrl+u`  | Silencia todos os sons\n"
 "| `Ctrl+m`  | Alterna captura do mouse\n"
-"| `Ctrl+Alt` e `9` ou `0` | Alterna para frente/para trás entre os filtros gráficos\n"
+"| `Ctrl+Alt` e `9` ou `0` | Alterna para frente/para trás entre os filtros "
+"gráficos\n"
 "| `Ctrl+Alt` e `+` ou `-` | Aumenta/reduz o fator de escala\n"
 "| `Ctrl+Alt+a` | Alterna a correção de aspecto ligado/desligado\n"
-"| `Ctrl+Alt+f` | Alterna entre escala sem filtro e interpolação bilinear (filtro de gráficos ligado/desligado)\n"
+"| `Ctrl+Alt+f` | Alterna entre escala sem filtro e interpolação bilinear "
+"(filtro de gráficos ligado/desligado)\n"
 "| `Ctrl+Alt+s` | Alterna entre os modos de redimensionamento\n"
 "| `Alt+Enter`   | Alterna entre o modo tela cheia/janela\n"
 "| `Alt+s`          | Captura um instantâneo\n"
-"| `Ctrl+F7`       | Abre o teclado virtual (se estiver habilitado). Este pode também ser aberto segurando por um tempo o toque com o botão do meio do mouse ou a roda.\n"
+"| `Ctrl+F7`       | Abre o teclado virtual (se estiver habilitado). Este "
+"pode também ser aberto segurando por um tempo o toque com o botão do meio do "
+"mouse ou a roda.\n"
 "| `Ctrl+Alt+d` | Abre o depurador do ScummVM\n"
 
 #: backends/platform/sdl/macosx/appmenu_osx.mm:303
@@ -6377,8 +6701,7 @@ msgstr "Mover para baixo e esquerda"
 msgid "Move down-right"
 msgstr "Mover para baixo e direita"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) This action is used to look at an object or npc in the game
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) This action is used to look at an object or npc in the game
 #: engines/access/metaengine.cpp:285 engines/bbvs/metaengine.cpp:124
 #: engines/dgds/metaengine.cpp:83 engines/drascula/metaengine.cpp:230
 #: engines/petka/metaengine.cpp:130 engines/scumm/help.cpp:167
@@ -6514,8 +6837,8 @@ msgstr "O arquivo de dados '%s' da engine está corrompido."
 #: engines/toon/toon.cpp:5449
 #, c-format
 msgid ""
-"Incorrect version of the '%s' engine data file found. Expected %d.%d but got"
-" %d.%d."
+"Incorrect version of the '%s' engine data file found. Expected %d.%d but got "
+"%d.%d."
 msgstr ""
 "Versão incorreta do arquivo de dados '%s\" da engine encontrada. Esperava "
 "por %d.%d mas obteve %d.%d."
@@ -6568,11 +6891,10 @@ msgstr "Utiliza o cursor quadriculado dos modelos posteriores do Apple II"
 #: engines/gob/metaengine.cpp:57 engines/got/metaengine.cpp:48
 #: engines/griffon/metaengine.cpp:40 engines/hugo/metaengine.cpp:56
 #: engines/made/metaengine.cpp:51 engines/mm/metaengine.cpp:91
-#: engines/mortevielle/metaengine.cpp:37
-#: engines/parallaction/metaengine.cpp:52 engines/sci/detection_options.h:221
-#: engines/scumm/dialogs.cpp:1252 engines/scumm/metaengine.cpp:872
-#: engines/supernova/metaengine.cpp:53 engines/wage/metaengine.cpp:51
-#: engines/wintermute/metaengine.cpp:81
+#: engines/mortevielle/metaengine.cpp:37 engines/parallaction/metaengine.cpp:52
+#: engines/sci/detection_options.h:221 engines/scumm/dialogs.cpp:1252
+#: engines/scumm/metaengine.cpp:872 engines/supernova/metaengine.cpp:53
+#: engines/wage/metaengine.cpp:51 engines/wintermute/metaengine.cpp:81
 msgid "Enable Text to Speech"
 msgstr "Habilitar Texto para Fala"
 
@@ -6596,10 +6918,13 @@ msgstr ""
 #: engines/agi/font.cpp:680
 msgid ""
 "Could not open/use file 'hgc_font' for Hercules hires font.\n"
-"If you have such file in other AGI (Sierra) game, you can copy it to the game directory"
+"If you have such file in other AGI (Sierra) game, you can copy it to the "
+"game directory"
 msgstr ""
-"Não foi possível abrir/utilizar o arquivo 'hgc_font' para a fonte Hercules hires.\n"
-"Se você tiver esse arquivo em outro jogo AGI (Sierra), você pode copiá-lo para o diretório do jogo"
+"Não foi possível abrir/utilizar o arquivo 'hgc_font' para a fonte Hercules "
+"hires.\n"
+"Se você tiver esse arquivo em outro jogo AGI (Sierra), você pode copiá-lo "
+"para o diretório do jogo"
 
 #: engines/agi/metaengine.cpp:111 engines/bagel/metaengine.cpp:105
 #: engines/chewy/metaengine.cpp:36 engines/cine/metaengine.cpp:46
@@ -6640,8 +6965,8 @@ msgid ""
 "Use an alternative palette, common for all Amiga games. This was the old "
 "behavior"
 msgstr ""
-"Utiliza uma paleta alternativa, comum para todos os jogos de Amiga. Este era"
-" o comportamento antigo"
+"Utiliza uma paleta alternativa, comum para todos os jogos de Amiga. Este era "
+"o comportamento antigo"
 
 #: engines/agi/metaengine.cpp:135
 msgid "Mouse support"
@@ -6660,11 +6985,15 @@ msgstr "Diálogo de Entrada Preditiva ao clicar o mouse"
 
 #: engines/agi/metaengine.cpp:148
 msgid ""
-"Enables the assistive Predictive Input Dialog specifically for when clicking the left mouse button within text input fields.\n"
-"The Predictive Input Dialog can still be activated on demand if there's a specified key mapping for it"
+"Enables the assistive Predictive Input Dialog specifically for when clicking "
+"the left mouse button within text input fields.\n"
+"The Predictive Input Dialog can still be activated on demand if there's a "
+"specified key mapping for it"
 msgstr ""
-"Habilita o Diálogo de Entrada Preditiva assistiva especificamente ao clicar com o botão esquerdo do mouse em campos de entrada de texto.\n"
-"O Diálogo de Entrada Preditiva também pode ser ativado sob demanda, caso exista um mapeamento de teclas configurado para essa função"
+"Habilita o Diálogo de Entrada Preditiva assistiva especificamente ao clicar "
+"com o botão esquerdo do mouse em campos de entrada de texto.\n"
+"O Diálogo de Entrada Preditiva também pode ser ativado sob demanda, caso "
+"exista um mapeamento de teclas configurado para essa função"
 
 #: engines/agi/metaengine.cpp:159
 msgid "Use Hercules hires font"
@@ -6681,8 +7010,8 @@ msgstr "Pausar quando estiver entrando com comandos"
 
 #: engines/agi/metaengine.cpp:172
 msgid ""
-"Shows a command prompt window and pauses the game (like in SCI) instead of a"
-" real-time prompt."
+"Shows a command prompt window and pauses the game (like in SCI) instead of a "
+"real-time prompt."
 msgstr ""
 "Exibe uma janela de linha de comando e pausa o jogo (como em SCI) em vez de "
 "linha em tempo real."
@@ -6709,11 +7038,10 @@ msgstr "Habilitar proteção contra cópia"
 #: engines/lure/metaengine.cpp:42 engines/mads/metaengine.cpp:57
 #: engines/mm/metaengine.cpp:47 engines/saga/metaengine.cpp:53
 #: engines/scumm/dialogs.cpp:1234 engines/scumm/metaengine.cpp:822
-msgid ""
-"Enable any copy protection that would otherwise be bypassed by default."
+msgid "Enable any copy protection that would otherwise be bypassed by default."
 msgstr ""
-"Ativa qualquer proteção contra cópia que, de outra forma, seria ignorada por"
-" padrão."
+"Ativa qualquer proteção contra cópia que, de outra forma, seria ignorada por "
+"padrão."
 
 #: engines/agi/metaengine.cpp:207
 msgid "Use PCjr's sound chip in 16-bit shift mode"
@@ -6723,8 +7051,8 @@ msgstr "Usar o chip de som do PCjr no modo de deslocamento de 16 bits"
 msgid ""
 "In PCjr sound mode, emulate a non-standard SN76496 sound chip, similar to "
 "chips found in SEGA Master System consoles. Allows certain music effects, "
-"especially in fanmade games, but original Sierra music designed strictly for"
-" PCjr may sound wrong."
+"especially in fanmade games, but original Sierra music designed strictly for "
+"PCjr may sound wrong."
 msgstr ""
 "No modo de som PCjr, emula um chip de som SN76496 não padrão, semelhante aos"
 " chips encontrados nos consoles SEGA Master System. Permite certos efeitos "
@@ -6808,8 +7136,8 @@ msgstr "Modo de MIDI:"
 
 #: engines/agos/dialogs.cpp:108 engines/sci/detection_options.h:262
 msgid ""
-"When using external MIDI devices (e.g. through USB-MIDI), select your device"
-" here"
+"When using external MIDI devices (e.g. through USB-MIDI), select your device "
+"here"
 msgstr ""
 "Quando utilizar dispositivos MIDI externos (ex: por interface USB-MIDI), "
 "selecione seu dispositivo aqui"
@@ -7095,26 +7423,30 @@ msgstr ""
 
 #: engines/ags/ags.cpp:165
 msgid ""
-"The selected game has a data file greater than 2Gb, which isn't supported by"
-" your version of ScummVM yet."
+"The selected game has a data file greater than 2Gb, which isn't supported by "
+"your version of ScummVM yet."
 msgstr ""
-"O jogo selecionado tem um arquivo de dados maior que 2 Gb, o que ainda não é"
-" compatível com a sua versão do ScummVM."
+"O jogo selecionado tem um arquivo de dados maior que 2 Gb, o que ainda não é "
+"compatível com a sua versão do ScummVM."
 
 #: engines/ags/ags.cpp:348
 msgid ""
-"To preserve the original experience, this game should be loaded using the in-game interface.\n"
+"To preserve the original experience, this game should be loaded using the in-"
+"game interface.\n"
 "You can, however, override this setting in Game Options."
 msgstr ""
-"Para preservar a experiência original, este jogo deve ser carregado utilizando a interface do jogo.\n"
+"Para preservar a experiência original, este jogo deve ser carregado "
+"utilizando a interface do jogo.\n"
 "Você pode, no entanto, substituir essa configuração nas Opções do Jogo."
 
 #: engines/ags/ags.cpp:363
 msgid ""
-"To preserve the original experience, this game should be saved using the in-game interface.\n"
+"To preserve the original experience, this game should be saved using the in-"
+"game interface.\n"
 "You can, however, override this setting in Game Options."
 msgstr ""
-"Para preservar a experiência original, este jogo deve ser salvo utilizando a interface do jogo.\n"
+"Para preservar a experiência original, este jogo deve ser salvo utilizando a "
+"interface do jogo.\n"
 "Você pode, no entanto, substituir essa configuração nas Opções do Jogo."
 
 #: engines/ags/dialogs.cpp:61
@@ -7134,7 +7466,8 @@ msgid ""
 "Never disable ScummVM save management and autosaves.\n"
 "NOTE: This could cause save duplication and other oddities"
 msgstr ""
-"Nunca desabilitar o gerenciamento de save e salvamento automático do ScummVM.\n"
+"Nunca desabilitar o gerenciamento de save e salvamento automático do "
+"ScummVM.\n"
 "NOTA: Isso pode causar duplicação de salvamento e outras esquisitices"
 
 #: engines/ags/dialogs.cpp:82
@@ -7157,12 +7490,16 @@ msgstr "Exibe a taxa de FPS atual, enquanto você joga."
 
 #: engines/ags/engine/ac/listbox.cpp:78
 msgid ""
-"The game will now list characters exported from the Sierra games that can be imported:\n"
-"1. Save files named qfg1*.sav or qfg1vga*.sav inside ScummVM save directory, or\n"
+"The game will now list characters exported from the Sierra games that can be "
+"imported:\n"
+"1. Save files named qfg1*.sav or qfg1vga*.sav inside ScummVM save directory, "
+"or\n"
 "2. Any .sav file inside the QfG2 Remake game directory"
 msgstr ""
-"O jogo agora listará personagens exportados dos jogos Sierra que podem ser importados:\n"
-"1. Salve os arquivos chamados qfg1*.sav ou qfg1vga*.sav dentro do diretório de salvamento do ScummVM, ou\n"
+"O jogo agora listará personagens exportados dos jogos Sierra que podem ser "
+"importados:\n"
+"1. Salve os arquivos chamados qfg1*.sav ou qfg1vga*.sav dentro do diretório "
+"de salvamento do ScummVM, ou\n"
 "2. Qualquer arquivo .sav dentro do diretório do jogo QfG2 Remake"
 
 #: engines/alcachofa/graphics-opengl.cpp:108
@@ -7246,8 +7583,7 @@ msgstr "Carregamento rápido"
 #: engines/phoenixvr/metaengine.cpp:100 engines/queen/metaengine.cpp:247
 #: engines/sludge/keymapper_tables.h:64 engines/sludge/keymapper_tables.h:303
 #: engines/sludge/keymapper_tables.h:410 engines/sludge/keymapper_tables.h:465
-#: engines/sludge/keymapper_tables.h:496
-#: engines/ultima/nuvie/metaengine.cpp:91
+#: engines/sludge/keymapper_tables.h:496 engines/ultima/nuvie/metaengine.cpp:91
 #: engines/ultima/ultima8/metaengine.cpp:43
 #: engines/wintermute/keymapper_tables.h:930
 msgid "Quick save"
@@ -7329,8 +7665,8 @@ msgid ""
 "Displays title and copy protection screens that would otherwise be bypassed "
 "by default."
 msgstr ""
-"Ativa qualquer proteção contra cópia que, de outra forma, seria ignorada por"
-" padrão."
+"Ativa qualquer proteção contra cópia que, de outra forma, seria ignorada por "
+"padrão."
 
 #: engines/awe/metaengine.cpp:61
 #, fuzzy
@@ -7441,8 +7777,8 @@ msgid ""
 "mode for this session until you completely Quit the game."
 msgstr ""
 "AVISO: Este jogo foi salvo no modo de Conteúdo Original, mas você está "
-"jogando no modo Restauração de Conteúdo Cortado. O modo será ajustado para o"
-" modo de Conteúdo Original para esta sessão até que você Saia completamente "
+"jogando no modo Restauração de Conteúdo Cortado. O modo será ajustado para o "
+"modo de Conteúdo Original para esta sessão até que você Saia completamente "
 "do jogo."
 
 #: engines/bladerunner/bladerunner.cpp:2758
@@ -7457,11 +7793,9 @@ msgstr "Continuar"
 msgid ""
 "The fan translator does not wish his translation to be incorporated into "
 "ScummVM."
-msgstr ""
-"O tradutor fã deseja que sua tradução não seja incorporada ao ScummVM."
+msgstr "O tradutor fã deseja que sua tradução não seja incorporada ao ScummVM."
 
-#. I18N: Blade Runner Enhanced Edition is a trademark, so please keep the
-#. capitalization
+#. I18N: Blade Runner Enhanced Edition is a trademark, so please keep the capitalization
 #. for Enhanced Edition as is.
 #: engines/bladerunner/detection_tables.h:137
 msgid ""
@@ -7545,38 +7879,30 @@ msgstr ""
 "Atualiza os créditos finais com créditos corrigidos para os dubladores "
 "espanhóis"
 
-#. I18N: These are keymaps that work in the main gameplay and also when KIA
-#. (Knowledge Integration Assistant) is open.
+#. I18N: These are keymaps that work in the main gameplay and also when KIA (Knowledge Integration Assistant) is open.
 #: engines/bladerunner/metaengine.cpp:199
 msgid "common shortcuts"
 msgstr "atalhos comuns"
 
-#. I18N: These are keymaps which work only in the main gameplay and not within
-#. KIA's (Knowledge Integration Assistant) screens.
+#. I18N: These are keymaps which work only in the main gameplay and not within KIA's (Knowledge Integration Assistant) screens.
 #: engines/bladerunner/metaengine.cpp:201
 msgid "main game shortcuts"
 msgstr "atalhos do jogo principal"
 
-#. I18N: These are keymaps that work only within KIA's (Knowledge Integration
-#. Assistant) screens.
+#. I18N: These are keymaps that work only within KIA's (Knowledge Integration Assistant) screens.
 #: engines/bladerunner/metaengine.cpp:203
 msgid "KIA only shortcuts"
 msgstr "Atalhos do AIC"
 
 #. I18N: This keymap is the main way for the user interact with the game.
-#. It is used with the game's cursor to select, walk-to, run-to, look-at,
-#. talk-to, pick up, use, shoot (combat mode), open KIA (when clicking on
-#. McCoy).
+#. It is used with the game's cursor to select, walk-to, run-to, look-at, talk-to, pick up, use, shoot (combat mode), open KIA (when clicking on McCoy).
 #: engines/bladerunner/metaengine.cpp:210
 msgid "Walk / Look / Talk / Select / Shoot"
 msgstr "Andar / Olhar / Conversar / Selecionar / Atirar"
 
-#. I18N: This keymap toggles McCoy's status between combat mode (drawing his
-#. gun) and normal mode (holstering his gun)
-#. In Blade Runner's official localizations, there is a description of this
-#. keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
-#. is
+#. I18N: This keymap toggles McCoy's status between combat mode (drawing his gun) and normal mode (holstering his gun)
+#. In Blade Runner's official localizations, there is a description of this keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
 #. TOGGLE MCCOY'S COMBAT MODE
 #: engines/bladerunner/metaengine.cpp:220
 #: engines/ultima/nuvie/metaengine.cpp:73
@@ -7596,10 +7922,8 @@ msgid "Skip cutscene"
 msgstr "Pular cena"
 
 #. I18N: This keymap allows skipping the current line of dialog.
-#. In Blade Runner's official localizations, there is a description of this
-#. keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
-#. is
+#. In Blade Runner's official localizations, there is a description of this keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
 #. SKIP PAST CURRENT LINE OF DIALOG
 #: engines/bladerunner/metaengine.cpp:242 engines/sludge/keymapper_tables.h:89
 #: engines/sludge/keymapper_tables.h:138 engines/sludge/keymapper_tables.h:194
@@ -7613,12 +7937,9 @@ msgstr "Pular cena"
 msgid "Skip dialog"
 msgstr "Pular diálogo"
 
-#. I18N: This keymap toggles between opening the KIA in the Game Options tab,
-#. and closing the KIA.
-#. In Blade Runner's official localizations, there is a description of this
-#. keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
-#. is
+#. I18N: This keymap toggles between opening the KIA in the Game Options tab, and closing the KIA.
+#. In Blade Runner's official localizations, there is a description of this keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
 #. GAME OPTIONS
 #: engines/bladerunner/metaengine.cpp:253
 #, fuzzy
@@ -7628,10 +7949,8 @@ msgstr "Opções de Jogo"
 
 #. I18N: This keymap opens the KIA database on one of the investigation tabs,
 #. CRIME SCENE DATABASE, SUSPECT DATABASE and CLUES DATABASE.
-#. In Blade Runner's official localizations, there is a description of this
-#. keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
-#. is
+#. In Blade Runner's official localizations, there is a description of this keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
 #. ACTIVATE KIA CLUE DATABASE SYSTEM
 #: engines/bladerunner/metaengine.cpp:264
 #, fuzzy
@@ -7648,11 +7967,8 @@ msgid "Delete selected saved game"
 msgstr "Apagar Jogo Salvo Selecionado"
 
 #. I18N: This keymap allows scrolling texts and lists upwards
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has a map, this action is used to scroll up in the map
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has multiple widgets for various purposes (eg. inventory,
-#. save files, etc.), this action is used to scroll up in the widget
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a map, this action is used to scroll up in the map
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has multiple widgets for various purposes (eg. inventory, save files, etc.), this action is used to scroll up in the widget
 #: engines/bladerunner/metaengine.cpp:296 engines/efh/metaengine.cpp:415
 #: engines/sherlock/metaengine.cpp:368 engines/sherlock/metaengine.cpp:999
 #: engines/sherlock/metaengine.cpp:1025 engines/titanic/metaengine.cpp:218
@@ -7671,11 +7987,8 @@ msgid "Scroll up"
 msgstr "Rolar para cima"
 
 #. I18N: This keymap allows scrolling texts and lists downwards
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has a map, this action is used to scroll down in the map
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has multiple widgets for various purposes (eg. inventory,
-#. save files, etc.), this action is used to scroll down in the widget
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a map, this action is used to scroll down in the map
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has multiple widgets for various purposes (eg. inventory, save files, etc.), this action is used to scroll down in the widget
 #: engines/bladerunner/metaengine.cpp:303 engines/efh/metaengine.cpp:403
 #: engines/sherlock/metaengine.cpp:374 engines/sherlock/metaengine.cpp:1007
 #: engines/sherlock/metaengine.cpp:1033 engines/titanic/metaengine.cpp:225
@@ -7693,8 +8006,7 @@ msgstr "Rolar para cima"
 msgid "Scroll down"
 msgstr "Rolar para baixo"
 
-#. I18N: This keymap allows (in KIA only) for a clue to be set as private or
-#. public
+#. I18N: This keymap allows (in KIA only) for a clue to be set as private or public
 #. (only when the KIA is upgraded).
 #: engines/bladerunner/metaengine.cpp:311
 #, fuzzy
@@ -7703,10 +8015,8 @@ msgid "Toggle clue privacy"
 msgstr "Alternar Privacidade de Pistas"
 
 #. I18N: This keymap opens KIA's SAVE GAME tab.
-#. In Blade Runner's official localizations, there is a description of this
-#. keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
-#. is
+#. In Blade Runner's official localizations, there is a description of this keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
 #. SAVE GAME
 #: engines/bladerunner/metaengine.cpp:330 engines/buried/metaengine.cpp:179
 #: engines/cge/metaengine.cpp:221 engines/cge2/metaengine.cpp:235
@@ -7728,16 +8038,13 @@ msgstr "Alternar Privacidade de Pistas"
 #: engines/titanic/metaengine.cpp:199 engines/toltecs/metaengine.cpp:234
 #: engines/toon/metaengine.cpp:112 engines/trecision/metaengine.cpp:169
 #: engines/tsage/metaengine.cpp:242 engines/ultima/ultima8/metaengine.cpp:44
-#: engines/vcruise/metaengine.cpp:175
-#: engines/wintermute/keymapper_tables.h:920
+#: engines/vcruise/metaengine.cpp:175 engines/wintermute/keymapper_tables.h:920
 msgid "Save game"
 msgstr "Salvar jogo"
 
 #. I18N: This keymap opens KIA's LOAD GAME tab.
-#. In Blade Runner's official localizations, there is a description of this
-#. keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
-#. is
+#. In Blade Runner's official localizations, there is a description of this keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
 #. LOAD GAME
 #: engines/bladerunner/metaengine.cpp:339 engines/buried/metaengine.cpp:184
 #: engines/cge/metaengine.cpp:227 engines/cge2/metaengine.cpp:241
@@ -7763,10 +8070,8 @@ msgid "Load game"
 msgstr "Carregar jogo"
 
 #. I18N: This keymap opens KIA's CRIME SCENE DATABASE tab.
-#. In Blade Runner's official localizations, there is a description of this
-#. keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
-#. is
+#. In Blade Runner's official localizations, there is a description of this keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
 #. CRIME SCENE DATABASE
 #: engines/bladerunner/metaengine.cpp:348
 #, fuzzy
@@ -7775,10 +8080,8 @@ msgid "Crime scene database"
 msgstr "Base de Dados de Cena do Crime"
 
 #. I18N: This keymap opens KIA's SUSPECT DATABASE tab.
-#. In Blade Runner's official localizations, there is a description of this
-#. keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
-#. is
+#. In Blade Runner's official localizations, there is a description of this keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
 #. SUSPECT DATABASE
 #: engines/bladerunner/metaengine.cpp:357
 #, fuzzy
@@ -7787,10 +8090,8 @@ msgid "Suspect database"
 msgstr "Base de Dados de Suspeitos"
 
 #. I18N: This keymap opens KIA's CLUE DATABASE tab.
-#. In Blade Runner's official localizations, there is a description of this
-#. keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
-#. is
+#. In Blade Runner's official localizations, there is a description of this keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
 #. CLUE DATABASE
 #: engines/bladerunner/metaengine.cpp:366
 #, fuzzy
@@ -7799,10 +8100,8 @@ msgid "Clue database"
 msgstr "Base de Dados de Pistas"
 
 #. I18N: This keymap opens KIA's QUIT GAME tab.
-#. In Blade Runner's official localizations, there is a description of this
-#. keymap
-#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it
-#. is
+#. In Blade Runner's official localizations, there is a description of this keymap
+#. on the KIA Help Page, under Keyboard Shortcuts. In the English version it is
 #. QUIT GAME
 #: engines/bladerunner/metaengine.cpp:375 engines/cruise/metaengine.cpp:229
 #: engines/darkseed/metaengine.cpp:60 engines/dragons/metaengine.cpp:223
@@ -7934,52 +8233,44 @@ msgstr "Mover para frente"
 msgid "Replay last AI comment"
 msgstr "Repetir o último comentário da IA"
 
-#. I18N: The game has an inventory with a list of biochips. This action is
-#. used to switch the equipped biochip to the Artificial Intelligence biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the Artificial Intelligence biochip.
 #: engines/buried/metaengine.cpp:237
 msgid "Biochip AI"
 msgstr "Biochip IA"
 
-#. I18N: The game has an inventory with a list of biochips. This action is
-#. used to switch the equipped biochip to the blank biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the blank biochip.
 #: engines/buried/metaengine.cpp:243
 msgid "Biochip blank"
 msgstr "Biochip em branco"
 
-#. I18N: The game has an inventory with a list of biochips. This action is
-#. used to switch the equipped biochip to the cloak biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the cloak biochip.
 #: engines/buried/metaengine.cpp:249
 msgid "Biochip cloak"
 msgstr "Biochip de camuflagem"
 
-#. I18N: The game has an inventory with a list of biochips. This action is
-#. used to switch the equipped biochip to the evidence biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the evidence biochip.
 #: engines/buried/metaengine.cpp:255
 msgid "Biochip evidence"
 msgstr "Biochip de evidências"
 
-#. I18N: The game has an inventory with a list of biochips. This action is
-#. used to switch the equipped biochip to the files biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the files biochip.
 #: engines/buried/metaengine.cpp:261
 #, fuzzy
 #| msgid "Show hidden files"
 msgid "Biochip files"
 msgstr "Exibir arquivos ocultos"
 
-#. I18N: The game has an inventory with a list of biochips. This action is
-#. used to switch the equipped biochip to the interface biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the interface biochip.
 #: engines/buried/metaengine.cpp:267
 msgid "Biochip interface"
 msgstr "Biochip de interface"
 
-#. I18N: The game has an inventory with a list of biochips. This action is
-#. used to switch the equipped biochip to the jump biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the jump biochip.
 #: engines/buried/metaengine.cpp:273
 msgid "Biochip jump"
 msgstr "Biochip de salto"
 
-#. I18N: The game has an inventory with a list of biochips. This action is
-#. used to switch the equipped biochip to the translate biochip.
+#. I18N: The game has an inventory with a list of biochips. This action is used to switch the equipped biochip to the translate biochip.
 #: engines/buried/metaengine.cpp:279
 msgid "Biochip translate"
 msgstr "Biochip de tradução"
@@ -7993,20 +8284,25 @@ msgstr "Exibir dicas"
 
 #: engines/buried/saveload.cpp:80
 msgid ""
-"ScummVM found that you have saved games that should be converted from the original saved game format.\n"
-"The original saved game format is no longer supported directly, so you will not be able to load your games if you don't convert them.\n"
+"ScummVM found that you have saved games that should be converted from the "
+"original saved game format.\n"
+"The original saved game format is no longer supported directly, so you will "
+"not be able to load your games if you don't convert them.\n"
 "\n"
-"Press OK to convert them now, otherwise you will be asked again the next time you start the game.\n"
+"Press OK to convert them now, otherwise you will be asked again the next "
+"time you start the game.\n"
 msgstr ""
-"ScummVM percebeu que você possui jogos salvos que precisam ser convertidos para um novo formato.\n"
-"O formato original do jogo salvo não é mais compatível, portanto, você não poderá carregar seus jogos se não convertê-los.\n"
+"ScummVM percebeu que você possui jogos salvos que precisam ser convertidos "
+"para um novo formato.\n"
+"O formato original do jogo salvo não é mais compatível, portanto, você não "
+"poderá carregar seus jogos se não convertê-los.\n"
 "\n"
-"Pressione OK para convertê-los agora, caso contrário, você será solicitado novamente na próxima vez que iniciar o jogo.\n"
+"Pressione OK para convertê-los agora, caso contrário, você será solicitado "
+"novamente na próxima vez que iniciar o jogo.\n"
 
 #: engines/buried/saveload.cpp:179 engines/mtropolis/saveload.cpp:158
 #: engines/tot/saveload.cpp:269 engines/vcruise/vcruise.cpp:356
-msgid ""
-"Saved game was created with a newer version of ScummVM. Unable to load."
+msgid "Saved game was created with a newer version of ScummVM. Unable to load."
 msgstr ""
 "O jogo salvo foi criado com uma versão mais recente do ScummVM. Não é "
 "possível carregar."
@@ -8429,16 +8725,9 @@ msgstr "Resposta 5"
 msgid "Reply 6"
 msgstr "Resposta 6"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
-#. Scalpel) The game has an inventory, this action is go ahead a page (one
-#. page displays 6 items) in the inventory
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has a journal, this action is used to go forward 1 page in
-#. the journal
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has multiple widgets for various purposes (eg. inventory,
-#. save files, etc.), this action is used to scroll down by a page in the
-#. widget
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has an inventory, this action is go ahead a page (one page displays 6 items) in the inventory
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a journal, this action is used to go forward 1 page in the journal
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has multiple widgets for various purposes (eg. inventory, save files, etc.), this action is used to scroll down by a page in the widget
 #: engines/crab/input/input.cpp:221 engines/sherlock/metaengine.cpp:591
 #: engines/sherlock/metaengine.cpp:902 engines/sherlock/metaengine.cpp:1048
 #: engines/supernova/metaengine.cpp:291 engines/titanic/metaengine.cpp:271
@@ -8452,15 +8741,9 @@ msgstr "Resposta 6"
 msgid "Next page"
 msgstr "Próxima página"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
-#. Scalpel) The game has an inventory, this action is go back a page (one page
-#. displays 6 items) in the inventory
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has a journal, this action is used to go back 1 page in
-#. the journal
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has multiple widgets for various purposes (eg. inventory,
-#. save files, etc.), this action is used to scroll up by a page in the widget
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has an inventory, this action is go back a page (one page displays 6 items) in the inventory
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a journal, this action is used to go back 1 page in the journal
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has multiple widgets for various purposes (eg. inventory, save files, etc.), this action is used to scroll up by a page in the widget
 #: engines/crab/input/input.cpp:226 engines/sherlock/metaengine.cpp:572
 #: engines/sherlock/metaengine.cpp:917 engines/sherlock/metaengine.cpp:1041
 #: engines/supernova/metaengine.cpp:285 engines/titanic/metaengine.cpp:264
@@ -8522,8 +8805,8 @@ msgstr "Utilizar velocidade da música da versão DOS"
 
 #: engines/darkseed/dialogs.cpp:107
 msgid ""
-"Use the music from the floppy version. The floppy version's music files must"
-" be copied to the SOUND directory."
+"Use the music from the floppy version. The floppy version's music files must "
+"be copied to the SOUND directory."
 msgstr ""
 "Usar a música da versão em disquete. Os arquivos de música da versão em "
 "disquete devem ser copiados para o diretório SOUND."
@@ -8633,8 +8916,7 @@ msgstr "Forçar o modo de cores reais (32bpp)"
 
 #: engines/director/metaengine.cpp:82
 #, fuzzy
-#| msgid ""
-#| "Use antialiasing to draw text even if the game does not ask for it"
+#| msgid "Use antialiasing to draw text even if the game does not ask for it"
 msgid ""
 "Use true color graphics mode (32 bits per pixel), even if the game is not "
 "designed for it"
@@ -8647,52 +8929,40 @@ msgstr ""
 msgid "Dialog choice selection keymappings"
 msgstr "Mapeamento de teclas do menu Iniciar"
 
-#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters
-#. called "champions" which they choose themselves. One of them can be
-#. assigned the "leader". This action toggles the inventory screen of the
-#. leader champion.
+#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters called "champions" which they choose themselves. One of them can be assigned the "leader". This action toggles the inventory screen of the leader champion.
 #: engines/dm/metaengine.cpp:137
 #, fuzzy
 #| msgid "Toggle Inventory/IQ Points display"
 msgid "Toggle leader inventory"
 msgstr "Alternar exibição do Inventário/Pontos de QI"
 
-#. I18N: (Game name: Dungeon Master) The game has multi-choice dialogs. If
-#. there is only one choice, then this action can be used to select it.
+#. I18N: (Game name: Dungeon Master) The game has multi-choice dialogs. If there is only one choice, then this action can be used to select it.
 #: engines/dm/metaengine.cpp:144
 msgid "Select dialog choice (only works if there is a single choice)"
 msgstr "Selecionar a opção de diálogo (só funciona se houver uma única opção)"
 
-#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters
-#. called "champions" which they choose themselves. This action toggles the
-#. inventory screen of champion 1.
+#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters called "champions" which they choose themselves. This action toggles the inventory screen of champion 1.
 #: engines/dm/metaengine.cpp:151
 #, fuzzy
 #| msgid "Toggle Inventory/IQ Points display"
 msgid "Toggle champion 1 inventory"
 msgstr "Alternar exibição do Inventário/Pontos de QI"
 
-#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters
-#. called "champions" which they choose themselves. This action toggles the
-#. inventory screen of champion 2.
+#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters called "champions" which they choose themselves. This action toggles the inventory screen of champion 2.
 #: engines/dm/metaengine.cpp:157
 #, fuzzy
 #| msgid "Toggle Inventory/IQ Points display"
 msgid "Toggle champion 2 inventory"
 msgstr "Alternar exibição do Inventário/Pontos de QI"
 
-#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters
-#. called "champions" which they choose themselves. This action toggles the
-#. inventory screen of champion 3.
+#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters called "champions" which they choose themselves. This action toggles the inventory screen of champion 3.
 #: engines/dm/metaengine.cpp:163
 #, fuzzy
 #| msgid "Toggle Inventory/IQ Points display"
 msgid "Toggle champion 3 inventory"
 msgstr "Alternar exibição do Inventário/Pontos de QI"
 
-#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters
-#. called "champions" which they choose themselves. This action toggles the
-#. inventory screen of champion 4.
+#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters called "champions" which they choose themselves. This action toggles the inventory screen of champion 4.
 #: engines/dm/metaengine.cpp:169
 #, fuzzy
 #| msgid "Toggle Inventory/IQ Points display"
@@ -8710,9 +8980,7 @@ msgstr "Alternar exibição do Inventário/Pontos de QI"
 msgid "Move backwards"
 msgstr "Mover para trás"
 
-#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters
-#. called "champions" which they choose themselves. The champions can be put
-#. to sleep. This action wakes up the sleeping champion.
+#. I18N: (Game name: Dungeon Master) The player has a team of 4 characters called "champions" which they choose themselves. The champions can be put to sleep. This action wakes up the sleeping champion.
 #: engines/dm/metaengine.cpp:247
 msgid "Wake up champion"
 msgstr "Acordar o campeão"
@@ -8771,24 +9039,29 @@ msgstr "Item seguinte do inventário"
 msgid ""
 "Error: The file '%s' hasn't been extracted properly.\n"
 "Please refer to the wiki page\n"
-"%s for details on how to properly extract the DTSPEECH.XA and *.STR files from your game disc."
+"%s for details on how to properly extract the DTSPEECH.XA and *.STR files "
+"from your game disc."
 msgstr ""
 "Erro: O arquivo '%s' não foi extraído corretamente.\n"
 "Por favor consulte a página wiki\n"
-"%s para detalhes de como extrair corretamente os arquivos DTSPEECH.XA e *.STR do seu disco de jogo."
+"%s para detalhes de como extrair corretamente os arquivos DTSPEECH.XA e "
+"*.STR do seu disco de jogo."
 
 #: engines/dragons/metaengine.cpp:120
 #, c-format
 msgid ""
 "Error: It appears that the game data files were extracted incorrectly.\n"
 "\n"
-"You should only extract STR and XA files using the special method. The rest should be copied normally from your game CD.\n"
+"You should only extract STR and XA files using the special method. The rest "
+"should be copied normally from your game CD.\n"
 "\n"
 " See %s"
 msgstr ""
-"Erro: Parece que os arquivos de dados do jogo foram extraídos incorretamente.\n"
+"Erro: Parece que os arquivos de dados do jogo foram extraídos "
+"incorretamente.\n"
 "\n"
-"Você só deve extrair arquivos STR e XA usando um método especial. O restante deve ser copiado normalmente do CD do jogo.\n"
+"Você só deve extrair arquivos STR e XA usando um método especial. O restante "
+"deve ser copiado normalmente do CD do jogo.\n"
 "\n"
 " Veja em %s"
 
@@ -8861,15 +9134,21 @@ msgstr "Confirmar"
 
 #: engines/drascula/saveload.cpp:49
 msgid ""
-"ScummVM found that you have old saved games for Drascula that should be converted.\n"
-"The old saved game format is no longer supported, so you will not be able to load your games if you don't convert them.\n"
+"ScummVM found that you have old saved games for Drascula that should be "
+"converted.\n"
+"The old saved game format is no longer supported, so you will not be able to "
+"load your games if you don't convert them.\n"
 "\n"
-"Press OK to convert them now, otherwise you will be asked again the next time you start the game.\n"
+"Press OK to convert them now, otherwise you will be asked again the next "
+"time you start the game.\n"
 msgstr ""
-"ScummVM percebeu que você possui antigos jogos salvos para Drascula que precisam ser convertidos.\n"
-"O antigo formato de jogo salvo não é mais suportado, portanto você não conseguirá carregar seus jogos se não os convertê-los.\n"
+"ScummVM percebeu que você possui antigos jogos salvos para Drascula que "
+"precisam ser convertidos.\n"
+"O antigo formato de jogo salvo não é mais suportado, portanto você não "
+"conseguirá carregar seus jogos se não os convertê-los.\n"
 "\n"
-"Pressione OK para convertê-los agora, caso contrário você será solicitado novamente da próxima vez que iniciar o jogo.\n"
+"Pressione OK para convertê-los agora, caso contrário você será solicitado "
+"novamente da próxima vez que iniciar o jogo.\n"
 
 #: engines/dreamweb/metaengine.cpp:60
 msgid "Use bright palette mode"
@@ -9141,17 +9420,14 @@ msgstr "Defender"
 
 #. I18N: Run is a movement type
 #. I18N: Action in In Cold Blood
-#: engines/efh/metaengine.cpp:530
-#: engines/freescape/games/castle/castle.cpp:506 engines/grim/grim.cpp:501
-#: engines/grim/grim.cpp:596 engines/hpl1/metaengine.cpp:82
-#: engines/icb/icb.cpp:131 engines/icb/icb.cpp:197
-#: engines/ultima/ultima8/metaengine.cpp:56
+#: engines/efh/metaengine.cpp:530 engines/freescape/games/castle/castle.cpp:506
+#: engines/grim/grim.cpp:501 engines/grim/grim.cpp:596
+#: engines/hpl1/metaengine.cpp:82 engines/icb/icb.cpp:131
+#: engines/icb/icb.cpp:197 engines/ultima/ultima8/metaengine.cpp:56
 msgid "Run"
 msgstr "Correr"
 
-#. I18N: (Game name: Escape from hell) This action is used to view the terrain
-#. during a fight so that the player can see where they can move if they
-#. decide to run.
+#. I18N: (Game name: Escape from hell) This action is used to view the terrain during a fight so that the player can see where they can move if they decide to run.
 #: engines/efh/metaengine.cpp:543
 #, fuzzy
 #| msgid "Exit conversation"
@@ -9398,8 +9674,7 @@ msgstr "Girar para baixo"
 msgid "Turn back"
 msgstr "Dar meia volta"
 
-#. I18N: Toggles between cursor lock modes, switching between free cursor
-#. movement and camera/head movement.
+#. I18N: Toggles between cursor lock modes, switching between free cursor movement and camera/head movement.
 #: engines/freescape/movement.cpp:101
 msgid "Change mode"
 msgstr "Alternar modo"
@@ -9476,8 +9751,7 @@ msgstr "Aumentando Volume"
 msgid "Decrease turn angle"
 msgstr "Diminuindo Volume"
 
-#. I18N: STEP SIZE: Measures the size of one movement in the direction you are
-#. facing (1-250 standard distance units (SDUs))
+#. I18N: STEP SIZE: Measures the size of one movement in the direction you are facing (1-250 standard distance units (SDUs))
 #: engines/freescape/games/dark/dark.cpp:284
 #: engines/freescape/games/driller/driller.cpp:165
 #, fuzzy
@@ -9485,8 +9759,7 @@ msgstr "Diminuindo Volume"
 msgid "Increase step size"
 msgstr "Aumentar Tamanho do Passo"
 
-#. I18N: STEP SIZE: Measures the size of one movement in the direction you are
-#. facing (1-250 standard distance units (SDUs))
+#. I18N: STEP SIZE: Measures the size of one movement in the direction you are facing (1-250 standard distance units (SDUs))
 #: engines/freescape/games/dark/dark.cpp:290
 #: engines/freescape/games/driller/driller.cpp:171
 #, fuzzy
@@ -9531,8 +9804,7 @@ msgstr "Colete equipamento de perfuração"
 msgid "Change angle"
 msgstr "Mudar Ângulo"
 
-#. I18N: STEP SIZE: Measures the size of one movement in the direction you are
-#. facing (1-250 standard distance units (SDUs))
+#. I18N: STEP SIZE: Measures the size of one movement in the direction you are facing (1-250 standard distance units (SDUs))
 #: engines/freescape/games/eclipse/eclipse.cpp:370
 #, fuzzy
 #| msgid "Change Step Size"
@@ -9806,8 +10078,7 @@ msgstr "Link:"
 msgid "Color for URLs if they appear in-game"
 msgstr "Cor para URLs caso apareçam no jogo"
 
-#. I18N: "More..." is a prompt in text windows, which appears when the text
-#. exceeds the window size
+#. I18N: "More..." is a prompt in text windows, which appears when the text exceeds the window size
 #: engines/glk/dialogs.cpp:264
 msgid "More:"
 msgstr "Mais:"
@@ -9850,8 +10121,8 @@ msgstr "Confirmar Saída"
 
 #: engines/glk/dialogs.cpp:286
 msgid ""
-"Custom marker in place of the \"More...\" marker for eg. \"continue\". Leave"
-" it blank to use the game's default"
+"Custom marker in place of the \"More...\" marker for eg. \"continue\". Leave "
+"it blank to use the game's default"
 msgstr ""
 "Marcador personalizado no lugar do marcador \"Mais...\", por exemplo "
 "\"continuar\". Deixe em branco para usar o padrão do jogo"
@@ -9943,8 +10214,7 @@ msgctxt "quotes"
 msgid "Off"
 msgstr "Desativado"
 
-#. I18N: This is a setting for using normal typographic quotes, which are like
-#. in most books, with the opening quote higher than the closing one
+#. I18N: This is a setting for using normal typographic quotes, which are like in most books, with the opening quote higher than the closing one
 #: engines/glk/dialogs.cpp:309
 #, fuzzy
 #| msgid "Normal"
@@ -9952,9 +10222,7 @@ msgctxt "quotes"
 msgid "Normal"
 msgstr "Normal"
 
-#. I18N: This is a setting for using "rabid" quotes, which are like normal
-#. typographic quotes but with the opening quote lower than the closing one,
-#. like in some comic books
+#. I18N: This is a setting for using "rabid" quotes, which are like normal typographic quotes but with the opening quote lower than the closing one, like in some comic books
 #: engines/glk/dialogs.cpp:311
 msgctxt "quotes"
 msgid "Rabid"
@@ -9983,16 +10251,12 @@ msgstr "Tipos de travessões"
 msgid "Off"
 msgstr "Desativado"
 
-#. I18N: This is a setting for using normal typographic dashes, which are like
-#. in most books, with the em dash being the longest and the en dash being
-#. half of it
+#. I18N: This is a setting for using normal typographic dashes, which are like in most books, with the em dash being the longest and the en dash being half of it
 #: engines/glk/dialogs.cpp:322
 msgid "Em dashes"
 msgstr "Travessões longos (em)"
 
-#. I18N: This is a setting for using "en+em" dashes, which are like normal
-#. typographic dashes but with the en dash being the same length as the em
-#. dash, like in some comic books
+#. I18N: This is a setting for using "en+em" dashes, which are like normal typographic dashes but with the en dash being the same length as the em dash, like in some comic books
 #: engines/glk/dialogs.cpp:324
 msgid "En+Em dashes"
 msgstr "Travessões en+em"
@@ -10015,14 +10279,12 @@ msgstr "Espaço"
 msgid "Types of spaces"
 msgstr "Tipos de espaços"
 
-#. I18N: This is a setting for compressing double spaces into single ones in
-#. text
+#. I18N: This is a setting for compressing double spaces into single ones in text
 #: engines/glk/dialogs.cpp:334
 msgid "Compress double spaces"
 msgstr "Comprimir espaços duplos"
 
-#. I18N: This is a setting for expanding single spaces into double ones in
-#. text
+#. I18N: This is a setting for expanding single spaces into double ones in text
 #: engines/glk/dialogs.cpp:336
 msgid "Expand single spaces"
 msgstr "Expandir espaços simples"
@@ -10079,8 +10341,7 @@ msgstr "Margem horizontal do texto"
 msgid "Vertical margin for text"
 msgstr "Margem vertical do texto"
 
-#. I18N: This is a setting for leading, which is the vertical distance between
-#. text rows
+#. I18N: This is a setting for leading, which is the vertical distance between text rows
 #: engines/glk/dialogs.cpp:353
 #, fuzzy
 msgid "Leading:"
@@ -10092,8 +10353,7 @@ msgstr ""
 "Distância vertical entre as linhas de texto. Valores válidos - 12, 16, 22, "
 "etc."
 
-#. I18N: This is a setting for baseline, which is the invisible horizontal
-#. line on which text sits
+#. I18N: This is a setting for baseline, which is the invisible horizontal line on which text sits
 #: engines/glk/dialogs.cpp:356
 msgid "Baseline:"
 msgstr "Linha de base:"
@@ -10124,14 +10384,12 @@ msgstr "Tamanho prop:"
 msgid "Font size scaling for the proportional text font"
 msgstr "Escala do tamanho da fonte para o texto proporcional"
 
-#. I18N: This is a section for settings related to the "More..." prompt in
-#. text windows
+#. I18N: This is a section for settings related to the "More..." prompt in text windows
 #: engines/glk/dialogs.cpp:367
 msgid "More"
 msgstr "Mais"
 
-#. I18N: This is a setting for alignment of the "More..." prompt in text
-#. windows
+#. I18N: This is a setting for alignment of the "More..." prompt in text windows
 #: engines/glk/dialogs.cpp:369
 msgid "Align:"
 msgstr "Alinhamento:"
@@ -10295,11 +10553,15 @@ msgstr "Introduzir Texto"
 #, c-format
 msgid ""
 "The game data file %s may be corrupted.\n"
-"If you are sure it is not please provide the ScummVM team the following code, along with the file name, the language and a description of your game version (i.e. dvd-box or jewelcase):\n"
+"If you are sure it is not please provide the ScummVM team the following "
+"code, along with the file name, the language and a description of your game "
+"version (i.e. dvd-box or jewelcase):\n"
 "%s"
 msgstr ""
 "O arquivo de dados do jogo %s pode estar corrompido.\n"
-"Se você tiver certeza de que não está, forneça à equipe ScummVM o seguinte código, junto com o nome do arquivo, o idioma e uma descrição da versão do seu jogo (por exemplo, caixa de dvd ou caixa de colecionador):\n"
+"Se você tiver certeza de que não está, forneça à equipe ScummVM o seguinte "
+"código, junto com o nome do arquivo, o idioma e uma descrição da versão do "
+"seu jogo (por exemplo, caixa de dvd ou caixa de colecionador):\n"
 "%s"
 
 #: engines/grim/md5check.cpp:620
@@ -10315,11 +10577,13 @@ msgstr ""
 
 #: engines/grim/md5checkdialog.cpp:41
 msgid ""
-"ScummVM will now verify the game data files, to make sure you have the best gaming experience.\n"
+"ScummVM will now verify the game data files, to make sure you have the best "
+"gaming experience.\n"
 "This may take a while, please wait.\n"
 "Successive runs will not check them again."
 msgstr ""
-"O ScummVM agora verificará os arquivos de dados do jogo para garantir que você tenha a melhor experiência de jogo.\n"
+"O ScummVM agora verificará os arquivos de dados do jogo para garantir que "
+"você tenha a melhor experiência de jogo.\n"
 "Isso pode demorar um pouco, aguarde.\n"
 "As execuções sucessivas não os verificarão novamente."
 
@@ -10366,7 +10630,8 @@ msgid ""
 "The original patch of Escape from Monkey Island is missing. \n"
 "Please download it from %s\n"
 "and put it in the game data files directory.\n"
-"Pay attention to download the correct version according to the game's language!"
+"Pay attention to download the correct version according to the game's "
+"language!"
 msgstr ""
 "A atualização original de Escape from Monkey Island não está presente.\n"
 "Faça o download em %s\n"
@@ -10415,8 +10680,7 @@ msgstr "Música de Créditos Atualizada"
 
 #: engines/groovie/metaengine.cpp:90
 msgid ""
-"Play the song The Final Hour during the credits instead of reusing MIDI "
-"songs"
+"Play the song The Final Hour during the credits instead of reusing MIDI songs"
 msgstr ""
 "Reproduz a música The Final Hour durante os créditos em vez de reutilizar "
 "músicas MIDI"
@@ -10689,8 +10953,7 @@ msgid "Enable restored content"
 msgstr "Habilitar conteúdo restaurado"
 
 #: engines/hypno/metaengine.cpp:82
-msgid ""
-"Add additional content that is not enabled the original implementation."
+msgid "Add additional content that is not enabled the original implementation."
 msgstr ""
 "Habilita conteúdo adicional que não está habilitado na implementação "
 "original."
@@ -10801,42 +11064,36 @@ msgid "Skip level (cheat)"
 msgstr "Pular fala"
 
 #. I18N: (Game name: Soldier Boyz) player refers to the users own character.
-#. I18N: (Game name: Marvel Comics Spider-Man: The Sinister Six) player refers
-#. to the users own character.
+#. I18N: (Game name: Marvel Comics Spider-Man: The Sinister Six) player refers to the users own character.
 #. I18N: (Game name: Wetlands) player refers to the users own character.
 #: engines/hypno/metaengine.cpp:238 engines/hypno/metaengine.cpp:334
 #: engines/hypno/metaengine.cpp:388
 msgid "Kill player"
 msgstr "Matar o jogador"
 
-#. I18N: (Game name: Soldier Boyz) the game has 3 difficulty levels: Chump,
-#. Punk and Badass. Chump is the easy mode.
+#. I18N: (Game name: Soldier Boyz) the game has 3 difficulty levels: Chump, Punk and Badass. Chump is the easy mode.
 #: engines/hypno/metaengine.cpp:262
 msgid "Chump"
 msgstr "Chump"
 
-#. I18N: (Game name: Soldier Boyz) the game has 3 difficulty levels: Chump,
-#. Punk and Badass. Punk is the medium mode.
+#. I18N: (Game name: Soldier Boyz) the game has 3 difficulty levels: Chump, Punk and Badass. Punk is the medium mode.
 #: engines/hypno/metaengine.cpp:269
 msgid "Punk"
 msgstr "Punk"
 
-#. I18N: (Game name: Soldier Boyz) the game has 3 difficulty levels: Chump,
-#. Punk and Badass. Badass is the hard mode.
+#. I18N: (Game name: Soldier Boyz) the game has 3 difficulty levels: Chump, Punk and Badass. Badass is the hard mode.
 #: engines/hypno/metaengine.cpp:276
 msgid "Badass"
 msgstr "Badass"
 
-#. I18N: (Game name: Soldier Boyz) This makes the player restart from the last
-#. checkpoint.
+#. I18N: (Game name: Soldier Boyz) This makes the player restart from the last checkpoint.
 #: engines/hypno/metaengine.cpp:289
 #, fuzzy
 #| msgid "Retreat"
 msgid "Retry sector"
 msgstr "Recuar"
 
-#. I18N: (Game name: Soldier Boyz) This makes the player restart the current
-#. mission / level.
+#. I18N: (Game name: Soldier Boyz) This makes the player restart the current mission / level.
 #: engines/hypno/metaengine.cpp:296
 #, fuzzy
 #| msgid "Restart animation"
@@ -10905,35 +11162,27 @@ msgstr "Rêmora"
 msgid "Side step"
 msgstr "Passo Lateral"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
 #: engines/illusions/metaengine.cpp:108 engines/sherlock/metaengine.cpp:1142
 msgid "Move cursor up"
 msgstr "Mover cursor para cima"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
 #: engines/illusions/metaengine.cpp:115 engines/sherlock/metaengine.cpp:1150
 msgid "Move cursor down"
 msgstr "Mover cursor para baixo"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) cursor refers to the text cursor in the save file name input field
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) cursor refers to the text cursor in the password input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the save file name input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the password input field
 #: engines/illusions/metaengine.cpp:122 engines/sherlock/metaengine.cpp:1094
 #: engines/sherlock/metaengine.cpp:1158 engines/sherlock/metaengine.cpp:1199
 msgid "Move cursor left"
 msgstr "Mover cursor para esquerda"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) cursor refers to the text cursor in the save file name input field
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) cursor refers to the text cursor in the password input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the save file name input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the foolscap puzzle input field
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) cursor refers to the text cursor in the password input field
 #: engines/illusions/metaengine.cpp:129 engines/sherlock/metaengine.cpp:1102
 #: engines/sherlock/metaengine.cpp:1166 engines/sherlock/metaengine.cpp:1207
 msgid "Move cursor right"
@@ -10953,17 +11202,15 @@ msgid ""
 "Missing language specific game code and/or resources for this fan "
 "translation."
 msgstr ""
-"Falta o código do jogo específico do idioma e/ou recursos para esta tradução"
-" de fã."
+"Falta o código do jogo específico do idioma e/ou recursos para esta tradução "
+"de fã."
 
 #: engines/kyra/detection_tables.h:78
 msgid "Demo plays simple animations without using Westwood's Engine."
-msgstr ""
-"Demonstração reproduz animações simples sem usar a engine de Westwood."
+msgstr "Demonstração reproduz animações simples sem usar a engine de Westwood."
 
 #: engines/kyra/detection_tables.h:1470
-msgid ""
-"You added the game incorrectly. Please add the root folder of the game."
+msgid "You added the game incorrectly. Please add the root folder of the game."
 msgstr "Você adicionou o jogo incorretamente. Adicione a pasta raiz do jogo."
 
 #. I18N: The file in the game directory needs to be extracted
@@ -11202,7 +11449,8 @@ msgid ""
 "Do you wish to use this saved game file with ScummVM?\n"
 "\n"
 msgstr ""
-"O seguinte arquivo de jogo salvo original foi encontrado no caminho de seu jogo:\n"
+"O seguinte arquivo de jogo salvo original foi encontrado no caminho de seu "
+"jogo:\n"
 "\n"
 "%s %S\n"
 "\n"
@@ -11215,7 +11463,8 @@ msgid ""
 "A saved game file was found in the specified slot %d. Overwrite?\n"
 "\n"
 msgstr ""
-"Um arquivo de jogo salvo foi encontrado no slot %d especificado. Substituir?\n"
+"Um arquivo de jogo salvo foi encontrado no slot %d especificado. "
+"Substituir?\n"
 "\n"
 
 #: engines/kyra/gui/saveload_eob.cpp:677
@@ -11223,12 +11472,15 @@ msgstr ""
 msgid ""
 "%d original saved games have been successfully imported into\n"
 "ScummVM. If you want to manually import original saved game later you will\n"
-"need to open the ScummVM debug console and use the command 'import_savefile'.\n"
+"need to open the ScummVM debug console and use the command "
+"'import_savefile'.\n"
 "\n"
 msgstr ""
 "%d jogos salvos originais foram importados para o\n"
-"ScummVM. Se deseja importar manualmente o jogo salvo original mais tarde você\n"
-"precisará abrir o console de depuração do ScummVM e utilizar o comando 'import_savefile'.\n"
+"ScummVM. Se deseja importar manualmente o jogo salvo original mais tarde "
+"você\n"
+"precisará abrir o console de depuração do ScummVM e utilizar o comando "
+"'import_savefile'.\n"
 "\n"
 
 #: engines/kyra/graphics/screen_eob_amiga.cpp:279
@@ -11264,11 +11516,15 @@ msgid ""
 "EOBF8.FONT\n"
 "EOBF8/8\n"
 "\n"
-"This is a localized (non-English) version of EOB II which uses language specific characters\n"
-"contained only in the specific font files that came with your game. You cannot use the font\n"
-"files from the English version or from any EOB I game which seems to be what you are doing.\n"
+"This is a localized (non-English) version of EOB II which uses language "
+"specific characters\n"
+"contained only in the specific font files that came with your game. You "
+"cannot use the font\n"
+"files from the English version or from any EOB I game which seems to be what "
+"you are doing.\n"
 "\n"
-"The game will continue, but the language specific characters will not be displayed.\n"
+"The game will continue, but the language specific characters will not be "
+"displayed.\n"
 "Please copy the correct font files into your EOB II game data directory.\n"
 "\n"
 msgstr ""
@@ -11279,12 +11535,17 @@ msgstr ""
 "EOBF8.FONT\n"
 "EOBF8/8\n"
 "\n"
-"Esta é uma versão localizada (não-Inglês) do EOB II que utiliza caractere de idioma específicos\n"
-"contido apenas nos arquivos de fontes que vieram com seu jogo. Você não pode utilizar os arquivos\n"
-"de fonte da versão em Inglês ou de nenhum jogo EOB I que aparentemente é o que você está fazendo.\n"
+"Esta é uma versão localizada (não-Inglês) do EOB II que utiliza caractere de "
+"idioma específicos\n"
+"contido apenas nos arquivos de fontes que vieram com seu jogo. Você não pode "
+"utilizar os arquivos\n"
+"de fonte da versão em Inglês ou de nenhum jogo EOB I que aparentemente é o "
+"que você está fazendo.\n"
 "\n"
-"O jogo irá prosseguir, mas os caracteres específicos do idioma não serão exibidos.\n"
-"Por favor copie os arquivos de fonte corretos para o diretório de dados do seu jogo EOB II.\n"
+"O jogo irá prosseguir, mas os caracteres específicos do idioma não serão "
+"exibidos.\n"
+"Por favor copie os arquivos de fonte corretos para o diretório de dados do "
+"seu jogo EOB II.\n"
 "\n"
 
 #: engines/lab/engine.cpp:126
@@ -11533,8 +11794,8 @@ msgstr "Reproduzir trilha sonora digital durante o vídeo de abertura"
 
 #: engines/made/metaengine.cpp:39
 msgid ""
-"If selected, the game will use a digital soundtrack during the introduction."
-" Otherwise, it will play MIDI music."
+"If selected, the game will use a digital soundtrack during the introduction. "
+"Otherwise, it will play MIDI music."
 msgstr ""
 "Se marcado, o jogo usará uma trilha sonora digital durante a introdução. "
 "Caso contrário, ele reproduzirá música MIDI."
@@ -11545,9 +11806,9 @@ msgstr "Utilizar cursores do Windows"
 
 #: engines/made/metaengine.cpp:64
 msgid ""
-"If selected, the game will use Windows mouse cursors bundled in the original"
-" .exe file. Otherwise, it will use lower resolution cursors from the data "
-"files."
+"If selected, the game will use Windows mouse cursors bundled in the "
+"original .exe file. Otherwise, it will use lower resolution cursors from the "
+"data files."
 msgstr ""
 "Se selecionado, o jogo usará os cursores de mouse do Windows incluídos no "
 "arquivo .exe original. Caso contrário, usará cursores de resolução inferior "
@@ -11646,8 +11907,7 @@ msgid "More durable armor"
 msgstr "Armadura mais durável"
 
 #: engines/mm/metaengine.cpp:69
-msgid ""
-"Armor won't break until character is at -80HP, rather than merely -10HP"
+msgid "Armor won't break until character is at -80HP, rather than merely -10HP"
 msgstr ""
 "A armadura não quebrará até que o personagem esteja com -80HP, em vez de "
 "meramente -10HP"
@@ -11765,11 +12025,9 @@ msgid "Reorder party"
 msgstr "Reorganizar Equipe"
 
 #. I18N: Action of hero party in Might & Magic 1
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
-#. Scalpel) The game has a journal, this action is used to search the journal
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a journal, this action is used to search the journal
 #: engines/mm/mm1/metaengine.cpp:116 engines/sherlock/metaengine.cpp:514
-#: engines/sherlock/metaengine.cpp:961
-#: engines/ultima/ultima4/metaengine.cpp:71
+#: engines/sherlock/metaengine.cpp:961 engines/ultima/ultima4/metaengine.cpp:71
 msgid "Search"
 msgstr "Pesquisar"
 
@@ -11811,20 +12069,22 @@ msgstr "Might and Magic 1 - Combate"
 
 #: engines/mm/mm1/mm1.cpp:57
 msgid ""
-"You cannot run the game directly from the Graphics Overhaul Mod. Instead, it"
-" will automatically be available if you detect the original game and select "
+"You cannot run the game directly from the Graphics Overhaul Mod. Instead, it "
+"will automatically be available if you detect the original game and select "
 "Enhanced mode."
 msgstr ""
 "Você não pode executar o jogo diretamente pelo Mod de Melhorias Gráficas "
-"(Graphics Overhaul Mod). Em vez disso, ele estará disponível automaticamente"
-" se você adicionar o jogo original e selecionar o modo Aprimorado."
+"(Graphics Overhaul Mod). Em vez disso, ele estará disponível automaticamente "
+"se você adicionar o jogo original e selecionar o modo Aprimorado."
 
 #: engines/mm/mm1/mm1.cpp:117
 msgid ""
-"In order to run in Enhanced mode,  please copy xeen.cc from a copy of World of Xeen\n"
+"In order to run in Enhanced mode,  please copy xeen.cc from a copy of World "
+"of Xeen\n"
 "or Clouds of Xeen to your Might and Magic 1 game folder"
 msgstr ""
-"Para executar no modo Aperfeiçoado, copie o arquivo xeen.cc do jogo World of Xeen\n"
+"Para executar no modo Aperfeiçoado, copie o arquivo xeen.cc do jogo World of "
+"Xeen\n"
 "ou Clouds of Xeen para a pasta do jogo Might and Magic 1"
 
 #: engines/mm/xeen/saves.cpp:294
@@ -11842,8 +12102,8 @@ msgid ""
 "takes you directly there, skipping intermediate screens. You can only 'Zip' "
 "to a precise area you've already been."
 msgstr ""
-"Quando ativado, clicar em um item ou área com o cursor em forma de raio leva"
-" você diretamente para lá, pulando as telas intermediárias. Você só pode "
+"Quando ativado, clicar em um item ou área com o cursor em forma de raio leva "
+"você diretamente para lá, pulando as telas intermediárias. Você só pode "
 "'Pular' para uma área específica em que você já esteve."
 
 #: engines/mohawk/dialogs.cpp:116
@@ -11872,6 +12132,7 @@ msgstr "O filme aéreo de Myst não foi reproduzido pela engine original."
 #. Normally game uses strict binary logic here.
 #. We change it to use fuzzy logic.
 #. By default the option is off.
+#.
 #: engines/mohawk/dialogs.cpp:133
 msgid "Improve Selenitic Age puzzle ~a~ccessibility"
 msgstr "Melhorar ~a~cessibilidade do enigma da Idade Selenítica"
@@ -12021,8 +12282,7 @@ msgstr ""
 #: engines/mohawk/myst_stacks/menu.cpp:299
 #: engines/mohawk/riven_stacks/aspit.cpp:370
 msgid ""
-"Are you sure you want to start a new game? All unsaved progress will be "
-"lost."
+"Are you sure you want to start a new game? All unsaved progress will be lost."
 msgstr ""
 "Você tem certeza de que deseja iniciar um novo jogo? Todo progresso não "
 "salvo será perdido."
@@ -12063,7 +12323,8 @@ msgstr ""
 
 #: engines/mohawk/riven.cpp:509
 msgid "You are missing the following required Riven data files:\n"
-msgstr "Você não possui os seguintes arquivos de dados necessários de Riven: \n"
+msgstr ""
+"Você não possui os seguintes arquivos de dados necessários de Riven: \n"
 
 #: engines/mohawk/riven.cpp:887
 msgid "Move forward left"
@@ -12082,7 +12343,8 @@ msgid ""
 "Exploration beyond this point available only within the full version of\n"
 "the game."
 msgstr ""
-"Exploração além deste ponto somente está disponível dentro da versão completa\n"
+"Exploração além deste ponto somente está disponível dentro da versão "
+"completa\n"
 "do jogo."
 
 #: engines/mohawk/riven_stacks/aspit.cpp:428
@@ -12129,8 +12391,7 @@ msgstr "Salvar automaticamente em pontos de progresso"
 
 #: engines/mtropolis/metaengine.cpp:76
 msgid "Automatically saves the game after completing puzzles and chapters."
-msgstr ""
-"Salva o jogo automaticamentem depois de completar puzzles e capítulos."
+msgstr "Salva o jogo automaticamentem depois de completar puzzles e capítulos."
 
 #: engines/mtropolis/metaengine.cpp:86
 msgid "Enable short transitions"
@@ -12197,8 +12458,7 @@ msgstr "Falha ao ler as informações da versão do arquivo salvo"
 
 #: engines/mtropolis/saveload.cpp:150 engines/vcruise/vcruise.cpp:351
 msgid ""
-"Failed to load save, the save file doesn't contain valid version "
-"information."
+"Failed to load save, the save file doesn't contain valid version information."
 msgstr ""
 "Falha ao carregar o salvamento, o arquivo salvo não contém informações de "
 "versão válidas."
@@ -12212,8 +12472,7 @@ msgstr ""
 "ScummVM. Não foi possível carregar."
 
 #: engines/mtropolis/saveload.cpp:174
-msgid ""
-"Failed to load save, an error occurred when reading the save game data."
+msgid "Failed to load save, an error occurred when reading the save game data."
 msgstr ""
 "Falha ao carregar o salvamento, ocorreu um erro ao ler os dados do jogo "
 "salvo."
@@ -12242,12 +12501,14 @@ msgstr "A versão para PS2 ainda não é suportada"
 #: engines/myst3/myst3.cpp:413
 #, c-format
 msgid ""
-"This version of Myst III has not been updated with the latest official patch.\n"
+"This version of Myst III has not been updated with the latest official "
+"patch.\n"
 "Please install the official update corresponding to your game's language.\n"
 "The updates can be downloaded from:\n"
 "%s"
 msgstr ""
-"Esta versão de Myst III não foi atualizada com a atualização oficial mais recente.\n"
+"Esta versão de Myst III não foi atualizada com a atualização oficial mais "
+"recente.\n"
 "Instale a atualização oficial correspondente ao idioma do seu jogo.\n"
 "As atualizações podem ser baixadas em:\n"
 "%s"
@@ -12335,8 +12596,8 @@ msgid ""
 "Get a little more time before failing the final puzzle. This is an official "
 "patch by HeR Interactive."
 msgstr ""
-"Recebe um pouco mais de tempo antes de falhar no quebra-cabeça final. Este é"
-" um patch oficial da HeR Interactive."
+"Recebe um pouco mais de tempo antes de falhar no quebra-cabeça final. Este é "
+"um patch oficial da HeR Interactive."
 
 #: engines/nancy/state/loadsave.cpp:108
 #, fuzzy
@@ -12409,22 +12670,19 @@ msgstr "Mover para esquerda"
 msgid "Pause / Exit menu"
 msgstr "Pular cena"
 
-#. I18N: (Game name: The Neverhood) The game has multiple cutscenes, and this
-#. action skips part of the scene.
+#. I18N: (Game name: The Neverhood) The game has multiple cutscenes, and this action skips part of the scene.
 #: engines/neverhood/metaengine.cpp:214
 #, fuzzy
 #| msgid "Skip cutscene"
 msgid "Skip section of cutscene"
 msgstr "Pular cena"
 
-#. I18N: (Game name: The Neverhood) The game has multiple cutscenes, and this
-#. action skips the entire scene.
+#. I18N: (Game name: The Neverhood) The game has multiple cutscenes, and this action skips the entire scene.
 #: engines/neverhood/metaengine.cpp:221
 msgid "Skip entire scene (works only in some scenes)"
 msgstr "Pular a cena inteira (funciona apenas em algumas cenas)"
 
-#. I18N: (Game name: The Neverhood) This action confirms the selected save or
-#. entered new save name in the save file management menus.
+#. I18N: (Game name: The Neverhood) This action confirms the selected save or entered new save name in the save file management menus.
 #: engines/neverhood/metaengine.cpp:228
 #, fuzzy
 #| msgid "Create a new saved game"
@@ -12501,15 +12759,20 @@ msgstr "Salvando jogo..."
 
 #: engines/parallaction/saveload.cpp:268
 msgid ""
-"ScummVM found that you have old saved games for Nippon Safes that should be renamed.\n"
-"The old names are no longer supported, so you will not be able to load your games if you don't convert them.\n"
+"ScummVM found that you have old saved games for Nippon Safes that should be "
+"renamed.\n"
+"The old names are no longer supported, so you will not be able to load your "
+"games if you don't convert them.\n"
 "\n"
 "Press OK to convert them now, otherwise you will be asked next time.\n"
 msgstr ""
-"ScummVM detectou que você possui antigos jogos salvos de Nippon Safes que devem ser renomeados.\n"
-"Os nomes antigos não são mais suportados, assim você não será capaz de carregar os seus jogos se você não convertê-los.\n"
+"ScummVM detectou que você possui antigos jogos salvos de Nippon Safes que "
+"devem ser renomeados.\n"
+"Os nomes antigos não são mais suportados, assim você não será capaz de "
+"carregar os seus jogos se você não convertê-los.\n"
 "\n"
-"Pressione OK para convertê-los agora, caso contrário você será solicitado na próxima vez.\n"
+"Pressione OK para convertê-los agora, caso contrário você será solicitado na "
+"próxima vez.\n"
 
 #: engines/parallaction/saveload.cpp:315
 msgid "ScummVM successfully converted all your saved games."
@@ -12517,11 +12780,13 @@ msgstr "ScummVM converteu com êxito todos os seus jogos salvos."
 
 #: engines/parallaction/saveload.cpp:317
 msgid ""
-"ScummVM printed some warnings in your console window and can't guarantee all your files have been converted.\n"
+"ScummVM printed some warnings in your console window and can't guarantee all "
+"your files have been converted.\n"
 "\n"
 "Please report to the team."
 msgstr ""
-"ScummVM exibiu alguns avisos em sua janela do console e não pode garantir que todos os seus arquivos foram convertidos.\n"
+"ScummVM exibiu alguns avisos em sua janela do console e não pode garantir "
+"que todos os seus arquivos foram convertidos.\n"
 "\n"
 "Por favor, relate para a equipe."
 
@@ -12621,18 +12886,14 @@ msgstr ""
 msgid "Interact / Skip dialog"
 msgstr "Ir para próximo diálogo"
 
-#. I18N: (Game Name: Red Comrades 1: Save the Galaxy) The game has multiple
-#. actions that you can perform(take, use, etc.), the action menu allows you
-#. to select one of them.
+#. I18N: (Game Name: Red Comrades 1: Save the Galaxy) The game has multiple actions that you can perform(take, use, etc.), the action menu allows you to select one of them.
 #: engines/petka/metaengine.cpp:124
 #, fuzzy
 #| msgid "Open action menu / Close menu"
 msgid "Open action menu / Close current interface"
 msgstr "Abrir menu de ação / Fechar menu"
 
-#. I18N: (Game Name: Red Comrades 1: Save the Galaxy) The game features two
-#. characters, but all actions are normally performed by Petka. This action
-#. allows you to "use" an object specifically with Chapayev instead.
+#. I18N: (Game Name: Red Comrades 1: Save the Galaxy) The game features two characters, but all actions are normally performed by Petka. This action allows you to "use" an object specifically with Chapayev instead.
 #: engines/petka/metaengine.cpp:166
 #, fuzzy
 #| msgid "Chapayev's action"
@@ -12690,51 +12951,40 @@ msgstr "Este item do menu ainda não foi implementado"
 msgid "Interact / Select"
 msgstr "Mover para esquerda"
 
-#. I18N: (Game Name: Pink Panther) The player normally clicks on a target
-#. (character/object) to move toward it and interact (talk,use etc.) with it.
-#. This action makes the player still walk to the target but not start
-#. interacting when they arrive.
+#. I18N: (Game Name: Pink Panther) The player normally clicks on a target (character/object) to move toward it and interact (talk,use etc.) with it. This action makes the player still walk to the target but not start interacting when they arrive.
 #: engines/pink/metaengine.cpp:136
 #, fuzzy
 #| msgid "Change game options"
 msgid "Cancel interaction"
 msgstr "Altera opções do jogo"
 
-#. I18N: (Game Name: Pink Panther) The player normally clicks on a target
-#. (character/object) to move toward it and interact (talk,use etc.) with it.
-#. This action skips the walking animation and immediately start interacting.
+#. I18N: (Game Name: Pink Panther) The player normally clicks on a target (character/object) to move toward it and interact (talk,use etc.) with it. This action skips the walking animation and immediately start interacting.
 #: engines/pink/metaengine.cpp:144
 #, fuzzy
 #| msgid "Skip dialogue"
 msgid "Skip walk"
 msgstr "Pular diálogo"
 
-#. I18N: (Game Name: Pink Panther) The player normally clicks on a target
-#. (character/object) to move toward it and interact (talk,use etc.) with it.
-#. This action skips the walking animation and also prevents the interaction,
-#. instead instantly placing the player next to the target.
+#. I18N: (Game Name: Pink Panther) The player normally clicks on a target (character/object) to move toward it and interact (talk,use etc.) with it. This action skips the walking animation and also prevents the interaction, instead instantly placing the player next to the target.
 #: engines/pink/metaengine.cpp:151
 msgid "Skip walk and cancel interaction"
 msgstr "Pular a caminhada e cancelar a interação"
 
-#. I18N: (Game Name: Pink Panther) This action fully skips the current running
-#. sequence (cutscene, dialog, interaction, etc).
+#. I18N: (Game Name: Pink Panther) This action fully skips the current running sequence (cutscene, dialog, interaction, etc).
 #: engines/pink/metaengine.cpp:158
 #, fuzzy
 #| msgid "Skip cutscene"
 msgid "Skip sequence"
 msgstr "Pular cena"
 
-#. I18N: (Game Name: Pink Panther) This action skips part of the current
-#. running sequence (cutscene, dialog, interaction, etc).
+#. I18N: (Game Name: Pink Panther) This action skips part of the current running sequence (cutscene, dialog, interaction, etc).
 #: engines/pink/metaengine.cpp:165
 #, fuzzy
 #| msgid "Skip cutscene"
 msgid "Skip sub-sequence"
 msgstr "Pular cena"
 
-#. I18N: (Game Name: Pink Panther) This action restarts the current running
-#. sequence (cutscene, dialog, interaction, etc).
+#. I18N: (Game Name: Pink Panther) This action restarts the current running sequence (cutscene, dialog, interaction, etc).
 #: engines/pink/metaengine.cpp:173
 #, fuzzy
 #| msgid "Restart the Scene"
@@ -12904,20 +13154,17 @@ msgstr "Falar"
 msgid "Close journal"
 msgstr "Exibir diário"
 
-#. I18N: Inherit the Earth had a "trial" version which is a full game with a
-#. simple check
+#. I18N: Inherit the Earth had a "trial" version which is a full game with a simple check
 #: engines/saga/detection_tables.h:875
 msgid "Windows Trial version is not supported"
 msgstr "A versão de teste do Windows não é compatível"
 
-#. I18N: Inherit the Earth had a "trial" version which is a full game with a
-#. simple check
+#. I18N: Inherit the Earth had a "trial" version which is a full game with a simple check
 #: engines/saga/detection_tables.h:902
 msgid "macOS Trial version is not supported"
 msgstr "A versão de teste do macOS não é compatível"
 
-#. I18N: Inherit the Earth had a "trial" version which is a full game with a
-#. simple check
+#. I18N: Inherit the Earth had a "trial" version which is a full game with a simple check
 #: engines/saga/detection_tables.h:928
 msgid "Pocket PC Trial version is not supported"
 msgstr "A versão de teste do Pocket PC não é compatível"
@@ -12957,10 +13204,8 @@ msgid "Converse panel keymappings"
 msgstr "Mapeamento de tecla do painel de conversa"
 
 #. I18N: the boss key is a feature,
-#. that allows players to quickly switch to a fake screen that looks like a
-#. business application,
-#. typically to avoid detection if someone, like a boss, walks by while they
-#. are playing.
+#. that allows players to quickly switch to a fake screen that looks like a business application,
+#. typically to avoid detection if someone, like a boss, walks by while they are playing.
 #: engines/saga/metaengine.cpp:298
 msgid "Boss key"
 msgstr "Tecla anti-chefe"
@@ -13001,8 +13246,7 @@ msgstr "Exibir diálogo"
 #. I18N: Walk to where cursor points
 #: engines/saga/metaengine.cpp:349 engines/scumm/help.cpp:143
 #: engines/scumm/help.cpp:168 engines/scumm/help.cpp:197
-#: engines/tinsel/metaengine.cpp:288
-#: engines/wintermute/keymapper_tables.h:1540
+#: engines/tinsel/metaengine.cpp:288 engines/wintermute/keymapper_tables.h:1540
 msgid "Walk to"
 msgstr "Andar até"
 
@@ -13224,8 +13468,8 @@ msgstr "Esta demo utiliza uma versão não implementada de vídeos Robot"
 #: engines/sci/detection_tables.h:4926
 msgid "Incomplete game detected. You have to copy data from all the CDs."
 msgstr ""
-"Jogo incompleto detectado. Você precisa copiar os arquivos de dados de todos"
-" os CDs."
+"Jogo incompleto detectado. Você precisa copiar os arquivos de dados de todos "
+"os CDs."
 
 #: engines/sci/engine/kfile.cpp:491 engines/sci/metaengine.cpp:289
 msgid "(Autosave)"
@@ -13240,8 +13484,8 @@ msgstr ""
 
 #: engines/sci/engine/kmisc.cpp:928
 msgid ""
-"The Poker logic is hardcoded in an external DLL, and is not implemented yet."
-" There exists some dummy logic for now, where opponent actions are chosen "
+"The Poker logic is hardcoded in an external DLL, and is not implemented yet. "
+"There exists some dummy logic for now, where opponent actions are chosen "
 "randomly"
 msgstr ""
 "A lógica do Poker está embutida em uma DLL externa e ainda não foi "
@@ -13280,26 +13524,26 @@ msgstr "O suporte a SCI32 não está compilado"
 
 #: engines/sci/resource/resource.cpp:859
 msgid ""
-"Missing or corrupt game resources have been detected. Some game features may"
-" not work properly. Please check the console for more information, and "
-"verify that your game files are valid."
+"Missing or corrupt game resources have been detected. Some game features may "
+"not work properly. Please check the console for more information, and verify "
+"that your game files are valid."
 msgstr ""
 "Recursos de jogo ausentes ou corrompidos foram detectados. Alguns recursos "
-"do jogo podem não funcionar corretamente. Por favor verifique o console para"
-" mais informação, e verifique se seus arquivos de jogos são válidos."
+"do jogo podem não funcionar corretamente. Por favor verifique o console para "
+"mais informação, e verifique se seus arquivos de jogos são válidos."
 
 #: engines/sci/sci.cpp:415
 msgid ""
 "Subtitles are enabled, but subtitling in King's Quest 7 was unfinished and "
-"disabled in the release version of the game. ScummVM allows the subtitles to"
-" be re-enabled, but because they were removed from the original game, they "
-"do not always render properly or reflect the actual game speech. This is not"
-" a ScummVM bug -- it is a problem with the game's assets."
+"disabled in the release version of the game. ScummVM allows the subtitles to "
+"be re-enabled, but because they were removed from the original game, they do "
+"not always render properly or reflect the actual game speech. This is not a "
+"ScummVM bug -- it is a problem with the game's assets."
 msgstr ""
 "Legendas estão habilitadas, mas as legendas em King's Quest 7 estão "
-"inacabadas e desabilitadas na versão lançada do jogo. ScummVM permite que as"
-" legendas sejam reabilitadas, mas por terem sido removidas do jogo original,"
-" elas nem sempre renderizam corretamente ou refletem a fala atual no jogo. "
+"inacabadas e desabilitadas na versão lançada do jogo. ScummVM permite que as "
+"legendas sejam reabilitadas, mas por terem sido removidas do jogo original, "
+"elas nem sempre renderizam corretamente ou refletem a fala atual no jogo. "
 "Isto não é um bug do ScummVM -- é um problema com os ativos do jogo."
 
 #: engines/sci/sci.cpp:439
@@ -13316,8 +13560,8 @@ msgid ""
 msgstr ""
 "Você selecionou MIDI Geral como dispositivo de som. Sierra forneceu suporte "
 "pós-market para MIDI Geral para este jogo em seu \"Utilitário Geral de "
-"MIDI\". Por favor, aplique esta correção para poder aproveitar a música MIDI"
-" com este jogo. Assim que o obtiver, você poderá descompactar todos seus "
+"MIDI\". Por favor, aplique esta correção para poder aproveitar a música MIDI "
+"com este jogo. Assim que o obtiver, você poderá descompactar todos seus "
 "arquivos *.PAT inclusos na pasta de extras de seu ScummVM que irá adicionar "
 "a correção apropriada automaticamente. Alternativamente você pode seguir as "
 "instruções no arquivo READ.ME incluso na correção e renomear o arquivo "
@@ -13365,25 +13609,34 @@ msgstr ""
 "\n"
 "\n"
 "Alguns drivers de áudio (pelo menos para alguns jogos) foram\n"
-"disponibilizados pela Sierra como correções pós comercialização e portanto podem não\n"
+"disponibilizados pela Sierra como correções pós comercialização e portanto "
+"podem não\n"
 "terem sido instalados como parte do instalador original do jogo.\n"
 "\n"
 "Por favor copie estes arquivo(s) para dentro do diretório de seu jogo.\n"
 "\n"
-"De qualquer forma, por favor note que os arquivo(s) pode não estar disponíveis\n"
-"separadamente mas somente como conteúdo de um pacote de recursos (corrigido).\n"
+"De qualquer forma, por favor note que os arquivo(s) pode não estar "
+"disponíveis\n"
+"separadamente mas somente como conteúdo de um pacote de recursos "
+"(corrigido).\n"
 "Neste caso você pode precisar aplicar a correção original da Sierra.\n"
 "\n"
 
 #: engines/scumm/detection_internal.h:384
 msgid ""
-"This version of Monkey Island can't be played, because Limited Run Games provided corrupted DISK03.LEC, DISK04.LEC and 903.LFL files.\n"
+"This version of Monkey Island can't be played, because Limited Run Games "
+"provided corrupted DISK03.LEC, DISK04.LEC and 903.LFL files.\n"
 "\n"
-"Please contact their technical support for replacement files, or look online for some guides which can help you recover valid files from the KryoFlux dumps that Limited Run Games also provided."
+"Please contact their technical support for replacement files, or look online "
+"for some guides which can help you recover valid files from the KryoFlux "
+"dumps that Limited Run Games also provided."
 msgstr ""
-"Esta versão do Monkey Island não pode ser jogada, porque a Limited Run Games forneceram arquivos DISK03.LEC, DISK04.LEC e 903.LFL corrompidos.\n"
+"Esta versão do Monkey Island não pode ser jogada, porque a Limited Run Games "
+"forneceram arquivos DISK03.LEC, DISK04.LEC e 903.LFL corrompidos.\n"
 "\n"
-"Entre em contato com o suporte técnico para arquivos de substituição ou procure online alguns tutoriais que possam ajudá-lo a recuperar arquivos válidos extraídos de KryoFlux que a Limited Run Games também forneceu."
+"Entre em contato com o suporte técnico para arquivos de substituição ou "
+"procure online alguns tutoriais que possam ajudá-lo a recuperar arquivos "
+"válidos extraídos de KryoFlux que a Limited Run Games também forneceu."
 
 #. I18N: Creates new online session for multiplayer
 #: engines/scumm/dialog-createsession.cpp:37
@@ -13494,8 +13747,8 @@ msgid ""
 "Makes adjustments not related to bugs for certain audio and graphics "
 "elements (e.g. version consistency changes)."
 msgstr ""
-"Realiza ajustes não relacionados a bugs em determinados elementos de áudio e"
-" gráficos (por exemplo, alterações na consistência da versão)."
+"Realiza ajustes não relacionados a bugs em determinados elementos de áudio e "
+"gráficos (por exemplo, alterações na consistência da versão)."
 
 #: engines/scumm/dialogs.cpp:1176
 msgid "Restored content"
@@ -13515,8 +13768,8 @@ msgstr "Ajustes modernos de interface"
 
 #: engines/scumm/dialogs.cpp:1181
 msgid ""
-"Activates some modern comforts; e.g it removes the fake sound loading screen"
-" in Sam&Max, and makes early save menus snappier."
+"Activates some modern comforts; e.g it removes the fake sound loading screen "
+"in Sam&Max, and makes early save menus snappier."
 msgstr ""
 "Ativa alguns confortos modernos; por exemplo, remove a tela falsa de "
 "carregamento de som no Sam&Max e acelera a aparição dos menus de salvamento."
@@ -13531,9 +13784,9 @@ msgid ""
 "save/load menu. Use it together with the \"Ask for confirmation on exit\" "
 "for a more complete experience."
 msgstr ""
-"Permite que o jogo use a interface gráfica da engine e o menu "
-"salvar/carregar originais. Utilize em conjunto com \"Solicitar confirmação "
-"ao sair\" para uma experiência mais completa."
+"Permite que o jogo use a interface gráfica da engine e o menu salvar/"
+"carregar originais. Utilize em conjunto com \"Solicitar confirmação ao "
+"sair\" para uma experiência mais completa."
 
 #: engines/scumm/dialogs.cpp:1213 engines/scumm/metaengine.cpp:793
 msgid "Brighten the graphics to simulate a Macintosh monitor."
@@ -13546,8 +13799,8 @@ msgstr "Simular as cores do Sega"
 #: engines/scumm/dialogs.cpp:1220
 msgid ""
 "Instead of using the colors defined in the game, simulate colors used on "
-"actual Sega hardware. These are significantly darker, though it's unclear if"
-" that was intended or not."
+"actual Sega hardware. These are significantly darker, though it's unclear if "
+"that was intended or not."
 msgstr ""
 "Em vez de usar as cores definidas no jogo, simula as cores usadas no "
 "hardware real do Sega. Elas são significativamente mais escuras, embora não "
@@ -13559,8 +13812,7 @@ msgstr "Mostrar o cursor de espera quando pausado"
 
 #: engines/scumm/dialogs.cpp:1227
 msgid ""
-"When paused, show the animated wait cursor from the original Sega CD "
-"version."
+"When paused, show the animated wait cursor from the original Sega CD version."
 msgstr ""
 "Quando pausado, mostra o cursor de espera animado da versão original do Sega"
 " CD."
@@ -13643,11 +13895,11 @@ msgstr "Ajustar Reprodução:"
 
 #: engines/scumm/dialogs.cpp:1601
 msgid ""
-"When playing sound from the CD audio track, adjust the start position of the"
-" sound by this much. Use this if you often hear bits of the wrong sound."
+"When playing sound from the CD audio track, adjust the start position of the "
+"sound by this much. Use this if you often hear bits of the wrong sound."
 msgstr ""
-"Ao reproduzir o som da faixa de áudio do CD, ajusta a posição inicial do som"
-" neste ponto. Use isso se você costuma ouvir trechos do som errado."
+"Ao reproduzir o som da faixa de áudio do CD, ajusta a posição inicial do som "
+"neste ponto. Use isso se você costuma ouvir trechos do som errado."
 
 #: engines/scumm/dialogs.cpp:1707
 msgid "Intro Adjust:"
@@ -13656,8 +13908,8 @@ msgstr "Ajustar Introdução:"
 #: engines/scumm/dialogs.cpp:1711
 msgid ""
 "When playing the intro track, play from this point in it. Use this if the "
-"music gets cut off prematurely, or if you are unhappy with the way the music"
-" syncs up with the intro."
+"music gets cut off prematurely, or if you are unhappy with the way the music "
+"syncs up with the intro."
 msgstr ""
 "Ao reproduzir a faixa de introdução, toca a partir deste ponto. Use isso se "
 "a música for cortada prematuramente ou se você não estiver satisfeito com a "
@@ -13686,8 +13938,8 @@ msgid ""
 "Replace music, sound effects, and speech clips with modded audio files, if "
 "available."
 msgstr ""
-"Substitui música, efeitos sonoros e falas por arquivos de áudio modificados,"
-" quando disponível."
+"Substitui música, efeitos sonoros e falas por arquivos de áudio modificados, "
+"quando disponível."
 
 #: engines/scumm/dialogs.cpp:1865 engines/scumm/dialogs.cpp:1878
 msgid "Multiplayer Server:"
@@ -13710,8 +13962,7 @@ msgid "Enable online competitive mods"
 msgstr "Habilitar mods competitivos online"
 
 #: engines/scumm/dialogs.cpp:1871
-msgid ""
-"Enables custom-made modifications intended for online competitive play."
+msgid "Enables custom-made modifications intended for online competitive play."
 msgstr ""
 "Permite modificações personalizadas destinadas a jogo online competitivo."
 
@@ -13732,8 +13983,7 @@ msgid "Host games over LAN"
 msgstr "Hospedar jogos por LAN"
 
 #: engines/scumm/dialogs.cpp:1882
-msgid ""
-"Allows the game sessions to be discovered over your local area network."
+msgid "Allows the game sessions to be discovered over your local area network."
 msgstr "Permite que as sessões de jogo sejam descobertas em sua rede local."
 
 #. I18N: Moonbase Console is a program name
@@ -14215,10 +14465,12 @@ msgstr ""
 
 #: engines/scumm/metaengine.cpp:404
 msgid ""
-"The Lite version of Putt-Putt Saves the Zoo iOS is not supported to avoid piracy.\n"
+"The Lite version of Putt-Putt Saves the Zoo iOS is not supported to avoid "
+"piracy.\n"
 "The full version is available for purchase from the iTunes Store."
 msgstr ""
-"A versão Lite de Putt-Putt Saves the Zoo do iOS não é suportada para evitar pirataria.\n"
+"A versão Lite de Putt-Putt Saves the Zoo do iOS não é suportada para evitar "
+"pirataria.\n"
 "A versão completa está disponível para compra na Loja do iTunes."
 
 #: engines/scumm/metaengine.cpp:415
@@ -14259,12 +14511,11 @@ msgstr "Cortar jogos FM-TOWNS para 200 pixels de altura"
 
 #: engines/scumm/metaengine.cpp:721
 msgid ""
-"Cut the extra 40 pixels at the bottom of the screen, to make it standard 200"
-" pixels height, allowing using 'aspect ratio correction'"
+"Cut the extra 40 pixels at the bottom of the screen, to make it standard 200 "
+"pixels height, allowing using 'aspect ratio correction'"
 msgstr ""
-"Corta os 40 pixels extras na parte inferior da tela, para torná-la padrão de"
-" 200 pixels de altura, permitindo o uso de 'correção de proporção de "
-"aspecto'"
+"Corta os 40 pixels extras na parte inferior da tela, para torná-la padrão de "
+"200 pixels de altura, permitindo o uso de 'correção de proporção de aspecto'"
 
 #: engines/scumm/metaengine.cpp:729
 msgid "Run in original 640 x 480 resolution"
@@ -14284,8 +14535,7 @@ msgstr "Música simplificada"
 
 #: engines/scumm/metaengine.cpp:738
 msgid "This music was intended for low-end Macs, and uses only one channel."
-msgstr ""
-"Esta música era destinada a Macs de baixo custo e usa apenas um canal."
+msgstr "Esta música era destinada a Macs de baixo custo e usa apenas um canal."
 
 #: engines/scumm/metaengine.cpp:746
 msgid "Enable smooth scrolling"
@@ -14318,8 +14568,8 @@ msgid ""
 "issues during normal gameplay."
 msgstr ""
 "Permite que o jogo utilize áudio de baixa latência, sacrificando a precisão "
-"do som. É recomendável habilitar esse recurso apenas se você tiver problemas"
-" de atraso de áudio durante o jogo normal."
+"do som. É recomendável habilitar esse recurso apenas se você tiver problemas "
+"de atraso de áudio durante o jogo normal."
 
 #: engines/scumm/metaengine.cpp:811
 msgid "Enable the \"A Pirate I Was Meant To Be\" song"
@@ -14332,8 +14582,8 @@ msgid ""
 "subtitles may not be fully translated."
 msgstr ""
 "Habilita a música no início da Parte 3 do jogo, \"A Pirate I Was Meant To "
-"Be\", que foi cortada em lançamentos internacionais. Observe que as legendas"
-" podem não estar totalmente traduzidas."
+"Be\", que foi cortada em lançamentos internacionais. Observe que as legendas "
+"podem não estar totalmente traduzidas."
 
 #: engines/scumm/metaengine.cpp:830
 msgid "Enable demo/kiosk mode"
@@ -14417,8 +14667,7 @@ msgid "Yoda mode"
 msgstr "Modo rápido"
 
 #: engines/scumm/metaengine.cpp:910
-msgid ""
-"Enable original Yoda mode shortcuts, including movie mode and auto play"
+msgid "Enable original Yoda mode shortcuts, including movie mode and auto play"
 msgstr ""
 "Ativar os atalhos originais do modo Yoda, incluindo o modo filme e a "
 "reprodução automática"
@@ -14519,42 +14768,51 @@ msgstr "Omitir menu principal"
 #: engines/scumm/saveload.cpp:1990
 #, c-format
 msgid ""
-"Warning: incompatible sound settings detected between the current configuration and this saved game.\n"
+"Warning: incompatible sound settings detected between the current "
+"configuration and this saved game.\n"
 "\n"
 "Current music device: %s (id %d)\n"
 "Save file music device: %s (id %d)\n"
 "\n"
 "Loading will be attempted, but the game may behave incorrectly or crash.\n"
-"Please change the audio configuration accordingly in order to properly load this save file."
+"Please change the audio configuration accordingly in order to properly load "
+"this save file."
 msgstr ""
-"Aviso: configurações de som incompatíveis detectadas entre a configuração atual e este jogo salvo.\n"
+"Aviso: configurações de som incompatíveis detectadas entre a configuração "
+"atual e este jogo salvo.\n"
 "\n"
 "Dispositivo de música atual: %s (id %d)\n"
 "Dispositivo de música do arquivo salvo: %s (id %d)\n"
 "\n"
-"Será feita uma tentativa de carregamento, mas o jogo pode se comportar incorretamente ou fechar.\n"
-"Por favor, altere a configuração de áudio adequadamente para carregar este arquivo salvo de forma correta."
+"Será feita uma tentativa de carregamento, mas o jogo pode se comportar "
+"incorretamente ou fechar.\n"
+"Por favor, altere a configuração de áudio adequadamente para carregar este "
+"arquivo salvo de forma correta."
 
 #: engines/scumm/scumm.cpp:320
 msgid ""
-"You have enabled 'aspect ratio correction'. However, FM-TOWNS' natural resolution is 320x240, which doesn't allow aspect ratio correction.\n"
-"Aspect ratio correction can be achieved by trimming the resolution to 320x200, under 'engine' tab."
+"You have enabled 'aspect ratio correction'. However, FM-TOWNS' natural "
+"resolution is 320x240, which doesn't allow aspect ratio correction.\n"
+"Aspect ratio correction can be achieved by trimming the resolution to "
+"320x200, under 'engine' tab."
 msgstr ""
-"Você habilitou a 'correção de proporção de aspecto'. No entanto, a resolução natural do FM-TOWNS é 320x240, o que não permite a correção da proporção de aspecto.\n"
-"A correção da proporção de aspecto pode ser obtida reduzindo a resolução para 320x200, na aba 'engine'."
+"Você habilitou a 'correção de proporção de aspecto'. No entanto, a resolução "
+"natural do FM-TOWNS é 320x240, o que não permite a correção da proporção de "
+"aspecto.\n"
+"A correção da proporção de aspecto pode ser obtida reduzindo a resolução "
+"para 320x200, na aba 'engine'."
 
 #: engines/scumm/scumm.cpp:1365
 #, fuzzy, c-format
-#| msgid ""
-#| "This game requires the 'Indy' Macintosh executable for its fonts."
+#| msgid "This game requires the 'Indy' Macintosh executable for its fonts."
 msgid "This game requires the '%s' Macintosh executable for its fonts."
-msgstr ""
-"Este jogo requer o executável de 'Indy' de Macintosh para suas fontes."
+msgstr "Este jogo requer o executável de 'Indy' de Macintosh para suas fontes."
 
 #: engines/scumm/scumm.cpp:1374
 #, fuzzy, c-format
 #| msgid ""
-#| "This game requires the 'Loom' Macintosh executable for its music and fonts."
+#| "This game requires the 'Loom' Macintosh executable for its music and "
+#| "fonts."
 msgid ""
 "This game requires the '%s' Macintosh executable for its music and fonts."
 msgstr ""
@@ -14564,13 +14822,15 @@ msgstr ""
 #: engines/scumm/scumm.cpp:1378
 #, fuzzy, c-format
 #| msgid ""
-#| "Could not find the 'Monkey Island' Macintosh executable to read resources\n"
+#| "Could not find the 'Monkey Island' Macintosh executable to read "
+#| "resources\n"
 #| "and instruments from. Music and Mac GUI will be disabled."
 msgid ""
-"Could not find the '%s' Macintosh executable to read resources from. %s will"
-" be disabled."
+"Could not find the '%s' Macintosh executable to read resources from. %s will "
+"be disabled."
 msgstr ""
-"Não foi possível encontrar o executável de 'Monkey Island' do Macintosh para ler recursos\n"
+"Não foi possível encontrar o executável de 'Monkey Island' do Macintosh para "
+"ler recursos\n"
 "e instrumentos. A música e a interface do Mac serão desabilitados."
 
 #: engines/scumm/scumm.cpp:1379
@@ -14624,8 +14884,10 @@ msgid ""
 "compression is not supported anymore for this game, audio will be disabled.\n"
 "Please copy the game from the original media without compression."
 msgstr ""
-"Arquivos de áudio compactados com ScummVM Tools foram detectados; *.BUN/*.SOU\n"
-"a compactação não é mais suportada para este jogo, o áudio será desabilitado.\n"
+"Arquivos de áudio compactados com ScummVM Tools foram detectados; *.BUN/"
+"*.SOU\n"
+"a compactação não é mais suportada para este jogo, o áudio será "
+"desabilitado.\n"
 "Por favor, copie o jogo da mídia de origem sem a compactação."
 
 #: engines/scumm/scumm.cpp:2408
@@ -14634,7 +14896,8 @@ msgid ""
 "Native MIDI support requires the Roland Upgrade from LucasArts,\n"
 "but %s is missing. Using AdLib instead."
 msgstr ""
-"O suporte nativo MIDI requer a atualização do sistema Roland pela LucasArts,\n"
+"O suporte nativo MIDI requer a atualização do sistema Roland pela "
+"LucasArts,\n"
 "mas %s está faltando. Utilizando AdLib ao invés."
 
 #: engines/scumm/scumm.cpp:2423
@@ -14642,8 +14905,10 @@ msgid ""
 "This particular version of Monkey Island 1 is known to miss some\n"
 "required resources for MT-32. Using AdLib instead."
 msgstr ""
-"Esta versão em particular de Monkey Island 1 é conhecida por não possuir alguns\n"
-"recursos necessários para usar música MT-32. Será utilizado AdLib em seu lugar."
+"Esta versão em particular de Monkey Island 1 é conhecida por não possuir "
+"alguns\n"
+"recursos necessários para usar música MT-32. Será utilizado AdLib em seu "
+"lugar."
 
 #: engines/scumm/scumm.cpp:4372
 msgid ""
@@ -14793,7 +15058,8 @@ msgid ""
 "Unimplemented development codepath encountered within the sound engine,\n"
 "please file a ticket at https://bugs.scummvm.org."
 msgstr ""
-"Caminho de código de desenvolvimento não implementado encontrado na engine de som,\n"
+"Caminho de código de desenvolvimento não implementado encontrado na engine "
+"de som,\n"
 "por favor, registre um chamado em https://bugs.scummvm.org."
 
 #: engines/scumm/imuse/drivers/amiga.cpp:660
@@ -14820,8 +15086,7 @@ msgstr "Transições de cena quadriculadas"
 
 #: engines/sherlock/metaengine.cpp:60
 msgid "When changing scenes, a randomized pixel transition is done"
-msgstr ""
-"Quando há mudança de cenas, uma transição aleatória de pixel é exibida"
+msgstr "Quando há mudança de cenas, uma transição aleatória de pixel é exibida"
 
 #: engines/sherlock/metaengine.cpp:71
 msgid "Don't show hotspots when moving mouse"
@@ -14848,8 +15113,7 @@ msgid "Slide dialogs into view"
 msgstr "Deslizar diálogos para área visível"
 
 #: engines/sherlock/metaengine.cpp:96
-msgid ""
-"Slide UI dialogs into view, rather than simply showing them immediately"
+msgid "Slide UI dialogs into view, rather than simply showing them immediately"
 msgstr ""
 "Desliza os diálogos de interface para dentro do campo de visão, em vez de "
 "simplesmente exibi-los imediatamente"
@@ -14923,39 +15187,27 @@ msgstr "Configurações"
 msgid "Files"
 msgstr "Conjunto de peças"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
-#. Scalpel) The game has a journal, this action is used to go back 10 pages in
-#. the journal
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has a journal, this action is used to go back 10 pages in
-#. the journal
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a journal, this action is used to go back 10 pages in the journal
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a journal, this action is used to go back 10 pages in the journal
 #: engines/sherlock/metaengine.cpp:501 engines/sherlock/metaengine.cpp:910
 msgid "Go back 10 pages"
 msgstr "Voltar 10 páginas"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
-#. Scalpel) The game has a journal, this action is used to go forward 10 pages
-#. in the journal
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has a journal, this action is used to go forward 10 pages
-#. in the journal
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a journal, this action is used to go forward 10 pages in the journal
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a journal, this action is used to go forward 10 pages in the journal
 #: engines/sherlock/metaengine.cpp:507 engines/sherlock/metaengine.cpp:895
 #, fuzzy
 #| msgid "Show journal"
 msgid "Go forward 10 pages"
 msgstr "Exibir diário"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
-#. Scalpel) The game has a journal, this action is used to go to the first
-#. page of the journal
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a journal, this action is used to go to the first page of the journal
 #: engines/sherlock/metaengine.cpp:521 engines/sherlock/metaengine.cpp:924
 #: engines/wintermute/keymapper_tables.h:965
 msgid "First page"
 msgstr "Primeira página"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
-#. Scalpel) The game has a journal, this action is used to go to the last page
-#. of the journal
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a journal, this action is used to go to the last page of the journal
 #: engines/sherlock/metaengine.cpp:528 engines/sherlock/metaengine.cpp:931
 #: engines/wintermute/keymapper_tables.h:970
 msgid "Last page"
@@ -14997,9 +15249,7 @@ msgstr "Mudar tamanho da fonte"
 msgid "Toggle windows mode"
 msgstr "Alternar modo rápido"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
-#. Scalpel) The game has an auto-help feature, this action is used to change
-#. the auto-help location between left and right
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has an auto-help feature, this action is used to change the auto-help location between left and right
 #: engines/sherlock/metaengine.cpp:713
 #, fuzzy
 #| msgid "Change game options"
@@ -15012,25 +15262,19 @@ msgstr "Altera opções do jogo"
 msgid "Toggle voices"
 msgstr "Habilitar trapaças"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
-#. Scalpel) The game has a fade animation when switching scenes, this action
-#. is used to change the fade mode to "Fade by pixel"
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a fade animation when switching scenes, this action is used to change the fade mode to "Fade by pixel"
 #: engines/sherlock/metaengine.cpp:726
 msgid "Fade by pixel"
 msgstr "Desvanecer por pixel"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
-#. Scalpel) The game has a fade animation when switching scenes, this action
-#. is used to change the fade mode to "Fade directly"
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a fade animation when switching scenes, this action is used to change the fade mode to "Fade directly"
 #: engines/sherlock/metaengine.cpp:732
 #, fuzzy
 #| msgid "Create directory"
 msgid "Fade directly"
 msgstr "Criar diretório"
 
-#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated
-#. Scalpel) The game has a fade animation when switching scenes, this action
-#. is used to change the fade mode
+#. I18N: (Game: The Lost Files of Sherlock Holmes: The Case of the Serrated Scalpel) The game has a fade animation when switching scenes, this action is used to change the fade mode
 #: engines/sherlock/metaengine.cpp:738
 #, fuzzy
 #| msgid "Change mode"
@@ -15091,9 +15335,7 @@ msgstr "Mapeamentos de teclas de índice"
 msgid "Move / Examine / Select"
 msgstr "Mover para esquerda"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) This action changes the speed of the game (walking, animations,
-#. etc.)
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) This action changes the speed of the game (walking, animations, etc.)
 #: engines/sherlock/metaengine.cpp:810
 #, fuzzy
 #| msgid "Change sound"
@@ -15130,36 +15372,28 @@ msgstr "Mudar a opção selecionada para a direita"
 msgid "Skip darts minigame"
 msgstr "Pular minigame"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has a map, this action is used to scroll to the top left
-#. of the map
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a map, this action is used to scroll to the top left of the map
 #: engines/sherlock/metaengine.cpp:983
 #, fuzzy
 #| msgid "Scroll list up"
 msgid "Scroll to top left"
 msgstr "Subir na lista"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has a map, this action is used to scroll to the bottom
-#. right of the map
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a map, this action is used to scroll to the bottom right of the map
 #: engines/sherlock/metaengine.cpp:991
 #, fuzzy
 #| msgid "Move to bottom"
 msgid "Scroll to bottom right"
 msgstr "Mover para o final"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has multiple widgets for various purposes (eg. inventory,
-#. save files, etc.), this action is used to scroll to the end of the widget
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has multiple widgets for various purposes (eg. inventory, save files, etc.), this action is used to scroll to the end of the widget
 #: engines/sherlock/metaengine.cpp:1055
 #, fuzzy
 #| msgid "Scroll list up"
 msgid "Scroll to end"
 msgstr "Subir na lista"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has multiple widgets for various purposes (eg. inventory,
-#. save files, etc.), this action is used to scroll to the start of the widget
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has multiple widgets for various purposes (eg. inventory, save files, etc.), this action is used to scroll to the start of the widget
 #: engines/sherlock/metaengine.cpp:1062
 #, fuzzy
 #| msgid "Scroll list up"
@@ -15184,22 +15418,15 @@ msgstr "Ir para o início do menu de salvar/carregar"
 msgid "Select save file"
 msgstr "Selecione um Tema"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) save file name input field has 2 modes, insert and overwrite, this
-#. action toggles between them
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) save password input field has 2 modes, insert and overwrite, this
-#. action toggles between them
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) save file name input field has 2 modes, insert and overwrite, this action toggles between them
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) save password input field has 2 modes, insert and overwrite, this action toggles between them
 #: engines/sherlock/metaengine.cpp:1124 engines/sherlock/metaengine.cpp:1229
 #, fuzzy
 #| msgid "Toggle fast mode"
 msgid "Toggle insert mode"
 msgstr "Alternar modo rápido"
 
-#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose
-#. Tattoo) The game has a foolscap puzzle, where the player has to decode a
-#. hidden message on a piece of paper called a foolscap. this action is used
-#. to exit the puzzle
+#. I18N: (Game name: The Lost Files of Sherlock Holmes: The Case of the Rose Tattoo) The game has a foolscap puzzle, where the player has to decode a hidden message on a piece of paper called a foolscap. this action is used to exit the puzzle
 #: engines/sherlock/metaengine.cpp:1135
 #, fuzzy
 #| msgid "Close popup"
@@ -15257,14 +15484,13 @@ msgstr "Introdução de disquete"
 
 #: engines/sky/metaengine.cpp:157
 msgid "Use the floppy version's intro (CD version only)"
-msgstr ""
-"Utiliza a introdução da versão de disquete (somente para versão de CD)"
+msgstr "Utiliza a introdução da versão de disquete (somente para versão de CD)"
 
 #: engines/sky/metaengine.cpp:237
 msgid "WARNING: Deleting the autosave slot is not supported by this engine"
 msgstr ""
-"AVISO: a exclusão do slot de salvamento automático não é compatível com esta"
-" engine"
+"AVISO: a exclusão do slot de salvamento automático não é compatível com esta "
+"engine"
 
 #: engines/sludge/keymapper_tables.h:34
 #, fuzzy
@@ -15393,8 +15619,8 @@ msgid ""
 "When linear filtering is enabled the background graphics are smoother in "
 "full screen mode, at the cost of some details."
 msgstr ""
-"Quando a filtragem linear está ativada, os gráficos de fundo são mais suaves"
-" no modo de tela inteira, à custa de alguns detalhes."
+"Quando a filtragem linear está ativada, os gráficos de fundo são mais suaves "
+"no modo de tela inteira, à custa de alguns detalhes."
 
 #: engines/stark/metaengine.cpp:63 engines/ultima/metaengine.cpp:144
 msgid "Enable font anti-aliasing"
@@ -15492,8 +15718,8 @@ msgstr "Estão faltando os arquivos de dados recomendados:"
 #: engines/stark/stark.cpp:306
 msgid ""
 "The 'fonts' folder is required to experience the text style as it was "
-"designed. The Steam release is known to be missing it. You can get the fonts"
-" from the demo version of the game."
+"designed. The Steam release is known to be missing it. You can get the fonts "
+"from the demo version of the game."
 msgstr ""
 "A pasta 'fonts' é necessária para experimentar o estilo do texto conforme "
 "foi projetado. O lançamento no Steam é conhecido por estar faltando isso. "
@@ -15528,11 +15754,10 @@ msgstr ""
 #: engines/supernova/supernova.cpp:479 engines/teenagent/resources.cpp:338
 #, c-format
 msgid ""
-"Incorrect version of the '%s' engine data file found. Expected %d but got "
-"%d."
+"Incorrect version of the '%s' engine data file found. Expected %d but got %d."
 msgstr ""
-"Versão incorreta do arquivo '%s' de dados da engine encontrada. Esperava por"
-" %d mas obteve %d."
+"Versão incorreta do arquivo '%s' de dados da engine encontrada. Esperava por "
+"%d mas obteve %d."
 
 #: engines/supernova/supernova.cpp:489
 #, c-format
@@ -15552,8 +15777,7 @@ msgid ""
 "set in ScummVM and that you can write to it."
 msgstr ""
 "Falha ao salvar o estado temporário do jogo. Certifique-se de que o "
-"diretório do jogo salvo está definido no ScummVM e que você pode gravar "
-"nele."
+"diretório do jogo salvo está definido no ScummVM e que você pode gravar nele."
 
 #: engines/supernova/supernova.cpp:853
 msgid "Failed to load temporary game state."
@@ -15565,8 +15789,7 @@ msgstr "Modo aperfeiçoado"
 
 #: engines/supernova/metaengine.cpp:42
 msgid ""
-"Removes some repetitive actions, adds possibility to change verbs by "
-"keyboard"
+"Removes some repetitive actions, adds possibility to change verbs by keyboard"
 msgstr ""
 "Remove algumas ações repetitivas, adiciona a possibilidade de mudar verbos "
 "por teclado"
@@ -15650,15 +15873,21 @@ msgstr "Vídeo '%s' não encontrado"
 
 #: engines/sword1/control.cpp:2814
 msgid ""
-"ScummVM found that you have old saved games for Broken Sword 1 that should be converted.\n"
-"The old saved game format is no longer supported, so you will not be able to load your games if you don't convert them.\n"
+"ScummVM found that you have old saved games for Broken Sword 1 that should "
+"be converted.\n"
+"The old saved game format is no longer supported, so you will not be able to "
+"load your games if you don't convert them.\n"
 "\n"
-"Press OK to convert them now, otherwise you will be asked again the next time you start the game.\n"
+"Press OK to convert them now, otherwise you will be asked again the next "
+"time you start the game.\n"
 msgstr ""
-"ScummVM percebeu que você possui jogos salvos antigos para Broken Sword 1 que precisam ser convertidos.\n"
-"O formato do jogo salvo antigo não é mais suportado, sendo assim você não conseguirá carregar seus jogos se não convertê-los.\n"
+"ScummVM percebeu que você possui jogos salvos antigos para Broken Sword 1 "
+"que precisam ser convertidos.\n"
+"O formato do jogo salvo antigo não é mais suportado, sendo assim você não "
+"conseguirá carregar seus jogos se não convertê-los.\n"
 "\n"
-"Pressione OK para convertê-los agora, caso contrário você será solicitado novamente da próxima vez em que iniciar o jogo.\n"
+"Pressione OK para convertê-los agora, caso contrário você será solicitado "
+"novamente da próxima vez em que iniciar o jogo.\n"
 
 #: engines/sword1/control.cpp:3000
 #, c-format
@@ -15729,8 +15958,7 @@ msgid ""
 msgstr ""
 "Faz o jogo usar curvas de áudio mais suaves (logarítmicas), mas remove o "
 "fade-in e o fade-out para efeitos sonoros, o fade-in para música e a "
-"atenuação automática do volume da música quando a fala está sendo "
-"reproduzida"
+"atenuação automática do volume da música quando a fala está sendo reproduzida"
 
 #: engines/sword1/metaengine.cpp:127
 msgid "Additional options:"
@@ -15745,8 +15973,7 @@ msgstr "Menu Principal"
 #: engines/sword2/detection_tables.h:431
 msgid "Remastered edition is not supported. Please, use the classic version"
 msgstr ""
-"A Versão Remasterizada não é compatível. Por favor, utilize a versão "
-"clássica"
+"A Versão Remasterizada não é compatível. Por favor, utilize a versão clássica"
 
 #: engines/sword2/metaengine.cpp:43
 msgid "Show object labels"
@@ -15764,8 +15991,8 @@ msgstr "Utilizar fala em Inglês"
 msgid ""
 "Use English speech instead of German for every language other than German"
 msgstr ""
-"Utiliza fala em Inglês em vez de Alemão para todos os outros idiomas que não"
-" sejam em Alemão"
+"Utiliza fala em Inglês em vez de Alemão para todos os outros idiomas que não "
+"sejam em Alemão"
 
 #: engines/sword25/metaengine.cpp:130
 msgid "Reveal all interactive hotspots (hold the key)"
@@ -16396,11 +16623,15 @@ msgstr "Piadas internas irritantes"
 
 #: engines/twp/dialogs.cpp:42
 msgid ""
-"The game will include in-jokes and references to past adventure games, in the form of both dialogues and objects.\n"
-"There is a game achievement that can be obtained only if the in-jokes option is switched on."
+"The game will include in-jokes and references to past adventure games, in "
+"the form of both dialogues and objects.\n"
+"There is a game achievement that can be obtained only if the in-jokes option "
+"is switched on."
 msgstr ""
-"O jogo incluirá piadas internas e referências a jogos de aventura anteriores, na forma de diálogos e objetos.\n"
-"Há uma conquista do jogo que só pode ser obtida se a opção de piadas internas estiver ativada."
+"O jogo incluirá piadas internas e referências a jogos de aventura "
+"anteriores, na forma de diálogos e objetos.\n"
+"Há uma conquista do jogo que só pode ser obtida se a opção de piadas "
+"internas estiver ativada."
 
 #: engines/twp/dialogs.cpp:44
 msgid "Controls:"
@@ -16557,11 +16788,9 @@ msgstr ""
 
 #: engines/twp/twp.cpp:1019
 #, fuzzy
-#| msgid ""
-#| "This game requires the FoxTail subengine, which is not compiled in."
+#| msgid "This game requires the FoxTail subengine, which is not compiled in."
 msgid ""
-"This game requires OpenGL with shaders, which is not supported on your "
-"system"
+"This game requires OpenGL with shaders, which is not supported on your system"
 msgstr "Este jogo requer a subengine FoxTail, que não está compilada."
 
 #: engines/twp/twp.cpp:1025
@@ -16595,8 +16824,7 @@ msgstr "Habilitar trapaças"
 
 #: engines/ultima/metaengine.cpp:90
 msgid "Allow cheats by commands and a menu when player is clicked."
-msgstr ""
-"Permite trapaças por comandos e abre um menu quando clicar no jogador."
+msgstr "Permite trapaças por comandos e abre um menu quando clicar no jogador."
 
 #: engines/ultima/metaengine.cpp:111
 msgid "Play foot step sounds"
@@ -16612,11 +16840,10 @@ msgstr "Habilitar pulo para a posição do mouse"
 
 #: engines/ultima/metaengine.cpp:123
 msgid ""
-"Jumping while not moving targets the mouse cursor rather than direction "
-"only."
+"Jumping while not moving targets the mouse cursor rather than direction only."
 msgstr ""
-"Pular quando não se está movendo causa um pulo na posição do cursor do mouse"
-" e não apenas a direção."
+"Pular quando não se está movendo causa um pulo na posição do cursor do mouse "
+"e não apenas a direção."
 
 #: engines/ultima/metaengine.cpp:133
 msgid "Enable font replacement"
@@ -16626,8 +16853,7 @@ msgstr "Habilitar substituição de fonte"
 msgid "Replaces game fonts with rendered fonts"
 msgstr "Substitui fontes do jogo por fontes renderizadas"
 
-#. I18N: Silencer is the player-character in Crusader games, known as the
-#. Avatar in Ultima series.
+#. I18N: Silencer is the player-character in Crusader games, known as the Avatar in Ultima series.
 #: engines/ultima/metaengine.cpp:156
 msgid "Camera moves with Silencer"
 msgstr "Câmera acompanha Jogador"
@@ -16636,8 +16862,7 @@ msgstr "Câmera acompanha Jogador"
 msgid ""
 "Camera tracks the player movement rather than snapping to defined positions."
 msgstr ""
-"A câmera segue o movimento do jogador em vez de travar em posições "
-"definidas."
+"A câmera segue o movimento do jogador em vez de travar em posições definidas."
 
 #: engines/ultima/metaengine.cpp:167
 msgid "Always enable Christmas easter-egg"
@@ -17883,8 +18108,7 @@ msgstr "Pré-carregar sons"
 
 #: engines/vcruise/metaengine.cpp:99
 msgid "Preload sounds. May improve performance on slow hard drives."
-msgstr ""
-"Pré-carrega sons. Pode melhorar o desempenho em discos rígidos lentos."
+msgstr "Pré-carrega sons. Pode melhorar o desempenho em discos rígidos lentos."
 
 #: engines/vcruise/metaengine.cpp:109
 msgid "Faster video decoder (lower quality)"
@@ -17928,7 +18152,8 @@ msgid ""
 "Music for this game requires Ogg Vorbis support, which was not compiled in.\n"
 "The game will still play, but will not have any music."
 msgstr ""
-"A música para este jogo requer suporte a Ogg Vorbis, o que não foi compilado.\n"
+"A música para este jogo requer suporte a Ogg Vorbis, o que não foi "
+"compilado.\n"
 "O jogo ainda pode ser jogado, mas não terá nenhuma música."
 
 #: engines/vcruise/vcruise.cpp:103
@@ -17999,8 +18224,7 @@ msgstr "Exibir contador de FPS"
 
 #: engines/wintermute/metaengine.cpp:43
 msgid "Show the current number of frames per second in the upper left corner"
-msgstr ""
-"Exibe o número atual de quadros por segundo no canto superior esquerdo"
+msgstr "Exibe o número atual de quadros por segundo no canto superior esquerdo"
 
 #: engines/wintermute/metaengine.cpp:54
 msgid "Sprite bilinear filtering (SLOW)"
@@ -18064,14 +18288,13 @@ msgstr "Este jogo requer a subengine HeroCraft, que não está compilada."
 
 #: engines/wintermute/wintermute.cpp:173
 msgid ""
-"This game requires 3D capabilities, which is not compiled in. As such, it is"
-" likely to be unplayable totally or partially."
+"This game requires 3D capabilities, which is not compiled in. As such, it is "
+"likely to be unplayable totally or partially."
 msgstr ""
 "Este jogo requer recursos 3D que não foram inclusos. Sendo assim, "
 "provavelmente não será possível jogar totalmente ou parcialmente."
 
-#. I18N: Debug feature to draw lines of scene geometry: walls, walking areas,
-#. etc
+#. I18N: Debug feature to draw lines of scene geometry: walls, walking areas, etc
 #: engines/wintermute/keymapper_tables.h:174
 #: engines/wintermute/keymapper_tables.h:685
 #: engines/wintermute/keymapper_tables.h:1855
@@ -18121,10 +18344,8 @@ msgstr "Botão para cima do telefone"
 msgid "Phone down button"
 msgstr "Botão para baixo do telefone"
 
-#. I18N: Some items are scripted to have alternative "Use" action, when
-#. MiddleClick is used
-#. It may result in actor saying different text or item being decomposed to
-#. it's parts
+#. I18N: Some items are scripted to have alternative "Use" action, when MiddleClick is used
+#. It may result in actor saying different text or item being decomposed to it's parts
 #: engines/wintermute/keymapper_tables.h:360
 msgid "Alternative action"
 msgstr "Ação alternativa"
@@ -18301,8 +18522,7 @@ msgstr "Velocidade de caminhada: Alta"
 msgid "Cancel waiting"
 msgstr "Cancelar espera"
 
-#. I18N: ultra_super_mega_fast_walk is the name of the variable used at game
-#. script for this speed
+#. I18N: ultra_super_mega_fast_walk is the name of the variable used at game script for this speed
 #: engines/wintermute/keymapper_tables.h:978
 msgid "Walking speed: Ultra Super Mega Fast"
 msgstr "Velocidade de caminhada: Ultra Super Mega Rápido"
@@ -18407,8 +18627,7 @@ msgstr "Cancelar entrada"
 msgid "Hide hints"
 msgstr "Ocultar dicas"
 
-#. I18N: At one of the puzzles game asks to press Up key / Shift key / Down
-#. key
+#. I18N: At one of the puzzles game asks to press Up key / Shift key / Down key
 #: engines/wintermute/keymapper_tables.h:1464
 msgid "Shift key"
 msgstr "Tecla Shift"
@@ -18443,14 +18662,12 @@ msgstr "Resposta ao diálogo 3"
 msgid "Dialog answer 4"
 msgstr "Resposta ao diálogo 4"
 
-#. I18N: This game is called "Pole Chudes" and it features a wheel similar to
-#. "Wheel of Fortune" TV show
+#. I18N: This game is called "Pole Chudes" and it features a wheel similar to "Wheel of Fortune" TV show
 #: engines/wintermute/keymapper_tables.h:1645
 msgid "Spin wheel slower"
 msgstr "Girar roda mais devagar"
 
-#. I18N: This game is called "Pole Chudes" and it features a wheel similar to
-#. "Wheel of Fortune" TV show
+#. I18N: This game is called "Pole Chudes" and it features a wheel similar to "Wheel of Fortune" TV show
 #: engines/wintermute/keymapper_tables.h:1653
 msgid "Spin wheel faster"
 msgstr "Girar roda mais rápido"
@@ -18531,8 +18748,8 @@ msgstr "Tecla i"
 #: engines/zvision/file/save_manager.cpp:207
 #, c-format
 msgid ""
-"This saved game uses version %u, but this engine only supports up to version"
-" %d. You will need an updated version of the engine to use this saved game."
+"This saved game uses version %u, but this engine only supports up to version "
+"%d. You will need an updated version of the engine to use this saved game."
 msgstr ""
 "Este jogo salvo utiliza a versão %u, mas esta engine suporta somente até a "
 "versão %d. Você precisará de uma versão atualizada da engine para utilizar "
@@ -18568,8 +18785,7 @@ msgstr "Usar vídeos MPEG de alta resolução"
 
 #: engines/zvision/metaengine.cpp:91
 msgid "Use MPEG video from the DVD version instead of lower resolution AVI"
-msgstr ""
-"Usar vídeo MPEG da versão em DVD em vez do AVI de resolução mais baixa"
+msgstr "Usar vídeo MPEG da versão em DVD em vez do AVI de resolução mais baixa"
 
 #: engines/zvision/metaengine.cpp:102
 #, fuzzy
@@ -18621,13 +18837,13 @@ msgstr "Preferências"
 #, fuzzy
 #| msgid ""
 #| "Before playing this game, you'll need to copy the required fonts into "
-#| "ScummVM's extras directory, or into the game directory. On Windows, you'll "
-#| "need the following font files from the Windows font directory: Times New "
-#| "Roman, Century Schoolbook, Garamond, Courier New and Arial. Alternatively, "
-#| "you can download the Liberation Fonts or the GNU FreeFont package. You'll "
-#| "need all the fonts from the font package you choose, i.e., LiberationMono, "
-#| "LiberationSans and LiberationSerif, or FreeMono, FreeSans and FreeSerif "
-#| "respectively."
+#| "ScummVM's extras directory, or into the game directory. On Windows, "
+#| "you'll need the following font files from the Windows font directory: "
+#| "Times New Roman, Century Schoolbook, Garamond, Courier New and Arial. "
+#| "Alternatively, you can download the Liberation Fonts or the GNU FreeFont "
+#| "package. You'll need all the fonts from the font package you choose, "
+#| "i.e., LiberationMono, LiberationSans and LiberationSerif, or FreeMono, "
+#| "FreeSans and FreeSerif respectively."
 msgid ""
 "Before playing this game, you'll need to copy the required fonts into "
 "ScummVM's extras directory, or into the game directory. On Windows, you'll "
@@ -18637,13 +18853,13 @@ msgid ""
 "from the font package you choose, i.e., LiberationMono, LiberationSans and "
 "LiberationSerif."
 msgstr ""
-"Antes de jogar este jogo, você precisará copiar as fontes necessárias para o"
-" diretório de extras do ScummVM, ou para o diretório do jogo. No Windows, "
+"Antes de jogar este jogo, você precisará copiar as fontes necessárias para o "
+"diretório de extras do ScummVM, ou para o diretório do jogo. No Windows, "
 "você precisará dos seguintes arquivos de fonte do diretório de fontes do "
-"Windows: Times New Roman, Century Schoolbook, Garamond, Courier New e Arial."
-" Alternativamente, você pode baixar as Fontes Liberation ou o pacote "
-"FreeFont do GNU. Você precisará de todas as fontes do pacote de fontes que "
-"você escolher, ex., LiberationMono, LiberationSans e LiberationSerif, ou "
+"Windows: Times New Roman, Century Schoolbook, Garamond, Courier New e Arial. "
+"Alternativamente, você pode baixar as Fontes Liberation ou o pacote FreeFont "
+"do GNU. Você precisará de todas as fontes do pacote de fontes que você "
+"escolher, ex., LiberationMono, LiberationSans e LiberationSerif, ou "
 "FreeMono, FreeSans e FreeSerif respectivamente."
 
 #: engines/zvision/zvision.cpp:323
@@ -18660,14 +18876,17 @@ msgstr ""
 "Continuar iniciando o jogo?"
 
 #, fuzzy
+#~| msgid "Move Back"
 #~ msgid "Menu back"
 #~ msgstr "Mover para Trás"
 
 #, fuzzy
+#~| msgid "Backspace"
 #~ msgid "Back / skip"
 #~ msgstr "Retroceder"
 
 #, fuzzy
+#~| msgid "No"
 #~ msgid "N"
 #~ msgstr "Não"
 
@@ -18687,18 +18906,22 @@ msgstr ""
 #~ msgstr "Salvar arquivo"
 
 #, fuzzy
+#~| msgid "Center"
 #~ msgid "Centre"
 #~ msgstr "Centralizado"
 
 #, fuzzy
+#~| msgid "L1"
 #~ msgid "1"
 #~ msgstr "L1"
 
 #, fuzzy
+#~| msgid "L2"
 #~ msgid "2"
 #~ msgstr "L2"
 
 #, fuzzy
+#~| msgid "L3"
 #~ msgid "3"
 #~ msgstr "L3"
 
@@ -18719,6 +18942,7 @@ msgstr ""
 #~ msgstr "Virar à Direita"
 
 #, fuzzy
+#~| msgid "Interact Mode"
 #~ msgid "Run in interactive mode"
 #~ msgstr "Modo de Interação"
 
@@ -18729,22 +18953,27 @@ msgstr ""
 #~ msgstr "Rolar inventário para baixo"
 
 #, fuzzy
+#~| msgid "Scroll up in your dialogues"
 #~ msgid "Scroll up in your dialogs"
 #~ msgstr "Rolar lista de diálogos para cima"
 
 #, fuzzy
+#~| msgid "Scroll down in your dialogues"
 #~ msgid "Scroll down in your dialogs"
 #~ msgstr "Rolar lista de diálogos para baixo"
 
 #, fuzzy
+#~| msgid "Switch to Game"
 #~ msgid "Switch test"
 #~ msgstr "Mudar para o Jogo"
 
 #, fuzzy
+#~| msgid "Enable/Disable Jetpack"
 #~ msgid "Enable/Disable fog"
 #~ msgstr "Habilitar/Desabilitar Jato Propulsor"
 
 #, fuzzy
+#~| msgid "Enable/Disable Jetpack"
 #~ msgid "Enable/Disable scissor"
 #~ msgstr "Habilitar/Desabilitar Jato Propulsor"
 
@@ -18785,10 +19014,12 @@ msgstr ""
 #~ msgstr "Mapeamento de tecla do jogo"
 
 #, fuzzy
+#~| msgid "C-Pad X"
 #~ msgid "C-pad X"
 #~ msgstr "C-Pad X"
 
 #, fuzzy
+#~| msgid "C-Pad Y"
 #~ msgid "C-pad Y"
 #~ msgstr "C-Pad Y"
 
@@ -18820,30 +19051,44 @@ msgstr ""
 #~ "(or click 'Download patch' button. But note - it only downloads, you will "
 #~ "have to continue from there)\n"
 #~ msgstr ""
-#~ "(ou clique no botão 'Baixar correção'. Mas observe - somente baixa, você tem"
-#~ " que dar continuidade a partir daí)\n"
+#~ "(ou clique no botão 'Baixar correção'. Mas observe - somente baixa, você "
+#~ "tem que dar continuidade a partir daí)\n"
 
 #, fuzzy
+#~| msgid ""
+#~| "GK2 has a fan made subtitles, available thanks to the good persons at "
+#~| "SierraHelp.\n"
+#~| "\n"
+#~| "Installation:\n"
+#~| "- download http://www.sierrahelp.com/Files/Patches/GabrielKnight/"
+#~| "GK2Subtitles.zip\n"
 #~ msgid ""
-#~ "GK2 has fan made subtitles, available thanks to the good people at SierraHelp.\n"
+#~ "GK2 has fan made subtitles, available thanks to the good people at "
+#~ "SierraHelp.\n"
 #~ "\n"
 #~ "Installation:\n"
-#~ "- download http://www.sierrahelp.com/Files/Patches/GabrielKnight/GK2Subtitles.zip\n"
+#~ "- download http://www.sierrahelp.com/Files/Patches/GabrielKnight/"
+#~ "GK2Subtitles.zip\n"
 #~ msgstr ""
-#~ "GK2 possui legendas feita por fãs, disponíveis graças às boas pessoas em SierraHelp.\n"
+#~ "GK2 possui legendas feita por fãs, disponíveis graças às boas pessoas em "
+#~ "SierraHelp.\n"
 #~ "\n"
 #~ "Instalação:\n"
-#~ "- baixe http://www.sierrahelp.com/Files/Patches/GabrielKnight/GK2Subtitles.zip\n"
+#~ "- baixe http://www.sierrahelp.com/Files/Patches/GabrielKnight/"
+#~ "GK2Subtitles.zip\n"
 
 #, fuzzy
+#~| msgid "Toggle music on/off"
 #~ msgid "Toggle music on / off"
 #~ msgstr "Ligar/desligar música"
 
 #, fuzzy
+#~| msgid "Toggle sound effects on/off"
 #~ msgid "Toggle sound effects on / off"
 #~ msgstr "Ligar/desligar efeitos sonoros"
 
 #, fuzzy
+#~| msgid "Toggle fast mode on/off"
 #~ msgid "Toggle fast mode on / off"
 #~ msgstr "Ativar/Desativar modo rápido"
 
@@ -18851,18 +19096,22 @@ msgstr ""
 #~ msgstr "Alterna entre correção do fator de proporção"
 
 #, fuzzy
+#~| msgid "Rotate up"
 #~ msgid "Page up"
 #~ msgstr "Girar para cima"
 
 #, fuzzy
+#~| msgid "Rotate down"
 #~ msgid "Page down"
 #~ msgstr "Girar para baixo"
 
 #, fuzzy
+#~| msgid "Scroll up"
 #~ msgid "Scroll up page"
 #~ msgstr "Rolar para cima"
 
 #, fuzzy
+#~| msgid "Scroll down"
 #~ msgid "Scroll down page"
 #~ msgstr "Rolar para baixo"
 
@@ -18873,46 +19122,57 @@ msgstr ""
 #~ msgstr "Salvar estado de jogo"
 
 #, fuzzy
+#~| msgid "Go to end of line"
 #~ msgid "Go to the line start"
 #~ msgstr "Ir para o fim da linha"
 
 #, fuzzy
+#~| msgid "Go to end of line"
 #~ msgid "Go to the line end"
 #~ msgstr "Ir para o fim da linha"
 
 #, fuzzy
+#~| msgid "Open action menu / Close menu"
 #~ msgid "Open verb menu / Close menu"
 #~ msgstr "Abrir menu de ação / Fechar menu"
 
 #, fuzzy
+#~| msgid "Open options menu"
 #~ msgid "Open options"
 #~ msgstr "Abrir menu de opções"
 
 #, fuzzy
+#~| msgid "Skip dialogue"
 #~ msgid "Skip prolog"
 #~ msgstr "Pular diálogo"
 
 #, fuzzy
+#~| msgid "Show journal"
 #~ msgid "Go forward 1 page"
 #~ msgstr "Exibir diário"
 
 #, fuzzy
+#~| msgid "Show journal"
 #~ msgid "Go back 1 page"
 #~ msgstr "Exibir diário"
 
 #, fuzzy
+#~| msgid "Go to start of line"
 #~ msgid "Go to start of journal"
 #~ msgstr "Ir para o início da linha"
 
 #, fuzzy
+#~| msgid "Go to end of line"
 #~ msgid "Go to end of journal"
 #~ msgstr "Ir para o fim da linha"
 
 #, fuzzy
+#~| msgid "Scroll bar up"
 #~ msgid "Scroll page up"
 #~ msgstr "Rolar barra para cima"
 
 #, fuzzy
+#~| msgid "Scroll bar down"
 #~ msgid "Scroll page down"
 #~ msgstr "Rolar barra para baixo"
 
@@ -18923,17 +19183,19 @@ msgstr ""
 #~ msgstr "Ok"
 
 #~ msgid ""
-#~ "Make implementation of AD&D rules more compliant with the AD&D 2nd edition "
-#~ "handbook"
+#~ "Make implementation of AD&D rules more compliant with the AD&D 2nd "
+#~ "edition handbook"
 #~ msgstr ""
 #~ "Torna a implementação das regras de AD&D mais conforme ao manual da 2ª "
 #~ "edição de AD&D"
 
 #, fuzzy
+#~| msgid "Show journal"
 #~ msgid "Go back a page"
 #~ msgstr "Exibir diário"
 
 #, fuzzy
+#~| msgid "Use Windows cursors"
 #~ msgid "Use Windows mouse cursors"
 #~ msgstr "Utilizar cursores do Windows"
 
@@ -18956,6 +19218,7 @@ msgstr ""
 #~ msgstr "Deslocar para Direita"
 
 #, fuzzy
+#~| msgid "Skip cutscene"
 #~ msgid "Skip Cutscene"
 #~ msgstr "Pular cena"
 
@@ -18963,14 +19226,17 @@ msgstr ""
 #~ msgstr "Licença Freefont"
 
 #, fuzzy
+#~| msgid "Toggle subtitles"
 #~ msgid "Display subtitles"
 #~ msgstr "Ativar/desativar legendas"
 
 #, fuzzy
+#~| msgid "Toggle subtitles"
 #~ msgid "Use subtitles."
 #~ msgstr "Ativar/desativar legendas"
 
 #, fuzzy
+#~| msgid "Toggle subtitles"
 #~ msgid "Use SFX subtitles."
 #~ msgstr "Ativar/desativar legendas"
 
@@ -19002,18 +19268,22 @@ msgstr ""
 #~ msgstr "Carregamento Rápido"
 
 #, fuzzy
+#~| msgid "Move up-left"
 #~ msgid "Move up left"
 #~ msgstr "Mover para cima e esquerda"
 
 #, fuzzy
+#~| msgid "Move up-right"
 #~ msgid "Move up right"
 #~ msgstr "Mover para cima e direita"
 
 #, fuzzy
+#~| msgid "Move down-left"
 #~ msgid "Move down left"
 #~ msgstr "Mover para baixo e esquerda"
 
 #, fuzzy
+#~| msgid "Move down-right"
 #~ msgid "Move down right"
 #~ msgstr "Mover para baixo e direita"
 
@@ -19069,22 +19339,27 @@ msgstr ""
 #~ msgstr "Pular Diálogo"
 
 #, fuzzy
+#~| msgid "Game menu"
 #~ msgid "Game Menu"
 #~ msgstr "Menu do jogo"
 
 #, fuzzy
+#~| msgid "Move up"
 #~ msgid "Move Up"
 #~ msgstr "Mover para cima"
 
 #, fuzzy
+#~| msgid "Move down"
 #~ msgid "Move Down"
 #~ msgstr "Mover para baixo"
 
 #, fuzzy
+#~| msgid "Step back"
 #~ msgid "Step Back"
 #~ msgstr "Passo para trás"
 
 #, fuzzy
+#~| msgid "Move left"
 #~ msgid "Roll Left"
 #~ msgstr "Mover para esquerda"
 
@@ -19095,16 +19370,19 @@ msgstr ""
 #~ msgstr "Olhar para Baixo"
 
 #, fuzzy
+#~| msgid "Toggle Combat"
 #~ msgid "Combat"
 #~ msgstr "Alternar Modo de Combate"
 
 #, fuzzy
+#~| msgid "Side Step"
 #~ msgid "Step"
 #~ msgstr "Passo Lateral"
 
 #~ msgid "Could not find any engine capable of running the selected game"
 #~ msgstr ""
-#~ "Não foi possível encontrar nenhuma engine capaz de rodar o jogo selecionado"
+#~ "Não foi possível encontrar nenhuma engine capaz de rodar o jogo "
+#~ "selecionado"
 
 #, c-format
 #~ msgid "PSX stream cutscene '%s' cannot be played in paletted mode"
@@ -19120,14 +19398,16 @@ msgstr ""
 #~ "Could not find the 'Fate of Atlantis' Macintosh executable.\n"
 #~ "Mac GUI will not be shown."
 #~ msgstr ""
-#~ "Não foi possível encontrar o executável de 'Fate of Atlantis' para Macintosh.\n"
+#~ "Não foi possível encontrar o executável de 'Fate of Atlantis' para "
+#~ "Macintosh.\n"
 #~ "A interface do Mac não será exibida."
 
 #~ msgid ""
 #~ "Could not find the 'LeChuck's Revenge' Macintosh executable.\n"
 #~ "Mac GUI will not be shown."
 #~ msgstr ""
-#~ "Não foi possível encontrar o executável de 'LeChuck's Revenge' para Macintosh.\n"
+#~ "Não foi possível encontrar o executável de 'LeChuck's Revenge' para "
+#~ "Macintosh.\n"
 #~ "A interface do Mac não será exibida."
 
 #~ msgid ""
@@ -19135,9 +19415,9 @@ msgstr ""
 #~ "save/load menu. \t\tUse it together with the \"Ask for confirmation on "
 #~ "exit\" for a more complete experience."
 #~ msgstr ""
-#~ "Permite que o jogo use a interface gráfica da engine e o menu "
-#~ "salvar/carregar originais. \t\tUtilize em conjunto com \"Solicitar "
-#~ "confirmação ao sair\" para uma experiência mais completa."
+#~ "Permite que o jogo use a interface gráfica da engine e o menu salvar/"
+#~ "carregar originais. \t\tUtilize em conjunto com \"Solicitar confirmação "
+#~ "ao sair\" para uma experiência mais completa."
 
 #~ msgid "Show memory consumption"
 #~ msgstr "Exibe o consumo de memória"
@@ -19203,8 +19483,8 @@ msgstr ""
 #~ msgid ""
 #~ "Allow the game to use the in-engine graphical interface and the original "
 #~ "save/load menu. \t\tUse it together with the \"Ask for confirmation on "
-#~ "exit\" for a more complete experience. \t\tAutosaving is disabled when this "
-#~ "mode is active."
+#~ "exit\" for a more complete experience. \t\tAutosaving is disabled when "
+#~ "this mode is active."
 #~ msgstr ""
 #~ "Permite que o jogo use a interface gráfica da engine e o menu original de "
 #~ "salvar/carregar. \t\tUtilize junto com \"Solicitar confirmação ao sair\" "
@@ -19230,26 +19510,32 @@ msgstr ""
 #~ msgstr "aceitar"
 
 #, fuzzy
+#~| msgid "The game in '%s' seems to be unknown."
 #~ msgid "Your set of game files seems to be unknown to us."
 #~ msgstr "O jogo em '% s' parece ser desconhecido."
 
 #, fuzzy
+#~| msgid "Next action"
 #~ msgid "Close action"
 #~ msgstr "Próxima ação"
 
 #, fuzzy
+#~| msgid "Next action"
 #~ msgid "Give action"
 #~ msgstr "Próxima ação"
 
 #, fuzzy
+#~| msgid "Talk to"
 #~ msgid "Talk to action"
 #~ msgstr "Falar"
 
 #, fuzzy
+#~| msgid "Previous action"
 #~ msgid "Push action"
 #~ msgstr "Ação anterior"
 
 #, fuzzy
+#~| msgid "Previous action"
 #~ msgid "Pull action"
 #~ msgstr "Ação anterior"
 
@@ -19257,21 +19543,23 @@ msgstr ""
 #~ msgstr "Abrir Configurações do 3DS"
 
 #, fuzzy
+#~| msgid "Very large"
 #~ msgid "Very very large"
 #~ msgstr "Muito grande"
 
 #~ msgid ""
 #~ "Your game is patched with a fan made script patch. Such patches have been "
 #~ "reported to cause issues, as they modify game scripts extensively. The "
-#~ "issues that these patches fix do not occur in ScummVM, so you are advised to"
-#~ " remove this patch from your game folder in order to avoid having unexpected"
-#~ " errors and/or issues later on."
+#~ "issues that these patches fix do not occur in ScummVM, so you are advised "
+#~ "to remove this patch from your game folder in order to avoid having "
+#~ "unexpected errors and/or issues later on."
 #~ msgstr ""
 #~ "Seu jogo foi corrigido com um script de correção feito por fãs. Tais "
 #~ "correções foram relatadas por causarem problemas, visto que modificam "
 #~ "scripts do jogo extensivamente. Os problemas que estas correções corrigem "
-#~ "não ocorrem com o ScummVM, assim você é aconselhado a remover essa correção "
-#~ "da pasta de seu jogo para evitar erros inesperados ou problemas posteriores."
+#~ "não ocorrem com o ScummVM, assim você é aconselhado a remover essa "
+#~ "correção da pasta de seu jogo para evitar erros inesperados ou problemas "
+#~ "posteriores."
 
 #~ msgid "Update Shaders"
 #~ msgstr "Atualizar Shaders"
@@ -19283,28 +19571,33 @@ msgstr ""
 #~ msgstr "Habilitar aprimoramentos específicos do jogo"
 
 #~ msgid ""
-#~ "Allow ScummVM to make small enhancements to the game, usually based on other"
-#~ " versions of the same game."
+#~ "Allow ScummVM to make small enhancements to the game, usually based on "
+#~ "other versions of the same game."
 #~ msgstr ""
-#~ "Permite que o ScummVM faça pequenas melhorias no jogo, geralmente baseadas "
-#~ "em outras versões do mesmo jogo."
+#~ "Permite que o ScummVM faça pequenas melhorias no jogo, geralmente "
+#~ "baseadas em outras versões do mesmo jogo."
 
 #~ msgid "New Line"
 #~ msgstr "Nova Linha"
 
 #~ msgid ""
-#~ "Could not find the 'Loom' Macintosh executable. Music and high-resolution\n"
+#~ "Could not find the 'Loom' Macintosh executable. Music and high-"
+#~ "resolution\n"
 #~ "versions of font and cursor will be disabled."
 #~ msgstr ""
-#~ "Não foi possível encontrar o executável de 'Loom' para Macintosh. Música e versões\n"
+#~ "Não foi possível encontrar o executável de 'Loom' para Macintosh. Música "
+#~ "e versões\n"
 #~ "de alta resolução da fonte e do cursor serão desativadas."
 
 #~ msgid ""
 #~ "## Keyboard shortcuts\n"
 #~ "\n"
-#~ "ScummVM supports various in-game keyboard and mouse shortcuts, and since version 2.2.0 these can be manually configured in the **Keymaps tab**, or in the **configuration file**.\n"
+#~ "ScummVM supports various in-game keyboard and mouse shortcuts, and since "
+#~ "version 2.2.0 these can be manually configured in the **Keymaps tab**, or "
+#~ "in the **configuration file**.\n"
 #~ "\n"
-#~ "For game-specific controls, see the [wiki entry](https://wiki.scummvm.org/index.php?title=Category:Supported_Games) for the game you are playing.\n"
+#~ "For game-specific controls, see the [wiki entry](https://wiki.scummvm.org/"
+#~ "index.php?title=Category:Supported_Games) for the game you are playing.\n"
 #~ "\n"
 #~ "Default shortcuts are shown in the table.\n"
 #~ "\n"
@@ -19314,9 +19607,13 @@ msgstr ""
 #~ msgstr ""
 #~ "## Atalhos do teclado\n"
 #~ "\n"
-#~ "ScummVM é compatível com vários atalhos de teclado e mouse no jogo e, desde a versão 2.2.0, eles podem ser configurados manualmente na **guia Mapeamento de Teclas** ou no **arquivo de configuração**.\n"
+#~ "ScummVM é compatível com vários atalhos de teclado e mouse no jogo e, "
+#~ "desde a versão 2.2.0, eles podem ser configurados manualmente na **guia "
+#~ "Mapeamento de Teclas** ou no **arquivo de configuração**.\n"
 #~ "\n"
-#~ "Para controles específicos do jogo, consulte o [registro wiki](https://wiki.scummvm.org/index.php?title=Category:Supported_Games) do jogo que você está jogando.\n"
+#~ "Para controles específicos do jogo, consulte o [registro wiki](https://"
+#~ "wiki.scummvm.org/index.php?title=Category:Supported_Games) do jogo que "
+#~ "você está jogando.\n"
 #~ "\n"
 #~ "Os atalhos padrão são exibidos na tabela.\n"
 #~ "\n"
@@ -19339,39 +19636,61 @@ msgstr ""
 #~ msgid ""
 #~ "| `Ctrl+u`  -- Mutes all sounds\n"
 #~ "| `Ctrl+m`  -- Toggles mouse capture\n"
-#~ "| `Ctrl+Alt` and `9` or `0` -- Cycles forwards/backwards between graphics filters\n"
+#~ "| `Ctrl+Alt` and `9` or `0` -- Cycles forwards/backwards between graphics "
+#~ "filters\n"
 #~ "| `Ctrl+Alt` and `+` or `-` -- Increases/decreases the scale factor\n"
 #~ "| `Ctrl+Alt+a` -- Toggles aspect ratio correction on/off\n"
-#~ "| `Ctrl+Alt+f` -- Toggles between nearest neighbor and bilinear interpolation (graphics filtering on/off)\n"
+#~ "| `Ctrl+Alt+f` -- Toggles between nearest neighbor and bilinear "
+#~ "interpolation (graphics filtering on/off)\n"
 #~ "| `Ctrl+Alt+s` -- Cycles through stretch modes\n"
 #~ "| `Alt+Enter`   -- Toggles full screen/windowed mode\n"
 #~ "| `Alt+s`          -- Takes a screenshot\n"
-#~ "| `Ctrl+F7`       -- Opens virtual keyboard (if enabled). This can also be opened with a long press of the middle mouse button or wheel.\n"
+#~ "| `Ctrl+F7`       -- Opens virtual keyboard (if enabled). This can also "
+#~ "be opened with a long press of the middle mouse button or wheel.\n"
 #~ "| `Ctrl+Alt+d` -- Opens the ScummVM debugger\n"
 #~ msgstr ""
 #~ "| `Ctrl+u`  -- Silencia todos os sons\n"
 #~ "| `Ctrl+m`  -- Alterna captura do mouse\n"
-#~ "| `Ctrl+Alt` e `9` ou `0` -- Alterna para frente/para trás entre os filtros gráficos\n"
+#~ "| `Ctrl+Alt` e `9` ou `0` -- Alterna para frente/para trás entre os "
+#~ "filtros gráficos\n"
 #~ "| `Ctrl+Alt` e `+` ou `-` -- Aumenta/reduz o fator de escala\n"
 #~ "| `Ctrl+Alt+a` -- Alterna a correção de aspecto ligado/desligado\n"
-#~ "| `Ctrl+Alt+f` -- Alterna entre escala sem filtro e interpolação bilinear (filtro de gráficos ligado/desligado)\n"
+#~ "| `Ctrl+Alt+f` -- Alterna entre escala sem filtro e interpolação bilinear "
+#~ "(filtro de gráficos ligado/desligado)\n"
 #~ "| `Ctrl+Alt+s` -- Alterna entre os modos de redimensionamento\n"
 #~ "| `Alt+Enter`   -- Alterna entre o modo tela cheia/janela\n"
 #~ "| `Alt+s`          -- Captura um instantâneo\n"
-#~ "| `Ctrl+F7`       -- Abre o teclado virtual (se estiver habilitado). Este pode também ser aberto segurando por um tempo o toque com o botão do meio do mouse ou a roda.\n"
+#~ "| `Ctrl+F7`       -- Abre o teclado virtual (se estiver habilitado). Este "
+#~ "pode também ser aberto segurando por um tempo o toque com o botão do meio "
+#~ "do mouse ou a roda.\n"
 #~ "| `Ctrl+Alt+d` -- Abre o depurador do ScummVM\n"
 
 #~ msgid "Controls Help"
 #~ msgstr "Ajuda sobre Controles"
 
 #, fuzzy
+#~| msgid ""
+#~| "Gestures and controls:\n"
+#~| "\n"
+#~| "One finger tap: Left mouse click\n"
+#~| "Two finger tap: Right mouse click\n"
+#~| "Two finger double tap: ESC\n"
+#~| "Two finger swipe (bottom to top): Toggles Click and drag mode\n"
+#~| "Two finger swipe (left to right): Toggles between touch direct mode and "
+#~| "touchpad mode\n"
+#~| "Two finger swipe (right to left): Shows/hides on-screen controls\n"
+#~| "Two finger swipe (top to bottom): Global Main Menu\n"
+#~| "Three finger swipe: Arrow keys\n"
+#~| "Pinch gesture: Enables/disables keyboard\n"
+#~| "Keyboard spacebar: Pause"
 #~ msgid ""
 #~ "Gestures and controls:\n"
 #~ "\n"
 #~ "One finger tap: Left mouse click\n"
 #~ "Two finger tap: Right mouse click\n"
 #~ "Two finger double tap: ESC\n"
-#~ "Two finger swipe (left to right): Toggles between touch direct mode and touchpad mode\n"
+#~ "Two finger swipe (left to right): Toggles between touch direct mode and "
+#~ "touchpad mode\n"
 #~ "Two finger swipe (right to left): Shows/hides on-screen controls\n"
 #~ "Two finger swipe (top to bottom): Global Main Menu\n"
 #~ "Three finger swipe: Arrow keys\n"
@@ -19383,9 +19702,12 @@ msgstr ""
 #~ "Toque com um dedo: Clique com o botão esquerdo do mouse\n"
 #~ "Toque com dois dedos: Clique com o botão direito do mouse\n"
 #~ "Toque duplo com dois dedos: ESC\n"
-#~ "Deslizar com dois dedos (de baixo para cima): Alterna o modo clicar e arrastar\n"
-#~ "Deslizar com dois dedos (da esquerda para a direita): Alterna entre o modo de toque direto e o modo de touchpad\n"
-#~ "Deslizar com dois dedos (da direita para a esquerda): Exibe/oculta os controles na tela\n"
+#~ "Deslizar com dois dedos (de baixo para cima): Alterna o modo clicar e "
+#~ "arrastar\n"
+#~ "Deslizar com dois dedos (da esquerda para a direita): Alterna entre o "
+#~ "modo de toque direto e o modo de touchpad\n"
+#~ "Deslizar com dois dedos (da direita para a esquerda): Exibe/oculta os "
+#~ "controles na tela\n"
 #~ "Deslizar com dois dedos (de cima para baixo): Menu Principal Global\n"
 #~ "Deslizar com três dedos: Teclas de seta\n"
 #~ "Gesto de pinça: Ativa/desativa o teclado\n"
@@ -19408,14 +19730,21 @@ msgstr ""
 #~ "Usando o controle remoto da Apple TV:\n"
 #~ "\n"
 #~ "Pressionar Área de toque: Clique com o botão esquerdo do mouse\n"
-#~ "Pressionar o botão Reproduzir/Pausar: Clique com o botão direito do mouse\n"
+#~ "Pressionar o botão Reproduzir/Pausar: Clique com o botão direito do "
+#~ "mouse\n"
 #~ "Pressionar o botão Voltar/Menu durante o jogo: Menu Principal Global\n"
-#~ "Pressionar o botão Voltar/Menu no inicializador: Tela Principal da Apple TV\n"
-#~ "Pressionar e segurar o botão Reproduzir/Pausar: Mostrar teclado com teclas adicionais\n"
-#~ "Toque (não pressionar) na parte superior da Área de toque: Tecla de seta para cima\n"
-#~ "Toque (não pressionar) à esquerda da Área de toque: Tecla de seta para a esquerda\n"
-#~ "Toque (não pressionar) à direita da Área de toque: Tecla de seta para a direita\n"
-#~ "Toque (não pressionar) na parte inferior da Área de toque: Tecla de seta para baixo\n"
+#~ "Pressionar o botão Voltar/Menu no inicializador: Tela Principal da Apple "
+#~ "TV\n"
+#~ "Pressionar e segurar o botão Reproduzir/Pausar: Mostrar teclado com "
+#~ "teclas adicionais\n"
+#~ "Toque (não pressionar) na parte superior da Área de toque: Tecla de seta "
+#~ "para cima\n"
+#~ "Toque (não pressionar) à esquerda da Área de toque: Tecla de seta para a "
+#~ "esquerda\n"
+#~ "Toque (não pressionar) à direita da Área de toque: Tecla de seta para a "
+#~ "direita\n"
+#~ "Toque (não pressionar) na parte inferior da Área de toque: Tecla de seta "
+#~ "para baixo\n"
 #~ "Barra de espaço do teclado: Pausa"
 
 #~ msgid "Mouse-click-and-drag mode"
@@ -19439,21 +19768,29 @@ msgstr ""
 #~ msgid ""
 #~ "## Adding SAF paths to ScummVM directory list\n"
 #~ "\n"
-#~ "Starting with version 2.7.0 of ScummVM for Android, significant changes were made to the file access system to allow support for modern versions of the Android Operating System.\n"
+#~ "Starting with version 2.7.0 of ScummVM for Android, significant changes "
+#~ "were made to the file access system to allow support for modern versions "
+#~ "of the Android Operating System.\n"
 #~ "\n"
-#~ "If you find that your existing added games or custom paths no longer work, please edit those paths and this time use the SAF system to browse to the desired locations.\n"
+#~ "If you find that your existing added games or custom paths no longer "
+#~ "work, please edit those paths and this time use the SAF system to browse "
+#~ "to the desired locations.\n"
 #~ "\n"
 #~ "To do that:\n"
 #~ "\n"
-#~ "  1. For each game whose data is not found, go to the \"Paths\" tab in the \"Game Options\" and change the \"Game path\"\n"
+#~ "  1. For each game whose data is not found, go to the \"Paths\" tab in "
+#~ "the \"Game Options\" and change the \"Game path\"\n"
 #~ "\n"
-#~ "  2. Inside the ScummVM file browser, use \"Go Up\" until you reach the \"root\" folder where you will see the \"<Add a new folder>\" option.\n"
+#~ "  2. Inside the ScummVM file browser, use \"Go Up\" until you reach the "
+#~ "\"root\" folder where you will see the \"<Add a new folder>\" option.\n"
 #~ "\n"
 #~ "  ![File browser](browser-root.png \"Android browser\")\n"
 #~ "\n"
 #~ "    File Browser root with <Add a new folder> item\n"
 #~ "\n"
-#~ "  3. Choose that, then browse and select the \"parent\" folder for your games subfolders, e.g. \"SD Card > ScummVMgames\". Click on \"Use this folder\".\n"
+#~ "  3. Choose that, then browse and select the \"parent\" folder for your "
+#~ "games subfolders, e.g. \"SD Card > ScummVMgames\". Click on \"Use this "
+#~ "folder\".\n"
 #~ "\n"
 #~ "  ![OS file browser root](fs-root.png \"OS file browser root\")\n"
 #~ "\n"
@@ -19463,11 +19800,13 @@ msgstr ""
 #~ "\n"
 #~ "    OS file browser selectable folder with \"Use this folder\" button\n"
 #~ "\n"
-#~ "  ![OS access permission dialog](fs-permission.png \"OS access permission\")\n"
+#~ "  ![OS access permission dialog](fs-permission.png \"OS access "
+#~ "permission\")\n"
 #~ "\n"
 #~ "    OS file browser ask to grant ScummVM directory access permission\n"
 #~ "\n"
-#~ "  4. Then, a new folder \"ScummVMgames\" will appear on the \"root\" folder of the ScummVM browser.\n"
+#~ "  4. Then, a new folder \"ScummVMgames\" will appear on the \"root\" "
+#~ "folder of the ScummVM browser.\n"
 #~ "\n"
 #~ "  ![SAF folder added](browser-folder-in-list.png \"SAF folder added\")\n"
 #~ "\n"
@@ -19480,76 +19819,105 @@ msgstr ""
 #~ "\n"
 #~ "## Removing SAF path authorizations\n"
 #~ "\n"
-#~ "In case you would like to revoke any of the granted SAF authorizations, there is an option for this in the \"Global Options > Backend\" tab as shown on the screenshot below:\n"
+#~ "In case you would like to revoke any of the granted SAF authorizations, "
+#~ "there is an option for this in the \"Global Options > Backend\" tab as "
+#~ "shown on the screenshot below:\n"
 #~ "\n"
-#~ "![\"Remove folder authorizations...\" button](gui-remove-permissions.png \"'Remove folder authorizations...' button\")\n"
+#~ "![\"Remove folder authorizations...\" button](gui-remove-permissions.png "
+#~ "\"'Remove folder authorizations...' button\")\n"
 #~ "\n"
 #~ "    GUI tab with \"Remove folder authorizations...\" button\n"
 #~ "\n"
-#~ "![List of authorizations to revoked](gui-remove-list.png \"List of authorizations to revoke\")\n"
+#~ "![List of authorizations to revoked](gui-remove-list.png \"List of "
+#~ "authorizations to revoke\")\n"
 #~ "\n"
 #~ "    GUI dialog with list of authorizations to revoke\n"
 #~ "\n"
-#~ "In case you revoke authorization to a path, still used for specific games/titles, please follow the procedure of fixing them outlined in the previous subheading.\n"
+#~ "In case you revoke authorization to a path, still used for specific games/"
+#~ "titles, please follow the procedure of fixing them outlined in the "
+#~ "previous subheading.\n"
 #~ msgstr ""
 #~ "## Adicionando caminhos SAF à lista de diretórios do ScummVM\n"
 #~ "\n"
-#~ "A partir da versão 2.7.0 do ScummVM para Android, foram feitas alterações significativas no sistema de acesso a arquivos para permitir suporte a versões modernas do sistema operacional Android.\n"
+#~ "A partir da versão 2.7.0 do ScummVM para Android, foram feitas alterações "
+#~ "significativas no sistema de acesso a arquivos para permitir suporte a "
+#~ "versões modernas do sistema operacional Android.\n"
 #~ "\n"
-#~ "Se você achar que seus jogos adicionados ou caminhos personalizados existentes não funcionam mais, edite esses caminhos e desta vez use o sistema SAF para navegar até os locais desejados.\n"
+#~ "Se você achar que seus jogos adicionados ou caminhos personalizados "
+#~ "existentes não funcionam mais, edite esses caminhos e desta vez use o "
+#~ "sistema SAF para navegar até os locais desejados.\n"
 #~ "\n"
 #~ "Para isso:\n"
 #~ "\n"
-#~ "  1. Para cada jogo cujos dados não forem encontrados, vá até a aba “Caminhos” em “Opções de Jogo” e altere o “Caminho do Jogo”\n"
+#~ "  1. Para cada jogo cujos dados não forem encontrados, vá até a aba "
+#~ "“Caminhos” em “Opções de Jogo” e altere o “Caminho do Jogo”\n"
 #~ "\n"
-#~ "  2. Dentro do navegador de arquivos do ScummVM, use \"Para cima\" até chegar à pasta \"raiz\" onde você verá a opção \"<Adicionar uma nova pasta>\".\n"
+#~ "  2. Dentro do navegador de arquivos do ScummVM, use \"Para cima\" até "
+#~ "chegar à pasta \"raiz\" onde você verá a opção \"<Adicionar uma nova "
+#~ "pasta>\".\n"
 #~ "\n"
 #~ "  ![Navegador de arquivos](browser-root.png \"Navegador Android\")\n"
 #~ "\n"
 #~ "    Raiz do navegador de arquivos com o item <Adicionar uma nova pasta>\n"
 #~ "\n"
-#~ "  3. Selecione isso, navegue e selecione a pasta \"pai\" para as subpastas de seus jogos, por exemplo. \"Cartão SD > JogosScummVM\". Clique em \"Utilizar esta pasta\".\n"
+#~ "  3. Selecione isso, navegue e selecione a pasta \"pai\" para as "
+#~ "subpastas de seus jogos, por exemplo. \"Cartão SD > JogosScummVM\". "
+#~ "Clique em \"Utilizar esta pasta\".\n"
 #~ "\n"
-#~ "  ![Raiz do navegador de arquivos do SO](fs-root.png \"Raiz do navegador de arquivos do SO\")\n"
+#~ "  ![Raiz do navegador de arquivos do SO](fs-root.png \"Raiz do navegador "
+#~ "de arquivos do SO\")\n"
 #~ "\n"
 #~ "    Raiz do navegador de arquivos do sistema operacional\n"
 #~ "\n"
-#~ "  ![Pasta selecionável do SO](fs-folder.png \"Pasta selecionável do SO\")\n"
+#~ "  ![Pasta selecionável do SO](fs-folder.png \"Pasta selecionável do "
+#~ "SO\")\n"
 #~ "\n"
-#~ "    Pasta selecionável pelo navegador de arquivos do sistema operacional com o botão \"Utilizar esta pasta\"\n"
+#~ "    Pasta selecionável pelo navegador de arquivos do sistema operacional "
+#~ "com o botão \"Utilizar esta pasta\"\n"
 #~ "\n"
-#~ "  ![Caixa de diálogo de permissão de acesso ao SO](fs-permission.png \"Permissão de acesso ao SO\")\n"
+#~ "  ![Caixa de diálogo de permissão de acesso ao SO](fs-permission.png "
+#~ "\"Permissão de acesso ao SO\")\n"
 #~ "\n"
-#~ "    O navegador de arquivos do sistema operacional solicita permissão de acesso ao diretório ScummVM\n"
+#~ "    O navegador de arquivos do sistema operacional solicita permissão de "
+#~ "acesso ao diretório ScummVM\n"
 #~ "\n"
-#~ "  4. Em seguida, uma nova pasta “JogosScummVM” aparecerá na pasta “raiz” do navegador ScummVM.\n"
+#~ "  4. Em seguida, uma nova pasta “JogosScummVM” aparecerá na pasta “raiz” "
+#~ "do navegador ScummVM.\n"
 #~ "\n"
-#~ "  ![Pasta SAF adicionada](browser-folder-in-list.png \"Pasta SAF adicionada\")\n"
+#~ "  ![Pasta SAF adicionada](browser-folder-in-list.png \"Pasta SAF "
+#~ "adicionada\")\n"
 #~ "\n"
 #~ "    Navegador de arquivos com pasta SAF adicionada na raiz\n"
 #~ "\n"
 #~ "  5. Navegue por esta pasta até chegar aos arquivos do jogo.\n"
 #~ "\n"
-#~ "As etapas 2 e 3 precisam ser executadas apenas uma vez para todos os seus jogos.\n"
+#~ "As etapas 2 e 3 precisam ser executadas apenas uma vez para todos os seus "
+#~ "jogos.\n"
 #~ "\n"
 #~ "\n"
 #~ "## Removendo autorizações de caminho SAF\n"
 #~ "\n"
-#~ "Caso você queira revogar alguma das autorizações SAF concedidas, existe uma opção para isso na aba \"Opções Globais > Backend\" conforme mostrado na imagem abaixo:\n"
+#~ "Caso você queira revogar alguma das autorizações SAF concedidas, existe "
+#~ "uma opção para isso na aba \"Opções Globais > Backend\" conforme mostrado "
+#~ "na imagem abaixo:\n"
 #~ "\n"
-#~ "![Botão \"Remover autorizações de pasta...\"](gui-remove-permissions.png \"Botão 'Remover autorizações de pasta...'\")\n"
+#~ "![Botão \"Remover autorizações de pasta...\"](gui-remove-permissions.png "
+#~ "\"Botão 'Remover autorizações de pasta...'\")\n"
 #~ "\n"
 #~ "    Guia da interface com botão \"Remover autorizações de pasta...\"\n"
 #~ "\n"
-#~ "![Lista de autorizações a serem revogadas](gui-remove-list.png \"Lista de autorizações a serem revogadas\")\n"
+#~ "![Lista de autorizações a serem revogadas](gui-remove-list.png \"Lista de "
+#~ "autorizações a serem revogadas\")\n"
 #~ "\n"
 #~ "    Diálogo da interface com lista de autorizações para revogar\n"
 #~ "\n"
-#~ "Caso você revogue a autorização de um caminho, ainda utilizado para jogos/títulos específicos, siga o procedimento de correção descrito no subtítulo anterior.\n"
+#~ "Caso você revogue a autorização de um caminho, ainda utilizado para jogos/"
+#~ "títulos específicos, siga o procedimento de correção descrito no "
+#~ "subtítulo anterior.\n"
 
 #~ msgid ""
-#~ "The teenagent.dat file is compressed and zlib hasn't been included in this "
-#~ "executable. Please decompress it"
+#~ "The teenagent.dat file is compressed and zlib hasn't been included in "
+#~ "this executable. Please decompress it"
 #~ msgstr ""
 #~ "O arquivo teenagent.dat está compactado e zlib não foi incluso neste "
 #~ "executável. Favor descompactá-lo"
@@ -19607,12 +19975,12 @@ msgstr ""
 #~ msgstr "Ir para tela do mapa"
 
 #~ msgid ""
-#~ "Use the original engine's main, save/load, and setup menus. ScummVM's Global"
-#~ " Main Menu can still be accessed through its keymap."
+#~ "Use the original engine's main, save/load, and setup menus. ScummVM's "
+#~ "Global Main Menu can still be accessed through its keymap."
 #~ msgstr ""
 #~ "Utiliza o menu principal, salvar/carregar e de configuração original da "
-#~ "engine. O Menu Principal Global do ScummVM ainda pode ser acessado por meio "
-#~ "de sua tecla de atalho mapeada."
+#~ "engine. O Menu Principal Global do ScummVM ainda pode ser acessado por "
+#~ "meio de sua tecla de atalho mapeada."
 
 #~ msgid "Enable Second Chance"
 #~ msgstr "Habilitar Segunda Chance"
@@ -19685,8 +20053,8 @@ msgstr ""
 #~ msgid ""
 #~ "Allows the game to use low latency audio, at the cost of sound accuracy."
 #~ msgstr ""
-#~ "Premite que o jogo utilize áudio de baixa latência, sacrificando a precisão "
-#~ "do som."
+#~ "Premite que o jogo utilize áudio de baixa latência, sacrificando a "
+#~ "precisão do som."
 
 #~ msgctxt "lowres"
 #~ msgid "Misc"
@@ -19696,8 +20064,8 @@ msgstr ""
 #~ "Compressed game detected. Please uncompress it as specified in the game "
 #~ "description on our Wiki"
 #~ msgstr ""
-#~ "Jogo compactado detectado. Por favor, descompacte-o conforme especificado na"
-#~ " descrição do jogo em nosso Wiki"
+#~ "Jogo compactado detectado. Por favor, descompacte-o conforme especificado "
+#~ "na descrição do jogo em nosso Wiki"
 
 #~ msgid "Group by: "
 #~ msgstr "Agrupar por: "
@@ -19802,11 +20170,11 @@ msgstr ""
 #~ "mais recente do ScummVM."
 
 #~ msgid ""
-#~ "WARNING: Existing save has longer gameplay duration than the current state. "
-#~ "Are you sure you want to overwrite it?"
+#~ "WARNING: Existing save has longer gameplay duration than the current "
+#~ "state. Are you sure you want to overwrite it?"
 #~ msgstr ""
-#~ "AVISO: O jogo salvo existente tem duração de jogo mais longa do que o estado"
-#~ " atual. Tem certeza de que deseja sobrescrever?"
+#~ "AVISO: O jogo salvo existente tem duração de jogo mais longa do que o "
+#~ "estado atual. Tem certeza de que deseja sobrescrever?"
 
 #~ msgid "I don't understand your command. "
 #~ msgstr "Eu não entendo seu comando. "
@@ -19959,8 +20327,8 @@ msgstr ""
 #~ msgstr "Utilizar espaçamento de fonte correto"
 
 #~ msgid ""
-#~ "Draw text with correct font spacing. This arguably looks better, but doesn't"
-#~ " match the original behavior."
+#~ "Draw text with correct font spacing. This arguably looks better, but "
+#~ "doesn't match the original behavior."
 #~ msgstr ""
 #~ "Desenha o texto com espaçamento de fonte correto. Isso sem dúvida fica "
 #~ "melhor, mas não corresponde ao comportamento original."
@@ -19973,11 +20341,12 @@ msgstr ""
 #~ msgstr "~E~ditar Jogo..."
 
 #~ msgid ""
-#~ "Adjusts the timing of the EGA Loom Overture when using enhanced music. The "
-#~ "lower the value, the earlier the Lucasfilm logo appears."
+#~ "Adjusts the timing of the EGA Loom Overture when using enhanced music. "
+#~ "The lower the value, the earlier the Lucasfilm logo appears."
 #~ msgstr ""
 #~ "Ajusta a sincronização da Abertura de Loom EGA ao utilizar música "
-#~ "aprimorada. Quanto menor o valor, mais cedo o logotipo da Lucasfilm aparece."
+#~ "aprimorada. Quanto menor o valor, mais cedo o logotipo da Lucasfilm "
+#~ "aparece."
 
 #~ msgid "Swap Menu and Back buttons"
 #~ msgstr "Inverter botões Menu e Voltar"
@@ -20107,7 +20476,8 @@ msgstr ""
 #~ msgstr "Usar controle de cursor estilo trackpad"
 
 #~ msgid "Tap for left click, double tap right click"
-#~ msgstr "Um toque para o clique esquerdo, e toque duplo para o clique direito"
+#~ msgstr ""
+#~ "Um toque para o clique esquerdo, e toque duplo para o clique direito"
 
 #~ msgid "Sensitivity"
 #~ msgstr "Sensibilidade"
@@ -20119,7 +20489,8 @@ msgstr ""
 #~ msgstr "Dimensão da tela principal:"
 
 #~ msgid "Unscaled (you must scroll left and right)"
-#~ msgstr "Sem redimensionamento (você precisa rolar para a esquerda e direita)"
+#~ msgstr ""
+#~ "Sem redimensionamento (você precisa rolar para a esquerda e direita)"
 
 #~ msgid "Brightness:"
 #~ msgstr "Brilho:"
@@ -20176,8 +20547,8 @@ msgstr ""
 #~ msgstr "Guarda média"
 
 #~ msgid ""
-#~ "The Russian version of Pajama Sam 2 is not supported yet due to incomplete "
-#~ "code."
+#~ "The Russian version of Pajama Sam 2 is not supported yet due to "
+#~ "incomplete code."
 #~ msgstr ""
 #~ "A versão Russa de Pajama Sam 2 ainda não é suportada devido ao código "
 #~ "incompleto."
@@ -20212,12 +20583,16 @@ msgstr ""
 #~ msgid ""
 #~ "Your game version appears to be unknown. If this is *NOT* a fan-modified\n"
 #~ "version (in particular, not a fan-made translation), please, report the\n"
-#~ "following data to the ScummVM team along with the name of the game you tried\n"
+#~ "following data to the ScummVM team along with the name of the game you "
+#~ "tried\n"
 #~ "to add and its version, language, etc.:\n"
 #~ msgstr ""
-#~ "A versão de seu jogo parece ser desconhecida. Se esta *NÃO É* uma versão modificada\n"
-#~ "por fãs (particularmente, não é uma tradução feita por fãs), por favor, relate\n"
-#~ "os seguintes dados para o time do ScummVM junto com o nome do jogo que você tentou\n"
+#~ "A versão de seu jogo parece ser desconhecida. Se esta *NÃO É* uma versão "
+#~ "modificada\n"
+#~ "por fãs (particularmente, não é uma tradução feita por fãs), por favor, "
+#~ "relate\n"
+#~ "os seguintes dados para o time do ScummVM junto com o nome do jogo que "
+#~ "você tentou\n"
 #~ "adicionar e sua versão, idioma, etc.:\n"
 
 #~ msgid ""
@@ -20239,8 +20614,8 @@ msgstr ""
 #~ "Use an IBM Music Feature card or a Yamaha FB-01 FM synth module for MIDI "
 #~ "output"
 #~ msgstr ""
-#~ "Utiliza uma placa IBM Music Feature ou um módulo sintetizador Yamaha FB-01 "
-#~ "para saída de MIDI"
+#~ "Utiliza uma placa IBM Music Feature ou um módulo sintetizador Yamaha "
+#~ "FB-01 para saída de MIDI"
 
 #~ msgid "Interact via Left Click)"
 #~ msgstr "Interagir com Clique Esquerdo)"
@@ -20336,12 +20711,13 @@ msgstr ""
 
 #~ msgid "You must map a key to the 'Right Click' action to play this game"
 #~ msgstr ""
-#~ "Você precisa mapear uma tecla para ação do \"Clique da Direita\" nesse jogo"
+#~ "Você precisa mapear uma tecla para ação do \"Clique da Direita\" nesse "
+#~ "jogo"
 
 #~ msgid "You must map a key to the 'Hide toolbar' action to play this game"
 #~ msgstr ""
-#~ "Você precisa mapear uma tecla para ação do \"Ocultar barra de ferramentas\" "
-#~ "nesse jogo"
+#~ "Você precisa mapear uma tecla para ação do \"Ocultar barra de "
+#~ "ferramentas\" nesse jogo"
 
 #~ msgid "Map Zoom Up action (optional)"
 #~ msgstr "Mapear Zoom para Cima (opcional)"
@@ -20353,8 +20729,8 @@ msgstr ""
 #~ "Don't forget to map a key to 'Hide Toolbar' action to see the whole "
 #~ "inventory"
 #~ msgstr ""
-#~ "Não se esqueça de mapear uma tecla para \"Ocultar a barra de ferramentas\" "
-#~ "para ver todo o seu inventário"
+#~ "Não se esqueça de mapear uma tecla para \"Ocultar a barra de "
+#~ "ferramentas\" para ver todo o seu inventário"
 
 #, fuzzy
 #~ msgid "Saved games sync complete."
@@ -20393,18 +20769,18 @@ msgstr ""
 #~ msgstr "Taxa de saída:"
 
 #~ msgid ""
-#~ "Higher value specifies better sound quality but may be not supported by your"
-#~ " soundcard"
+#~ "Higher value specifies better sound quality but may be not supported by "
+#~ "your soundcard"
 #~ msgstr ""
-#~ "Maior valor especifica melhor qualidade de som, mas pode não ser suportado "
-#~ "por sua placa de som"
+#~ "Maior valor especifica melhor qualidade de som, mas pode não ser "
+#~ "suportado por sua placa de som"
 
 #~ msgid ""
-#~ "The theme you selected does not support your current language. If you want "
-#~ "to use this theme you need to switch to another language first."
+#~ "The theme you selected does not support your current language. If you "
+#~ "want to use this theme you need to switch to another language first."
 #~ msgstr ""
-#~ "O tema que você selecionou não suporta seu idioma atual. Se você quiser usar"
-#~ " este tema você precisa mudar para outro idioma."
+#~ "O tema que você selecionou não suporta seu idioma atual. Se você quiser "
+#~ "usar este tema você precisa mudar para outro idioma."
 
 #, fuzzy
 #~ msgid "Speed multiplier for mouse emulation"
@@ -20424,9 +20800,11 @@ msgstr ""
 #~ "O arquivo \"sky.cpt\" possui um tamanho incorreto.\n"
 #~ "Por favor, refaça o download em www.scummvm.org"
 
-#~ msgid "Please, report the following data to the ScummVM team along with name"
+#~ msgid ""
+#~ "Please, report the following data to the ScummVM team along with name"
 #~ msgstr ""
-#~ "Por favor, informe os seguintes dados para a equipe ScummVM junto com o nome"
+#~ "Por favor, informe os seguintes dados para a equipe ScummVM junto com o "
+#~ "nome"
 
 #~ msgid "of the game you tried to add and its version/language/etc.:"
 #~ msgstr "do jogo que você tentou adicionar e sua versão/idioma/etc.:"
@@ -20451,9 +20829,11 @@ msgstr ""
 #~ "Vídeos no formato DXA foram encontrados, mas o ScummVM foi compilado sem "
 #~ "suporte a zlib"
 
-#~ msgid "Turns off General MIDI mapping for games with Roland MT-32 soundtrack"
+#~ msgid ""
+#~ "Turns off General MIDI mapping for games with Roland MT-32 soundtrack"
 #~ msgstr ""
-#~ "Desliga o mapeamento General MIDI para jogos com trilha sonora Roland MT-32"
+#~ "Desliga o mapeamento General MIDI para jogos com trilha sonora Roland "
+#~ "MT-32"
 
 #~ msgid "Standard (16bpp)"
 #~ msgstr "Padrão (16bpp)"


### PR DESCRIPTION
Translate the 318 previously untranslated (empty) strings in the Brazilian Portuguese (pt_BR) translation, bringing the catalogue to full coverage of all non-fuzzy entries.
- Translate all empty msgstr entries across GUI, backend and engine strings (add-on management, backup/restore, graphics and audio  options, keymap actions, and per-engine messages)
- Preserve all format specifiers (%s), escaped newlines and quotes
- Keep proper nouns and game-specific terms untranslated where   appropriate (e.g. Rebel Assault, Lord British, ProText), while  translating technical and UI terminology consistently


Existing fuzzy entries are left untouched, as they already carry a translation and fall outside the scope of this change.