### PR TITLE
GUI: Fix MIDI / MT-32 device selection in Game Options override

### DIFF
--- a/gui/options.cpp
+++ b/gui/options.cpp
@@ -1350,8 +1350,8 @@ void OptionsDialog::setMIDISettingsState(bool enabled) {
 	if (_guioptions.contains(GUIO_NOMIDI))
 		enabled = false;
 
-	_gmDevicePopUpDesc->setEnabled(_domain.equals(Common::ConfigManager::kApplicationDomain) ? enabled : false);
-	_gmDevicePopUp->setEnabled(_domain.equals(Common::ConfigManager::kApplicationDomain) ? enabled : false);
+	_gmDevicePopUpDesc->setEnabled(enabled);
+	_gmDevicePopUp->setEnabled(enabled);
 
 	_enableMIDISettings = enabled;
 
@@ -1372,8 +1372,8 @@ void OptionsDialog::setMIDISettingsState(bool enabled) {
 void OptionsDialog::setMT32SettingsState(bool enabled) {
 	_enableMT32Settings = enabled;
 
-	_mt32DevicePopUpDesc->setEnabled(_domain.equals(Common::ConfigManager::kApplicationDomain) ? enabled : false);
-	_mt32DevicePopUp->setEnabled(_domain.equals(Common::ConfigManager::kApplicationDomain) ? enabled : false);
+	_mt32DevicePopUpDesc->setEnabled(enabled);
+	_mt32DevicePopUp->setEnabled(enabled);
 
 	_mt32Checkbox->setEnabled(enabled);
 	_enableGSCheckbox->setEnabled(enabled);


### PR DESCRIPTION
**Fixes Trac#14995**

**Summary of changes:**
Removed the `kApplicationDomain` domain check for the MIDI and MT-32 device dropdowns in `setMIDISettingsState` and `setMT32SettingsState`.

**Reasoning:**
This restrictive domain check forced the dropdowns to permanently disable ('false') whenever a user was in the Game Options menu, completely breaking the "Override global settings" functionality for those specific widgets. 