### PR TITLE
DRAFT: DGDS: Fix Willy Beamish CD conversation glitches (#16583)

### DIFF
--- a/engines/dgds/dgds.cpp
+++ b/engines/dgds/dgds.cpp
@@ -706,7 +706,10 @@ Common::Error DgdsEngine::run() {
 
 			dumpFrame(_compositionBuffer, "comp-before-ads");
 
-			if (shouldRunScripts && (!_inventory->isOpen() || (_inventory->isZoomVisible() && getGameId() != GID_WILLY)))
+			// Pause the room animation while a Willy Beamish CD conversation animates the
+			// talking actor over the room, or that actor is drawn twice (bug #16583).
+			bool conversationAnimating = _scene->isConversationAnimating();
+			if (shouldRunScripts && (!_inventory->isOpen() || (_inventory->isZoomVisible() && getGameId() != GID_WILLY)) && !conversationAnimating)
 				_adsInterp->run();
 
 			if (_inventory->isOpen()) {

--- a/engines/dgds/head.cpp
+++ b/engines/dgds/head.cpp
@@ -432,7 +432,7 @@ bool Conversation::runScriptFrame(int16 frameNum) {
 	return _ttmScript->run(_ttmEnv, *seq);
 }
 
-void Conversation::checkAndRunScript() {
+void Conversation::checkAndRunScript(bool advanceTiming) {
 	if (!_ttmScript || _finished)
 		return;
 
@@ -445,13 +445,17 @@ void Conversation::checkAndRunScript() {
 		runScriptFrame(_tempFrameNum);
 	}
 	runScriptFrame(_ttmEnv._cdsFrame);
-	if (_ttmEnv._cdsDelay > 0) {
-		_nextExecMs = _thisFrameMs + _ttmEnv._cdsDelay;
-		debug(10, "CDS: This fame %d. Next frame will be on or after %d", _thisFrameMs, _nextExecMs);
-		_ttmEnv._cdsDelay = -1;
-	} else {
-		_nextExecMs = 0;
+	// Only update the next-frame time on an actual advance; the frame is re-drawn every game
+	// frame, so otherwise the delay would be reset each frame and never elapse.
+	if (advanceTiming) {
+		if (_ttmEnv._cdsDelay > 0) {
+			_nextExecMs = _thisFrameMs + _ttmEnv._cdsDelay;
+			debug(10, "CDS: This fame %d. Next frame will be on or after %d", _thisFrameMs, _nextExecMs);
+		} else {
+			_nextExecMs = 0;
+		}
 	}
+	_ttmEnv._cdsDelay = -1;
 }
 
 void Conversation::incrementFrame() {
@@ -531,10 +535,13 @@ void Conversation::runScriptStep() {
 		return;
 
 	_thisFrameMs = engine->getThisFrameMs();
-	if (!_nextExecMs || _nextExecMs <= _thisFrameMs) {
+	// Re-draw the current frame every game frame (the main loop clears the buffer each frame),
+	// but only advance the frame counter once its delay has elapsed - otherwise the actor
+	// flickers against the background between advances (bug #16583).
+	bool advance = (!_nextExecMs || _nextExecMs <= _thisFrameMs);
+	if (advance)
 		incrementFrame();
-		checkAndRunScript();
-	}
+	checkAndRunScript(advance);
 }
 
 
@@ -587,7 +594,7 @@ void Conversation::runScriptExclusive() {
 		if (!_nextExecMs || _nextExecMs <= _thisFrameMs) {
 			incrementFrame();
 
-			checkAndRunScript();
+			checkAndRunScript(true);
 
 			// Redraw active dialogs eg to make sure thought bubble dots are
 			// over the moving heads

--- a/engines/dgds/head.h
+++ b/engines/dgds/head.h
@@ -169,7 +169,7 @@ private:
 	uint32 _nextExecMs;
 
 	bool runScriptFrame(int16 frameNum);
-	void checkAndRunScript();
+	void checkAndRunScript(bool advanceTiming);
 	void incrementFrame();
 	bool isScriptRunning();
 	void pumpMessages();

--- a/engines/dgds/head.h
+++ b/engines/dgds/head.h
@@ -149,6 +149,11 @@ public:
 	void loadData(uint16 num, uint16 num2, int16 sub, bool haveHeadData);
 	bool isForDlg(const Dialog *dlg) const;
 	bool isFinished() const { return _finished; }
+	// True while a non-exclusive (over-the-room) CDS conversation is playing.  The room's own
+	// animation of the talking actor is paused while this is true (bug #16583).
+	bool isRunningNonExclusiveScript() const {
+		return _ttmScript.get() != nullptr && !_haveHeadData;
+	}
 	void clear();
 
 	DgdsRect _drawRect;

--- a/engines/dgds/scene.h
+++ b/engines/dgds/scene.h
@@ -323,6 +323,8 @@ public:
 	bool loadTalkDataAndSetFlags(uint16 talknum, uint16 headnum);
 	void drawAndUpdateHeads(Graphics::ManagedSurface &dst);
 	bool hasVisibleHead() const;
+	// A Willy Beamish CD conversation is animating the talking actor over the room this frame.
+	bool isConversationAnimating() { return _conversation.isForDlg(getVisibleDialog()) && _conversation.isRunningNonExclusiveScript(); }
 
 	// dragon-specific scene ops
 	void addAndShowTiredDialog();


### PR DESCRIPTION
## Summary

Fixes glitching character animation in conversations in the CD (talkie) version of Willy Beamish ([bug #16583](https://bugs.scummvm.org/ticket/16583)) - the talking actor (e.g. the nurse) was drawn duplicated and flickering. Willy-only; CDS conversations only load for `GID_WILLY`.

- **Fix duplicated talking actor**: speech is animated by a non-exclusive CDS script over the room, but the room's ADS animation of the same actor kept running too, drawing it twice. Skip the room ADS while a non-exclusive CD conversation animates.
- **Redraw every frame**: the conversation only redrew when its timer advanced, but the main loop clears the buffer every frame, so it flickered. Draw every game frame; advance the counter only on the timer.

## Note

I'm not sure the first commit is scoped right — it pauses *all* room ADS during a CD conversation, not just the speaking actor. I suspect some scenes need their scripts to keep running, but I couldn't find a link from a conversation to its ADS segment, so I went broad for now.

*Assisted-by: Claude (claude-opus-4-8) — used for investigation, root-causing (incl. frame-dump analysis) and drafting; reviewed and tested by me.*
