### PR TITLE
BACKENDS: ATARI: Build fix

### DIFF
--- a/backends/plugins/elf/version.cpp
+++ b/backends/plugins/elf/version.cpp
@@ -25,7 +25,7 @@
 #ifdef USE_ELF_LOADER
 	const char *gScummVMPluginBuildDate __attribute__((visibility("hidden"))) =
 #if defined(RELEASE_BUILD)
-		SCUMMVM_VERSION;
+		gScummVMVersion;
 #else
 		__DATE__ " " __TIME__;
 #endif


### PR DESCRIPTION
Build fix related to SCUMMVM_VERSION removal (triggered with --enable-release). @sev- 