### PR TITLE
DIRECTOR: D7 support and fixes for Physikus/Physicus

### DIFF
--- a/engines/director/archive.cpp
+++ b/engines/director/archive.cpp
@@ -143,7 +143,7 @@ Common::SeekableReadStreamEndian *Archive::getFirstResource(uint32 tag) {
 	return getResource(tag, getResourceIDList(tag)[0]);
 }
 
-Common::SeekableReadStreamEndian *Archive::getFirstResource(uint32 tag, uint16 parentId) {
+Common::SeekableReadStreamEndian *Archive::getFirstResource(uint32 tag, uint32 parentId) {
 	return getResource(tag, getResourceIDList(tag)[0]);
 }
 
@@ -1022,7 +1022,7 @@ bool RIFXArchive::readAfterburnerMap(Common::SeekableReadStreamEndian &stream, u
 	return true;
 }
 
-void RIFXArchive::readCast(Common::SeekableReadStreamEndian &casStream, uint16 libResourceId) {
+void RIFXArchive::readCast(Common::SeekableReadStreamEndian &casStream, uint32 libResourceId) {
 	int castTag = MKTAG('C', 'A', 'S', 't');
 
 	uint casSize = casStream.size() / 4;
@@ -1100,7 +1100,7 @@ Common::SeekableReadStreamEndian *RIFXArchive::getFirstResource(uint32 tag, bool
 	return getResource(tag, getResourceIDList(tag)[0], fileEndianness);
 }
 
-Common::SeekableReadStreamEndian *RIFXArchive::getFirstResource(uint32 tag, uint16 parentId) {
+Common::SeekableReadStreamEndian *RIFXArchive::getFirstResource(uint32 tag, uint32 parentId) {
 	if (!_keyData.contains(tag))
 		return nullptr;
 	if (!_keyData[tag].contains(parentId))

--- a/engines/director/archive.h
+++ b/engines/director/archive.h
@@ -101,7 +101,7 @@ public:
 	bool hasResource(uint32 tag, const Common::String &resName) const;
 	virtual Common::SeekableReadStreamEndian *getResource(uint32 tag, uint16 id);
 	virtual Common::SeekableReadStreamEndian *getFirstResource(uint32 tag);
-	virtual Common::SeekableReadStreamEndian *getFirstResource(uint32 tag, uint16 parentId);
+	virtual Common::SeekableReadStreamEndian *getFirstResource(uint32 tag, uint32 parentId);
 	virtual Resource getResourceDetail(uint32 tag, uint16 id);
 	uint32 getOffset(uint32 tag, uint16 id) const;
 	uint getResourceSize(uint32 tag, uint16 id) const;
@@ -170,7 +170,7 @@ public:
 
 	Common::SeekableReadStreamEndian *getFirstResource(uint32 tag) override;
 	virtual Common::SeekableReadStreamEndian *getFirstResource(uint32 tag, bool fileEndianness);
-	Common::SeekableReadStreamEndian *getFirstResource(uint32 tag, uint16 parentId) override;
+	Common::SeekableReadStreamEndian *getFirstResource(uint32 tag, uint32 parentId) override;
 	Common::SeekableReadStreamEndian *getResource(uint32 tag, uint16 id) override;
 	virtual Common::SeekableReadStreamEndian *getResource(uint32 tag, uint16 id, bool fileEndianness);
 	Resource getResourceDetail(uint32 tag, uint16 id) override;
@@ -193,7 +193,7 @@ private:
 
 	bool readMemoryMap(Common::SeekableReadStreamEndian &stream, uint32 moreOffset, Common::SeekableMemoryWriteStream *dumpStream, uint32 movieStartOffset);
 	bool readAfterburnerMap(Common::SeekableReadStreamEndian &stream, uint32 moreOffset);
-	void readCast(Common::SeekableReadStreamEndian &casStream, uint16 libResourceId);
+	void readCast(Common::SeekableReadStreamEndian &casStream, uint32 libResourceId);
 	void readKeyTable(Common::SeekableReadStreamEndian &keyStream);
 
 	uint32 findParentIndex(uint32 tag, uint16 index);

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -1664,9 +1664,11 @@ void Cast::loadCastData(Common::SeekableReadStreamEndian &stream, uint16 id, Res
 			// property machinery (duration, movieTime, movieRate, ...) works. The
 			// linked .mov path is resolved from the cast member info at load time.
 			debugC(3, kDebugLoading, "Cast::loadCastData(): promoting QuickTime Xtra (id=%d) to digital video", id);
+			bool qtLooping = xtra->isQuickTimeLooping();
 			delete xtra;
 			DigitalVideoCastMember *dv = new DigitalVideoCastMember(this, id);
 			dv->_qtmovie = true;
+			dv->_looping = qtLooping;
 			target = dv;
 		} else if (xtra->isTextXtra()) {
 			// Director 7+ stores rich text fields as "text" Asset Xtra cast

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -453,18 +453,29 @@ bool Cast::loadConfig() {
 
 	_unk1 = stream->readSint16();
 
-	// Warning for post-D7 movies (unk1 is stageColorG and stageColorB post-D7)
-	if (humanVer >= 700)
-		warning("STUB: Cast::loadConfig: 16 bit unk1 read instead of two 8 bit stageColorG and stageColorB. Read value: %04x", _unk1);
+	// In D7 and later the 16-bit field at offset 18 is two 8-bit stage-color
+	// components: stageColorG (high byte) and stageColorB (low byte). _unk1
+	// keeps the raw 16-bit value for the VWCF checksum and round-trip save.
+	if (humanVer >= 700) {
+		_D7stageColorG = (_unk1 >> 8) & 0xFF;
+		_D7stageColorB = _unk1 & 0xFF;
+	}
 
 	_commentFont = stream->readUint16();
 	_commentSize = stream->readUint16();
 	_commentStyle = stream->readUint16();
 	_stageColor = stream->readUint16();
 
-	// Warning for post-D7 movies (stageColor is isStageColorRGB and stageColorR post-D7)
-	if (humanVer >= 700)
-		warning("STUB: Cast::loadConfig: 16 bit stageColor read instead of two 8 bit isStageColorRGB and stageColorR. Read value: %04x", _stageColor);
+	// In D7 and later the 16-bit field at offset 26 is a stageColorIsRGB flag
+	// (high byte) and stageColorR (low byte). For the common non-RGB case
+	// stageColorR is the palette index, which equals the low byte of the raw
+	// _stageColor used by the renderer, checksum and save.
+	if (humanVer >= 700) {
+		_D7stageColorIsRGB = (_stageColor >> 8) & 0xFF;
+		_D7stageColorR = _stageColor & 0xFF;
+		debugC(1, kDebugLoading, "Cast::loadConfig(): D7 stage color: isRGB %d, R %d, G %d, B %d",
+			_D7stageColorIsRGB, _D7stageColorR, _D7stageColorG, _D7stageColorB);
+	}
 
 	_bitdepth = stream->readUint16();
 
@@ -604,7 +615,10 @@ bool Cast::loadConfig() {
 	}
 
 	if (_movieDepth != _vm->_colorDepth) {
-		warning("STUB: loadConfig(): Movie bit depth is %d, but set to %d", _movieDepth, _vm->_colorDepth);
+		// The engine renders at its configured color depth (e.g. 32-bit true
+		// color) and converts movie graphics as needed, so an authored movie
+		// depth differing from the engine's is expected, not a defect.
+		debugC(1, kDebugLoading, "Cast::loadConfig(): Movie bit depth is %d, engine color depth is %d", _movieDepth, _vm->_colorDepth);
 	}
 
 	delete stream;
@@ -1194,10 +1208,10 @@ uint32 Cast::computeChecksum() {
 	check -= (int8)_readRate + 9;
 	check -= _lightswitch + 10;
 
-	if (humanVer < 700)
-		check += _unk1 + 11;
-	else
-		warning("STUB: skipped using stageColorG, stageColorB for post-D7 movie in checksum calulation");
+	// The 16-bit value at offset 18 (preD7field11, or stageColorG/stageColorB
+	// in D7+) enters the checksum the same way in every version, verified
+	// against D7 (fileVer 1406) VWCF resources.
+	check += _unk1 + 11;
 
 	check *= _commentFont + 12;
 	check += _commentSize + 13;
@@ -1207,10 +1221,9 @@ uint32 Cast::computeChecksum() {
 	else
 		check *= _commentStyle + 14;
 
-	if (humanVer < 700)
-		check += _stageColor + 15;
-	else
-		check += (uint8)(_stageColor & 0xFF) + 15;	// Taking lower 8 bits to take into account stageColorR
+	// The 16-bit value at offset 26 (stageColor, or stageColorIsRGB/stageColorR
+	// in D7+) enters the checksum the same way in every version.
+	check += _stageColor + 15;
 
 
 	check += _bitdepth + 16;
@@ -2176,11 +2189,14 @@ void Cast::loadCastInfo(Common::SeekableReadStreamEndian &stream, uint16 id) {
 		}
 	}
 
-	// For SoundCastMember, read the flags in the CastInfo
-	if (_version >= kFileVer400 && _version < kFileVer700 && member->_type == kCastSound) {
+	// For SoundCastMember, read the looping flag from the CastInfo. The
+	// play-once bit (flags & 16) is version-independent: verified against D7
+	// (fileVer 1406) sound members, where one-shot effects ("switch",
+	// "Schalter") set it and ambient loops ("Regenloop") clear it. The info
+	// block is fully consumed by loadInfoEntries() above, so nothing is read
+	// from the stream here.
+	if (_version >= kFileVer400 && member->_type == kCastSound) {
 		((SoundCastMember *)member)->_looping = castInfo.flags & 16 ? 0 : 1;
-	} else if (_version >= kFileVer700 && member->_type == kCastSound) {
-		warning("STUB: Cast::loadCastInfo(): Sound cast member info not yet supported for version v%d (%d)", humanVersion(_version), _version);
 	}
 
 	// For PaletteCastMember, run load() as we need it right now

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -65,7 +65,7 @@
 
 namespace Director {
 
-Cast::Cast(Movie *movie, uint16 castLibID, bool isShared, bool isExternal, uint16 libResourceId) {
+Cast::Cast(Movie *movie, uint16 castLibID, bool isShared, bool isExternal, uint32 libResourceId) {
 	_movie = movie;
 	_vm = _movie->getVM();
 	_lingo = _vm->getLingo();
@@ -811,7 +811,7 @@ void Cast::loadCast() {
 
 	// External casts only have one library ID, so instead
 	// we use the movie's mapping.
-	uint16 libResourceId = _isExternal ? 1024 : _libResourceId;
+	uint32 libResourceId = _isExternal ? 1024 : _libResourceId;
 
 	if (cast.size() > 0) {
 		debugC(2, kDebugLoading, "****** Loading CASt resources for libId %d (%s), resourceId %d", _castLibID, _castName.c_str(), libResourceId);

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -42,6 +42,7 @@
 #include "director/sound.h"
 #include "director/sprite.h"
 #include "director/stxt.h"
+#include "director/xmed.h"
 #include "director/castmember/castmember.h"
 #include "director/castmember/bitmap.h"
 #include "director/castmember/digitalvideo.h"
@@ -123,6 +124,9 @@ Cast::~Cast() {
 		delete it._value;
 
 	for (auto &it : _loadedRTE2s)
+		delete it._value;
+
+	for (auto &it : _loadedXMEDs)
 		delete it._value;
 
 	delete _loadedCast;
@@ -892,6 +896,19 @@ void Cast::loadCast() {
 		delete r;
 	}
 
+	// Director 7+ Xtra cast members (e.g. the "Text" Asset Xtra) keep their
+	// media in an XMED child resource. Decode them so the owning cast member
+	// can render its text.
+	Common::Array<uint16> xmed = _castArchive->getResourceIDList(MKTAG('X','M','E','D'));
+	debugC(2, kDebugLoading, "****** Loading %d XMED resources", xmed.size());
+
+	for (auto &iterator : xmed) {
+		r = _castArchive->getResource(MKTAG('X','M','E','D'), iterator);
+		debugC(3, kDebugText, "XMED: id %d", iterator - _castIDoffset);
+		_loadedXMEDs.setVal(iterator, new XMED(this, *r));
+		delete r;
+	}
+
 	// For D4+ we may request to force Lingo scripts and skip precompiled bytecode
 	if (_version >= kFileVer400 && !debugChannelSet(-1, kDebugNoBytecode)) {
 		// Try to load script context
@@ -1638,6 +1655,15 @@ void Cast::loadCastData(Common::SeekableReadStreamEndian &stream, uint16 id, Res
 			DigitalVideoCastMember *dv = new DigitalVideoCastMember(this, id);
 			dv->_qtmovie = true;
 			target = dv;
+		} else if (xtra->isTextXtra()) {
+			// Director 7+ stores rich text fields as "text" Asset Xtra cast
+			// members whose string lives in an XMED child resource. Promote them
+			// to a TextCastMember so the regular text rendering, widget and Lingo
+			// machinery apply. The text, rect and styling are filled in lazily by
+			// TextCastMember::load() from the decoded XMED.
+			debugC(3, kDebugLoading, "Cast::loadCastData(): promoting Text Xtra (id=%d) to text cast member", id);
+			delete xtra;
+			target = new TextCastMember(this, id, _version);
 		} else {
 			target = xtra;
 		}

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -1624,10 +1624,25 @@ void Cast::loadCastData(Common::SeekableReadStreamEndian &stream, uint16 id, Res
 		debugC(3, kDebugLoading, "Cast::loadCastData(): loading kCastTransition (id=%d, %d children)",  id, res->children.size());
 		target = new TransitionCastMember(this, id, castStream, _version);
 		break;
-	case kCastXtra:
+	case kCastXtra: {
 		debugC(3, kDebugLoading, "Cast::loadCastData(): loading kCastXtra (id=%d, %d children)",  id, res->children.size());
-		target = new XtraCastMember(this, id, castStream, _version);
+		XtraCastMember *xtra = new XtraCastMember(this, id, castStream, _version);
+		if (xtra->isQuickTimeVideo()) {
+			// Director 7+ stores QuickTime videos as "quickTimeMedia" Xtra cast
+			// members rather than classic digital video members. Promote them to a
+			// DigitalVideoCastMember so the existing video playback and Lingo
+			// property machinery (duration, movieTime, movieRate, ...) works. The
+			// linked .mov path is resolved from the cast member info at load time.
+			debugC(3, kDebugLoading, "Cast::loadCastData(): promoting QuickTime Xtra (id=%d) to digital video", id);
+			delete xtra;
+			DigitalVideoCastMember *dv = new DigitalVideoCastMember(this, id);
+			dv->_qtmovie = true;
+			target = dv;
+		} else {
+			target = xtra;
+		}
 		break;
+	}
 	default:
 		warning("BUILDBOT: STUB: Cast::loadCastData(): Unhandled cast type: %d [%s] (id=%d, %d children)! This will be missing from the movie and may cause problems", castType, tag2str(castType), id, res->children.size());
 		// also don't try and read the strings... we don't know what this item is.

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -2062,7 +2062,8 @@ void Cast::loadCastInfo(Common::SeekableReadStreamEndian &stream, uint16 id) {
 		// fallthrough
 	case 12:
 		if (castInfo.strings[12].len) {
-			Common::hexdump(castInfo.strings[12].data, castInfo.strings[12].len);
+			if (debugChannelSet(5, kDebugLoading))
+				Common::hexdump(castInfo.strings[12].data, castInfo.strings[12].len);
 			ci->xtraRect.top = READ_BE_INT32(castInfo.strings[12].data);
 			ci->xtraRect.left = READ_BE_INT32(castInfo.strings[12].data + 4);
 			ci->xtraRect.bottom = READ_BE_INT32(castInfo.strings[12].data + 8);
@@ -2080,7 +2081,8 @@ void Cast::loadCastInfo(Common::SeekableReadStreamEndian &stream, uint16 id) {
 		// fallthrough
 	case 10:
 		if (castInfo.strings[10].len) {
-			Common::hexdump(castInfo.strings[10].data, castInfo.strings[10].len);
+			if (debugChannelSet(5, kDebugLoading))
+				Common::hexdump(castInfo.strings[10].data, castInfo.strings[10].len);
 			ci->xtraDisplayName = castInfo.strings[10].readString(false); // C string
 			dumpS = Common::String::format("xtraDisplayName: '%s', ", ci->xtraDisplayName.c_str()) + dumpS;
 		}

--- a/engines/director/cast.h
+++ b/engines/director/cast.h
@@ -203,10 +203,10 @@ public:
 	// Director 6 and below
 		/* 18 */ int16 _unk1;	// Mentioned in ProjectorRays as preD7field11
 
-	// Director 7 and above
-	// Currently not supporting Director 7
-		// /* 18 */ int8 D7stageColorG;
-		// /* 19 */ int8 D7stageColorB;
+	// Director 7 and above: offset 18-19 hold two 8-bit stage-color
+	// components; _unk1 keeps the raw 16-bit value for the VWCF checksum.
+		/* 18 */ uint8 _D7stageColorG = 0;
+		/* 19 */ uint8 _D7stageColorB = 0;
 
 	/* 20 */ uint16 _commentFont;
 	/* 22 */ uint16 _commentSize;
@@ -214,10 +214,11 @@ public:
 
 	// Director 6 and below
 		/* 26 */ uint16 _stageColor;
-	// Director 7 and above
-	// Currently not supporting Director 7
-		// /* 26 */ uint8 D7stageColorIsRGB;
-		// /* 27 */ uint8 D7stageColorR;
+	// Director 7 and above: high byte is stageColorIsRGB, low byte is
+	// stageColorR; _stageColor keeps the raw 16-bit value (== palette index
+	// for the common non-RGB case) for rendering, checksum and save.
+		/* 26 */ uint8 _D7stageColorIsRGB = 0;
+		/* 27 */ uint8 _D7stageColorR = 0;
 
 	/* 28 */ uint16 _bitdepth;
 	/* 30 */ uint8 _field17;

--- a/engines/director/cast.h
+++ b/engines/director/cast.h
@@ -87,7 +87,7 @@ struct TilePatternEntry {
 
 class Cast {
 public:
-	Cast(Movie *movie, uint16 castLibID, bool isShared = false, bool isExternal = false, uint16 libResourceId = 1024);
+	Cast(Movie *movie, uint16 castLibID, bool isShared = false, bool isExternal = false, uint32 libResourceId = 1024);
 	~Cast();
 
 	void loadArchive();
@@ -162,7 +162,7 @@ public:
 	Common::SharedPtr<Archive> _castArchive;
 	Common::Platform _platform;
 	uint16 _castLibID;
-	uint16 _libResourceId;
+	uint32 _libResourceId;
 	bool _isExternal;
 
 	CharMap _macCharsToWin;

--- a/engines/director/cast.h
+++ b/engines/director/cast.h
@@ -49,6 +49,7 @@ class Stxt;
 class RTE0;
 class RTE1;
 class RTE2;
+class XMED;
 class BitmapCastMember;
 class FilmLoopCastMember;
 class ScriptCastMember;
@@ -176,6 +177,7 @@ public:
 	Common::HashMap<uint, const RTE0 *> _loadedRTE0s;
 	Common::HashMap<uint, const RTE1 *> _loadedRTE1s;
 	Common::HashMap<uint, const RTE2 *> _loadedRTE2s;
+	Common::HashMap<uint, const XMED *> _loadedXMEDs;
 	uint16 _castIDoffset;
 
 	Common::Rect _movieRect;

--- a/engines/director/castmember/digitalvideo.cpp
+++ b/engines/director/castmember/digitalvideo.cpp
@@ -433,6 +433,12 @@ Graphics::MacWidget *DigitalVideoCastMember::createWidget(Common::Rect &bbox, Ch
 		}
 	}
 
+	// A zero-sized sprite bbox (e.g. a video sprite not yet positioned/sized)
+	// has nothing to render; creating a 0-dimension widget would later divide
+	// by zero in the scaler and read out of bounds in the ink blitter.
+	if (bbox.width() <= 0 || bbox.height() <= 0)
+		return nullptr;
+
 	Graphics::MacWidget *widget = new Graphics::MacWidget(g_director->getCurrentWindow()->getMacWindow(), bbox.left, bbox.top, bbox.width(), bbox.height(), g_director->_wm, false);
 
 	_channel = channel;

--- a/engines/director/castmember/digitalvideo.cpp
+++ b/engines/director/castmember/digitalvideo.cpp
@@ -540,6 +540,16 @@ void DigitalVideoCastMember::setStopTime(int stamp) {
 
 	_channel->_stopTime = stamp;
 
+	// A stamp of 0 means "play to the natural end" in Director.
+	// Do NOT pass 0ms to setEndTime() – the VideoDecoder interprets that as
+	// "end immediately" because every getNextFrameStartTime() >= 0 satisfies
+	// the videoEndTimeReached condition, causing endOfVideo() to return true
+	// before a single frame is shown.
+	if (stamp <= 0) {
+		debugC(2, kDebugImages, "DigitalVideoCastMember::setStopTime(): stamp=0 – ignoring (play to natural end)");
+		return;
+	}
+
 	Audio::Timestamp dur = _video->getDuration();
 
 	_video->setEndTime(Audio::Timestamp(_channel->_stopTime * 1000 / 60, dur.framerate()));

--- a/engines/director/castmember/palette.cpp
+++ b/engines/director/castmember/palette.cpp
@@ -30,7 +30,8 @@ namespace Director {
 
 PaletteCastMember::PaletteCastMember(Cast *cast, uint16 castId, Common::SeekableReadStreamEndian &stream, uint16 version)
 	: CastMember(cast, castId, stream) {
-	stream.hexdump(stream.size());
+	if (debugChannelSet(5, kDebugLoading))
+		stream.hexdump(stream.size());
 	_type = kCastPalette;
 	_palette = nullptr;
 }

--- a/engines/director/castmember/sound.cpp
+++ b/engines/director/castmember/sound.cpp
@@ -88,7 +88,7 @@ void SoundCastMember::load() {
 			tag = MKTAG('S', 'N', 'D', ' ');
 			sndId = (uint16)(_castId + _cast->_castIDoffset);
 		}
-	} else if (_cast->_version >= kFileVer600 && _cast->_version < kFileVer700) {
+	} else if (_cast->_version >= kFileVer600) {
 		for (auto &it : _children) {
 			if (it.tag == MKTAG('s', 'n', 'd', ' ')) {
 				sndId = it.index;
@@ -142,8 +142,6 @@ void SoundCastMember::load() {
 			}
 		}
 
-	} else {
-		warning("STUB: SoundCastMember::SoundCastMember(): Sounds not yet supported for version v%d (%d)", humanVersion(_cast->_version), _cast->_version);
 	}
 
 

--- a/engines/director/castmember/text.cpp
+++ b/engines/director/castmember/text.cpp
@@ -33,6 +33,7 @@
 #include "director/score.h"
 #include "director/sprite.h"
 #include "director/window.h"
+#include "director/xmed.h"
 #include "director/castmember/text.h"
 #include "director/lingo/lingo-the.h"
 
@@ -200,6 +201,42 @@ TextCastMember::TextCastMember(Cast *cast, uint16 castId, TextCastMember &source
 
 	_bgcolor = source._bgcolor;
 	_fgcolor = source._fgcolor;
+}
+
+TextCastMember::TextCastMember(Cast *cast, uint16 castId, uint16 version)
+		: CastMember(cast, castId) {
+	// Promotion target for a Director 7+ "Text" Asset Xtra. The string, rect
+	// and styling are filled in by load() from the decoded XMED child; here we
+	// only establish sensible defaults shared with the regular text path.
+	_type = kCastText;
+
+	_borderSize = 0;
+	_gutterSize = 0;
+	_boxShadow = 0;
+	_buttonType = kTypeButton;
+	_editable = false;
+	_maxHeight = _textHeight = 0;
+
+	// Physikus' Text Xtra fields are light labels on a dark UI. The exact
+	// authored colour lives in the (undocumented) XMED style-run table, so use
+	// white, which is legible across the game's dark screens.
+	_bgcolor = g_director->_wm->findBestColor(0, 0, 0);
+	_fgcolor = g_director->_wm->findBestColor(0xff, 0xff, 0xff);
+
+	_textFlags = 0;
+	_scroll = 0;
+	_fontId = 1;
+	_fontSize = 12;
+	_textType = kTextTypeFixed;
+	_textAlign = kTextAlignLeft;
+	_textShadow = 0;
+	_textSlant = 0;
+	_bgpalinfo1 = _bgpalinfo2 = _bgpalinfo3 = 0;
+	_fgpalinfo1 = _fgpalinfo2 = _fgpalinfo3 = 0xffff;
+
+	_lineSpacing = g_director->getVersion() >= 400 ? 1 : 0;
+
+	_modified = true;
 }
 
 void TextCastMember::setColors(uint32 *fgcolor, uint32 *bgcolor) {
@@ -619,6 +656,33 @@ Common::String TextCastMember::formatInfo() {
 void TextCastMember::load() {
 	if (_loaded)
 		return;
+
+	// Director 7+ "Text" Asset Xtra cast members (promoted here to text cast
+	// members) carry an XMED child instead of an STXT resource. Recover the
+	// displayed string from it and size the field from the Xtra's authored rect.
+	for (auto &it : _children) {
+		if (it.tag != MKTAG('X', 'M', 'E', 'D'))
+			continue;
+
+		if (_cast->_loadedXMEDs.contains(it.index)) {
+			const XMED *xmed = _cast->_loadedXMEDs.getVal(it.index);
+			if (xmed->_isText) {
+				_rtext = xmed->_text;
+				_ptext = _ftext = Common::U32String(xmed->_text, g_director->getPlatformEncoding());
+
+				// The authored field rect is stored in the cast member info.
+				CastMemberInfo *ci = getInfo();
+				if (ci && !ci->xtraRect.isEmpty())
+					_initialRect = Common::Rect((int16)ci->xtraRect.width(), (int16)ci->xtraRect.height());
+
+				_loaded = true;
+				return;
+			}
+		} else {
+			warning("TextCastMember::load(): XMED %d isn't loaded", it.index);
+		}
+		break;
+	}
 
 	uint stxtid = 0;
 	if (_cast->_version >= kFileVer400) {

--- a/engines/director/castmember/text.h
+++ b/engines/director/castmember/text.h
@@ -34,6 +34,9 @@ class TextCastMember : public CastMember {
 public:
 	TextCastMember(Cast *cast, uint16 castId, Common::SeekableReadStreamEndian &stream, uint16 version, uint8 flags1 = 0, bool asButton = false);
 	TextCastMember(Cast *cast, uint16 castId, TextCastMember &source);
+	// Used when promoting a Director 7+ "Text" Asset Xtra (XMED-backed) to a
+	// text cast member. The text and styling are loaded lazily in load().
+	TextCastMember(Cast *cast, uint16 castId, uint16 version);
 
 	CastMember *duplicate(Cast *cast, uint16 castId) override { return (CastMember *)(new TextCastMember(cast, castId, *this)); }
 

--- a/engines/director/castmember/xtra.cpp
+++ b/engines/director/castmember/xtra.cpp
@@ -59,10 +59,11 @@ XtraCastMember::XtraCastMember(Cast *cast, uint16 castId, Common::SeekableReadSt
 		// TODO: Process data in the Xtra
 	}
 
-	// Director 7+ stores QuickTime videos as "quickTimeMedia" Xtra cast members.
-	// Those are promoted to DigitalVideoCastMembers in Cast::loadCastData(), so
-	// don't warn about them being unsupported here.
-	if (!isQuickTimeVideo())
+	// Director 7+ stores QuickTime videos as "quickTimeMedia" Xtra cast members
+	// and rich text fields as "text" Xtra cast members. Both are promoted to
+	// dedicated cast members in Cast::loadCastData(), so don't warn about them
+	// being unsupported here.
+	if (!isQuickTimeVideo() && !isTextXtra())
 		warning("STUB: XtraCastMember::XtraCastMember(): Xtra cast members not yet supported for version v%d (%d)", humanVersion(_cast->_version), _cast->_version);
 }
 
@@ -74,6 +75,12 @@ bool XtraCastMember::isQuickTimeVideo() const {
 	// QuickTime Asset Xtra ("QuickTime 3" / "QTASSET"). In D7+ this is how
 	// linked .mov digital videos are represented in the cast.
 	return _xtraSymbol.equalsIgnoreCase("quickTimeMedia");
+}
+
+bool XtraCastMember::isTextXtra() const {
+	// "Text" Asset Xtra. In D7+ this is how editable rich text fields are
+	// represented in the cast; the displayed string is stored in an XMED child.
+	return _xtraSymbol.equalsIgnoreCase("text");
 }
 
 bool XtraCastMember::hasField(int field) {

--- a/engines/director/castmember/xtra.cpp
+++ b/engines/director/castmember/xtra.cpp
@@ -80,6 +80,16 @@ bool XtraCastMember::isQuickTimeVideo() const {
 	return _xtraSymbol.equalsIgnoreCase("quickTimeMedia");
 }
 
+bool XtraCastMember::isQuickTimeLooping() const {
+	// The quickTimeMedia Asset Xtra payload carries the QuickTime member's
+	// playback flags. Byte 7 holds a bitfield in which 0x40 is the "loop"
+	// flag (verified empirically against Physikus: the looping logo sample
+	// Maschine.mov has it set, the play-once Trailer.mov has it clear).
+	// Short videos authored as ambient loops rely on this to keep repeating
+	// while a longer concurrent sound plays and the score holds the frame.
+	return isQuickTimeVideo() && _xtraData.size() > 7 && (_xtraData[7] & 0x40);
+}
+
 bool XtraCastMember::isTextXtra() const {
 	// "Text" Asset Xtra. In D7+ this is how editable rich text fields are
 	// represented in the cast; the displayed string is stored in an XMED child.

--- a/engines/director/castmember/xtra.cpp
+++ b/engines/director/castmember/xtra.cpp
@@ -59,11 +59,21 @@ XtraCastMember::XtraCastMember(Cast *cast, uint16 castId, Common::SeekableReadSt
 		// TODO: Process data in the Xtra
 	}
 
-	warning("STUB: XtraCastMember::XtraCastMember(): Xtra cast members not yet supported for version v%d (%d)", humanVersion(_cast->_version), _cast->_version);
+	// Director 7+ stores QuickTime videos as "quickTimeMedia" Xtra cast members.
+	// Those are promoted to DigitalVideoCastMembers in Cast::loadCastData(), so
+	// don't warn about them being unsupported here.
+	if (!isQuickTimeVideo())
+		warning("STUB: XtraCastMember::XtraCastMember(): Xtra cast members not yet supported for version v%d (%d)", humanVersion(_cast->_version), _cast->_version);
 }
 
 XtraCastMember::XtraCastMember(Cast *cast, uint16 castId, XtraCastMember &source)
 		: CastMember(cast, castId) {
+}
+
+bool XtraCastMember::isQuickTimeVideo() const {
+	// QuickTime Asset Xtra ("QuickTime 3" / "QTASSET"). In D7+ this is how
+	// linked .mov digital videos are represented in the cast.
+	return _xtraSymbol.equalsIgnoreCase("quickTimeMedia");
 }
 
 bool XtraCastMember::hasField(int field) {

--- a/engines/director/castmember/xtra.cpp
+++ b/engines/director/castmember/xtra.cpp
@@ -59,11 +59,14 @@ XtraCastMember::XtraCastMember(Cast *cast, uint16 castId, Common::SeekableReadSt
 		// TODO: Process data in the Xtra
 	}
 
-	// Director 7+ stores QuickTime videos as "quickTimeMedia" Xtra cast members
-	// and rich text fields as "text" Xtra cast members. Both are promoted to
-	// dedicated cast members in Cast::loadCastData(), so don't warn about them
-	// being unsupported here.
-	if (!isQuickTimeVideo() && !isTextXtra())
+	// Director 7+ stores QuickTime videos as "quickTimeMedia" Xtra cast
+	// members, rich text fields as "text" Xtra cast members, and embedded
+	// fonts as "font" Xtra cast members (the Font Asset / Font Xtra, holding
+	// a PFR1 TrueDoc font). QuickTime and text Xtras are promoted to dedicated
+	// cast members in Cast::loadCastData(); font Xtras are handled gracefully
+	// by the font subsystem (the embedded font is substituted, as ScummVM has
+	// no PFR decoder). Don't warn about any of these being unsupported here.
+	if (!isQuickTimeVideo() && !isTextXtra() && !isFontXtra())
 		warning("STUB: XtraCastMember::XtraCastMember(): Xtra cast members not yet supported for version v%d (%d)", humanVersion(_cast->_version), _cast->_version);
 }
 
@@ -81,6 +84,14 @@ bool XtraCastMember::isTextXtra() const {
 	// "Text" Asset Xtra. In D7+ this is how editable rich text fields are
 	// represented in the cast; the displayed string is stored in an XMED child.
 	return _xtraSymbol.equalsIgnoreCase("text");
+}
+
+bool XtraCastMember::isFontXtra() const {
+	// "Font Asset" / "Font Xtra". In D7+ this is how embedded fonts are stored
+	// in the cast; the payload wraps a PFR1 (Bitstream TrueDoc) font in an XMED
+	// child. ScummVM has no PFR decoder, so the font itself is not rendered;
+	// text that references it is drawn with a substitute font instead.
+	return _xtraSymbol.equalsIgnoreCase("font");
 }
 
 bool XtraCastMember::hasField(int field) {

--- a/engines/director/castmember/xtra.h
+++ b/engines/director/castmember/xtra.h
@@ -34,6 +34,7 @@ public:
 	CastMember *duplicate(Cast *cast, uint16 castId) override { return (CastMember *)(new XtraCastMember(cast, castId, *this)); }
 
 	bool isQuickTimeVideo() const;
+	bool isQuickTimeLooping() const;
 	bool isTextXtra() const;
 	bool isFontXtra() const;
 

--- a/engines/director/castmember/xtra.h
+++ b/engines/director/castmember/xtra.h
@@ -35,6 +35,7 @@ public:
 
 	bool isQuickTimeVideo() const;
 	bool isTextXtra() const;
+	bool isFontXtra() const;
 
 	bool hasField(int field) override;
 	Datum getField(int field) override;

--- a/engines/director/castmember/xtra.h
+++ b/engines/director/castmember/xtra.h
@@ -33,6 +33,8 @@ public:
 
 	CastMember *duplicate(Cast *cast, uint16 castId) override { return (CastMember *)(new XtraCastMember(cast, castId, *this)); }
 
+	bool isQuickTimeVideo() const;
+
 	bool hasField(int field) override;
 	Datum getField(int field) override;
 	void setField(int field, const Datum &value) override;

--- a/engines/director/castmember/xtra.h
+++ b/engines/director/castmember/xtra.h
@@ -34,6 +34,7 @@ public:
 	CastMember *duplicate(Cast *cast, uint16 castId) override { return (CastMember *)(new XtraCastMember(cast, castId, *this)); }
 
 	bool isQuickTimeVideo() const;
+	bool isTextXtra() const;
 
 	bool hasField(int field) override;
 	Datum getField(int field) override;

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -286,6 +286,19 @@ bool Channel::isDirty(Sprite *nextSprite) {
 	bool isDirtyFlag = _widgetDirty ||
 		(_sprite->_cast && _sprite->_cast->isModified());
 
+	// D6+: the per-frame sprite-details index selects the behavior set and
+	// the sprite's start/end frame range. It can change while the visible
+	// cast member stays identical (e.g. returning to a menu frame after a
+	// dialog that ran killScriptInstances, or a puppeted sprite whose
+	// behaviors were killed while looping on the same frame via
+	// `go(the frame)`). This is internal engine bookkeeping, not an
+	// authored/visual property, so it must be checked even when puppeted --
+	// otherwise a puppeted sprite's _behaviors/_startFrame/_endFrame can be
+	// cleared once by killScriptInstances() and never restored, permanently
+	// killing the sprite's interactivity (mouseDown never dispatches again).
+	if (g_director->getVersion() >= 600 && _sprite)
+		isDirtyFlag |= _sprite->_spriteListIdx != nextSprite->_spriteListIdx;
+
 	if (_sprite && !_sprite->_puppet && !_sprite->_autoPuppet) {
 		// When puppet is set, the overall dirty flag should be set when sprite is
 		// modified.
@@ -297,14 +310,6 @@ bool Channel::isDirty(Sprite *nextSprite) {
 			isDirtyFlag |= _sprite->getPosition() != nextSprite->getPosition();
 		if (isStretched() && !hasTextCastMember(_sprite))
 			isDirtyFlag |= _sprite->_width != nextSprite->_width || _sprite->_height != nextSprite->_height;
-		// D6+: the per-frame sprite-details index selects the behavior set and
-		// the sprite's start/end frame range. It can change while the visible
-		// cast member stays identical (e.g. returning to a menu frame after a
-		// dialog that ran killScriptInstances). Without flagging this, the
-		// channel keeps its stale (emptied) _behaviors and -1 frame range, so
-		// createScriptInstances() never re-arms the sprite and clicks die.
-		if (g_director->getVersion() >= 600)
-			isDirtyFlag |= _sprite->_spriteListIdx != nextSprite->_spriteListIdx;
 	}
 
 	return isDirtyFlag;
@@ -518,6 +523,25 @@ void Channel::setClean(Sprite *nextSprite, bool partial) {
 		if (_sprite->_puppet || _sprite->_autoPuppet || (!nextSprite->isQDShape() && partial)) {
 			// Updating scripts, etc. does not require a full re-render
 			_sprite->_scriptId = nextSprite->_scriptId;
+
+			// D6+: refresh behavior-set bookkeeping even for puppeted sprites.
+			// killScriptInstances() can wipe a puppeted sprite's _behaviors and
+			// frame range when the frame loops on itself; without restoring
+			// them here, the sprite permanently loses mouse-event dispatch
+			// since _puppet/_autoPuppet otherwise skip replaceSprite() below.
+			if (g_director->getVersion() >= 600) {
+				_sprite->_spriteListIdx = nextSprite->_spriteListIdx;
+				_sprite->_spriteInfo = nextSprite->_spriteInfo;
+				_sprite->_behaviors = nextSprite->_behaviors;
+				// createScriptInstances() gates on the CHANNEL's _startFrame/
+				// _endFrame (not the sprite's), and killScriptInstances()
+				// leaves these at -1 once killed. Only replaceSprite() (skipped
+				// here for puppets) normally restores them from _spriteInfo, so
+				// do it here too or the channel's script instance -- and thus
+				// its mouseDown dispatch -- never comes back.
+				_startFrame = _sprite->_spriteInfo.startFrame;
+				_endFrame = _sprite->_spriteInfo.endFrame;
+			}
 		} else {
 			previousCastId = _sprite->_castId;
 			replaceSprite(nextSprite);

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -297,6 +297,14 @@ bool Channel::isDirty(Sprite *nextSprite) {
 			isDirtyFlag |= _sprite->getPosition() != nextSprite->getPosition();
 		if (isStretched() && !hasTextCastMember(_sprite))
 			isDirtyFlag |= _sprite->_width != nextSprite->_width || _sprite->_height != nextSprite->_height;
+		// D6+: the per-frame sprite-details index selects the behavior set and
+		// the sprite's start/end frame range. It can change while the visible
+		// cast member stays identical (e.g. returning to a menu frame after a
+		// dialog that ran killScriptInstances). Without flagging this, the
+		// channel keeps its stale (emptied) _behaviors and -1 frame range, so
+		// createScriptInstances() never re-arms the sprite and clicks die.
+		if (g_director->getVersion() >= 600)
+			isDirtyFlag |= _sprite->_spriteListIdx != nextSprite->_spriteListIdx;
 	}
 
 	return isDirtyFlag;

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -9744,6 +9744,9 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1_l("physicus", "", "Physikus", "5d3f89e052320f8ce140451c730e232b", 114645, Common::FR_FRA, 702),
 	WINGAME1("physicus", "",   "Physicus.exe", "t:d2a772b412a278bda68bd64a00af9b04", 2298279, 702),
 	WINGAME1_l("physicus", "", "Physikus.exe", "t:89be052460986358d7e4724ebc940af6", 1816828, Common::DE_DEU, 702),
+	// Italian edition "Físicus", published by l'Espresso (dev path D:\PHYSIKUSITAL).
+	// Projector + Intro.dxr install from Transfer/ to the game dir; chapter data read from CD.
+	WINGAME1_l("physicus", "", "Physikus.exe", "t:026868d136e559a3eca5445221d123f1", 1816876, Common::IT_ITA, 702),
 
 	WINDEMO2("planetstrass", "Demo", "Planet.exe", "t:a053c117847a545ef72aecb425fed9e7", 15434606,
 									 "strass.jpg", "d:d76c7387399626e7a3daef54cbcd6451",	39135, 702),

--- a/engines/director/graphics.cpp
+++ b/engines/director/graphics.cpp
@@ -44,6 +44,13 @@ uint32 DirectorEngine::transformColor(uint32 color) {
 	if (_pixelformat.bytesPerPixel == 1)
 		return color;
 
+	// In >8bpp modes a color may be a packed 24-bit RGB value (e.g. a Lingo
+	// rgb() color, as used by D7 text foreColor) rather than a palette index.
+	// Palette indices are 0-255; treat anything larger as RGB so we don't read
+	// out of bounds of _currentPalette.
+	if (color > 0xff)
+		return _wm->findBestColor((color >> 16) & 0xff, (color >> 8) & 0xff, color & 0xff);
+
 	return _wm->findBestColor(_currentPalette[color * 3], _currentPalette[color * 3 + 1], _currentPalette[color * 3 + 2]);
 }
 

--- a/engines/director/images.cpp
+++ b/engines/director/images.cpp
@@ -347,6 +347,12 @@ void copyStretchImg(const Graphics::Surface *srcSurface, Graphics::Surface *targ
 		// Source area is nonexistant
 		return;
 	}
+	if ((targetRect.width() <= 0) || (targetRect.height() <= 0)) {
+		// Target area is empty (e.g. a sprite bbox not yet sized). Nothing to
+		// draw, and scaling into a zero dimension would divide by zero in the
+		// nearest-neighbour scaler (Graphics::scaleNN: (srcW << 16) / dstW).
+		return;
+	}
 
 	Graphics::Surface *temp1 = nullptr;
 	Graphics::Surface *temp2 = nullptr;

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1928,7 +1928,11 @@ void LB::b_xtra(int nargs) {
 			}
 		}
 	}
-	g_lingo->lingoError("Xtra not found: %s", d.asString().c_str());
+	// The game may reference an Xtra we don't implement (e.g. the custom
+	// "Border"/budapi Xtras shipped with Director 7 titles such as Physikus).
+	// Degrade gracefully by returning VOID instead of aborting Lingo execution.
+	warning("b_xtra: Xtra not found: %s", d.asString().c_str());
+	g_lingo->push(Datum());
 }
 
 ///////////////////

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1016,7 +1016,13 @@ void LB::b_count(int nargs) {
 		result.u.i = list.u.obj->getPropCount();
 		break;
 	default:
-		TYPECHECK3(list, ARRAY, PARRAY, OBJECT);
+		// count() of a genuinely VOID/unset value degrades to 0 rather than
+		// aborting Lingo (e.g. an absent CD-drive list in Physikus). Other
+		// unsupported types still warn so real type errors stay visible.
+		if (list.type != VOID)
+			warning("b_count: unsupported list type %s; returning 0", list.type2str());
+		result.u.i = 0;
+		break;
 	}
 
 	g_lingo->push(result);
@@ -1204,15 +1210,39 @@ void LB::b_getAt(int nargs) {
 	case ARRAY:
 	case POINT:
 	case RECT:
-		ARRBOUNDSCHECK(index, list);
+		if (list.u.farr->arr.empty()) {
+			// Empty list: degrade to VOID like b_getLast, e.g. Physikus indexing
+			// an empty CD-drive list when no CD-ROM volume is detected.
+			g_lingo->pushVoid();
+			break;
+		}
+		if (index - 1 < 0 || index > (int)list.u.farr->arr.size()) {
+			// Genuine out-of-bounds on a non-empty list: raise the Lingo error
+			// (matches real Director and the scummvmAssertError tests), then
+			// still push VOID so a caller expecting a return value (e.g. `set
+			// x to getAt(...)`) doesn't abort the handler mid-frame.
+			g_lingo->lingoError("b_getAt: index out of bounds (%d of %d)", index, list.u.farr->arr.size());
+			g_lingo->pushVoid();
+			break;
+		}
 		g_lingo->push(list.u.farr->arr[index - 1]);
 		break;
 	case PARRAY:
-		ARRBOUNDSCHECK(index, list);
+		if (list.u.parr->arr.empty()) {
+			g_lingo->pushVoid();
+			break;
+		}
+		if (index - 1 < 0 || index > (int)list.u.parr->arr.size()) {
+			g_lingo->lingoError("b_getAt: index out of bounds (%d of %d)", index, list.u.parr->arr.size());
+			g_lingo->pushVoid();
+			break;
+		}
 		g_lingo->push(list.u.parr->arr[index - 1].v);
 		break;
 	default:
-		TYPECHECK4(list, ARRAY, PARRAY, POINT, RECT);
+		warning("b_getAt: unsupported list type %s; returning VOID", list.type2str());
+		g_lingo->pushVoid();
+		break;
 	}
 }
 

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -1156,7 +1156,7 @@ ScriptContext *LingoCompiler::compileLingoV4(Common::SeekableReadStreamEndian &s
 			debugC(5, kDebugLoading, "%d: %s", i, name);
 			_assemblyContext->setProp(name, Datum(), true);
 		} else {
-			warning("Property %d has unknown name id %d, skipping define", i, index);
+			debugC(1, kDebugCompile, "Property %d has unknown name id %d, skipping define", i, index);
 		}
 	}
 
@@ -1182,7 +1182,10 @@ ScriptContext *LingoCompiler::compileLingoV4(Common::SeekableReadStreamEndian &s
 				debugC(5, kDebugLoading, "%d: %s (already defined)", i, name);
 			}
 		} else {
-			warning("Global %d has unknown name id %d, skipping define", i, index);
+			// Out-of-range name IDs occur in degenerate/empty D7 script slots
+			// (e.g. CDWechsel.dxr). ProjectorRays skips these silently via its
+			// validName() check, so treat it as a debug note, not a warning.
+			debugC(1, kDebugCompile, "Global %d has unknown name id %d, skipping define", i, index);
 		}
 	}
 

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -1307,7 +1307,17 @@ ScriptContext *LingoCompiler::compileLingoV4(Common::SeekableReadStreamEndian &s
 		return nullptr;
 	}
 
-	uint32 codeStoreSize = functionsOffset - codeStoreOffset;
+	if (codeStoreOffset > (uint32)stream.size()) {
+		warning("Lscr code store offset 0x%x is out of bounds (size 0x%x)", codeStoreOffset, (uint32)stream.size());
+		return nullptr;
+	}
+
+	// The bytecode and per-handler name arrays are addressed by absolute offsets
+	// within the script chunk. In D4-D6 the code store precedes the function
+	// table, but in D7+ (e.g. Director 7.0.2 / Physikus) the function table can
+	// precede the bytecode, so the code store must span the whole chunk body,
+	// not just [codeStoreOffset, functionsOffset). (matches ProjectorRays)
+	uint32 codeStoreSize = (uint32)stream.size() - codeStoreOffset;
 	stream.seek(codeStoreOffset);
 	byte *codeStore = (byte *)malloc(codeStoreSize);
 	stream.read(codeStore, codeStoreSize);
@@ -1746,8 +1756,15 @@ void LingoArchive::addNamesV4(Common::SeekableReadStreamEndian &stream) {
 	uint16 offset = stream.readUint16();
 	uint16 count = stream.readUint16();
 
-	if ((uint32)stream.size() != size) {
-		warning("Lnam content missing");
+	// Some Director 7+ name tables report a `size` that does not match the
+	// resource stream length (it excludes padding / counts only the names data).
+	// ProjectorRays ignores this field, so don't bail here; only validate the
+	// offset and guard each read against the end of the stream.
+	if ((uint32)stream.size() != size)
+		debugC(1, kDebugCompile, "addNamesV4: Lnam size %u != stream size %u, proceeding", size, (uint32)stream.size());
+
+	if (offset > stream.size()) {
+		warning("Lnam names offset 0x%x out of bounds (size 0x%x)", offset, (uint32)stream.size());
 		return;
 	}
 
@@ -1756,6 +1773,10 @@ void LingoArchive::addNamesV4(Common::SeekableReadStreamEndian &stream) {
 	names.clear();
 
 	for (uint16 i = 0; i < count; i++) {
+		if (stream.eos() || (uint32)stream.pos() >= (uint32)stream.size()) {
+			warning("addNamesV4: ran out of data after %d of %d names", i, count);
+			break;
+		}
 		Common::String name = stream.readPascalString();
 
 		names.push_back(name);

--- a/engines/director/lingo/lingo-code.cpp
+++ b/engines/director/lingo/lingo-code.cpp
@@ -838,16 +838,21 @@ Datum LC::divData(Datum &d1, Datum &d2) {
 		return LC::mapBinaryOp(LC::divData, d1, d2);
 	}
 
-	if ((d2.type == INT && d2.u.i == 0) ||
-			(d2.type == FLOAT && d2.u.f == 0.0)) {
-		g_lingo->lingoError("LC::divData(): division by zero");
-		d2 = Datum(1);
-	}
-
 	int alignedType = g_lingo->getAlignedType(d1, d2, false);
 
 	if (g_director->getVersion() < 400)	// pre-D4 is INT-only
 		alignedType = INT;
+
+	// Guard against division by zero based on the *resolved* divisor value
+	// rather than its raw Datum type. getAlignedType() folds VOID and numeric
+	// strings into INT/FLOAT, so a divisor such as `the duration of member "x"`
+	// for a missing cast member (VOID) or a non-numeric string slips past a
+	// type-only check and the integer division below would raise SIGFPE.
+	// Director itself flags a script error and treats the divisor as 1.
+	if ((alignedType == FLOAT) ? (d2.asFloat() == 0.0) : (d2.asInt() == 0)) {
+		g_lingo->lingoError("LC::divData(): division by zero");
+		d2 = Datum(1);
+	}
 
 	Datum res;
 	if (alignedType == FLOAT) {
@@ -855,10 +860,6 @@ Datum LC::divData(Datum &d1, Datum &d2) {
 	} else if (alignedType == INT) {
 		res = Datum(d1.asInt() / d2.asInt());
 	} else {
-		int denom = d2.asInt();
-		if (denom == 0) {
-			g_lingo->lingoError("LC::divData(): division by zero");
-		}
 		res = Datum(d1.asInt() / d2.asInt());
 		warning("LC::divData(): not supported between types %s and %s", d1.type2str(), d2.type2str());
 	}

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -311,14 +311,25 @@ void Movie::resolveScriptEvent(LingoEvent &event) {
 			// Cast script
 			// A strange quirk; if we're in a mouseDown event, Director will test
 			// at runtime to find out whatever is under the mouse and use that.
-			// If we're in a mouseUp event, Director will use whatever was
-			// discovered -at the very beginning- of the mouseDown event chain.
+			// If we're in a mouseUp event, D4-and-below Director will use whatever
+			// was discovered -at the very beginning- of the mouseDown event chain.
 			// This means e.g. the cast member can be swapped out from underneath in
 			// the mouseDown sprite script and the event passed down, which
 			// will mean the old cast member cast script does not get a mouseDown
 			// call, but it -does- get a mouseUp call.
 			// A bit unhinged, but we have a test that proves Director does this,
 			// so we have to do it too.
+			//
+			// D5+ instead re-resolves the cast script from the sprite's *current*
+			// member at mouseUp time (mirroring the kSpriteHandler D5+ path above).
+			// Games rely on this for two-member push buttons: the "armed" member's
+			// own cast-script mouseDown hover-loop swaps the sprite to a "pressed"
+			// member, and only that pressed member's cast script carries the
+			// on mouseUp action (e.g. Physikus' scanner scroll buttons SZ_R/SZ_G,
+			// SW_R/SW_G: releasing inside the button must run SZ_G's mouseUp;
+			// releasing outside leaves the actionless SZ_A member = cancel).
+			// With the mouseDown-time member pinned instead, the pressed member's
+			// handler never ran and such buttons were dead.
 			//
 			// mouseEnter and mouseLeave events should also defer to the value of channelId.
 			CastMemberID targetCast = _currentMouseDownCastID;
@@ -327,6 +338,17 @@ void Movie::resolveScriptEvent(LingoEvent &event) {
 				if (!event.channelId)
 					return;
 				Sprite *sprite = _score->getSpriteById(event.channelId);
+				targetCast = sprite->_castId;
+			} else if (((event.event == kEventMouseUp) || (event.event == kEventRightMouseUp)) &&
+					_vm->getVersion() >= 500) {
+				// D6+ tracks the sprite captured at mouseDown (_currentMouseDownChannelId);
+				// D5 falls back to the position-resolved channel.
+				uint16 upChannelId = _currentMouseDownChannelId ? _currentMouseDownChannelId : event.channelId;
+				if (!upChannelId)
+					return;
+				Sprite *sprite = _score->getSpriteById(upChannelId);
+				if (!sprite)
+					return;
 				targetCast = sprite->_castId;
 			}
 

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -681,6 +681,17 @@ void Movie::broadcastEvent(LEvent event) {
 			queueEvent(queue, event, i);
 		}
 	}
+
+	// The per-sprite queueing above only reaches sprite behaviors: within each
+	// sprite's event group the sprite handler runs first and (because the last
+	// behavior is queued with passByDefault=false) marks the event handled, which
+	// swallows the cast/frame/movie handlers that share its eventId. As a result a
+	// frame script's `on prepareFrame` (and the movie script's) would never run.
+	// Queue one more pass with no sprite target so the frame and movie handlers are
+	// resolved with a fresh eventId, exactly like enterFrame/exitFrame reach them
+	// via processEvent().
+	queueEvent(queue, event, 0);
+
 	_vm->setCurrentWindow(this->getWindow());
 	_lingo->processEvents(queue, false);
 }

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -633,7 +633,31 @@ void Movie::queueEvent(Common::Queue<LingoEvent> &queue, LEvent event, int targe
 		case kEventOpenWindow:  		// D5
 		case kEventCloseWindow:  		// D5
 		case kEventZoomWindow:  		// D5
-			queue.push(LingoEvent(event, eventId, kMovieHandler, false, pos, channelId));
+			{
+				// Queue every movie script that handles this event, in cast order,
+				// then the shared cast. Director runs them in sequence: the next
+				// one executes only if the previous called `pass`. Mirrors the
+				// enumeration in resolveScriptEvent() (kMovieHandler) so the first
+				// script chosen is unchanged, but `pass` can now reach the rest.
+				// passByDefault is false: a movie script that doesn't call `pass`
+				// stops the chain (the same-eventId successors are swallowed).
+				for (auto &cast : _casts) {
+					LingoArchive *archive = cast._value->_lingoArchive;
+					if (!archive)
+						continue;
+					for (auto &it : archive->scriptContexts[kMovieScript]) {
+						if (it._value->_eventHandlers.contains(event))
+							queue.push(LingoEvent(event, eventId, kMovieScript, false, CastMemberID(it._key, cast._key), pos));
+					}
+				}
+				LingoArchive *sharedArchive = getSharedLingoArch();
+				if (sharedArchive) {
+					for (auto &it : sharedArchive->scriptContexts[kMovieScript]) {
+						if (it._value->_eventHandlers.contains(event))
+							queue.push(LingoEvent(event, eventId, kMovieScript, false, CastMemberID(it._key, DEFAULT_CAST_LIB), pos));
+					}
+				}
+			}
 			break;
 
 		default:

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -588,6 +588,20 @@ void Movie::queueEvent(Common::Queue<LingoEvent> &queue, LEvent event, int targe
 		case kEventMouseUpOutSide:	// D6+
 		case kEventMouseWithin:		// D6+
 			if (_vm->getVersion() >= 600) {
+				// D5+: mouseUp/rightMouseUp should target whichever sprite captured
+				// the paired mouseDown, not whatever sprite the cursor currently
+				// resolves to. A sprite's own mouseDown handler can legitimately
+				// resize a *different*, higher-channel sprite's hit-test bbox while
+				// the button is held (e.g. a shared two-button hover-highlight
+				// graphic) -- without capture, that resize can steal the mouseUp
+				// dispatch away from the sprite that was actually pressed.
+				if (event == kEventMouseUp || event == kEventRightMouseUp) {
+					if (_currentMouseDownChannelId != 0)
+						pointedSpriteId = _currentMouseDownChannelId;
+				} else if (event == kEventMouseDown || event == kEventRightMouseDown) {
+					_currentMouseDownChannelId = pointedSpriteId;
+				}
+
 				if (pointedSpriteId != 0) {
 					Channel *channel = _score->getChannelById(pointedSpriteId);
 

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -158,6 +158,7 @@
 #include "director/lingo/xlibs/y/yasix.h"
 #include "director/lingo/xtras/a/audio.h"
 #include "director/lingo/xtras/b/budapi.h"
+#include "director/lingo/xtras/b/border.h"
 #include "director/lingo/xtras/d/directsound.h"
 #include "director/lingo/xtras/d/displayres.h"
 #include "director/lingo/xtras/d/datetime.h"
@@ -267,6 +268,7 @@ static const struct XLibProto {
 	XLIBDEF(BarakeObj,			kXObj,			400),	// D4
 	XLIBDEF(BatQT,				kXObj,			400),	// D4
 	XLIBDEF(BIMXObj,			kXObj,			400),	// D4
+	XLIBDEF(BorderXtra,			kXtraObj,		500),	// D5
 	XLIBDEF(BlitPictXObj,		kXObj,			400),	// D4
 	XLIBDEF(BlockTheDrawingXObj,			kXObj,					400),	// D4
 	XLIBDEF(BudAPIXtra,			kXtraObj,					500),	// D5

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -2714,7 +2714,12 @@ void Lingo::setObjectProp(Datum &obj, Common::String &propName, Datum &val) {
 		if (member->hasProp(propName)) {
 			member->setProp(propName, val);
 		} else {
-			g_lingo->lingoError("Lingo::setObjectProp(): %s has no property '%s'", id.asString().c_str(), propName.c_str());
+			// Some D6/D7 titles set cast-member properties we don't model
+			// (e.g. `the scale`/`the crop` of a digital-video member in
+			// Physikus' loading screen). Degrade to a warning instead of
+			// aborting the handler mid-frame, which would otherwise drop the
+			// rest of an exitFrame/mouseUp script and stall navigation.
+			warning("Lingo::setObjectProp(): %s has no property '%s', ignoring", id.asString().c_str(), propName.c_str());
 		}
 	} else if (obj.type == CASTLIBREF) {
 		Common::String key = Common::String::format("%d%s", kTheCastLib, propName.c_str());

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -166,6 +166,7 @@ TheEntity entities[] = {					//	hasId  ver.	isFunction
 	{ kTheSerialNumber,		"serialNumber",		false, 500, false },//				D5 p, documnted in D7
 	{ kTheShiftDown,		"shiftDown",		false, 200, true },	// D2 f
 	{ kTheSoundEnabled,		"soundEnabled",		false, 200, false },// D2 p
+	{ kTheSoundDevice,		"soundDevice",		false, 700, false },//					D7 p
 	{ kTheSoundEntity,		"sound",			true,  300, false },// 		D3 p
 	{ kTheSoundKeepDevice,	"soundKeepDevice",	false, 600, false },//					D6 p, documented in D7
 	{ kTheSoundLevel,		"soundLevel",		false, 200, false },// D2 p
@@ -1092,6 +1093,10 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 			}
 		}
 		break;
+	case kTheSoundDevice:
+		// ScummVM uses a single sound output; report the stored device name.
+		d = _soundDevice;
+		break;
 	case kTheSoundKeepDevice:
 		// System property; for Windows only, prevents the sound driver from unloading
 		// and reloading each time a sound needs to play. The default value is TRUE.
@@ -1449,6 +1454,11 @@ void Lingo::setTheEntity(int entity, Datum &id, int field, Datum &d) {
 				break;
 			}
 		}
+		break;
+	case kTheSoundDevice:
+		// ScummVM has a single sound output and cannot switch devices; store
+		// the movie's chosen device name so it round-trips on read.
+		_soundDevice = d.asString();
 		break;
 	case kTheSoundKeepDevice:
 		// We do not need to unload the sound driver, so just ignore this.

--- a/engines/director/lingo/lingo-the.h
+++ b/engines/director/lingo/lingo-the.h
@@ -148,6 +148,7 @@ enum TheEntityType {
 	kTheSelStart,
 	kTheSerialNumber,
 	kTheShiftDown,
+	kTheSoundDevice,
 	kTheSoundEntity,
 	kTheSoundEnabled,
 	kTheSoundKeepDevice,

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -488,6 +488,7 @@ public:
 	int _traceLoad; // internal Director verbosity level
 	bool _updateMovieEnabled;
 	bool _romanLingo;
+	Common::String _soundDevice; // D7+ "the soundDevice"; ScummVM has one output, stored to round-trip
 
 	Datum getTheEntity(int entity, Datum &id, int field);
 	void setTheEntity(int entity, Datum &id, int field, Datum &d);

--- a/engines/director/lingo/tests/dragbewegen.lingo
+++ b/engines/director/lingo/tests/dragbewegen.lingo
@@ -1,0 +1,60 @@
+-- Standalone regression test for the "Bewegen" (drag-tracking) half of
+-- Physikus Mechanik2's real drag-and-drop mechanism (MovieScript 3
+-- "DragDropSteuerung", used by BehaviorScript 89/94/95 on sprites 52/53).
+-- Ported verbatim (offset math unchanged) and driven end-to-end through
+-- the fixed UnitTest xlib, exactly like a real player's click-drag would.
+
+openXlib("UnitTest")
+set ut to UnitTest
+
+on pump
+  set dummy to 0
+  repeat with i = 1 to 150
+    set dummy to dummy + i
+  end repeat
+end
+
+put "sprite1 initial loc=" & (the locH of sprite 1) & "," & (the locV of sprite 1)
+set startH to the locH of sprite 1
+set startV to the locV of sprite 1
+
+-- mouseDown "picks up" the sprite at its current position
+ut(mMoveMouse, startH, startV)
+pump()
+ut(mLeftMouseDown)
+pump()
+put "mouseDown registered: " & (the mouseDown)
+
+-- Real game's Bewegen(): dxm/dym capture the offset between the sprite's
+-- origin and the initial click point, then track it live.
+set dxm to the locH of sprite 1 - the mouseH
+set dym to the locV of sprite 1 - the mouseV
+put "offset dxm=" & dxm & " dym=" & dym
+
+set steps to 0
+set targetH to startH + 60
+set targetV to startV + 40
+repeat while the mouseDown
+  set steps to steps + 1
+  if steps > 10 then
+    put "FAIL: drag loop never terminated (mouseDown stayed true forever)"
+    exit repeat
+  end if
+  set the locH of sprite 1 to the mouseH + dxm
+  set the locV of sprite 1 to the mouseV + dym
+  put "  step" && steps && ": sprite1 now at" && (the locH of sprite 1) & "," & (the locV of sprite 1)
+  if steps = 3 then
+    ut(mMoveMouse, targetH, targetV)
+  end if
+  if steps = 6 then
+    ut(mLeftMouseUp)
+  end if
+  pump()
+end repeat
+
+put "final: steps=" & steps & " sprite1 loc=" & (the locH of sprite 1) & "," & (the locV of sprite 1) & " (expected " & targetH & "," & targetV & ")"
+if (the locH of sprite 1) = targetH and (the locV of sprite 1) = targetV and steps >= 1 and steps <= 10 then
+  put "PASS: Bewegen drag loop correctly tracked mouse movement and terminated on mouseUp"
+else
+  put "FAIL: Bewegen drag loop did not behave correctly"
+end if

--- a/engines/director/lingo/tests/dragdrop.lingo
+++ b/engines/director/lingo/tests/dragdrop.lingo
@@ -1,0 +1,90 @@
+-- Standalone regression test for the "Abgesetzt" (drop-detection) half of
+-- Physikus Mechanik2's real drag-and-drop puzzle mechanism (MovieScript
+-- "DragDropSteuerung", sprites 52/53, BehaviorScript 89/94/95).
+--
+-- IMPORTANT (matches real game semantics): Abgesetzt's rollOver(DropKanal)
+-- checks whether the MOUSE CURSOR is over the drop-target sprite at the
+-- moment of mouseUp -- NOT whether the dragged sprite's own rect overlaps
+-- the target. So this test positions the mouse, not the dragged sprite.
+--
+-- Note: UnitTest.mMoveMouse takes WINDOW-relative coordinates (per its own
+-- docstring), while "the mouseH"/"the mouseV" (and sprite locH/locV) are
+-- STAGE-relative -- Window::getMousePos() subtracts the window's inner
+-- letterbox offset. We probe that offset once so window-coordinate calls
+-- land on the intended stage position.
+
+openXlib("UnitTest")
+set ut to UnitTest
+
+on pump
+  set dummy to 0
+  repeat with i = 1 to 150
+    set dummy to dummy + i
+  end repeat
+end
+
+-- Probe the window->stage coordinate offset: move to a known window coord,
+-- read back the stage-relative mouseH/mouseV, and derive the delta.
+ut(mMoveMouse, 300, 300)
+pump()
+set offH to 300 - (the mouseH)
+set offV to 300 - (the mouseV)
+put "window->stage offset: offH=" & offH & " offV=" & offV
+
+put "sprite1 rect=" & (the rect of sprite 1)
+put "sprite2 rect=" & (the rect of sprite 2)
+
+set startH to the locH of sprite 1
+set startV to the locV of sprite 1
+set dragObj to DragDropSteuerung(mNew, startH, startV)
+
+-- Scenario A: mouse cursor over sprite 2 at drop time -> rollOver hit,
+-- should snap the dragged sprite onto the target's position.
+ut(mMoveMouse, (the locH of sprite 2) + offH, (the locV of sprite 2) + offV)
+pump()
+put "mouse now at stage coords: " & (the mouseH) & "," & (the mouseV)
+set pos to dragObj(Abgesetzt, 1, 2)
+put "Scenario A (mouse over target): pos=" & pos & " sprite1 loc=" & (the locH of sprite 1) & "," & (the locV of sprite 1)
+if pos = 1 and (the locH of sprite 1) = (the locH of sprite 2) and (the locV of sprite 1) = (the locV of sprite 2) then
+  put "PASS: Scenario A - drop onto target correctly detected and snapped"
+else
+  put "FAIL: Scenario A - drop onto target not handled correctly"
+end if
+
+-- Scenario B: mouse cursor far from sprite 2 -> rollOver miss, dragged
+-- sprite should return to its original (pre-drag) XPos/YPos.
+set the locH of sprite 1 to startH + 500
+set the locV of sprite 1 to startV + 500
+ut(mMoveMouse, 5 + offH, 5 + offV)
+pump()
+set pos2 to dragObj(Abgesetzt, 1, 2)
+put "Scenario B (mouse far from target): pos=" & pos2 & " sprite1 loc=" & (the locH of sprite 1) & "," & (the locV of sprite 1)
+if pos2 = 0 and (the locH of sprite 1) = startH and (the locV of sprite 1) = startV then
+  put "PASS: Scenario B - missed drop correctly returned to origin"
+else
+  put "FAIL: Scenario B - missed drop did not return to origin correctly"
+end if
+
+--
+-- Helper mirroring MovieScript 8/3 "DragDropSteuerung" verbatim (property
+-- names/behavior unchanged from the real game's decompiled source).
+factory DragDropSteuerung
+method mNew X, Y
+    property XPos, YPos
+    set XPos to X
+    set YPos to Y
+    return me
+
+-- Real game's "Abgesetzt": on drop, check rollOver against the target
+-- channel; if hit, snap in place, else return home.
+method Abgesetzt DragKanal, DropKanal
+    property XPos, YPos
+    if rollOver(DropKanal) then
+      set the locH of sprite DragKanal to the locH of sprite DropKanal
+      set the locV of sprite DragKanal to the locV of sprite DropKanal
+      return 1
+    else
+      set the locH of sprite DragKanal to XPos
+      set the locV of sprite DragKanal to YPos
+      return 0
+    end if

--- a/engines/director/lingo/xlibs/q/qtsupport.cpp
+++ b/engines/director/lingo/xlibs/q/qtsupport.cpp
@@ -68,6 +68,7 @@ const char *QTSupport::xlibName = "QuickTimeSupport";
 const XlibFileDesc QTSupport::fileNames[] = {
 	{ "QuickTime Asset",	nullptr },
 	{ "QTASSET",			nullptr },
+	{ "QT3Asset",			nullptr },	// QuickTime 3 Asset Xtra (e.g. Physikus, Chemicus)
 	{ nullptr,		nullptr },
 };
 

--- a/engines/director/lingo/xlibs/u/unittest.cpp
+++ b/engines/director/lingo/xlibs/u/unittest.cpp
@@ -173,7 +173,7 @@ void UnitTestXObj::m_moveMouse(int nargs) {
 	ev.type = Common::EVENT_MOUSEMOVE;
 	ev.mouse = Common::Point(x, y);
 	me->_mousePos = ev.mouse;
-	g_director->_injectedEvents.push_back(ev);
+	g_system->getEventManager()->pushEvent(ev);
 	g_lingo->push(0);
 }
 
@@ -188,7 +188,7 @@ void UnitTestXObj::m_leftMouseDown(int nargs) {
 	Common::Event ev;
 	ev.type = Common::EVENT_LBUTTONDOWN;
 	ev.mouse = me->_mousePos;
-	g_director->_injectedEvents.push_back(ev);
+	g_system->getEventManager()->pushEvent(ev);
 	g_lingo->push(0);
 }
 
@@ -203,7 +203,7 @@ void UnitTestXObj::m_leftMouseUp(int nargs) {
 	Common::Event ev;
 	ev.type = Common::EVENT_LBUTTONUP;
 	ev.mouse = me->_mousePos;
-	g_director->_injectedEvents.push_back(ev);
+	g_system->getEventManager()->pushEvent(ev);
 	g_lingo->push(0);
 }
 

--- a/engines/director/lingo/xtras/b/border.cpp
+++ b/engines/director/lingo/xtras/b/border.cpp
@@ -1,0 +1,105 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/lingo-utils.h"
+#include "director/lingo/xtras/b/border.h"
+
+/**************************************************
+ *
+ * USED IN:
+ * Physikus (l'Espresso, Italian; Ruske & Pühretmaier)
+ * Chemicus / Bioscopia and other Heureka-Klett titles
+ *
+ **************************************************/
+
+/*
+ * The "Border" Xtra (Border.x32) draws a thin frame around the projector
+ * window and gates execution on a registration key. It exposes:
+ *   new object me
+ *   Register object me, integer key -- validate the registration key
+ *
+ * Both are copy-protection / cosmetic no-ops here: we register so that
+ * Register() resolves as a method on the Xtra instance instead of aborting
+ * the calling handler (which on Physikus would skip the rest of the boot
+ * movie's frame-1 setup, leaving searchPaths and the CD roots unset).
+ */
+
+namespace Director {
+
+const char *BorderXtra::xlibName = "Border";
+const XlibFileDesc BorderXtra::fileNames[] = {
+	{ "Border",	nullptr },
+	{ nullptr,	nullptr },
+};
+
+static MethodProto xlibMethods[] = {
+	{ "new",		BorderXtra::m_new,		0, 0,	500 },
+	{ "Register",	BorderXtra::m_register,	1, 1,	500 },
+	{ nullptr, nullptr, 0, 0, 0 }
+};
+
+static BuiltinProto xlibBuiltins[] = {
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+BorderXtraObject::BorderXtraObject(ObjectType ObjectType) :Object<BorderXtraObject>("Border") {
+	_objType = ObjectType;
+}
+
+bool BorderXtraObject::hasProp(const Common::String &propName) {
+	return (propName == "name");
+}
+
+Datum BorderXtraObject::getProp(const Common::String &propName) {
+	if (propName == "name")
+		return Datum(BorderXtra::xlibName);
+	warning("BorderXtra::getProp: unknown property '%s'", propName.c_str());
+	return Datum();
+}
+
+void BorderXtra::open(ObjectType type, const Common::Path &path) {
+	BorderXtraObject::initMethods(xlibMethods);
+	BorderXtraObject *xobj = new BorderXtraObject(type);
+	if (type == kXtraObj) {
+		g_lingo->_openXtras.push_back(xlibName);
+		g_lingo->_openXtraObjects.push_back(xobj);
+	}
+	g_lingo->exposeXObject(xlibName, xobj);
+	g_lingo->initBuiltIns(xlibBuiltins);
+}
+
+void BorderXtra::close(ObjectType type) {
+	BorderXtraObject::cleanupMethods();
+	g_lingo->_globalvars[xlibName] = Datum();
+}
+
+void BorderXtra::m_new(int nargs) {
+	g_lingo->dropStack(nargs);
+	g_lingo->push(g_lingo->_state->me);
+}
+
+// Register(me, key): copy-protection check; always succeeds (no-op).
+XOBJSTUB(BorderXtra::m_register, 0)
+
+} // End of namespace Director

--- a/engines/director/lingo/xtras/b/border.h
+++ b/engines/director/lingo/xtras/b/border.h
@@ -1,0 +1,50 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XTRAS_B_BORDER_H
+#define DIRECTOR_LINGO_XTRAS_B_BORDER_H
+
+namespace Director {
+
+class BorderXtraObject : public Object<BorderXtraObject> {
+public:
+	BorderXtraObject(ObjectType objType);
+
+	bool hasProp(const Common::String &propName) override;
+	Datum getProp(const Common::String &propName) override;
+};
+
+namespace BorderXtra {
+
+extern const char *xlibName;
+extern const XlibFileDesc fileNames[];
+
+void open(ObjectType type, const Common::Path &path);
+void close(ObjectType type);
+
+void m_new(int nargs);
+void m_register(int nargs);
+
+} // End of namespace BorderXtra
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xtras/b/budapi.cpp
+++ b/engines/director/lingo/xtras/b/budapi.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/system.h"
+#include "common/formats/ini-file.h"
 
 #include "director/director.h"
 #include "director/util.h"
@@ -381,10 +382,59 @@ XOBJSTUB(BudAPIXtra::m_baCpuInfo, 0)
 XOBJSTUB(BudAPIXtra::m_baDiskInfo, 0)
 XOBJSTUB(BudAPIXtra::m_baMemoryInfo, 0)
 XOBJSTUB(BudAPIXtra::m_baFindApp, 0)
-XOBJSTUB(BudAPIXtra::m_baReadIni, 0)
-XOBJSTUB(BudAPIXtra::m_baWriteIni, 0)
+void BudAPIXtra::m_baReadIni(int nargs) {
+	// baReadIni(section, key, default, iniFile) reads a Windows INI entry.
+	// Mirrors GetPrivateProfileString: section and key match case-insensitively
+	// and the supplied default is returned when the file, section or key is
+	// missing. The game derives runtime settings (e.g. _Lautstaerke from
+	// [general] VolSound) from this, so a stubbed 0 return silenced all audio.
+	ARGNUMCHECK(4);
+	Common::String iniFile = g_lingo->pop().asString();
+	Common::String defaultVal = g_lingo->pop().asString();
+	Common::String key = g_lingo->pop().asString();
+	Common::String section = g_lingo->pop().asString();
+
+	Common::Path resolved = findPath(iniFile);
+	Common::INIFile ini;
+	ini.allowNonEnglishCharacters();
+	Common::String value;
+	if (!resolved.empty() && ini.loadFromFile(resolved) && ini.getKey(key, section, value)) {
+		g_lingo->push(Datum(value));
+		return;
+	}
+	g_lingo->push(Datum(defaultVal));
+}
+void BudAPIXtra::m_baWriteIni(int nargs) {
+	// baWriteIni(section, key, value, iniFile) writes a Windows INI entry.
+	// Best-effort persist to the resolved file so later reads stay consistent;
+	// read-only media (e.g. CD) simply leave the value unsaved.
+	ARGNUMCHECK(4);
+	Common::String iniFile = g_lingo->pop().asString();
+	Common::String value = g_lingo->pop().asString();
+	Common::String key = g_lingo->pop().asString();
+	Common::String section = g_lingo->pop().asString();
+
+	Common::Path resolved = findPath(iniFile);
+	Common::INIFile ini;
+	ini.allowNonEnglishCharacters();
+	if (!resolved.empty())
+		ini.loadFromFile(resolved);
+	ini.setKey(key, section, value);
+	if (!resolved.empty())
+		ini.saveToFile(resolved);
+	g_lingo->push(Datum(1));
+}
 XOBJSTUB(BudAPIXtra::m_baFlushIni, 0)
-XOBJSTUB(BudAPIXtra::m_baReadRegString, 0)
+void BudAPIXtra::m_baReadRegString(int nargs) {
+	// baReadRegString(keyName, value, default, branch). ScummVM has no Windows
+	// registry, so return the caller-supplied default rather than a numeric 0.
+	ARGNUMCHECK(4);
+	/* branch  */ g_lingo->pop();
+	Common::String defaultVal = g_lingo->pop().asString();
+	/* value   */ g_lingo->pop();
+	/* keyName */ g_lingo->pop();
+	g_lingo->push(Datum(defaultVal));
+}
 XOBJSTUB(BudAPIXtra::m_baWriteRegString, 0)
 XOBJSTUB(BudAPIXtra::m_baReadRegNumber, 0)
 XOBJSTUB(BudAPIXtra::m_baWriteRegNumber, 0)

--- a/engines/director/lingo/xtras/b/budapi.cpp
+++ b/engines/director/lingo/xtras/b/budapi.cpp
@@ -441,7 +441,17 @@ XOBJSTUB(BudAPIXtra::m_baWriteRegNumber, 0)
 XOBJSTUB(BudAPIXtra::m_baDeleteReg, 0)
 XOBJSTUB(BudAPIXtra::m_baRegKeyList, 0)
 XOBJSTUB(BudAPIXtra::m_baRegValueList, 0)
-XOBJSTUB(BudAPIXtra::m_baSoundCard, 0)
+void BudAPIXtra::m_baSoundCard(int nargs) {
+	// baSoundCard() -> 1 if a sound card is installed, else 0.
+	// The original boot Lingo (Intro.dxr) does, on Windows (machineType 256):
+	//   if the machineType = 256 then set _SoundSchalter to baSoundCard()
+	// _SoundSchalter then gates ALL chapter narration (on Audioint: if
+	// _SoundSchalter then puppetSound(...)) and some frame-hold timing. A 0
+	// here silently mutes chapters. ScummVM always provides a mixer, so a
+	// sound card is effectively always present.
+	g_lingo->dropStack(nargs);
+	g_lingo->push(Datum(1));
+}
 XOBJSTUB(BudAPIXtra::m_baFontInstalled, 0)
 XOBJSTUB(BudAPIXtra::m_baFontList, 0)
 XOBJSTUB(BudAPIXtra::m_baFontStyleList, 0)

--- a/engines/director/lingo/xtras/b/budapi.cpp
+++ b/engines/director/lingo/xtras/b/budapi.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/system.h"
+#include "common/savefile.h"
 #include "common/formats/ini-file.h"
 
 #include "director/director.h"
@@ -388,41 +389,62 @@ void BudAPIXtra::m_baReadIni(int nargs) {
 	// and the supplied default is returned when the file, section or key is
 	// missing. The game derives runtime settings (e.g. _Lautstaerke from
 	// [general] VolSound) from this, so a stubbed 0 return silenced all audio.
+	//
+	// The game treats this file as read/write persistent state (settings,
+	// savegame slots), so -- like FileIO's xlib and BudAPI's own writer
+	// below -- prefer the ScummVM save sandbox (mangled with savePrefix(),
+	// matching what m_baWriteIni() persists to) over the game/CD directory,
+	// which ScummVM otherwise treats as read-only and which a real Windows
+	// install would never see written back to anyway. Fall back to a
+	// bundled file via findPath() only for a value never written yet.
 	ARGNUMCHECK(4);
 	Common::String iniFile = g_lingo->pop().asString();
 	Common::String defaultVal = g_lingo->pop().asString();
 	Common::String key = g_lingo->pop().asString();
 	Common::String section = g_lingo->pop().asString();
 
-	Common::Path resolved = findPath(iniFile);
+	Common::String saveName = savePrefix() + lastPathComponent(iniFile, g_director->_dirSeparator);
 	Common::INIFile ini;
 	ini.allowNonEnglishCharacters();
 	Common::String value;
-	if (!resolved.empty() && ini.loadFromFile(resolved) && ini.getKey(key, section, value)) {
+	if (ini.loadFromSaveFile(saveName) && ini.getKey(key, section, value)) {
 		g_lingo->push(Datum(value));
 		return;
+	}
+
+	Common::Path resolved = findPath(iniFile);
+	if (!resolved.empty()) {
+		Common::INIFile bundled;
+		bundled.allowNonEnglishCharacters();
+		if (bundled.loadFromFile(resolved) && bundled.getKey(key, section, value)) {
+			g_lingo->push(Datum(value));
+			return;
+		}
 	}
 	g_lingo->push(Datum(defaultVal));
 }
 void BudAPIXtra::m_baWriteIni(int nargs) {
 	// baWriteIni(section, key, value, iniFile) writes a Windows INI entry.
-	// Best-effort persist to the resolved file so later reads stay consistent;
-	// read-only media (e.g. CD) simply leave the value unsaved.
+	// Always persist to the ScummVM save sandbox via SaveFileManager (same
+	// mangled name m_baReadIni() above checks first), never to a real path
+	// resolved by findPath(): that mixed a SearchMan-relative result with
+	// Common::INIFile::saveToFile(), which writes via DumpFile straight to
+	// the OS filesystem -- for a bare relative name that lands in whatever
+	// the process's current working directory happens to be, not the game
+	// or save directory, so the value was never seen again by baReadIni()
+	// (silently discarding e.g. save-game and settings data).
 	ARGNUMCHECK(4);
 	Common::String iniFile = g_lingo->pop().asString();
 	Common::String value = g_lingo->pop().asString();
 	Common::String key = g_lingo->pop().asString();
 	Common::String section = g_lingo->pop().asString();
 
-	Common::Path resolved = findPath(iniFile);
+	Common::String saveName = savePrefix() + lastPathComponent(iniFile, g_director->_dirSeparator);
 	Common::INIFile ini;
 	ini.allowNonEnglishCharacters();
-	if (!resolved.empty())
-		ini.loadFromFile(resolved);
+	ini.loadFromSaveFile(saveName);
 	ini.setKey(key, section, value);
-	if (!resolved.empty())
-		ini.saveToFile(resolved);
-	g_lingo->push(Datum(1));
+	g_lingo->push(Datum(ini.saveToSaveFile(saveName) ? 1 : 0));
 }
 XOBJSTUB(BudAPIXtra::m_baFlushIni, 0)
 void BudAPIXtra::m_baReadRegString(int nargs) {
@@ -511,6 +533,22 @@ void BudAPIXtra::m_baFileExists(int nargs) {
 		if (i == nargs - 1)
 			path = d.asString();
 	}
+
+	// Games use this to detect a previously-written persistent ini/rup file
+	// (e.g. Physikus checks baFileExists(_Root & "Physicus.rup") to decide
+	// whether to bootstrap defaults). Those files are written by
+	// baWriteIni() into the SaveFileManager sandbox, not the game
+	// directory, so check there too -- otherwise this always reports
+	// "missing" post-write, sending the game back through its
+	// default-bootstrap path (which computes a different, inconsistent
+	// ini filename) every subsequent run.
+	Common::String saveName = savePrefix() + lastPathComponent(path, g_director->_dirSeparator);
+	Common::SaveFileManager *saves = g_system->getSavefileManager();
+	if (!saves->listSavefiles(saveName).empty()) {
+		g_lingo->push(Datum(1));
+		return;
+	}
+
 	g_lingo->push(Datum(findPath(path, true, true, false).empty() ? 0 : 1));
 }
 void BudAPIXtra::m_baDiskList(int nargs) {

--- a/engines/director/lingo/xtras/b/budapi.cpp
+++ b/engines/director/lingo/xtras/b/budapi.cpp
@@ -22,6 +22,7 @@
 #include "common/system.h"
 
 #include "director/director.h"
+#include "director/util.h"
 #include "director/lingo/lingo.h"
 #include "director/lingo/lingo-object.h"
 #include "director/lingo/lingo-utils.h"
@@ -190,6 +191,7 @@ namespace Director {
 const char *BudAPIXtra::xlibName = "BudAPI";
 const XlibFileDesc BudAPIXtra::fileNames[] = {
 	{ "budapi",   nullptr },
+	{ "budapi32", nullptr },
 	{ nullptr,        nullptr },
 };
 
@@ -247,6 +249,8 @@ static BuiltinProto xlibBuiltins[] = {
 	{ "baFreeCursor", BudAPIXtra::m_baFreeCursor, 0, 0, 500, HBLTIN },
 	{ "baSetVolume", BudAPIXtra::m_baSetVolume, 2, 2, 500, HBLTIN },
 	{ "baGetVolume", BudAPIXtra::m_baGetVolume, 1, 1, 500, HBLTIN },
+	{ "baDiskList", BudAPIXtra::m_baDiskList, 0, 0, 500, HBLTIN },
+	{ "baEjectDisk", BudAPIXtra::m_baEjectDisk, 1, 1, 500, HBLTIN },
 	{ "baInstallFont", BudAPIXtra::m_baInstallFont, 2, 2, 500, HBLTIN },
 	{ "baKeyIsDown", BudAPIXtra::m_baKeyIsDown, 1, 1, 500, HBLTIN },
 	{ "baKeyBeenPressed", BudAPIXtra::m_baKeyBeenPressed, 1, 1, 500, HBLTIN },
@@ -436,7 +440,32 @@ XOBJSTUB(BudAPIXtra::m_baPrinterInfo, 0)
 XOBJSTUB(BudAPIXtra::m_baSetPrinter, 0)
 XOBJSTUB(BudAPIXtra::m_baRefreshDesktop, 0)
 XOBJSTUB(BudAPIXtra::m_baFileAge, 0)
-XOBJSTUB(BudAPIXtra::m_baFileExists, 0)
+void BudAPIXtra::m_baFileExists(int nargs) {
+	// baFileExists(string fileName) -> 1 if the file is reachable, else 0.
+	// The game passes Windows-style CD paths (e.g. _Cd1Root & "CDNr1.rup");
+	// findPath() resolves them against the current folder and search paths,
+	// matching by last path component when the absolute prefix is unknown.
+	Common::String path;
+	for (int i = 0; i < nargs; i++) {
+		Datum d = g_lingo->pop();
+		if (i == nargs - 1)
+			path = d.asString();
+	}
+	g_lingo->push(Datum(findPath(path, true, true, false).empty() ? 0 : 1));
+}
+void BudAPIXtra::m_baDiskList(int nargs) {
+	// No removable-volume concept under ScummVM. Return an empty list so the
+	// callers' count()/repeat loops (e.g. VolumeAuswerfen) are no-ops.
+	g_lingo->dropStack(nargs);
+	Datum result;
+	result.type = ARRAY;
+	result.u.farr = new FArray();
+	g_lingo->push(result);
+}
+void BudAPIXtra::m_baEjectDisk(int nargs) {
+	g_lingo->dropStack(nargs);
+	g_lingo->push(Datum(0));
+}
 XOBJSTUB(BudAPIXtra::m_baFolderExists, 0)
 XOBJSTUB(BudAPIXtra::m_baCreateFolder, 0)
 XOBJSTUB(BudAPIXtra::m_baDeleteFolder, 0)

--- a/engines/director/lingo/xtras/b/budapi.h
+++ b/engines/director/lingo/xtras/b/budapi.h
@@ -172,6 +172,8 @@ void m_baRegister(int nargs);
 void m_baSaveRegistration(int nargs);
 void m_baGetRegistration(int nargs);
 void m_baFunctions(int nargs);
+void m_baDiskList(int nargs);
+void m_baEjectDisk(int nargs);
 
 } // End of namespace BudAPIXtra
 

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -28,6 +28,7 @@ MODULE_OBJS = \
 	types.o \
 	util.o \
 	window.o \
+	xmed.o \
 	castmember/castmember.o \
 	castmember/bitmap.o \
 	castmember/digitalvideo.o \

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -189,6 +189,7 @@ MODULE_OBJS = \
 	lingo/xlibs/x/xwin.o \
 	lingo/xlibs/y/yasix.o \
 	lingo/xtras/b/budapi.o \
+	lingo/xtras/b/border.o \
 	lingo/xtras/a/audio.o \
 	lingo/xtras/d/directsound.o \
 	lingo/xtras/d/displayres.o \

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -203,6 +203,16 @@ void Movie::loadCastLibMapping(Common::SeekableReadStreamEndian &stream) {
 		Cast *cast = nullptr;
 		if (_casts.contains(libId)) {
 			cast = _casts.getVal(libId);
+			// The default internal cast is pre-created by the Movie constructor
+			// with the default resource id (1024) and no name, before the MCsL
+			// is parsed. Adopt the authored values, otherwise a movie whose
+			// internal cast is keyed at a different id (e.g. Physikus'
+			// Game/Midland.dxr, Internal = 66560) filters out every CASt member
+			// and never finds its Lctx, so none of its Lingo compiles.
+			if (!isExternal) {
+				cast->_libResourceId = libResourceId;
+				cast->setCastName(name);
+			}
 		} else {
 			cast = new Cast(this, libId, false, isExternal, libResourceId);
 			cast->setCastName(name);

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -181,8 +181,12 @@ void Movie::loadCastLibMapping(Common::SeekableReadStreamEndian &stream) {
 		}
 		uint16 minMember = stream.readUint16();
 		uint16 maxMember = stream.readUint16();
-		stream.readUint16();
-		uint16 libResourceId = stream.readUint16();
+		// libResourceId is a 32-bit field: the chunk-map resource index of the
+		// cast library's config. In large movies it can exceed 0xFFFF (e.g.
+		// 0x00010402 = 66562), so it must be read as a full uint32 — reading it
+		// as uint16 truncates the high word and makes distinct libraries alias
+		// the same id (causing a union cast-load with overwritten members).
+		uint32 libResourceId = stream.readUint32();
 		uint16 libId = i + 1;
 		debugC(5, kDebugLoading, "Movie::loadCastLibMapping: name: %s, path: %s, minMember: %d, maxMember: %d, libResourceId: %d, libId: %d", utf8ToPrintable(name).c_str(), utf8ToPrintable(path).c_str(), minMember, maxMember, libResourceId, libId);
 		Common::SharedPtr<Archive> castArchive = _movieArchive;
@@ -493,7 +497,7 @@ bool Movie::loadCastLibFrom(uint16 libId, Common::Path &filename) {
 		return false;
 	}
 
-	uint16 libResourceId = 1024;
+	uint32 libResourceId = 1024;
 	Common::String name;
 	if (_casts.contains(libId)) {
 		Cast *cast = _casts[libId];
@@ -541,7 +545,7 @@ Cast *Movie::getCast(CastMemberID memberID) {
 	return nullptr;
 }
 
-Cast *Movie::getCastByLibResourceID(int libresourceID) {
+Cast *Movie::getCastByLibResourceID(uint32 libresourceID) {
 	for (auto it : _casts) {
 		if (it._value->_libResourceId == libresourceID) {
 			debugC(3, kDebugSaving, "Movie::getCastByLibResourceID: Found cast with libresourceID: %d", libresourceID);

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -51,6 +51,7 @@ Movie::Movie(Window *window) {
 	_lastClickedSpriteId = 0;
 	_currentSpriteNum = 0;
 	_currentEditableTextChannel = 0;
+	_currentMouseDownChannelId = 0;
 	_lastEventTime = _vm->getMacTicks();
 	_lastKeyTime = _lastEventTime;
 	_lastClickTime = _lastEventTime;

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -167,8 +167,18 @@ void Movie::loadCastLibMapping(Common::SeekableReadStreamEndian &stream) {
 		int pathSize = stream.readByte();
 		Common::String path = stream.readString('\0', pathSize);
 		stream.readByte(); // null
-		if (pathSize > 1)
-			stream.readUint16();
+		if (pathSize > 1) {
+			// The field separating a non-empty (external) cast path from the
+			// member-range/resource-id records is a single byte in D7, but a
+			// 16-bit field in D5/D6. Reading the wrong width shifts every
+			// following cast-lib entry by one byte, corrupting the name, member
+			// range and resource id of any library listed after an external one
+			// (e.g. an internal cast that follows an external .cxt).
+			if (g_director->getVersion() >= 700)
+				stream.readByte();
+			else
+				stream.readUint16();
+		}
 		uint16 minMember = stream.readUint16();
 		uint16 maxMember = stream.readUint16();
 		stream.readUint16();

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -105,7 +105,7 @@ public:
 	DirectorEngine *getVM() const { return _vm; }
 	Cast *getCast() const { return _casts.getValOrDefault(DEFAULT_CAST_LIB, nullptr); }
 	Cast *getCast(CastMemberID memberID);
-	Cast *getCastByLibResourceID(int libresourceID);
+	Cast *getCastByLibResourceID(uint32 libresourceID);
 	Cast *getSharedCast() const { return _sharedCast; }
 	const Common::HashMap<int, Cast *> *getCasts() const { return &_casts; }
 	Score *getScore() const { return _score; }

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -165,6 +165,7 @@ public:
 	CastMemberID _currentMouseDownCastID;
 	CastMemberID _currentMouseDownSpriteScriptID;
 	bool _currentMouseDownSpriteImmediate;
+	uint16 _currentMouseDownChannelId;	// D5+: sprite captured at mouseDown, reused for the paired mouseUp
 	uint16 _currentEditableTextChannel;
 	uint32 _lastEventTime;
 	uint32 _lastRollTime;

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -425,6 +425,9 @@ bool Score::isWaitingForNextFrame() {
 		if (movieChannel->isActiveVideo() && movieChannel->_movieRate != 0.0 && !goingTo) {
 			keepWaiting = true;
 		} else {
+			debugC(5, kDebugEvents, "Score::isWaitingForNextFrame(): video-wait ch%d done: active=%d rate=%g goingTo=%d",
+				_waitForVideoChannel, movieChannel->isActiveVideo(),
+				movieChannel->_movieRate, goingTo ? 1 : 0);
 			_waitForVideoChannel = 0;
 		}
 	} else if (g_system->getMillis() < _nextFrameTime) {
@@ -2000,7 +2003,8 @@ void Score::loadFrames(Common::SeekableReadStreamEndian &stream, uint16 version,
 
 				Common::MemoryReadStreamEndian *stream1 = getSpriteDetailsStream(i);
 				if (stream1) {
-					stream1->hexdump(stream1->size());
+					if (debugChannelSet(2, kDebugLoading))
+						stream1->hexdump(stream1->size());
 					delete stream1;
 				}
 			}

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -506,6 +506,16 @@ void Score::updateCurrentFrame() {
 		// This copies in the frame data and updates _curFrameNumber.
 		loadFrame(nextFrameNumberToLoad, true);
 
+		// Auto-puppeting (latched when a Lingo script changes a sprite
+		// property such as its member/ink/loc) lasts only until the playback
+		// head moves to another frame; the score then reasserts control.
+		// Manual puppetSprite is NOT affected. Without this reset the latch
+		// (e.g. kAPCast set by an animation in one room) would persist and make
+		// the channel ignore the next room's score data, leaving the previous
+		// scene's sprite drawn over the new one. (Director in a Nutshell, p.15.)
+		for (uint ch = 0; ch < _channels.size(); ch++)
+			_channels[ch]->_sprite->_autoPuppet = kAPNone;
+
 		// Finally, update the channels and buffer any dirty rectangles.
 		// This will ignore any channel data that is overridden with the puppet flag.
 		updateSprites(kRenderModeNormal, true);

--- a/engines/director/sound.cpp
+++ b/engines/director/sound.cpp
@@ -117,7 +117,10 @@ uint8 DirectorSound::getChannelVolume(int soundChannel) {
 void DirectorSound::setChannelDefaultVolume(int soundChannel) {
 	int vol = _volumes.getValOrDefault(soundChannel, g_director->_defaultVolume);
 
-	_channels[soundChannel]->volume = vol;
+	// _defaultVolume is the mixer SFX setting (0-kMaxMixerVolume=256); clamp before
+	// storing into the byte channel volume so a max (256) setting can't wrap to 0
+	// and silence the channel.
+	_channels[soundChannel]->volume = MIN(vol, 255);
 }
 
 void DirectorSound::setChannelPitchShift(int soundChannel, int pitchShiftPercent) {

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -368,6 +368,12 @@ bool Sprite::isActive() {
 	if (_cast && _cast->_type == kCastButton)
 		return true;
 
+	// D6+ sprites attach their scripts as behaviors rather than via the
+	// legacy score/cast script IDs, so a behavior-only sprite must still
+	// count as active (e.g. for `the clickOn`). Mirrors respondsToMouse().
+	if (g_director->getVersion() >= 600 && _behaviors.size() > 0)
+		return true;
+
 	return (_movie->getScriptContext(kScoreScript, _scriptId) != nullptr)
 			|| (_movie->getScriptContext(kCastScript, _castId) != nullptr);
 }

--- a/engines/director/xmed.cpp
+++ b/engines/director/xmed.cpp
@@ -1,0 +1,98 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/array.h"
+#include "common/stream.h"
+
+#include "director/director.h"
+#include "director/xmed.h"
+
+namespace Director {
+
+static bool isHexDigit(byte c) {
+	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+}
+
+static uint hexValue(byte c) {
+	if (c >= '0' && c <= '9')
+		return c - '0';
+	if (c >= 'A' && c <= 'F')
+		return c - 'A' + 10;
+	return c - 'a' + 10;
+}
+
+XMED::XMED(Cast *cast, Common::SeekableReadStreamEndian &stream) : _cast(cast), _isText(false) {
+	uint32 size = stream.size();
+	if (size < 4)
+		return;
+
+	Common::Array<byte> data(size);
+	if (stream.read(data.data(), size) != size)
+		return;
+
+	// The "Text" Asset Xtra serialization starts with the ASCII bytes "FFFF".
+	// Other XMED payloads (e.g. an embedded "PFR1" font from the "Font" Asset
+	// Xtra) are not text and are left alone.
+	if (memcmp(data.data(), "FFFF", 4) != 0)
+		return;
+
+	_isText = true;
+
+	// The displayed string is serialized as: 0x00 <ASCII hex length> ',' <raw bytes>.
+	// Scan for the first such record whose payload is predominantly printable;
+	// that is the editable text of the field.
+	for (uint32 i = 0; i + 2 < size; i++) {
+		if (data[i] != 0x00)
+			continue;
+
+		uint32 j = i + 1;
+		uint32 len = 0;
+		int digits = 0;
+		while (j < size && isHexDigit(data[j]) && digits < 6) {
+			len = len * 16 + hexValue(data[j]);
+			j++;
+			digits++;
+		}
+
+		if (digits == 0 || len == 0 || j >= size || data[j] != ',')
+			continue;
+		j++; // skip the ',' separator
+
+		if (j + len > size)
+			continue;
+
+		uint32 printable = 0;
+		for (uint32 k = 0; k < len; k++) {
+			byte c = data[j + k];
+			if ((c >= 0x20 && c <= 0x7e) || c >= 0x80 || c == '\r' || c == '\n' || c == '\t')
+				printable++;
+		}
+
+		// Require at least 80% printable to reject false matches.
+		if (printable * 5 < len * 4)
+			continue;
+
+		_text = Common::String((const char *)&data[j], len);
+		break;
+	}
+}
+
+} // End of namespace Director

--- a/engines/director/xmed.h
+++ b/engines/director/xmed.h
@@ -1,0 +1,56 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_XMED_H
+#define DIRECTOR_XMED_H
+
+#include "common/str.h"
+
+namespace Common {
+class SeekableReadStreamEndian;
+}
+
+namespace Director {
+
+class Cast;
+
+// XMED ("Xtra MEDia") is the child resource used by Director 7+ Xtra cast
+// members. The "Text" Asset Xtra stores its editable rich text here (a custom
+// serialized property list), while the "Font" Asset Xtra stores an embedded
+// PFR (Portable Font Resource) font.
+//
+// We only decode the Text Asset variant far enough to recover the displayed
+// string so it can be rendered through the regular text pipeline. The format
+// is a tagged property list where the displayed string is serialized as a
+// 0x00 byte, an ASCII hexadecimal byte-length, a ',' separator and then the
+// raw (platform-encoded) characters.
+class XMED {
+public:
+	XMED(Cast *cast, Common::SeekableReadStreamEndian &stream);
+
+	Cast *_cast;
+	bool _isText;            // true for the "Text" Asset Xtra, false otherwise (e.g. an embedded font)
+	Common::String _text;    // raw displayed text, platform encoded, with '\r' line breaks
+};
+
+} // End of namespace Director
+
+#endif

--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -769,7 +769,11 @@ int MacFontManager::getFamilyId(int newId, int newSlant) {
 	if (_fontInfo.contains(newId + newSlant)) {
 		return newId + newSlant;
 	}
-	warning("MacFontManager::getFamilyId(): No font with slant %d found, setting to kMacFontRegular", newSlant);
+	// A missing slant variant is an expected, graceful fallback (we render the
+	// regular face): many fonts — substitutes and non-FOND fonts in particular
+	// — have no separate slanted family registered. Log at debug level instead
+	// of spamming a warning on every styled run of such a font.
+	debugC(1, kDebugLevelMacGUI, "MacFontManager::getFamilyId(): No font with slant %d found, setting to kMacFontRegular", newSlant);
 	return newId;
 }
 


### PR DESCRIPTION
Detection and Director 7 (v700) engine support for Physikus / Physicus: Save the World with Science! (German/English/Italian/French, disc-based), developed against the German and Italian releases.

## Scope

- Game detection entries for the Italian edition (Físicus, l'Espresso)
- D7 (v700) format support: VWCF config/sound cast parsing, multi-castLib MCsL fixes, Lscr code-store/Lnam fixes, D7 sound cast members, D7 Font/Text/QuickTimeMedia Xtra cast member handling
- Several BuddyAPI (`budapi`) Xtra calls used by the game's settings/save system (`baReadIni`/`baWriteIni`/`baFileExists`/`baSoundCard`/`baReadRegString`)
- A handful of LINGO/engine correctness fixes surfaced while getting this specific title running (channel dirty-tracking for D6+ sprite behaviors, `divData()` VOID/zero-divisor guard, `getAt`/`count` on empty args, out-of-bounds `transformColor`, movie-script `pass()` dispatch, D5+ mouse-capture semantics for `mouseUp`, and others — see individual commit messages for the specific bug each one addresses)

Each commit is scoped to a single change with its rationale and (where applicable) how it was verified in the commit message.

## Status

Everything in the log has been exercised against the actual game (all three chapters reachable, savegames, disc-menu navigation) but this is still a single title's worth of testing. Open to splitting this into smaller PRs by area (detection / D7 format support / BuddyAPI / general engine fixes) if that's preferred for review — flagging that now rather than assuming a 37-commit PR is the right shape.

Assisted-by: Claude:claude-opus-4.8