### PR TITLE
DIRECTOR: Fix text wrapping in D4 text cast members

### DIFF
--- a/engines/director/castmember/text.cpp
+++ b/engines/director/castmember/text.cpp
@@ -299,7 +299,8 @@ bool textWindowCallback(Graphics::WindowClick click, Common::Event &event, void 
 Graphics::MacWidget *TextCastMember::createWindowOrWidget(Common::Rect &bbox, Common::Rect dims, Graphics::MacFont *macFont) {
 	Graphics::MacText *widget = nullptr;
 
-	widget = new Graphics::MacText(g_director->getCurrentWindow()->getMacWindow(), bbox.left, bbox.top, dims.width(), dims.height(), g_director->_wm, _ftext, macFont, getForeColor(), getBackColor(), _initialRect.width(), getAlignment(), _lineSpacing, _borderSize, _gutterSize, _boxShadow, _textShadow, _textType == kTextTypeFixed || _textType == kTextTypeScrolling, _textType == kTextTypeScrolling);
+	int maxWidth = _initialRect.width() + _borderSize * 2 + _gutterSize * 2 + _boxShadow;
+	widget = new Graphics::MacText(g_director->getCurrentWindow()->getMacWindow(), bbox.left, bbox.top, dims.width(), dims.height(), g_director->_wm, _ftext, macFont, getForeColor(), getBackColor(), maxWidth, getAlignment(), _lineSpacing, _borderSize, _gutterSize, _boxShadow, _textShadow, _textType == kTextTypeFixed || _textType == kTextTypeScrolling, _textType == kTextTypeScrolling);
 	widget->setSelRange(g_director->getCurrentMovie()->_selStart, g_director->getCurrentMovie()->_selEnd);
 	widget->draw();
 

--- a/graphics/font.cpp
+++ b/graphics/font.cpp
@@ -280,7 +280,7 @@ int wordWrapTextImpl(const Font &font, const StringType &str, int maxWidth, Comm
 			const int w = currentCharWidth + font.getKerningOffset(last, c);
 			last = c;
 			const bool wouldExceedWidth =
-				(lineWidth + tmpWidth + w > targetMaxLineWidth) &&
+				(lineWidth + tmpWidth + w >= targetMaxLineWidth) &&
 				!(mode & kWordWrapAllowTrailingWhitespace && Common::isSpace(c));
 
 			// If this char is a whitespace, then it represents a potential


### PR DESCRIPTION
MacText treats maxWidth as the outer width and subtracts border/gutter/shadow internally. Pass _initialRect.width() + padding so the effective inner wrap width matches the cast member's designed text area.

Also fix wordWrapTextImpl to use >= instead of > so text that exactly fills the available width wraps correctly, matching Director's behavior.
