### PR TITLE
DIRECTOR: DT: Fix script not rendering in script viewer 

### DIFF
--- a/engines/director/debugger/debugtools.cpp
+++ b/engines/director/debugger/debugtools.cpp
@@ -62,7 +62,7 @@ const LingoDec::Handler *getHandler(const Cast *cast, CastMemberID id, const Com
 			continue;
 
 		for (const LingoDec::Handler &handler : p.second->handlers) {
-			if (handler.name == handlerId) {
+			if (handler.name == handlerId || (handler.isGenericEvent && handlerId == "scummvm_generic")) {
 				return &handler;
 			}
 		}
@@ -533,6 +533,21 @@ ImVec4 convertColor(uint32 color) {
 }
 
 void addToOpenHandlers(ImGuiScript handler) {
+	// If no decompiled AST is available, fall back to the source text from CastMemberInfo.
+	if (!handler.root && !handler.oldAst && handler.rawText.empty()) {
+		Movie *movie = g_director->getCurrentMovie();
+		if (movie) {
+			CastMember *member = movie->getCastMember(handler.id);
+			if (member) {
+				const CastMemberInfo *info = member->getInfo();
+				if (info && !info->script.empty()) {
+					handler.rawText = info->script;
+					handler.rawText.replace('\r', '\n');
+				}
+			}
+		}
+	}
+
 	ScriptData &data = _state->_openScripts;
 	_state->_w.scripts = true;  // always (re)open the window
 	// Truncate forward history when navigating to a new script

--- a/engines/director/debugger/dt-castdetails.cpp
+++ b/engines/director/debugger/dt-castdetails.cpp
@@ -581,6 +581,13 @@ void drawBaseCMprops(CastMember *member) {
 									script.handlerName = formatHandlerName(scriptCtx->_scriptId, scriptCastId.member, script.handlerId, scriptCtx->_scriptType, false);
 									addToOpenHandlers(script);
 								}
+							} else {
+								ImGuiScript script;
+								script.id = scriptCastId;
+								script.type = kCastScript;
+								script.moviePath = g_director->getCurrentMovie()->getArchive()->getPathName().toString();
+								script.handlerName = Common::String::format("Cast %d (source)", scriptCastId.member);
+								addToOpenHandlers(script);
 							}
 						}
 					} else {

--- a/engines/director/debugger/dt-internal.h
+++ b/engines/director/debugger/dt-internal.h
@@ -75,6 +75,7 @@ typedef struct ImGuiScript {
 	Common::Array<LingoDec::Bytecode> bytecodeArray;
 	Common::Array<uint> startOffsets;
 	Common::SharedPtr<Node> oldAst;
+	Common::String rawText;
 
 	bool operator==(const ImGuiScript &c) const {
 		return moviePath == c.moviePath && score == c.score && id == c.id && handlerId == c.handlerId;

--- a/engines/director/debugger/dt-score.cpp
+++ b/engines/director/debugger/dt-score.cpp
@@ -974,13 +974,20 @@ static void drawMainChannelGrid(ImDrawList *dl, ImVec2 startPos, Score *score) {
 				case kChScript: // open script in script editor
 					if (mc.actionId.member) {
 						ScriptContext *ctx = getScriptContext(mc.actionId);
-						if (!ctx)
-							break;
-						for (auto &handler : ctx->_functionHandlers) {
-							ImGuiScript script = toImGuiScript(kScoreScript, mc.actionId, handler._key);
-							script.byteOffsets = ctx->_functionByteOffsets[script.handlerId];
+						if (ctx) {
+							for (auto &handler : ctx->_functionHandlers) {
+								ImGuiScript script = toImGuiScript(kScoreScript, mc.actionId, handler._key);
+								script.byteOffsets = ctx->_functionByteOffsets[script.handlerId];
+								script.moviePath = g_director->getCurrentMovie()->getArchive()->getPathName().toString();
+								script.handlerName = formatHandlerName(ctx->_scriptId, mc.actionId.member, handler._key, kScoreScript, false);
+								addToOpenHandlers(script);
+							}
+						} else {
+							ImGuiScript script;
+							script.id = mc.actionId;
+							script.type = kScoreScript;
 							script.moviePath = g_director->getCurrentMovie()->getArchive()->getPathName().toString();
-							script.handlerName = formatHandlerName(ctx->_scriptId, mc.actionId.member, handler._key, kScoreScript, false);
+							script.handlerName = Common::String::format("Cast %d (source)", mc.actionId.member);
 							addToOpenHandlers(script);
 						}
 					}

--- a/engines/director/debugger/dt-scripts.cpp
+++ b/engines/director/debugger/dt-scripts.cpp
@@ -42,8 +42,11 @@ static void renderScript(ImGuiScript &script, bool showByteCode, bool scrollTo) 
 		return;
 	}
 
-	if (!script.root)
+	if (!script.root) {
+		if (!script.rawText.empty())
+			ImGui::TextUnformatted(script.rawText.c_str());
 		return;
+	}
 
 	renderScriptAST(script, showByteCode, scrollTo);
 }
@@ -206,8 +209,10 @@ void showScriptsWindow() {
 
 	if (ImGui::Begin("Scripts", &_state->_w.scripts)) {
 		ScriptContext *ctx = getScriptContext(data._scripts[data._current].id);
+
 		if (ctx)
 			ImGui::Text("%s", ctx->asString().c_str());
+
 
 		if (renderScriptNavBar(data)) {
 			ImGui::Separator();


### PR DESCRIPTION
Two fixes in this PR:

The issues:
- Some scripts fail to open in the script viewer when clicking them in the Cast or Score windows, because getScriptContext() returns null. This affects cast members whose scripts are loaded from an external shared cast whose Lingo context was not resolved at the time of the DT lookup.
- Scripts using internal generic event handlers (scummvm_generic) were failing to render in the script viewer because `getHandler()` matched by `handler.name == handlerId` exactly, but generic event handlers store an empty name and are only identified by the `isGenericEvent` flag.

The fixes:

- Fix generic event scripts by also matching on `handler.isGenericEvent && handlerId == "scummvm_generic"` in `getHandler()`, so the correct handler is returned and the AST renders correctly.
- When `getScriptContext()` returns null, fall back to displaying the raw Lingo source text from `CastMemberInfo::script` in the script viewer. `addToOpenHandlers()` now populates rawText automatically from the cast member info when no compiled AST is available. This is a workaround until the root cause is investigated further.
