### PR TITLE
DIRECTOR: D7 loading/parsing fixes (Lscr/Lnam, MCsL, VWCF, sound) + Italian Physikus detection

### DIFF
--- a/engines/director/archive.cpp
+++ b/engines/director/archive.cpp
@@ -143,7 +143,7 @@ Common::SeekableReadStreamEndian *Archive::getFirstResource(uint32 tag) {
 	return getResource(tag, getResourceIDList(tag)[0]);
 }
 
-Common::SeekableReadStreamEndian *Archive::getFirstResource(uint32 tag, uint16 parentId) {
+Common::SeekableReadStreamEndian *Archive::getFirstResource(uint32 tag, uint32 parentId) {
 	return getResource(tag, getResourceIDList(tag)[0]);
 }
 
@@ -1022,7 +1022,7 @@ bool RIFXArchive::readAfterburnerMap(Common::SeekableReadStreamEndian &stream, u
 	return true;
 }
 
-void RIFXArchive::readCast(Common::SeekableReadStreamEndian &casStream, uint16 libResourceId) {
+void RIFXArchive::readCast(Common::SeekableReadStreamEndian &casStream, uint32 libResourceId) {
 	int castTag = MKTAG('C', 'A', 'S', 't');
 
 	uint casSize = casStream.size() / 4;
@@ -1100,7 +1100,7 @@ Common::SeekableReadStreamEndian *RIFXArchive::getFirstResource(uint32 tag, bool
 	return getResource(tag, getResourceIDList(tag)[0], fileEndianness);
 }
 
-Common::SeekableReadStreamEndian *RIFXArchive::getFirstResource(uint32 tag, uint16 parentId) {
+Common::SeekableReadStreamEndian *RIFXArchive::getFirstResource(uint32 tag, uint32 parentId) {
 	if (!_keyData.contains(tag))
 		return nullptr;
 	if (!_keyData[tag].contains(parentId))

--- a/engines/director/archive.h
+++ b/engines/director/archive.h
@@ -101,7 +101,7 @@ public:
 	bool hasResource(uint32 tag, const Common::String &resName) const;
 	virtual Common::SeekableReadStreamEndian *getResource(uint32 tag, uint16 id);
 	virtual Common::SeekableReadStreamEndian *getFirstResource(uint32 tag);
-	virtual Common::SeekableReadStreamEndian *getFirstResource(uint32 tag, uint16 parentId);
+	virtual Common::SeekableReadStreamEndian *getFirstResource(uint32 tag, uint32 parentId);
 	virtual Resource getResourceDetail(uint32 tag, uint16 id);
 	uint32 getOffset(uint32 tag, uint16 id) const;
 	uint getResourceSize(uint32 tag, uint16 id) const;
@@ -170,7 +170,7 @@ public:
 
 	Common::SeekableReadStreamEndian *getFirstResource(uint32 tag) override;
 	virtual Common::SeekableReadStreamEndian *getFirstResource(uint32 tag, bool fileEndianness);
-	Common::SeekableReadStreamEndian *getFirstResource(uint32 tag, uint16 parentId) override;
+	Common::SeekableReadStreamEndian *getFirstResource(uint32 tag, uint32 parentId) override;
 	Common::SeekableReadStreamEndian *getResource(uint32 tag, uint16 id) override;
 	virtual Common::SeekableReadStreamEndian *getResource(uint32 tag, uint16 id, bool fileEndianness);
 	Resource getResourceDetail(uint32 tag, uint16 id) override;
@@ -193,7 +193,7 @@ private:
 
 	bool readMemoryMap(Common::SeekableReadStreamEndian &stream, uint32 moreOffset, Common::SeekableMemoryWriteStream *dumpStream, uint32 movieStartOffset);
 	bool readAfterburnerMap(Common::SeekableReadStreamEndian &stream, uint32 moreOffset);
-	void readCast(Common::SeekableReadStreamEndian &casStream, uint16 libResourceId);
+	void readCast(Common::SeekableReadStreamEndian &casStream, uint32 libResourceId);
 	void readKeyTable(Common::SeekableReadStreamEndian &keyStream);
 
 	uint32 findParentIndex(uint32 tag, uint16 index);

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -449,18 +449,36 @@ bool Cast::loadConfig() {
 
 	_unk1 = stream->readSint16();
 
-	// Warning for post-D7 movies (unk1 is stageColorG and stageColorB post-D7)
-	if (humanVer >= 700)
-		warning("STUB: Cast::loadConfig: 16 bit unk1 read instead of two 8 bit stageColorG and stageColorB. Read value: %04x", _unk1);
+	// D7+: stageColorG is file byte 18, stageColorB is byte 19 (fixed
+	// offsets, so the split depends on the stream endianness); the raw
+	// 16-bit value is kept for checksum/save
+	if (humanVer >= 700) {
+		if (stream->isBE()) {
+			_D7stageColorG = (_unk1 >> 8) & 0xFF;
+			_D7stageColorB = _unk1 & 0xFF;
+		} else {
+			_D7stageColorG = _unk1 & 0xFF;
+			_D7stageColorB = (_unk1 >> 8) & 0xFF;
+		}
+	}
 
 	_commentFont = stream->readUint16();
 	_commentSize = stream->readUint16();
 	_commentStyle = stream->readUint16();
 	_stageColor = stream->readUint16();
 
-	// Warning for post-D7 movies (stageColor is isStageColorRGB and stageColorR post-D7)
-	if (humanVer >= 700)
-		warning("STUB: Cast::loadConfig: 16 bit stageColor read instead of two 8 bit isStageColorRGB and stageColorR. Read value: %04x", _stageColor);
+	// D7+: stageColorIsRGB is file byte 26, stageColorR is byte 27
+	if (humanVer >= 700) {
+		if (stream->isBE()) {
+			_D7stageColorIsRGB = (_stageColor >> 8) & 0xFF;
+			_D7stageColorR = _stageColor & 0xFF;
+		} else {
+			_D7stageColorIsRGB = _stageColor & 0xFF;
+			_D7stageColorR = (_stageColor >> 8) & 0xFF;
+		}
+		debugC(1, kDebugLoading, "Cast::loadConfig(): D7 stage color: isRGB %d, R %d, G %d, B %d",
+			_D7stageColorIsRGB, _D7stageColorR, _D7stageColorG, _D7stageColorB);
+	}
 
 	_bitdepth = stream->readUint16();
 
@@ -600,6 +618,7 @@ bool Cast::loadConfig() {
 	}
 
 	if (_movieDepth != _vm->_colorDepth) {
+		// TODO: switch Director and WindowManager to the requested color depth
 		warning("STUB: loadConfig(): Movie bit depth is %d, but set to %d", _movieDepth, _vm->_colorDepth);
 	}
 
@@ -1177,10 +1196,16 @@ uint32 Cast::computeChecksum() {
 	check -= (int8)_readRate + 9;
 	check -= _lightswitch + 10;
 
-	if (humanVer < 700)
-		check += _unk1 + 11;
-	else
-		warning("STUB: skipped using stageColorG, stageColorB for post-D7 movie in checksum calulation");
+	int32 operand11;
+	if (humanVer < 700) {
+		operand11 = _unk1;
+	} else {
+		// Reconstructs the int16 Director summed here pre-D7 (ProjectorRays)
+		operand11 = _castArchive->_isBigEndian
+			? (int16)((_D7stageColorG << 8) | _D7stageColorB)
+			: (int16)((_D7stageColorB << 8) | _D7stageColorG);
+	}
+	check += operand11 + 11;
 
 	check *= _commentFont + 12;
 	check += _commentSize + 13;
@@ -1190,10 +1215,8 @@ uint32 Cast::computeChecksum() {
 	else
 		check *= _commentStyle + 14;
 
-	if (humanVer < 700)
-		check += _stageColor + 15;
-	else
-		check += (uint8)(_stageColor & 0xFF) + 15;	// Taking lower 8 bits to take into account stageColorR
+	int32 operand15 = (humanVer < 700) ? _stageColor : _D7stageColorR;
+	check += operand15 + 15;
 
 
 	check += _bitdepth + 16;
@@ -2135,10 +2158,10 @@ void Cast::loadCastInfo(Common::SeekableReadStreamEndian &stream, uint16 id) {
 		}
 	}
 
-	// For SoundCastMember, read the flags in the CastInfo
-	if (_version >= kFileVer400 && _version < kFileVer700 && member->_type == kCastSound) {
+	// Looping = play-once bit (flags & 16) cleared; verified on D7 only
+	if (_version >= kFileVer400 && _version < kFileVer800 && member->_type == kCastSound) {
 		((SoundCastMember *)member)->_looping = castInfo.flags & 16 ? 0 : 1;
-	} else if (_version >= kFileVer700 && member->_type == kCastSound) {
+	} else if (_version >= kFileVer800 && member->_type == kCastSound) {
 		warning("STUB: Cast::loadCastInfo(): Sound cast member info not yet supported for version v%d (%d)", humanVersion(_version), _version);
 	}
 

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -64,7 +64,7 @@
 
 namespace Director {
 
-Cast::Cast(Movie *movie, uint16 castLibID, bool isShared, bool isExternal, uint16 libResourceId) {
+Cast::Cast(Movie *movie, uint16 castLibID, bool isShared, bool isExternal, uint32 libResourceId) {
 	_movie = movie;
 	_vm = _movie->getVM();
 	_lingo = _vm->getLingo();
@@ -807,7 +807,7 @@ void Cast::loadCast() {
 
 	// External casts only have one library ID, so instead
 	// we use the movie's mapping.
-	uint16 libResourceId = _isExternal ? 1024 : _libResourceId;
+	uint32 libResourceId = _isExternal ? 1024 : _libResourceId;
 
 	if (cast.size() > 0) {
 		debugC(2, kDebugLoading, "****** Loading CASt resources for libId %d (%s), resourceId %d", _castLibID, _castName.c_str(), libResourceId);

--- a/engines/director/cast.h
+++ b/engines/director/cast.h
@@ -86,7 +86,7 @@ struct TilePatternEntry {
 
 class Cast {
 public:
-	Cast(Movie *movie, uint16 castLibID, bool isShared = false, bool isExternal = false, uint16 libResourceId = 1024);
+	Cast(Movie *movie, uint16 castLibID, bool isShared = false, bool isExternal = false, uint32 libResourceId = 1024);
 	~Cast();
 
 	void loadArchive();
@@ -161,7 +161,7 @@ public:
 	Common::SharedPtr<Archive> _castArchive;
 	Common::Platform _platform;
 	uint16 _castLibID;
-	uint16 _libResourceId;
+	uint32 _libResourceId;
 	bool _isExternal;
 
 	CharMap _macCharsToWin;

--- a/engines/director/cast.h
+++ b/engines/director/cast.h
@@ -201,10 +201,10 @@ public:
 	// Director 6 and below
 		/* 18 */ int16 _unk1;	// Mentioned in ProjectorRays as preD7field11
 
-	// Director 7 and above
-	// Currently not supporting Director 7
-		// /* 18 */ int8 D7stageColorG;
-		// /* 19 */ int8 D7stageColorB;
+	// Director 7 and above: stageColorG at byte 18, stageColorB at byte 19;
+	// _unk1 keeps the raw 16-bit value for the VWCF checksum and save.
+		/* 18 */ uint8 _D7stageColorG;
+		/* 19 */ uint8 _D7stageColorB;
 
 	/* 20 */ uint16 _commentFont;
 	/* 22 */ uint16 _commentSize;
@@ -212,10 +212,10 @@ public:
 
 	// Director 6 and below
 		/* 26 */ uint16 _stageColor;
-	// Director 7 and above
-	// Currently not supporting Director 7
-		// /* 26 */ uint8 D7stageColorIsRGB;
-		// /* 27 */ uint8 D7stageColorR;
+	// Director 7 and above: stageColorIsRGB at byte 26, stageColorR at
+	// byte 27; _stageColor keeps the raw 16-bit value for checksum and save.
+		/* 26 */ uint8 _D7stageColorIsRGB;
+		/* 27 */ uint8 _D7stageColorR;
 
 	/* 28 */ uint16 _bitdepth;
 	/* 30 */ uint8 _field17;

--- a/engines/director/castmember/sound.cpp
+++ b/engines/director/castmember/sound.cpp
@@ -88,7 +88,7 @@ void SoundCastMember::load() {
 			tag = MKTAG('S', 'N', 'D', ' ');
 			sndId = (uint16)(_castId + _cast->_castIDoffset);
 		}
-	} else if (_cast->_version >= kFileVer600 && _cast->_version < kFileVer700) {
+	} else if (_cast->_version >= kFileVer600 && _cast->_version < kFileVer800) {
 		for (auto &it : _children) {
 			if (it.tag == MKTAG('s', 'n', 'd', ' ')) {
 				sndId = it.index;
@@ -143,7 +143,7 @@ void SoundCastMember::load() {
 		}
 
 	} else {
-		warning("STUB: SoundCastMember::SoundCastMember(): Sounds not yet supported for version v%d (%d)", humanVersion(_cast->_version), _cast->_version);
+		warning("STUB: SoundCastMember::load(): Sounds not yet supported for version v%d (%d)", humanVersion(_cast->_version), _cast->_version);
 	}
 
 

--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -9747,6 +9747,8 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1_l("physicus", "", "Physikus", "5d3f89e052320f8ce140451c730e232b", 114645, Common::FR_FRA, 702),
 	WINGAME1("physicus", "",   "Physicus.exe", "t:d2a772b412a278bda68bd64a00af9b04", 2298279, 702),
 	WINGAME1_l("physicus", "", "Physikus.exe", "t:89be052460986358d7e4724ebc940af6", 1816828, Common::DE_DEU, 702),
+	// Italian edition "Físicus", published by l'Espresso
+	WINGAME1_l("physicus", "", "Physikus.exe", "t:026868d136e559a3eca5445221d123f1", 1816876, Common::IT_ITA, 702),
 
 	WINDEMO2("planetstrass", "Demo", "Planet.exe", "t:a053c117847a545ef72aecb425fed9e7", 15434606,
 									 "strass.jpg", "d:d76c7387399626e7a3daef54cbcd6451",	39135, 702),

--- a/engines/director/graphics.cpp
+++ b/engines/director/graphics.cpp
@@ -44,6 +44,11 @@ uint32 DirectorEngine::transformColor(uint32 color) {
 	if (_pixelformat.bytesPerPixel == 1)
 		return color;
 
+	// A palette index can never exceed 0xff (max 256 colors); a larger value
+	// must be a packed RGB int from a Lingo color assignment (e.g. rgb()).
+	if (color > 0xff)
+		return _wm->findBestColor((color >> 16) & 0xff, (color >> 8) & 0xff, color & 0xff);
+
 	return _wm->findBestColor(_currentPalette[color * 3], _currentPalette[color * 3 + 1], _currentPalette[color * 3 + 2]);
 }
 

--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -1307,7 +1307,14 @@ ScriptContext *LingoCompiler::compileLingoV4(Common::SeekableReadStreamEndian &s
 		return nullptr;
 	}
 
-	uint32 codeStoreSize = functionsOffset - codeStoreOffset;
+	if (codeStoreOffset > (uint32)stream.size()) {
+		warning("Lscr code store offset 0x%x is out of bounds (size 0x%x)", codeStoreOffset, (uint32)stream.size());
+		return nullptr;
+	}
+
+	// D7+ may place the function table before the bytecode, so the code store
+	// must span the whole chunk, not [codeStoreOffset, functionsOffset)
+	uint32 codeStoreSize = (uint32)stream.size() - codeStoreOffset;
 	stream.seek(codeStoreOffset);
 	byte *codeStore = (byte *)malloc(codeStoreSize);
 	stream.read(codeStore, codeStoreSize);
@@ -1746,8 +1753,12 @@ void LingoArchive::addNamesV4(Common::SeekableReadStreamEndian &stream) {
 	uint16 offset = stream.readUint16();
 	uint16 count = stream.readUint16();
 
-	if ((uint32)stream.size() != size) {
-		warning("Lnam content missing");
+	// D7+ `size` may not match the stream length; validate offsets instead of bailing
+	if ((uint32)stream.size() != size)
+		debugC(1, kDebugCompile, "addNamesV4: Lnam size %u != stream size %u, proceeding", size, (uint32)stream.size());
+
+	if (offset > stream.size()) {
+		warning("Lnam names offset 0x%x out of bounds (size 0x%x)", offset, (uint32)stream.size());
 		return;
 	}
 
@@ -1756,6 +1767,10 @@ void LingoArchive::addNamesV4(Common::SeekableReadStreamEndian &stream) {
 	names.clear();
 
 	for (uint16 i = 0; i < count; i++) {
+		if (stream.eos() || (uint32)stream.pos() >= (uint32)stream.size()) {
+			warning("addNamesV4: ran out of data after %d of %d names", i, count);
+			break;
+		}
 		Common::String name = stream.readPascalString();
 
 		names.push_back(name);

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -182,8 +182,15 @@ void Movie::loadCastLibMapping(Common::SeekableReadStreamEndian &stream) {
 		}
 		uint16 minMember = stream.readUint16();
 		uint16 maxMember = stream.readUint16();
-		stream.readUint16();
-		uint16 libResourceId = stream.readUint16();
+		uint32 libResourceId;
+		if (g_director->getVersion() >= 700) {
+			// D7+: single 32-bit resource id; verified against a D7 specimen
+			// (0x00010402) that a 16-bit read would truncate.
+			libResourceId = stream.readUint32();
+		} else {
+			stream.readUint16(); // unknown/reserved; 0 in tested D5/D6 movies
+			libResourceId = stream.readUint16();
+		}
 		uint16 libId = i + 1;
 		debugC(5, kDebugLoading, "Movie::loadCastLibMapping: name: %s, path: %s, minMember: %d, maxMember: %d, libResourceId: %d, libId: %d", utf8ToPrintable(name).c_str(), utf8ToPrintable(path).c_str(), minMember, maxMember, libResourceId, libId);
 		Common::SharedPtr<Archive> castArchive = _movieArchive;
@@ -494,7 +501,7 @@ bool Movie::loadCastLibFrom(uint16 libId, Common::Path &filename) {
 		return false;
 	}
 
-	uint16 libResourceId = 1024;
+	uint32 libResourceId = 1024;
 	Common::String name;
 	if (_casts.contains(libId)) {
 		Cast *cast = _casts[libId];
@@ -542,7 +549,7 @@ Cast *Movie::getCast(CastMemberID memberID) {
 	return nullptr;
 }
 
-Cast *Movie::getCastByLibResourceID(int libresourceID) {
+Cast *Movie::getCastByLibResourceID(uint32 libresourceID) {
 	for (auto it : _casts) {
 		if (it._value->_libResourceId == libresourceID) {
 			debugC(3, kDebugSaving, "Movie::getCastByLibResourceID: Found cast with libresourceID: %d", libresourceID);

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -206,6 +206,12 @@ void Movie::loadCastLibMapping(Common::SeekableReadStreamEndian &stream) {
 		Cast *cast = nullptr;
 		if (_casts.contains(libId)) {
 			cast = _casts.getVal(libId);
+			// The default internal cast is created before the MCsL is parsed;
+			// adopt the authored resource id and name
+			if (!isExternal) {
+				cast->_libResourceId = libResourceId;
+				cast->setCastName(name);
+			}
 		} else {
 			cast = new Cast(this, libId, false, isExternal, libResourceId);
 			cast->setCastName(name);

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -167,8 +167,19 @@ void Movie::loadCastLibMapping(Common::SeekableReadStreamEndian &stream) {
 		int pathSize = stream.readByte();
 		Common::String path = stream.readString('\0', pathSize);
 		stream.readByte(); // null
-		if (pathSize > 1)
-			stream.readUint16();
+		if (pathSize > 1) {
+			// Separator after an external cast path: 1 byte in D7, uint16 in D5/D6.
+			// Not verified for D8+; falls back to the D7 (1-byte) guess with a warning.
+			uint16 ver = g_director->getVersion();
+			if (ver >= 700 && ver < 800) {
+				stream.readByte();
+			} else if (ver >= 800) {
+				warning("STUB: Movie::loadCastLibMapping(): cast-lib path separator width not verified for version v%d", ver);
+				stream.readByte();
+			} else {
+				stream.readUint16();
+			}
+		}
 		uint16 minMember = stream.readUint16();
 		uint16 maxMember = stream.readUint16();
 		stream.readUint16();

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -105,7 +105,7 @@ public:
 	DirectorEngine *getVM() const { return _vm; }
 	Cast *getCast() const { return _casts.getValOrDefault(DEFAULT_CAST_LIB, nullptr); }
 	Cast *getCast(CastMemberID memberID);
-	Cast *getCastByLibResourceID(int libresourceID);
+	Cast *getCastByLibResourceID(uint32 libresourceID);
 	Cast *getSharedCast() const { return _sharedCast; }
 	const Common::HashMap<int, Cast *> *getCasts() const { return &_casts; }
 	Score *getScore() const { return _score; }


### PR DESCRIPTION
This is the loading/parsing part of the earlier Physikus PR, split as requested: only fixes grounded in the file format, plus one detection entry. Event dispatch, Lingo semantics, rendering and Xtra changes will follow separately.

Contents:

- Detection entry for the Italian Physikus (Físicus, l'Espresso)
- D7 Lscr code store span and Lnam size check; before this no D7 bytecode compiled at all
- transformColor() out-of-bounds read for packed rgb() colors
- MCsL: the field after an external cast path is one byte in D7, not uint16; every cast library listed after an external one loaded zero members
- MCsL: the cast-library resource id is 32-bit in D7; ids above 0xFFFF were truncated and collided with other libraries
- D7 sound cast members, same snd/sndH/sndS layout as D6
- D7 VWCF config parsing and checksum, following ProjectorRays
- The pre-created internal cast now adopts the resource id and name from its MCsL entry

D7-specific paths are version-gated; anything not verified beyond D7 is bounded < kFileVer800 and D8+ keeps a STUB warning.