### PR TITLE
SLUDGE: Replace blendBlitTo with blendBlitFrom and blendFillRect

### DIFF
--- a/engines/sludge/backdrop.cpp
+++ b/engines/sludge/backdrop.cpp
@@ -299,7 +299,7 @@ void GraphicsManager::hardScroll(int distance) {
 	if (!distance)
 		return;
 
-	Graphics::Surface tmp;
+	Graphics::ManagedSurface tmp;
 	tmp.copyFrom(_backdropSurface);
 
 	// copy part of the backdrop to it
@@ -362,7 +362,7 @@ bool GraphicsManager::loadLightMap(int v) {
 
 	Graphics::ManagedSurface tmp;
 
-	if (!ImgLoader::loadImage(v, "lightmap", g_sludge->_resMan->getData(), tmp.surfacePtr()))
+	if (!ImgLoader::loadImage(v, "lightmap", g_sludge->_resMan->getData(), &tmp))
 		return false;
 
 	if (tmp.w != (int16)_sceneWidth || tmp.h != (int16)_sceneHeight) {
@@ -416,7 +416,7 @@ bool GraphicsManager::loadHSI(int num, Common::SeekableReadStream *stream, int x
 		killAllBackDrop(); // kill all
 	}
 
-	Graphics::Surface tmp;
+	Graphics::ManagedSurface tmp;
 
 	if (!ImgLoader::loadImage(num, "hsi", stream, &tmp, (int)reserve))
 		return false;
@@ -459,7 +459,7 @@ bool GraphicsManager::loadHSI(int num, Common::SeekableReadStream *stream, int x
 
 bool GraphicsManager::mixHSI(int num, Common::SeekableReadStream *stream, int x, int y) {
 	debugC(1, kSludgeDebugGraphics, "Load mixHSI");
-	Graphics::Surface mixSurface;
+	Graphics::ManagedSurface mixSurface;
 	if (!ImgLoader::loadImage(num, "mixhsi", stream, &mixSurface, 0))
 		return false;
 

--- a/engines/sludge/backdrop.cpp
+++ b/engines/sludge/backdrop.cpp
@@ -113,12 +113,9 @@ void GraphicsManager::drawParallax() {
 
 		debugC(1, kSludgeDebugGraphics, "drawParallax(): camX: %d camY: %d dims: %d x %d sceneDims: %d x %d winDims: %d x %d surf: %d x %d", p->cameraX, p->cameraY, w, h, _sceneWidth, _sceneHeight, _winWidth, _winHeight, p->surface.w, p->surface.h);
 
-		Graphics::ManagedSurface tmp;
-		tmp.copyFrom(p->surface);
-
 		for (uint y = 0; y < _sceneHeight; y += p->surface.h) {
 			for (uint x = 0; x < _sceneWidth; x += p->surface.w) {
-				tmp.blendBlitTo(_renderSurface, x - p->cameraX, y - p->cameraY);
+				_renderSurface.blendBlitFrom(p->surface, Common::Point(x - p->cameraX, y - p->cameraY));
 				debugC(3, kSludgeDebugGraphics, "drawParallax(): blit to: %d, %d", x - p->cameraX, y - p->cameraY);
 			}
 		}
@@ -329,9 +326,7 @@ void GraphicsManager::drawHorizontalLine(uint x1, uint y, uint x2) {
 }
 
 void GraphicsManager::darkScreen() {
-	Graphics::ManagedSurface tmp;
-	tmp.copyFrom(_backdropSurface);
-	tmp.blendBlitTo(_backdropSurface, 0, 0, Graphics::FLIP_NONE, nullptr, MS_ARGB(255 >> 1, 0, 0, 0));
+	_backdropSurface.blendBlitFrom(_backdropSurface, Graphics::FLIP_NONE, MS_ARGB(255 >> 1, 0, 0, 0));
 
 	// reset zBuffer
 	if (_zBuffer->originalNum >= 0) {
@@ -346,9 +341,7 @@ void GraphicsManager::drawBackDrop() {
 	if (!_backdropExists && !_backdropSurface.getPixels())
 		return;
 	// draw backdrop
-	Graphics::ManagedSurface tmp;
-	tmp.copyFrom(_backdropSurface);
-	tmp.blendBlitTo(_renderSurface, -_cameraX, -_cameraY);
+	_renderSurface.blendBlitFrom(_backdropSurface, Common::Point(-_cameraX, -_cameraY));
 }
 
 bool GraphicsManager::loadLightMap(int v) {
@@ -369,7 +362,7 @@ bool GraphicsManager::loadLightMap(int v) {
 		if (_lightMapMode == LIGHTMAPMODE_HOTSPOT) {
 			return fatal("Light map width and height don't match scene width and height. That is required for lightmaps in HOTSPOT mode.");
 		} else if (_lightMapMode == LIGHTMAPMODE_PIXEL) {
-			tmp.blendBlitTo(_lightMap, 0, 0, Graphics::FLIP_NONE, nullptr, MS_ARGB((uint)255, (uint)255, (uint)255, (uint)255), (int)_sceneWidth, (int)_sceneHeight);
+			_lightMap.blendBlitFrom(tmp, tmp.getBounds(), Common::Rect(_sceneWidth, _sceneHeight));
 		} else {
 			_lightMap.copyFrom(tmp);
 		}
@@ -446,10 +439,7 @@ bool GraphicsManager::loadHSI(int num, Common::SeekableReadStream *stream, int x
 		_backdropSurface.fillRect(Common::Rect(x, y, x + tmp.w, y + tmp.h), _renderSurface.format.ARGBToColor(0, 0, 0, 0));
 
 	// copy surface loaded to backdrop
-	Graphics::ManagedSurface tmp_trans;
-	tmp_trans.copyFrom(tmp);
-	tmp_trans.blendBlitTo(_backdropSurface, x, y);
-	tmp.free();
+	_backdropSurface.blendBlitFrom(tmp, Common::Point(x, y));
 
 	_origBackdropSurface.copyFrom(_backdropSurface);
 	_backdropExists = true;
@@ -475,9 +465,7 @@ bool GraphicsManager::mixHSI(int num, Common::SeekableReadStream *stream, int x,
 		return false;
 	}
 
-	Graphics::ManagedSurface tmp;
-	tmp.copyFrom(mixSurface);
-	tmp.blendBlitTo(_backdropSurface, x, y, Graphics::FLIP_NONE, nullptr, MS_ARGB(255 >> 1, 255, 255, 255));
+	_backdropSurface.blendBlitFrom(mixSurface, Common::Point(x, y), Graphics::FLIP_NONE, MS_ARGB(255 >> 1, 255, 255, 255));
 	mixSurface.free();
 
 	return true;

--- a/engines/sludge/backdrop.cpp
+++ b/engines/sludge/backdrop.cpp
@@ -351,7 +351,6 @@ bool GraphicsManager::loadLightMap(int v) {
 
 	killLightMap();
 	_lightMapNumber = v;
-	_lightMap.create(_sceneWidth, _sceneWidth, *_vm->getScreenPixelFormat());
 
 	Graphics::ManagedSurface tmp;
 
@@ -362,15 +361,15 @@ bool GraphicsManager::loadLightMap(int v) {
 		if (_lightMapMode == LIGHTMAPMODE_HOTSPOT) {
 			return fatal("Light map width and height don't match scene width and height. That is required for lightmaps in HOTSPOT mode.");
 		} else if (_lightMapMode == LIGHTMAPMODE_PIXEL) {
+			_lightMap.create(_sceneWidth, _sceneWidth, *_vm->getScreenPixelFormat());
 			_lightMap.blendBlitFrom(tmp, tmp.getBounds(), Common::Rect(_sceneWidth, _sceneHeight));
 		} else {
-			_lightMap.copyFrom(tmp);
+			_lightMap = Common::move(tmp);
 		}
 	} else {
-		_lightMap.copyFrom(tmp);
+		_lightMap = Common::move(tmp);
 	}
 
-	tmp.free();
 	g_sludge->_resMan->finishAccess();
 	setResourceForFatal(-1);
 
@@ -440,8 +439,6 @@ bool GraphicsManager::loadHSI(int num, Common::SeekableReadStream *stream, int x
 
 	// copy surface loaded to backdrop
 	_backdropSurface.blendBlitFrom(tmp, Common::Point(x, y));
-
-	_origBackdropSurface.copyFrom(_backdropSurface);
 	_backdropExists = true;
 
 	return true;

--- a/engines/sludge/freeze.h
+++ b/engines/sludge/freeze.h
@@ -41,8 +41,8 @@ class Parallax;
 struct FrozenStuffStruct {
 	OnScreenPersonList *allPeople;
 	ScreenRegionList *allScreenRegions;
-	Graphics::Surface backdropSurface;
-	Graphics::Surface lightMapSurface;
+	Graphics::ManagedSurface backdropSurface;
+	Graphics::ManagedSurface lightMapSurface;
 	uint8 *zBufferTex;
 	int zPanels;
 	ParallaxLayers *parallaxLayers;

--- a/engines/sludge/graphics.cpp
+++ b/engines/sludge/graphics.cpp
@@ -135,9 +135,6 @@ void GraphicsManager::kill() {
 	if (_backdropSurface.getPixels())
 		_backdropSurface.free();
 
-	if (_origBackdropSurface.getPixels())
-		_origBackdropSurface.free();
-
 	if (_transitionTexture) {
 		_transitionTexture->free();
 		delete _transitionTexture;

--- a/engines/sludge/graphics.h
+++ b/engines/sludge/graphics.h
@@ -229,7 +229,6 @@ private:
 
 	// Back drop
 	Graphics::ManagedSurface _backdropSurface;
-	Graphics::ManagedSurface _origBackdropSurface;
 	bool _backdropExists;
 	bool reserveBackdrop();
 

--- a/engines/sludge/graphics.h
+++ b/engines/sludge/graphics.h
@@ -53,7 +53,7 @@ enum ELightMapMode {
 
 // Parallax
 struct ParallaxLayer {
-	Graphics::Surface surface;
+	Graphics::ManagedSurface surface;
 	int speedX, speedY;
 	bool wrapS, wrapT;
 	uint16 fileNum, fractionX, fractionY;
@@ -158,7 +158,7 @@ public:
 	void saveZBuffer(Common::WriteStream *stream);
 	bool loadZBuffer(Common::SeekableReadStream *stream);
 
-	void drawSpriteToZBuffer(int x, int y, uint8 depth, const Graphics::Surface &surface);
+	void drawSpriteToZBuffer(int x, int y, uint8 depth, const Graphics::ManagedSurface &surface);
 	void fillZBuffer(uint8 d);
 
 	// Colors
@@ -206,17 +206,17 @@ private:
 	uint _winWidth, _winHeight, _sceneWidth, _sceneHeight;
 
 	// renderSurface
-	Graphics::Surface _renderSurface;
+	Graphics::ManagedSurface _renderSurface;
 
 	// Z Buffer Surface
 	uint8 *_zBufferSurface = nullptr;
 
 	// Snapshot
-	Graphics::Surface _snapshotSurface;
+	Graphics::ManagedSurface _snapshotSurface;
 
 	// LightMap
 	int _lightMapNumber;
-	Graphics::Surface _lightMap;
+	Graphics::ManagedSurface _lightMap;
 
 	// Camera
 	float _cameraZoom;
@@ -224,20 +224,20 @@ private:
 
 	// Freeze
 	FrozenStuffStruct *_frozenStuff;
-	Graphics::Surface _freezeSurface;
+	Graphics::ManagedSurface _freezeSurface;
 	void freezeGraphics();
 
 	// Back drop
-	Graphics::Surface _backdropSurface;
-	Graphics::Surface _origBackdropSurface;
+	Graphics::ManagedSurface _backdropSurface;
+	Graphics::ManagedSurface _origBackdropSurface;
 	bool _backdropExists;
 	bool reserveBackdrop();
 
 	// Sprites
 	void fontSprite(bool flip, int x, int y, Sprite &single, const SpritePalette &fontPal);
-	Graphics::Surface *duplicateSurface(Graphics::Surface *surface);
-	void blendColor(Graphics::Surface * surface, uint32 color, Graphics::TSpriteBlendMode mode);
-	Graphics::Surface *applyLightmapToSprite(Graphics::Surface *&blitted, OnScreenPerson *thisPerson, bool mirror, int x, int y, int x1, int y1, int diffX, int diffY);
+	Graphics::ManagedSurface *duplicateSurface(Graphics::ManagedSurface *surface);
+	void blendColor(Graphics::ManagedSurface * surface, uint32 color, Graphics::TSpriteBlendMode mode);
+	Graphics::ManagedSurface *applyLightmapToSprite(Graphics::ManagedSurface *&blitted, OnScreenPerson *thisPerson, bool mirror, int x, int y, int x1, int y1, int diffX, int diffY);
 
 	// Sprite banks
 	LoadedSpriteBanks _allLoadedBanks;

--- a/engines/sludge/imgloader.cpp
+++ b/engines/sludge/imgloader.cpp
@@ -22,7 +22,7 @@
 #include "common/debug.h"
 
 #include "image/png.h"
-#include "graphics/surface.h"
+#include "graphics/managed_surface.h"
 
 #include "sludge/fileset.h"
 #include "sludge/hsi.h"
@@ -31,7 +31,7 @@
 
 namespace Sludge {
 
-bool ImgLoader::loadImage(int num, const char *fname, Common::SeekableReadStream *stream, Graphics::Surface *dest, int reserve) {
+bool ImgLoader::loadImage(int num, const char *fname, Common::SeekableReadStream *stream, Graphics::ManagedSurface *dest, int reserve) {
 	debugC(3, kSludgeDebugGraphics, "Loading image at position: %d", (int)stream->pos());
 
 	bool dumpPng = false;
@@ -74,7 +74,7 @@ bool ImgLoader::loadImage(int num, const char *fname, Common::SeekableReadStream
 	return true;
 }
 
-bool ImgLoader::loadPNGImage(Common::SeekableReadStream *stream, Graphics::Surface *dest, bool checkSig) {
+bool ImgLoader::loadPNGImage(Common::SeekableReadStream *stream, Graphics::ManagedSurface *dest, bool checkSig) {
 	::Image::PNGDecoder png;
 
 	// set skip signature
@@ -98,7 +98,7 @@ bool ImgLoader::loadPNGImage(Common::SeekableReadStream *stream, Graphics::Surfa
 	return true;
 }
 
-bool ImgLoader::loadHSIImage(Common::SeekableReadStream *stream, Graphics::Surface *dest, int reserve) {
+bool ImgLoader::loadHSIImage(Common::SeekableReadStream *stream, Graphics::ManagedSurface *dest, int reserve) {
 	HSIDecoder hsiDecoder;
 	hsiDecoder.setReserve(reserve);
 	if (!hsiDecoder.loadStream(*stream)) {

--- a/engines/sludge/imgloader.h
+++ b/engines/sludge/imgloader.h
@@ -31,9 +31,9 @@ protected:
 	ImgLoader() {}
 
 public:
-	static bool loadImage(int num, const char *fname, Common::SeekableReadStream *stream, Graphics::Surface *dest, int reserve = -1);
-	static bool loadPNGImage(Common::SeekableReadStream *stream, Graphics::Surface *dest, bool checkSig = true);
-	static bool loadHSIImage(Common::SeekableReadStream *stream, Graphics::Surface *dest, int reserve = -1);
+	static bool loadImage(int num, const char *fname, Common::SeekableReadStream *stream, Graphics::ManagedSurface *dest, int reserve = -1);
+	static bool loadPNGImage(Common::SeekableReadStream *stream, Graphics::ManagedSurface *dest, bool checkSig = true);
+	static bool loadHSIImage(Common::SeekableReadStream *stream, Graphics::ManagedSurface *dest, int reserve = -1);
 };
 
 } // End of namespace Sludge

--- a/engines/sludge/sludger.cpp
+++ b/engines/sludge/sludger.cpp
@@ -247,7 +247,7 @@ bool initSludge(const Common::String &filename) {
 		debugC(2, kSludgeDebugDataLoad, "There is an icon - read it!");
 
 		// read game icon
-		Graphics::Surface gameIcon;
+		Graphics::ManagedSurface gameIcon;
 		if (!ImgLoader::loadImage(-1, "icon", fp, &gameIcon, false)) {
 			delete fp;
 			return false;
@@ -259,7 +259,7 @@ bool initSludge(const Common::String &filename) {
 		debugC(2, kSludgeDebugDataLoad, "There is a logo - read it!");
 
 		// read game logo
-		Graphics::Surface gameLogo;
+		Graphics::ManagedSurface gameLogo;
 		if (!ImgLoader::loadImage(-1, "logo", fp, &gameLogo)) {
 			delete fp;
 			return false;

--- a/engines/sludge/sprites.cpp
+++ b/engines/sludge/sprites.cpp
@@ -340,21 +340,21 @@ void GraphicsManager::flipFontSprite(int x, int y, Sprite &single, const SpriteP
 	fontSprite(true, x, y, single, fontPal);
 }
 
-Graphics::Surface *GraphicsManager::duplicateSurface(Graphics::Surface *surface) {
-	Graphics::Surface *res = new Graphics::Surface();
+Graphics::ManagedSurface *GraphicsManager::duplicateSurface(Graphics::ManagedSurface *surface) {
+	Graphics::ManagedSurface *res = new Graphics::ManagedSurface();
 	res->copyFrom(*surface);
 	return res;
 }
 
-void GraphicsManager::blendColor(Graphics::Surface *blitted, uint32 color, Graphics::TSpriteBlendMode mode) {
+void GraphicsManager::blendColor(Graphics::ManagedSurface *blitted, uint32 color, Graphics::TSpriteBlendMode mode) {
 	Graphics::ManagedSurface tmp(blitted->w, blitted->h, blitted->format);
 	tmp.fillRect(Common::Rect(0, 0, tmp.w, tmp.h), color);
 	tmp.blendBlitTo(*blitted, 0, 0, Graphics::FLIP_NONE, nullptr, MS_ARGB((uint)255, (uint)255, (uint)255, (uint)255), (int)blitted->w, (int)blitted->h, mode);
 	tmp.free();
 }
 
-Graphics::Surface *GraphicsManager::applyLightmapToSprite(Graphics::Surface *&blitted, OnScreenPerson *thisPerson, bool mirror, int x, int y, int x1, int y1, int diffX, int diffY) {
-	Graphics::Surface * toDetele = nullptr;
+Graphics::ManagedSurface *GraphicsManager::applyLightmapToSprite(Graphics::ManagedSurface *&blitted, OnScreenPerson *thisPerson, bool mirror, int x, int y, int x1, int y1, int diffX, int diffY) {
+	Graphics::ManagedSurface * toDelete = nullptr;
 
 	// if light map is used
 	bool light = !(thisPerson->extra & EXTRA_NOLITE);
@@ -376,7 +376,7 @@ Graphics::Surface *GraphicsManager::applyLightmapToSprite(Graphics::Surface *&bl
 		} else if (_lightMapMode == LIGHTMAPMODE_PIXEL) {
 			curLight[0] = curLight[1] = curLight[2] = 255;
 
-			toDetele = blitted = duplicateSurface(blitted);
+			toDelete = blitted = duplicateSurface(blitted);
 
 			// apply light map texture
 			Graphics::ManagedSurface tmp;
@@ -414,20 +414,20 @@ Graphics::Surface *GraphicsManager::applyLightmapToSprite(Graphics::Surface *&bl
 
 	// apply primary color
 	if (primaryColor != (uint32)MS_ARGB(255, 255, 255, 255)) {
-		if (!toDetele) {
-			toDetele = blitted = duplicateSurface(blitted);
+		if (!toDelete) {
+			toDelete = blitted = duplicateSurface(blitted);
 			blendColor(blitted, primaryColor, Graphics::BLEND_MULTIPLY);
 		}
 	}
 
 	// apply secondary light map color
 	if (secondaryColor != 0x0) {
-		if (!toDetele) {
-			toDetele = blitted = duplicateSurface(blitted);
+		if (!toDelete) {
+			toDelete = blitted = duplicateSurface(blitted);
 		}
 		blendColor(blitted, secondaryColor, Graphics::BLEND_ADDITIVE);
 	}
-	return toDetele;
+	return toDelete;
 }
 
 bool GraphicsManager::scaleSprite(Sprite &single, const SpritePalette &fontPal, OnScreenPerson *thisPerson, bool mirror) {
@@ -482,8 +482,8 @@ bool GraphicsManager::scaleSprite(Sprite &single, const SpritePalette &fontPal, 
 		z = 0xFF;
 	}
 
-	Graphics::Surface *blitted = &single.surface;
-	Graphics::Surface *toDelete = applyLightmapToSprite(blitted, thisPerson, mirror, x, y, x1, y1, diffX, diffY);
+	Graphics::ManagedSurface *blitted = &single.surface;
+	Graphics::ManagedSurface *toDelete = applyLightmapToSprite(blitted, thisPerson, mirror, x, y, x1, y1, diffX, diffY);
 
 	// Use Managed surface to scale and blit
 	if (!_zBuffer->numPanels) {
@@ -499,7 +499,7 @@ bool GraphicsManager::scaleSprite(Sprite &single, const SpritePalette &fontPal, 
 		tmp.copyFrom(*blitted);
 		tmp.blendBlitTo(scaled, x1, y1, (mirror ? Graphics::FLIP_H : Graphics::FLIP_NONE), nullptr, MS_ARGB(255 - thisPerson->transparency, 255, 255, 255), diffX, diffY);
 
-		drawSpriteToZBuffer(0, 0, z, scaled.rawSurface());
+		drawSpriteToZBuffer(0, 0, z, scaled);
 	}
 
 	if (toDelete) {
@@ -559,8 +559,8 @@ void GraphicsManager::fixScaleSprite(int x, int y, Sprite &single, const SpriteP
 		z = 0xFF;
 	}
 
-	Graphics::Surface *blitted = &single.surface;
-	Graphics::Surface *toDelete = applyLightmapToSprite(blitted, thisPerson, mirror, x, y, x1, y1, diffX, diffY);
+	Graphics::ManagedSurface *blitted = &single.surface;
+	Graphics::ManagedSurface *toDelete = applyLightmapToSprite(blitted, thisPerson, mirror, x, y, x1, y1, diffX, diffY);
 
 	// draw backdrop
 	drawBackDrop();
@@ -583,7 +583,7 @@ void GraphicsManager::fixScaleSprite(int x, int y, Sprite &single, const SpriteP
 		tmp.copyFrom(*blitted);
 		tmp.blendBlitTo(scaled, x1, y1, (mirror ? Graphics::FLIP_H : Graphics::FLIP_NONE), nullptr, MS_ARGB(255 - thisPerson->transparency, 255, 255, 255), diffX, diffY);
 
-		drawSpriteToZBuffer(0, 0, z, scaled.rawSurface());
+		drawSpriteToZBuffer(0, 0, z, scaled);
 	}
 
 	if (toDelete) {

--- a/engines/sludge/sprites.cpp
+++ b/engines/sludge/sprites.cpp
@@ -280,9 +280,7 @@ void GraphicsManager::pasteSpriteToBackDrop(int x1, int y1, Sprite &single, cons
 	x1 -= single.xhot;
 	y1 -= single.yhot;
 
-	Graphics::ManagedSurface tmp;
-	tmp.copyFrom(single.surface);
-	tmp.blendBlitTo(_backdropSurface, x1, y1, Graphics::FLIP_NONE, nullptr, MS_RGB(fontPal.originalRed, fontPal.originalGreen, fontPal.originalBlue));
+	_backdropSurface.blendBlitFrom(single.surface, Common::Point(x1, y1), Graphics::FLIP_NONE, MS_RGB(fontPal.originalRed, fontPal.originalGreen, fontPal.originalBlue));
 
 }
 
@@ -304,9 +302,7 @@ void GraphicsManager::burnSpriteToBackDrop(int x1, int y1, Sprite &single, const
 	x1 -= single.xhot;
 	y1 -= single.yhot - 1;
 
-	Graphics::ManagedSurface tmp;
-	tmp.copyFrom(single.burnSurface);
-	tmp.blendBlitTo(_backdropSurface, x1, y1, Graphics::FLIP_NONE, nullptr,
+	_backdropSurface.blendBlitFrom(single.burnSurface, Common::Point(x1, y1), Graphics::FLIP_NONE,
 			MS_RGB(_currentBurnR, _currentBurnG, _currentBurnB));
 }
 
@@ -320,15 +316,10 @@ void GraphicsManager::fontSprite(bool flip, int x, int y, Sprite &single, const 
 	float y1 = (float)y - (float)single.yhot / _cameraZoom;
 
 	// Use Managed surface to scale and blit
-	Graphics::ManagedSurface tmp;
-	tmp.copyFrom(single.surface);
-	tmp.blendBlitTo(_renderSurface, x1, y1, (flip ? Graphics::FLIP_H : Graphics::FLIP_NONE), 0, MS_RGB(fontPal.originalRed, fontPal.originalGreen, fontPal.originalBlue));
+	_renderSurface.blendBlitFrom(single.surface, Common::Point(x1, y1), (flip ? Graphics::FLIP_H : Graphics::FLIP_NONE), MS_RGB(fontPal.originalRed, fontPal.originalGreen, fontPal.originalBlue));
 
 	if (single.burnSurface.getPixels() != nullptr) {
-		Graphics::ManagedSurface tmp2;
-		tmp2.copyFrom(single.burnSurface);
-		tmp2.blendBlitTo(_renderSurface, x1, y1, (flip ? Graphics::FLIP_H : Graphics::FLIP_NONE), 0, MS_RGB(fontPal.originalRed, fontPal.originalGreen, fontPal.originalBlue));
-
+		_renderSurface.blendBlitFrom(single.burnSurface, Common::Point(x1, y1), (flip ? Graphics::FLIP_H : Graphics::FLIP_NONE), MS_RGB(fontPal.originalRed, fontPal.originalGreen, fontPal.originalBlue));
 	}
 }
 
@@ -347,10 +338,7 @@ Graphics::ManagedSurface *GraphicsManager::duplicateSurface(Graphics::ManagedSur
 }
 
 void GraphicsManager::blendColor(Graphics::ManagedSurface *blitted, uint32 color, Graphics::TSpriteBlendMode mode) {
-	Graphics::ManagedSurface tmp(blitted->w, blitted->h, blitted->format);
-	tmp.fillRect(Common::Rect(0, 0, tmp.w, tmp.h), color);
-	tmp.blendBlitTo(*blitted, 0, 0, Graphics::FLIP_NONE, nullptr, MS_ARGB((uint)255, (uint)255, (uint)255, (uint)255), (int)blitted->w, (int)blitted->h, mode);
-	tmp.free();
+	blitted->blendFillRect(Common::Rect(0, 0, blitted->w, blitted->h), color, mode);
 }
 
 Graphics::ManagedSurface *GraphicsManager::applyLightmapToSprite(Graphics::ManagedSurface *&blitted, OnScreenPerson *thisPerson, bool mirror, int x, int y, int x1, int y1, int diffX, int diffY) {
@@ -379,15 +367,14 @@ Graphics::ManagedSurface *GraphicsManager::applyLightmapToSprite(Graphics::Manag
 			toDelete = blitted = duplicateSurface(blitted);
 
 			// apply light map texture
-			Graphics::ManagedSurface tmp;
-			tmp.copyFrom(_lightMap);
 			Common::Rect rect_h(_sceneWidth - x1 - diffX, y1, _sceneWidth - x1, y1 + diffY);
 			Common::Rect rect_none(x1, y1, x1 + diffX, y1 + diffY);
-			tmp.blendBlitTo(*blitted, 0, 0,
+			blitted->blendBlitFrom(_lightMap,
+					(mirror ? rect_h : rect_none),
+			                Common::Rect((int)blitted->w, (int)blitted->h),
 					(mirror ? Graphics::FLIP_H : Graphics::FLIP_NONE),
-					(mirror ? &rect_h : &rect_none),
 					MS_ARGB((uint)255, (uint)255, (uint)255, (uint)255),
-					(int)blitted->w, (int)blitted->h, Graphics::BLEND_MULTIPLY);
+			                Graphics::BLEND_MULTIPLY);
 
 		} else {
 			curLight[0] = curLight[1] = curLight[2] = 255;
@@ -487,17 +474,14 @@ bool GraphicsManager::scaleSprite(Sprite &single, const SpritePalette &fontPal, 
 
 	// Use Managed surface to scale and blit
 	if (!_zBuffer->numPanels) {
-		Graphics::ManagedSurface tmp;
-		tmp.copyFrom(*blitted);
-		tmp.blendBlitTo(_renderSurface, x1, y1, (mirror ? Graphics::FLIP_H : Graphics::FLIP_NONE), nullptr, MS_ARGB(255 - thisPerson->transparency, 255, 255, 255), diffX, diffY);
+		_renderSurface.blendBlitFrom(*blitted, blitted->getBounds(), Common::Rect(x1, y1, x1 + diffX, y1 + diffY),
+			(mirror ? Graphics::FLIP_H : Graphics::FLIP_NONE), MS_ARGB(255 - thisPerson->transparency, 255, 255, 255));
 	} else {
 		// TODO: you dont need to copy the whole render surface, just the part to which the sprite may be drawn
 		Graphics::ManagedSurface scaled;
 		scaled.copyFrom(_renderSurface);
-
-		Graphics::ManagedSurface tmp;
-		tmp.copyFrom(*blitted);
-		tmp.blendBlitTo(scaled, x1, y1, (mirror ? Graphics::FLIP_H : Graphics::FLIP_NONE), nullptr, MS_ARGB(255 - thisPerson->transparency, 255, 255, 255), diffX, diffY);
+		scaled.blendBlitFrom(*blitted, blitted->getBounds(), Common::Rect(x1, y1, x1 + diffX, y1 + diffY),
+			(mirror ? Graphics::FLIP_H : Graphics::FLIP_NONE), MS_ARGB(255 - thisPerson->transparency, 255, 255, 255));
 
 		drawSpriteToZBuffer(0, 0, z, scaled);
 	}
@@ -572,16 +556,13 @@ void GraphicsManager::fixScaleSprite(int x, int y, Sprite &single, const SpriteP
 
 	// draw sprite
 	if (!_zBuffer->numPanels) {
-		Graphics::ManagedSurface tmp;
-		tmp.copyFrom(single.surface);
-		tmp.blendBlitTo(_renderSurface, x1, y1, (mirror ? Graphics::FLIP_H : Graphics::FLIP_NONE), nullptr, MS_ARGB((uint)255, (uint)255, (uint)255, (uint)255), diffX, diffY);
+		_renderSurface.blendBlitFrom(single.surface, single.surface.getBounds(), Common::Rect(x1, y1, x1 + diffX, y1 + diffY),
+			(mirror ? Graphics::FLIP_H : Graphics::FLIP_NONE));
 	} else {
 		Graphics::ManagedSurface scaled;
 		scaled.copyFrom(_renderSurface);
-
-		Graphics::ManagedSurface tmp;
-		tmp.copyFrom(*blitted);
-		tmp.blendBlitTo(scaled, x1, y1, (mirror ? Graphics::FLIP_H : Graphics::FLIP_NONE), nullptr, MS_ARGB(255 - thisPerson->transparency, 255, 255, 255), diffX, diffY);
+		scaled.blendBlitFrom(*blitted, blitted->getBounds(), Common::Rect(x1, y1, x1 + diffX, y1 + diffY),
+			(mirror ? Graphics::FLIP_H : Graphics::FLIP_NONE), MS_ARGB(255 - thisPerson->transparency, 255, 255, 255));
 
 		drawSpriteToZBuffer(0, 0, z, scaled);
 	}

--- a/engines/sludge/sprites.h
+++ b/engines/sludge/sprites.h
@@ -27,8 +27,8 @@ namespace Sludge {
 
 struct Sprite {
 	int xhot, yhot;
-	Graphics::Surface surface;
-	Graphics::Surface burnSurface;
+	Graphics::ManagedSurface surface;
+	Graphics::ManagedSurface burnSurface;
 };
 
 class SpritePalette {
@@ -89,10 +89,10 @@ struct SpriteDisplay {
 	int width, height;
 	bool freeAfterUse;
 	Graphics::FLIP_FLAGS flip;
-	Graphics::Surface *surface;
+	Graphics::ManagedSurface *surface;
 	byte transparency;
 
-	SpriteDisplay(int xpos, int ypos, Graphics::FLIP_FLAGS f, Graphics::Surface *ptr, int w = -1, int h = 1, bool free = false, byte trans = 255) :
+	SpriteDisplay(int xpos, int ypos, Graphics::FLIP_FLAGS f, Graphics::ManagedSurface *ptr, int w = -1, int h = 1, bool free = false, byte trans = 255) :
 			x(xpos), y(ypos), flip(f), surface(ptr), width(w), height(h), freeAfterUse(free), transparency(trans) {
 	}
 };

--- a/engines/sludge/sprites.h
+++ b/engines/sludge/sprites.h
@@ -83,20 +83,6 @@ struct SpriteBank {
 	bool isFont;
 };
 
-// Sprite display informations
-struct SpriteDisplay {
-	int x, y;
-	int width, height;
-	bool freeAfterUse;
-	Graphics::FLIP_FLAGS flip;
-	Graphics::ManagedSurface *surface;
-	byte transparency;
-
-	SpriteDisplay(int xpos, int ypos, Graphics::FLIP_FLAGS f, Graphics::ManagedSurface *ptr, int w = -1, int h = 1, bool free = false, byte trans = 255) :
-			x(xpos), y(ypos), flip(f), surface(ptr), width(w), height(h), freeAfterUse(free), transparency(trans) {
-	}
-};
-
 } // End of namespace Sludge
 
 #endif

--- a/engines/sludge/thumbnail.cpp
+++ b/engines/sludge/thumbnail.cpp
@@ -95,7 +95,7 @@ void GraphicsManager::showThumbnail(const Common::String &filename, int atX, int
 		int fileHeight = fp->readUint32LE();
 
 		Graphics::ManagedSurface thumbnail;
-		if (!ImgLoader::loadPNGImage(fp, thumbnail.surfacePtr()))
+		if (!ImgLoader::loadPNGImage(fp, &thumbnail))
 			return;
 
 		delete fp;
@@ -125,7 +125,7 @@ bool GraphicsManager::skipThumbnail(Common::SeekableReadStream *stream) {
 	_thumbHeight = stream->readUint32LE();
 
 	// Load image
-	Graphics::Surface tmp;
+	Graphics::ManagedSurface tmp;
 	if (_thumbWidth && _thumbHeight) {
 		if (!ImgLoader::loadPNGImage(stream, &tmp))
 			return false;

--- a/engines/sludge/thumbnail.cpp
+++ b/engines/sludge/thumbnail.cpp
@@ -115,7 +115,7 @@ void GraphicsManager::showThumbnail(const Common::String &filename, int atX, int
 		if (fileHeight + atY > (int)_sceneHeight)
 			fileHeight = _sceneHeight - atY;
 
-		thumbnail.blendBlitTo(_backdropSurface, atX, atY, Graphics::FLIP_NONE, nullptr, MS_ARGB((uint)255, (uint)255, (uint)255, (uint)255), fileWidth, fileHeight);
+		_backdropSurface.blendBlitFrom(thumbnail, thumbnail.getBounds(), Common::Rect(atX, atY, atX + fileWidth, atY + fileHeight));
 		thumbnail.free();
 	}
 }

--- a/engines/sludge/transition.cpp
+++ b/engines/sludge/transition.cpp
@@ -62,7 +62,7 @@ void GraphicsManager::transitionSnapshotBox() {
 	uint32 xScale = (255 - _brightnessLevel) * _winWidth / 255;
 	uint32 yScale = (255 - _brightnessLevel) * _winHeight / 255;
 
-	Graphics::Surface *surf = _snapshotSurface.scale(xScale, yScale);
+	Graphics::ManagedSurface *surf = _snapshotSurface.scale(xScale, yScale);
 
 	_renderSurface.copyRectToSurface(surf->getPixels(), surf->pitch, (_winWidth - xScale) / 2, (_winHeight - yScale) / 2, xScale, yScale);
 

--- a/engines/sludge/transition.cpp
+++ b/engines/sludge/transition.cpp
@@ -47,9 +47,7 @@ void GraphicsManager::transitionCrossFader() {
 	if (_brightnessLevel == 255)
 		return;
 
-	Graphics::ManagedSurface tmp;
-	tmp.copyFrom(_snapshotSurface);
-	tmp.blendBlitTo(_renderSurface, 0, 0, Graphics::FLIP_NONE, nullptr, MS_ARGB(255 - _brightnessLevel, 0xff, 0xff, 0xff));
+	_renderSurface.blendBlitFrom(_snapshotSurface, Graphics::FLIP_NONE, MS_ARGB(255 - _brightnessLevel, 0xff, 0xff, 0xff));
 }
 
 void GraphicsManager::transitionSnapshotBox() {
@@ -132,7 +130,7 @@ void GraphicsManager::transitionDisolve() {
 	// The original stretched the texture, we just tile it
 	for (uint y = 0; y < _sceneHeight; y += _transitionTexture->h)
 		for (uint x = 0; x < _sceneWidth; x += _transitionTexture->w)
-			_transitionTexture->blendBlitTo(_renderSurface, x, y);
+			_renderSurface.blendBlitFrom(*_transitionTexture, Common::Point(x, y));
 }
 
 void GraphicsManager::transitionTV() {
@@ -169,7 +167,7 @@ void GraphicsManager::transitionTV() {
 	// The original stretched the texture, we just tile it
 	for (uint y = 0; y < _sceneHeight; y += _transitionTexture->h)
 		for (uint x = 0; x < _sceneWidth; x += _transitionTexture->w)
-			_transitionTexture->blendBlitTo(_renderSurface, x, y);
+			_renderSurface.blendBlitFrom(*_transitionTexture, Common::Point(x, y));
 }
 
 void GraphicsManager::transitionBlinds() {
@@ -198,7 +196,7 @@ void GraphicsManager::transitionBlinds() {
 	// The original stretched the texture, we just tile it
 	for (uint y = 0; y < _sceneHeight; y += _transitionTexture->h)
 		for (uint x = 0; x < _sceneWidth; x += _transitionTexture->w)
-			_transitionTexture->blendBlitTo(_renderSurface, x, y);
+			_renderSurface.blendBlitFrom(*_transitionTexture, Common::Point(x, y));
 }
 
 //----------------------------------------------------

--- a/engines/sludge/zbuffer.cpp
+++ b/engines/sludge/zbuffer.cpp
@@ -161,7 +161,7 @@ void GraphicsManager::fillZBuffer(uint8 d) {
 	memset(_zBufferSurface, d, _winHeight * _winWidth);
 }
 
-void GraphicsManager::drawSpriteToZBuffer(int x, int y, uint8 depth, const Graphics::Surface &surface) {
+void GraphicsManager::drawSpriteToZBuffer(int x, int y, uint8 depth, const Graphics::ManagedSurface &surface) {
 
 	for (uint y1 = 0; y1 < (uint)surface.h; y1++) {
 		for (uint x1 = 0; x1 < (uint)surface.w; x1++) {

--- a/engines/sludge/zbuffer.h
+++ b/engines/sludge/zbuffer.h
@@ -31,7 +31,7 @@ struct ZBufferData {
 	int originalNum;
 
 	uint8 *tex;
-	Graphics::Surface *sprites;
+	Graphics::ManagedSurface *sprites;
 };
 
 } // End of namespace Sludges

--- a/engines/sludge/zbuffer.h
+++ b/engines/sludge/zbuffer.h
@@ -31,7 +31,6 @@ struct ZBufferData {
 	int originalNum;
 
 	uint8 *tex;
-	Graphics::ManagedSurface *sprites;
 };
 
 } // End of namespace Sludges


### PR DESCRIPTION
This is closer to the other blit functions in `ManagedSurface`, and reduces the amount of surface copying required.