### PR TITLE
CHAMBER: Week 4 fixes

### DIFF
--- a/engines/chamber/kult.cpp
+++ b/engines/chamber/kult.cpp
@@ -184,13 +184,19 @@ void gameLoop(byte *target) {
 				goto process;
 			}
 
-			if (Swap16(next_vorts_ticks) < script_word_vars.timer_ticks2) { /*TODO: is this ok? ticks2 is BE, ticks3 is LE*/
+			// next_vorts_ticks is a plain numeric value (always set as
+			// Swap16(timer_ticks2) + 5), but timer_ticks2 is stored big-endian.
+			// Byteswap the timer side so both operands are numeric; the old
+			// Swap16(next_vorts_ticks) compared two BE representations, so the
+			// vort command fired at the wrong times (vorts popping in/out of
+			// rooms and leaving artifacts from the interrupted walk anim).
+			if (next_vorts_ticks < Swap16(script_word_vars.timer_ticks2)) {
 				the_command = next_vorts_cmd;
 				if (the_command)
 					goto process;
 			}
 
-			if (Swap16(next_turkey_ticks) < script_word_vars.timer_ticks2) { /*TODO: is this ok? ticks2 is BE, ticks4 is LE*/
+			if (next_turkey_ticks < Swap16(script_word_vars.timer_ticks2)) {
 				the_command = next_turkey_cmd;
 				if (the_command)
 					goto process;

--- a/engines/chamber/room.cpp
+++ b/engines/chamber/room.cpp
@@ -40,13 +40,21 @@
 
 namespace Chamber {
 
-// 1500-byte spot-backup region, then the lutin/anim scratch (scratch_mem2).
+// Spot-backup region, then the lutin/anim scratch (scratch_mem2).
+// backupSpotsImages() fills the spot-backup region from scratch_mem1 upward.
+// The original CGA budget for it is 1500 bytes, but EGA stores each backup as
+// CLUT8 (4 bytes per CGA byte), so it needs up to 4*1500 = 6000 bytes. With the
+// old 1500-byte gap the EGA backups spilled past scratch_mem2 and were then
+// clobbered by the next lutin load, corrupting the backup headers (garbage
+// stamped into the backbuffer's top rows). Use the EGA worst case for the gap.
+//
 // The scratch holds up to four simultaneous lutin slots (see getScratchBuffer).
-// CGA needs 4*1600 = 6400 there; EGA decodes lutins to CLUT8 (4 bytes per CGA
-// byte) so it needs 4*3200 = 12800. Sized for the EGA worst case so a big lutin
-// can't overrun into the adjacent sprites_list[].
-byte scratch_mem1[14400];
-byte *scratch_mem2 = scratch_mem1 + 1500;
+// CGA needs 4*1600 = 6400 there; EGA decodes lutins to CLUT8 so it needs
+// 4*3200 = 12800. Size scratch_mem1 for gap + EGA lutin worst case so neither a
+// big backup nor a big lutin can overrun into the adjacent sprites_list[].
+#define SCRATCH_SPOT_GAP 6000
+byte scratch_mem1[SCRATCH_SPOT_GAP + 12800];
+byte *scratch_mem2 = scratch_mem1 + SCRATCH_SPOT_GAP;
 
 rect_t room_bounds_rect = {0, 0, 0, 0};
 byte last_object_hint = 0;

--- a/engines/chamber/room.h
+++ b/engines/chamber/room.h
@@ -90,7 +90,7 @@ typedef struct turkeyanims_t {
 	animdesc_t field_4;
 } turkeyanims_t;
 
-extern byte scratch_mem1[14400];
+extern byte scratch_mem1[];
 extern byte *scratch_mem2;
 
 extern rect_t room_bounds_rect;

--- a/engines/chamber/script.cpp
+++ b/engines/chamber/script.cpp
@@ -3665,7 +3665,8 @@ uint16 CMD_D_PsiBrainwarp(void) {
 
 
 uint16 CMD_E_PsiZoneScan(void) {
-	byte x, y, w, h;
+	byte y, h;
+	uint16 x, w;
 	uint16 offs;
 
 	if (!ConsumePsiEnergy(1))
@@ -3683,6 +3684,11 @@ uint16 CMD_E_PsiZoneScan(void) {
 	offs = g_vm->_renderer->calcXY_p(room_bounds_rect.sx, room_bounds_rect.sy);
 	w = room_bounds_rect.ex - room_bounds_rect.sx;
 	h = room_bounds_rect.ey - room_bounds_rect.sy;
+
+	/*room coords are in 4-pixel blocks; EGA is 1 byte/pixel so the scan line
+	  spans w*4 bytes, while CGA packs 4 pixels/byte and spans w bytes*/
+	if (g_vm->_videoMode == Common::kRenderEGA)
+		w *= 4;
 
 	for (y = room_bounds_rect.sy; h; y++, h--) {
 		spot_t *spot;


### PR DESCRIPTION
The fixes are:
1. EGA spot-backup overflow – In rooms with animated spots (e.g. "Placating
  the Powers"), garbage pixels are stamped into the top rows of the EGA
  backbuffer. The spot backups are stored in EGA as CLUT8 (4 bytes per CGA
  byte), so they overrun the original 1500-byte scratch budget and get clobbered
  by the next lutin sprite load. I resize the scratch region to handle the EGA
  worst case.
  2. Vort/turkey timer endianness – I fix a timer comparison that doesn't
  account for endianness, which affects the vort/turkey logic.
  3. EGA zone scan – The zone scan only covers a quarter of the screen width; I
  fix it to cover the full width.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
