### PR TITLE
BACKENDS: ATARI: Allow setting output_rate & friends per-game

### DIFF
--- a/backends/audiocd/default/default-audiocd.cpp
+++ b/backends/audiocd/default/default-audiocd.cpp
@@ -35,9 +35,7 @@ DefaultAudioCDManager::DefaultAudioCDManager() {
 	_cd.numLoops = 0;
 	_cd.volume = Audio::Mixer::kMaxChannelVolume;
 	_cd.balance = 0;
-	_mixer = g_system->getMixer();
 	_emulating = false;
-	assert(_mixer);
 }
 
 DefaultAudioCDManager::~DefaultAudioCDManager() {
@@ -128,8 +126,8 @@ bool DefaultAudioCDManager::play(int track, int numLoops, int startFrame, int du
 			repetitions. Finally, -1 means infinitely many
 			*/
 			_emulating = true;
-			_mixer->playStream(soundType, &_handle,
-			                        Audio::makeLoopingAudioStream(stream, start, end, (numLoops < 1) ? numLoops + 1 : numLoops), -1, _cd.volume, _cd.balance);
+			g_system->getMixer()->playStream(soundType, &_handle,
+				Audio::makeLoopingAudioStream(stream, start, end, (numLoops < 1) ? numLoops + 1 : numLoops), -1, _cd.volume, _cd.balance);
 			return true;
 		}
 	}
@@ -162,7 +160,7 @@ bool DefaultAudioCDManager::playAbsolute(int startFrame, int numLoops, int durat
 void DefaultAudioCDManager::stop() {
 	if (_emulating) {
 		// Audio CD emulation
-		_mixer->stopHandle(_handle);
+		g_system->getMixer()->stopHandle(_handle);
 		_emulating = false;
 	}
 }
@@ -170,7 +168,7 @@ void DefaultAudioCDManager::stop() {
 bool DefaultAudioCDManager::isPlaying() const {
 	// Audio CD emulation
 	if (_emulating)
-		return _mixer->isSoundHandleActive(_handle);
+		return g_system->getMixer()->isSoundHandleActive(_handle);
 
 	// The default class only handles emulation
 	return false;
@@ -181,7 +179,7 @@ void DefaultAudioCDManager::setVolume(byte volume) {
 
 	// Audio CD emulation
 	if (_emulating && isPlaying())
-		_mixer->setChannelVolume(_handle, _cd.volume);
+		g_system->getMixer()->setChannelVolume(_handle, _cd.volume);
 }
 
 void DefaultAudioCDManager::setBalance(int8 balance) {
@@ -189,13 +187,13 @@ void DefaultAudioCDManager::setBalance(int8 balance) {
 
 	// Audio CD emulation
 	if (_emulating && isPlaying())
-		_mixer->setChannelBalance(_handle, _cd.balance);
+		g_system->getMixer()->setChannelBalance(_handle, _cd.balance);
 }
 
 void DefaultAudioCDManager::update() {
 	if (_emulating) {
 		// Check whether the audio track stopped playback
-		if (!_mixer->isSoundHandleActive(_handle)) {
+		if (!g_system->getMixer()->isSoundHandleActive(_handle)) {
 			// FIXME: We do not update the numLoops parameter here (and in fact,
 			// currently can't do that). Luckily, only one engine ever checks
 			// this part of the AudioCD status, namely the SCUMM engine; and it

--- a/backends/audiocd/default/default-audiocd.h
+++ b/backends/audiocd/default/default-audiocd.h
@@ -79,7 +79,6 @@ protected:
 	bool _emulating;
 
 	Status _cd;
-	Audio::Mixer *_mixer;
 };
 
 #endif

--- a/backends/audiocd/linux/linux-audiocd.cpp
+++ b/backends/audiocd/linux/linux-audiocd.cpp
@@ -320,7 +320,7 @@ bool LinuxAudioCDManager::play(int track, int numLoops, int startFrame, int dura
 	// Fake emulation since we're really playing an AudioStream
 	_emulating = true;
 
-	_mixer->playStream(
+	g_system->getMixer()->playStream(
 	    soundType,
 	    &_handle,
 	    Audio::makeLoopingAudioStream(audioStream, start, end, (numLoops < 1) ? numLoops + 1 : numLoops),

--- a/backends/audiocd/macosx/macosx-audiocd.cpp
+++ b/backends/audiocd/macosx/macosx-audiocd.cpp
@@ -252,8 +252,8 @@ bool MacOSXAudioCDManager::play(int track, int numLoops, int startFrame, int dur
 	// Fake emulation since we're really playing an AIFF file
 	_emulating = true;
 
-	_mixer->playStream(soundType, &_handle,
-	                   Audio::makeLoopingAudioStream(seekStream, start, end, (numLoops < 1) ? numLoops + 1 : numLoops), -1, _cd.volume, _cd.balance);
+	g_system->getMixer()->playStream(soundType, &_handle,
+		Audio::makeLoopingAudioStream(seekStream, start, end, (numLoops < 1) ? numLoops + 1 : numLoops), -1, _cd.volume, _cd.balance);
 	return true;
 }
 

--- a/backends/audiocd/win32/win32-audiocd.cpp
+++ b/backends/audiocd/win32/win32-audiocd.cpp
@@ -294,7 +294,7 @@ bool Win32AudioCDManager::play(int track, int numLoops, int startFrame, int dura
 	// Fake emulation since we're really playing an AudioStream
 	_emulating = true;
 
-	_mixer->playStream(
+	g_system->getMixer()->playStream(
 	    soundType,
 	    &_handle,
 	    Audio::makeLoopingAudioStream(audioStream, start, end, (numLoops < 1) ? numLoops + 1 : numLoops),

--- a/backends/graphics/atari/atari-graphics.cpp
+++ b/backends/graphics/atari/atari-graphics.cpp
@@ -1149,7 +1149,9 @@ void AtariGraphicsManager::copyRectToAtariSurface(AtariSurface &dstSurface,
 	const Common::Rect rect = AtariSurface::alignRect(x, y, x + w, y + h);
 
 	// TODO: mask the unaligned parts and copy the rest
-	buf -= (x - rect.left);	// HACK: this assumes pointer to a complete buffer
+	// HACK: this assumes pointer to a complete buffer
+	// NOTE: unfortunately this shows the ScummVM logo shifted in 16 colours
+	buf -= (x - rect.left);
 
 	dstSurface.copyRectToSurface(buf, pitch, rect.left, rect.top, rect.width(), rect.height());
 }

--- a/backends/mixer/atari/atari-mixer.cpp
+++ b/backends/mixer/atari/atari-mixer.cpp
@@ -72,19 +72,8 @@ AtariMixerManager::AtariMixerManager() : MixerManager() {
 	suspendAudio();
 
 	ConfMan.registerDefault("output_rate", DEFAULT_OUTPUT_RATE);
-	_outputRate = ConfMan.getInt("output_rate");
-	if (_outputRate <= 0)
-		_outputRate = DEFAULT_OUTPUT_RATE;
-
 	ConfMan.registerDefault("output_channels", DEFAULT_OUTPUT_CHANNELS);
-	_outputChannels = ConfMan.getInt("output_channels");
-	if (_outputChannels <= 0 || _outputChannels > 2)
-		_outputChannels = DEFAULT_OUTPUT_CHANNELS;
-
 	ConfMan.registerDefault("audio_buffer_size", DEFAULT_SAMPLES);
-	_samples = ConfMan.getInt("audio_buffer_size");
-	if (_samples <= 0)
-		_samples = DEFAULT_SAMPLES;
 
 	g_system->getEventManager()->getEventDispatcher()->registerObserver(this, 10, false);
 }
@@ -94,16 +83,28 @@ AtariMixerManager::~AtariMixerManager() {
 
 	g_system->getEventManager()->getEventDispatcher()->unregisterObserver(this);
 
-	AtariAudioShutdown();
-
-	Mfree(_atariSampleBuffer);
-	_atariSampleBuffer = _atariPhysicalSampleBuffer = _atariLogicalSampleBuffer = nullptr;
-
-	delete[] _samplesBuf;
-	_samplesBuf = nullptr;
+	deinit();
 }
 
 void AtariMixerManager::init() {
+	debug("audio init");
+
+	assert(!_mixer);
+
+	// read either from game domain or from defaults
+	// but never write back so 22050 Hz will stay even on TT/stock Falcon
+	_outputRate = ConfMan.getInt("output_rate");
+	if (_outputRate <= 0)
+		_outputRate = DEFAULT_OUTPUT_RATE;
+
+	_outputChannels = ConfMan.getInt("output_channels");
+	if (_outputChannels <= 0 || _outputChannels > 2)
+		_outputChannels = DEFAULT_OUTPUT_CHANNELS;
+
+	_samples = ConfMan.getInt("audio_buffer_size");
+	if (_samples <= 0)
+		_samples = DEFAULT_SAMPLES;
+
 	USoundSpec desired, obtained;
 
 	desired.frequency = _outputRate;
@@ -128,15 +129,9 @@ void AtariMixerManager::init() {
 	_samples = obtained.samples;
 	_downsample = (obtained.format == USoundFormatSigned8);
 
-	ConfMan.setInt("output_rate", _outputRate, Common::ConfigManager::kApplicationDomain);
-	ConfMan.setInt("output_channels", _outputChannels, Common::ConfigManager::kApplicationDomain);
-	ConfMan.setInt("audio_buffer_size", _samples, Common::ConfigManager::kApplicationDomain);
-
 	debug("setting %d Hz mixing frequency (%d-bit, %s)",
 		  _outputRate, obtained.format == USoundFormatSigned8 ? 8 : 16, _outputChannels == 1 ? "mono" : "stereo");
 	debug("sample buffer size: %d", _samples);
-
-	ConfMan.flushToDisk();
 
 	_atariSampleBuffer = (byte*)Mxalloc(obtained.size * 2, MX_STRAM);
 	if (!_atariSampleBuffer)
@@ -160,6 +155,23 @@ void AtariMixerManager::init() {
 	_mixer->setReady(true);
 
 	resumeAudio();
+}
+
+void AtariMixerManager::deinit() {
+	debug("audio deinit");
+
+	suspendAudio();
+
+	AtariAudioShutdown();
+
+	delete _mixer;
+	_mixer = nullptr;
+
+	Mfree(_atariSampleBuffer);
+	_atariSampleBuffer = _atariPhysicalSampleBuffer = _atariLogicalSampleBuffer = nullptr;
+
+	delete[] _samplesBuf;
+	_samplesBuf = nullptr;
 }
 
 void AtariMixerManager::suspendAudio() {

--- a/backends/mixer/atari/atari-mixer.cpp
+++ b/backends/mixer/atari/atari-mixer.cpp
@@ -84,19 +84,8 @@ AtariMixerManager::AtariMixerManager() : MixerManager() {
 	suspendAudio();
 
 	ConfMan.registerDefault("output_rate", DEFAULT_OUTPUT_RATE);
-	_outputRate = ConfMan.getInt("output_rate");
-	if (_outputRate <= 0)
-		_outputRate = DEFAULT_OUTPUT_RATE;
-
 	ConfMan.registerDefault("output_channels", DEFAULT_OUTPUT_CHANNELS);
-	_outputChannels = ConfMan.getInt("output_channels");
-	if (_outputChannels <= 0 || _outputChannels > 2)
-		_outputChannels = DEFAULT_OUTPUT_CHANNELS;
-
 	ConfMan.registerDefault("audio_buffer_size", DEFAULT_SAMPLES);
-	_samples = ConfMan.getInt("audio_buffer_size");
-	if (_samples <= 0)
-		_samples = DEFAULT_SAMPLES;
 
 	g_system->getEventManager()->getEventDispatcher()->registerObserver(this, 10, false);
 }
@@ -106,16 +95,28 @@ AtariMixerManager::~AtariMixerManager() {
 
 	g_system->getEventManager()->getEventDispatcher()->unregisterObserver(this);
 
-	AtariAudioShutdown();
-
-	Mfree(_atariSampleBuffer);
-	_atariSampleBuffer = nullptr;
-
-	delete[] _sampleBuffer;
-	_sampleBuffer = nullptr;
+	deinit();
 }
 
 void AtariMixerManager::init() {
+	debug("audio init");
+
+	assert(!_mixer);
+
+	// read either from game domain or from defaults
+	// but never write back so 22050 Hz will stay even on TT/stock Falcon
+	_outputRate = ConfMan.getInt("output_rate");
+	if (_outputRate <= 0)
+		_outputRate = DEFAULT_OUTPUT_RATE;
+
+	_outputChannels = ConfMan.getInt("output_channels");
+	if (_outputChannels <= 0 || _outputChannels > 2)
+		_outputChannels = DEFAULT_OUTPUT_CHANNELS;
+
+	_samples = ConfMan.getInt("audio_buffer_size");
+	if (_samples <= 0)
+		_samples = DEFAULT_SAMPLES;
+
 	USoundSpec desired, obtained;
 
 	desired.frequency = _outputRate;
@@ -179,6 +180,26 @@ void AtariMixerManager::init() {
 	_mixer->setReady(true);
 
 	resumeAudio();
+}
+
+void AtariMixerManager::deinit() {
+	debug("audio deinit");
+
+	suspendAudio();
+
+	AtariAudioShutdown();
+
+	delete _mixer;
+	_mixer = nullptr;
+
+	Mfree(_atariSampleBuffer);
+	_atariSampleBuffer = nullptr;
+	_atariSampleBufferSize = 0;
+
+	delete[] _sampleBuffer;
+	_sampleBuffer = nullptr;
+	_sampleBufferSize = 0;
+	_samples = 0;
 }
 
 void AtariMixerManager::suspendAudio() {

--- a/backends/mixer/atari/atari-mixer.h
+++ b/backends/mixer/atari/atari-mixer.h
@@ -32,9 +32,10 @@
 class AtariMixerManager : public MixerManager, Common::EventObserver {
 public:
 	AtariMixerManager();
-	virtual ~AtariMixerManager();
+	~AtariMixerManager() override;
 
 	void init() override;
+	void deinit();
 	void update();
 
 	void suspendAudio() override;

--- a/backends/platform/atari/osystem_atari.cpp
+++ b/backends/platform/atari/osystem_atari.cpp
@@ -356,13 +356,18 @@ void OSystem_Atari::initBackend() {
 		ConfMan.setInt("autosave_period", 0);
 	}
 
+	// init() will be called upon starting a new game
 	_mixerManager = new AtariMixerManager();
-	// Setup and start mixer
-	_mixerManager->init();
 
 	_audiocdManager = new AtariAudioCDManager();
 
 	BaseBackend::initBackend();
+}
+
+void OSystem_Atari::engineBeforeCreate() {
+	debug("engineBeforeCreate");
+
+	((AtariMixerManager *)_mixerManager)->init();
 }
 
 void OSystem_Atari::engineInit() {
@@ -375,6 +380,12 @@ void OSystem_Atari::engineDone() {
 	//debug("engineDone");
 
 	g_gameEngineActive = false;
+}
+
+void OSystem_Atari::engineAfterDelete() {
+	debug("engineAfterDelete");
+
+	((AtariMixerManager *)_mixerManager)->deinit();
 }
 
 Common::MutexInternal *OSystem_Atari::createMutex() {
@@ -409,7 +420,7 @@ void OSystem_Atari::getTimeAndDate(TimeDate &td, bool skipRecord) const {
 Common::KeymapArray OSystem_Atari::getGlobalKeymaps() {
 	Common::KeymapArray globalMaps = BaseBackend::getGlobalKeymaps();
 
-	Common::Keymap *keymap = ((AtariGraphicsManager*)_graphicsManager)->getKeymap();
+	Common::Keymap *keymap = ((AtariGraphicsManager *)_graphicsManager)->getKeymap();
 	globalMaps.push_back(keymap);
 
 	return globalMaps;

--- a/backends/platform/atari/osystem_atari.cpp
+++ b/backends/platform/atari/osystem_atari.cpp
@@ -363,13 +363,18 @@ void OSystem_Atari::initBackend() {
 		ConfMan.setInt("autosave_period", 0);
 	}
 
+	// init() will be called upon starting a new game
 	_mixerManager = new AtariMixerManager();
-	// Setup and start mixer
-	_mixerManager->init();
 
 	_audiocdManager = new AtariAudioCDManager();
 
 	BaseBackend::initBackend();
+}
+
+void OSystem_Atari::engineBeforeCreate() {
+	debug("engineBeforeCreate");
+
+	((AtariMixerManager *)_mixerManager)->init();
 }
 
 void OSystem_Atari::engineInit() {
@@ -382,6 +387,12 @@ void OSystem_Atari::engineDone() {
 	//debug("engineDone");
 
 	g_gameEngineActive = false;
+}
+
+void OSystem_Atari::engineAfterDelete() {
+	debug("engineAfterDelete");
+
+	((AtariMixerManager *)_mixerManager)->deinit();
 }
 
 Common::MutexInternal *OSystem_Atari::createMutex() {
@@ -416,7 +427,7 @@ void OSystem_Atari::getTimeAndDate(TimeDate &td, bool skipRecord) const {
 Common::KeymapArray OSystem_Atari::getGlobalKeymaps() {
 	Common::KeymapArray globalMaps = BaseBackend::getGlobalKeymaps();
 
-	Common::Keymap *keymap = ((AtariGraphicsManager*)_graphicsManager)->getKeymap();
+	Common::Keymap *keymap = ((AtariGraphicsManager *)_graphicsManager)->getKeymap();
 	globalMaps.push_back(keymap);
 
 	return globalMaps;

--- a/backends/platform/atari/osystem_atari.h
+++ b/backends/platform/atari/osystem_atari.h
@@ -31,8 +31,10 @@ public:
 
 	void initBackend() override;
 
+	void engineBeforeCreate() override;
 	void engineInit() override;
 	void engineDone() override;
+	void engineAfterDelete() override;
 
 	Common::MutexInternal *createMutex() override;
 	uint32 getMillis(bool skipRecord = false) override;

--- a/backends/platform/atari/readme.txt
+++ b/backends/platform/atari/readme.txt
@@ -178,6 +178,12 @@ If you want to play with "audio_buffer_size", the rule of thumb is: (lag in ms)
 = (audio_buffer_size / output_rate) * 1000. But it's totally OK just to double
 the samples value to get rid of stuttering in a heavier game.
 
+Please note that unlike previous versions, these values will never be written
+back to scummvm.ini. This is beneficial if you want to switch between Falcon
+and TT or between Falcon with and without external DSP clock (as mentioned,
+DOS/Windows friendly values are automatically converted to a frequency which
+TT/Falcon supports).
+
 "gaudio" debug channel: used for optimising sample playback (where
 available). It prints input and output sample format as well as the name of the
 converter used. See below for details.
@@ -401,15 +407,20 @@ Mute vs. "No music"
 
 Currently ScummVM requires each backend to mix samples, even though they may
 contain muted output (i.e. zeroes). This is because the progression of sample
-playback tells ScummVM how much time has passed in e.g. an animation.
+playback tells ScummVM how much time has passed in e.g. an animation. However,
+one part of the pending audio mixing changes is an optimisation: the input
+stream is still loaded and decoded but it is not mixed which alone leads to an
+enormous performance boost!
 
 "No music" means using the null audio plugin which prevents generating any MIDI
 music (and therefore avoiding the expensive synthesis emulation) but beware, it
-doesn't affect CD (*.wav) playback at all! Same applies for speech and sfx.
+doesn't affect CD (*.wav) playback at all! Same applies for speech and sfx. So
+mute one or all of those if frame rate drops noticeably.
 
 The least amount of cycles is spent when:
 - "No music" as "Preferred device": This prevents MIDI/OPL synthesis of any
   kind.
+- "Mute all" in "Volume" setting.
 - "output_rate" set to a DOS/Windows compatible value (default). Even if game
   uses 22050 Hz and your Falcon supports 22050 Hz, it is always faster to use
   11025 Hz!
@@ -476,8 +487,9 @@ whether the given game's demands match your setting.
 Btw, you can use the same command line parameter for showing what MIDI mode is
 being used (Roland GS, MT-32, General MIDI), sometimes it is not very obvious.
 
-Unfortunately, currently per-game "output_rate" / "output_channels" is not
-possible but this may change in the future.
+Good news is that "output_rate", "output_channels", "audio_buffer_size" and
+even "print_rate" are now possible to set per-game so one can fine-tune every
+game separately.
 
 Slow GUI
 ~~~~~~~~

--- a/backends/platform/atari/readme.txt
+++ b/backends/platform/atari/readme.txt
@@ -489,8 +489,8 @@ whether the given game's demands match your setting.
 Btw, you can use the same command line parameter for showing what MIDI mode is
 being used (Roland GS, MT-32, General MIDI), sometimes it is not very obvious.
 
-Unfortunately, currently per-game "output_rate" / "output_channels" is not
-possible but this may change in the future.
+Good news is that "output_rate", "output_channels" and "audio_buffer_size" are
+now possible to set per-game so one can fine-tune every game separately.
 
 Slow GUI
 ~~~~~~~~

--- a/backends/platform/atari/readme.txt.in
+++ b/backends/platform/atari/readme.txt.in
@@ -178,6 +178,12 @@ If you want to play with "audio_buffer_size", the rule of thumb is: (lag in ms)
 = (audio_buffer_size / output_rate) * 1000. But it's totally OK just to double
 the samples value to get rid of stuttering in a heavier game.
 
+Please note that unlike previous versions, these values will never be written
+back to scummvm.ini. This is beneficial if you want to switch between Falcon
+and TT or between Falcon with and without external DSP clock (as mentioned,
+DOS/Windows friendly values are automatically converted to a frequency which
+TT/Falcon supports).
+
 "gaudio" debug channel: used for optimising sample playback (where
 available). It prints input and output sample format as well as the name of the
 converter used. See below for details.
@@ -401,15 +407,20 @@ Mute vs. "No music"
 
 Currently ScummVM requires each backend to mix samples, even though they may
 contain muted output (i.e. zeroes). This is because the progression of sample
-playback tells ScummVM how much time has passed in e.g. an animation.
+playback tells ScummVM how much time has passed in e.g. an animation. However,
+one part of the pending audio mixing changes is an optimisation: the input
+stream is still loaded and decoded but it is not mixed which alone leads to an
+enormous performance boost!
 
 "No music" means using the null audio plugin which prevents generating any MIDI
 music (and therefore avoiding the expensive synthesis emulation) but beware, it
-doesn't affect CD (*.wav) playback at all! Same applies for speech and sfx.
+doesn't affect CD (*.wav) playback at all! Same applies for speech and sfx. So
+mute one or all of those if frame rate drops noticeably.
 
 The least amount of cycles is spent when:
 - "No music" as "Preferred device": This prevents MIDI/OPL synthesis of any
   kind.
+- "Mute all" in "Volume" setting.
 - "output_rate" set to a DOS/Windows compatible value (default). Even if game
   uses 22050 Hz and your Falcon supports 22050 Hz, it is always faster to use
   11025 Hz!
@@ -476,8 +487,9 @@ whether the given game's demands match your setting.
 Btw, you can use the same command line parameter for showing what MIDI mode is
 being used (Roland GS, MT-32, General MIDI), sometimes it is not very obvious.
 
-Unfortunately, currently per-game "output_rate" / "output_channels" is not
-possible but this may change in the future.
+Good news is that "output_rate", "output_channels", "audio_buffer_size" and
+even "print_rate" are now possible to set per-game so one can fine-tune every
+game separately.
 
 Slow GUI
 ~~~~~~~~

--- a/backends/platform/atari/readme.txt.in
+++ b/backends/platform/atari/readme.txt.in
@@ -489,8 +489,8 @@ whether the given game's demands match your setting.
 Btw, you can use the same command line parameter for showing what MIDI mode is
 being used (Roland GS, MT-32, General MIDI), sometimes it is not very obvious.
 
-Unfortunately, currently per-game "output_rate" / "output_channels" is not
-possible but this may change in the future.
+Good news is that "output_rate", "output_channels" and "audio_buffer_size" are
+now possible to set per-game so one can fine-tune every game separately.
 
 Slow GUI
 ~~~~~~~~

--- a/base/main.cpp
+++ b/base/main.cpp
@@ -219,6 +219,9 @@ static Common::Error runGame(const Plugin *enginePlugin, OSystem &system, const 
 	// Create the game's MetaEngine.
 	MetaEngine &metaEngine = enginePlugin->get<MetaEngine>();
 	if (err.getCode() == Common::kNoError) {
+		// Inform backend that the engine is about to be created
+		system.engineBeforeCreate();
+
 		// Set default values for all of the custom engine options
 		// Apparently some engines query them in their constructor, thus we
 		// need to set this up before instance creation.
@@ -252,6 +255,9 @@ static Common::Error runGame(const Plugin *enginePlugin, OSystem &system, const 
 		}
 
 		metaEngine.deleteInstance(engine, game, meDescriptor);
+
+		// Inform backend that the engine has been deleted
+		system.engineAfterDelete();
 
 		return err;
 	}
@@ -339,6 +345,9 @@ static Common::Error runGame(const Plugin *enginePlugin, OSystem &system, const 
 
 	// Free up memory
 	metaEngine.deleteInstance(engine, game, meDescriptor);
+
+	// Inform backend that the engine has been deleted
+	system.engineAfterDelete();
 
 	// Reset the file/directory mappings
 	SearchMan.clear();

--- a/common/system.h
+++ b/common/system.h
@@ -329,6 +329,13 @@ public:
 	bool backendInitialized() const { return _backendInitialized; }
 
 	/**
+	 * Allow the backend to perform creation of engine's dependencies.
+	 *
+	 * Called just before the engine is created.
+	 */
+	virtual void engineBeforeCreate() { }
+
+	/**
 	 * Allow the backend to perform engine-specific initialization.
 	 *
 	 * Called just before the engine is run.
@@ -341,6 +348,13 @@ public:
 	 * Called after the engine finishes.
 	 */
 	virtual void engineDone() { }
+
+	/**
+	 * Allow the backend to perform deletion of engine's dependencies.
+	 *
+	 * Called after the engine is deleted.
+	 */
+	virtual void engineAfterDelete() { }
 
 	/**
 	 * Identify a task that ScummVM can perform.


### PR DESCRIPTION
This also disables sample mixing while being in the launcher.

Another piece of the puzzle to make mixing more efficient on weaker platforms. Basically it offers an option to tailor each mixer instance to given engine.

Currently one can set only a single static output frequency and then for every engine the mixer converts engine's frequency to the output frequency. This is very unfortunate, especially now when the user actually can query each engine's frequency via `--debugflags=gaudio`.

The bits for review here are `base/main.cpp` and `common/system.h` but I welcome feedback on other parts. :) I couldn't find a better way to implement this reliably and with a minimal impact on other backends.

The change is atari-mixer specific, other backends do not have to change anything.