### PR TITLE
DIRECTOR: Fix filmloop shift when swapping cast member with lingo

### DIFF
--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -456,6 +456,10 @@ void Channel::setCast(CastMemberID memberID) {
 		_sprite->_cast->releaseWidget();
 
 	bool hasChanged = _sprite->_castId != memberID;
+
+	// Save bbox before swapping cast so we can restore visual position afterward.
+	Common::Rect oldBbox = getBbox();
+
 	// Replace the cast member in the sprite.
 	// Only change the dimensions if the "stretch" flag is set,
 	// indicating that the sprite has already been warped away from cast
@@ -463,6 +467,14 @@ void Channel::setCast(CastMemberID memberID) {
 	// dimensions of the sprite, -then- change the cast ID, and expect
 	// those custom dimensions to stick around.
 	_sprite->setCast(memberID, !_sprite->_stretch);
+
+	// If the new cast member is a film loop, adjust _startPoint so the sprite
+	// stays at the same visual position regardless of registration offset changes.
+	if (hasChanged && _sprite->_cast && _sprite->_cast->_type == kCastFilmLoop) {
+		Common::Rect newBbox = getBbox();
+		_sprite->_startPoint.x += oldBbox.left - newBbox.left;
+		_sprite->_startPoint.y += oldBbox.top - newBbox.top;
+	}
 
 	// Duplicate of the special cases in setClean.
 	// Maybe it makes sense to force setClean to use setCast instead?


### PR DESCRIPTION
When set the castNum of sprite X to Y is called with a film loop cast member, the sprite's _startPoint was not adjusted to account for the difference in registration offset between the previous cast member (top-left, 0,0) and the film loop (center, width/2, height/2).

Fix by saving the visual bbox before the cast swap in Channel::setCast(), then adjusting _startPoint by the difference after the swap so the sprite stays at the same visual position on screen.

Fixes position shift of animal sprites when clicking film loops in shotgal.dir (guscarn-win).

