### PR TITLE
COMMON: Fix incorrect @param names in OSystem doc comments

### DIFF
--- a/common/system.h
+++ b/common/system.h
@@ -938,7 +938,7 @@ public:
 	 *
 	 * If loading the new shader fails, this method returns false.
 	 *
-	 * @param fileNode File node of the new shader.
+	 * @param fileName File node of the new shader.
 	 *
 	 * @return True if the switch was successful, false otherwise.
 	 */
@@ -1386,7 +1386,7 @@ public:
 	 * This works because we assume the game to be "paused" whenever an overlay
 	 * is active.
 	 *
-	 * @param inGame Whether the overlay is used to display GUI or in game images
+	 * @param inGUI Whether the overlay is used to display GUI or in game images
 	 *
 	 */
 


### PR DESCRIPTION
Two Doxygen `@param` comments in the `OSystem` interface (`common/system.h`) reference parameter names that do not match their signatures:

- `setShader(const Common::Path &fileName)` documents `@param fileNode` instead of `fileName`.
- `showOverlay(bool inGUI = true)` documents `@param inGame` instead of `inGUI`.

This corrects the documented names to match the signatures. Documentation-only change; no behaviour is affected.
