### PR TITLE
AUDIO: Atari TOS hardware / software OPL2 / 3 (YM262 / YM3812)

### DIFF
--- a/audio/nfmopl.cpp
+++ b/audio/nfmopl.cpp
@@ -32,10 +32,6 @@
 #include "audio/fmopl.h"
 #include "audio/nfmopl.h"
 
-#ifdef ATARI
-#include <hwinfo.h>
-#endif
-
 #include <nfmoplshadowregs.h>
 
 #ifndef RELEASE_BUILD
@@ -135,11 +131,6 @@ namespace RealChip {
 OPL::OPL(Config::OplType type, NfmOPL::OplDevice deviceType) : _type(type), _deviceType(deviceType), _activeReg(0), _initialized(false), _useBuffer(NFM_ENABLE_BUFFERED_OUTPUT), _incapableDevice(false) {
 #if NFM_ENABLE_LOGS
 	debug("NfmOPL::RealChip create");
-	debug("Requesting hardware info");
-#endif
-
-#ifdef ATARI
-	Supexec(scOsUpdateHardwareInfo);
 #endif
 
 	// defaults
@@ -283,6 +274,7 @@ OPL::~OPL() {
 		_oplReset = nullptr;
 
 		(void)nfDestroyInterface(&_iface);
+		(void)nfDeinit();
 
 		_incapableDevice = false;
 		_useBuffer = false;
@@ -457,11 +449,6 @@ namespace EmulatedChip {
 OPL::OPL(Config::OplType type, enum NfmOPL::OplDevice deviceType): _type(type), _rate(0), _deviceType(deviceType), _activeReg(0), _initialized(false), _useBuffer(NFM_ENABLE_BUFFERED_OUTPUT), _incapableDevice(false) {
 #if NFM_ENABLE_LOGS
 	debug("NfmOPL::EmulatedChip create");
-	debug("Requesting hardware info");
-#endif
-
-#ifdef ATARI
-	Supexec(scOsUpdateHardwareInfo);
 #endif
 	
 	// defaults
@@ -537,7 +524,7 @@ OPL::~OPL() {
 		_generateAudioStream = nullptr;
 
 		(void)nfDestroyInterface(&_iface);
-
+		(void)nfDeinit();
 		_incapableDevice = false;
 		_useBuffer = false;
 		_initialized = false;

--- a/audio/nfmopl.h
+++ b/audio/nfmopl.h
@@ -61,7 +61,7 @@ class OPL : public ::OPL::OPL, public Audio::RealChip {
 private:
 	Config::OplType _type;
 	OplDevice _deviceType;
-	sOplInterface _iface;
+	sFmInterface _iface;
 	funcPtrOplWrite _oplWrite;
 	funcPtrOplWrite _oplEnqueWrite;
 	funcPtrOplFlush _oplFlush;
@@ -95,7 +95,7 @@ class OPL : public ::OPL::OPL, public Audio::EmulatedChip {
 private:
 	Config::OplType _type;
 	OplDevice _deviceType;
-	sOplInterface _iface;
+	sFmInterface _iface;
 	funcPtrOplWrite _oplWrite;
 	funcPtrOplWrite _oplEnqueWrite;
 	funcPtrOplFlush _oplFlush;

--- a/backends/platform/atari/get-nfm.sh
+++ b/backends/platform/atari/get-nfm.sh
@@ -4,8 +4,8 @@
 # -x: Display expanded script commands
 
 # downloads and unpacks in ./deps folder precompiled nFM library release for m68k Atari TOS / mintelf gcc stdlib
-NFM_VERSION=0.3.0
-COMMIT_SHORT_SHA=ee64d5f7
+NFM_VERSION=0.4.0
+COMMIT_SHORT_SHA=3f970a17
 
 curl -o ./backends/platform/atari/nfm.zip https://nokturnal.pl/downloads/atari/nokturnfm/nfmplay/builds/releases/${NFM_VERSION}/ataritos-mintelf-gcc-stdlib-m68k-${NFM_VERSION}-${COMMIT_SHORT_SHA}.zip
 rm -rf ./backends/platform/atari/deps/nfm

--- a/configure
+++ b/configure
@@ -5639,7 +5639,7 @@ if test "$_nfm" = auto ; then
 #include <nfmcore.h>
 #include <nfmutil.h>
 
-sOplInterface gOplIf;
+sFmInterface gOplIf;
 
 int main(void)
 {


### PR DESCRIPTION
- Removed Atari specific calls / ifdefs,
- Moved Atari specific calls to nfInit() internals, 
- Added missing nfDeinit() calls, 
- Bumped up nFM library version to 0.4.0, so some nFM types had to be updated.