### PR TITLE
DIRECTOR: Seed RNG from system time instead of a fixed value

### DIFF
--- a/engines/director/util.cpp
+++ b/engines/director/util.cpp
@@ -25,7 +25,9 @@
 #include "common/memstream.h"
 #include "common/punycode.h"
 #include "common/str-array.h"
+#include "common/system.h"
 #include "common/tokenizer.h"
+#include "common/util.h"
 #include "common/xpfloat.h"
 #include "common/compression/deflate.h"
 
@@ -1203,7 +1205,19 @@ Common::Path dumpFactoryName(const char *prefix, const char *name, const char *e
 	return Common::Path(Common::String::format("./dumps/%s-factory-%s.%s", prefix, name, ext), '/');
 }
 
-void RandomState::setSeed(int seed, bool runInit) {
+// Seconds between the classic Mac OS epoch and the Unix epoch.
+static const uint32 kMacEpochOffset = 2082844800U;
+
+uint32 macTimeSeed() {
+	// Director seeds its RNG with the local wall-clock time in seconds since
+	// the classic Mac OS epoch.
+	TimeDate td;
+	g_system->getTimeAndDate(td);
+
+	return (uint32)(Common::DateTime::dateTimeToInt64(td) + kMacEpochOffset);
+}
+
+void RandomState::setSeed(uint32 seed, bool runInit) {
 	if (runInit)
 		init(32);
 
@@ -1245,9 +1259,7 @@ void RandomState::init(int len) {
 		_len = (1 << len) - 1;
 	}
 
-	// The original is _always_ initalized with a seed of 1. It is hardcoded and is by design
-	// The developers were offered to use `set the randomSeed` Lingo
-	setSeed(1, false);
+	setSeed(macTimeSeed(), false);
 	_mask = masks[len - 2];
 }
 

--- a/engines/director/util.h
+++ b/engines/director/util.h
@@ -71,6 +71,8 @@ Common::Path dumpFactoryName(const char *prefix, const char *name, const char *e
 
 bool isButtonSprite(SpriteType spriteType);
 
+uint32 macTimeSeed();
+
 class RandomState {
 public:
 	uint32 _seed;
@@ -81,7 +83,7 @@ public:
 		_seed = _mask = _len = 0;
 	}
 
-	void setSeed(int seed, bool runInit = true);
+	void setSeed(uint32 seed, bool runInit = true);
 	uint32 getSeed() { return _seed; }
 	int32 getRandom(int32 range);
 


### PR DESCRIPTION
Director seeds its RNG by time from the classic MacOS epoch. Use this instead of the hard coded 1 orginally implemented unless the seed is set in the GUI.

This fixes RNG in games that do not explicitly call `set the randomSeed`


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
