### PR TITLE
SDL: Fix game cursor position at scale factors above 1x

### DIFF
--- a/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
+++ b/backends/graphics/surfacesdl/surfacesdl-graphics.cpp
@@ -2521,10 +2521,19 @@ void SurfaceSdlGraphicsManager::undrawMouse() {
 	_mouseNextRect.x = virtualCursor.x + _gameScreenShakeXOffset;
 	_mouseNextRect.y = virtualCursor.y + _gameScreenShakeYOffset;
 
-	_mouseNextRect.w = _mouseCurState.rW;
-	_mouseNextRect.h = _mouseCurState.rH;
-	_mouseNextRect.x -= _mouseCurState.rHotX;
-	_mouseNextRect.y -= _mouseCurState.rHotY;
+	if (!_overlayInGUI) {
+		// The game cursor rect is kept in virtual coordinates: drawMouse()
+		// scales and aspect-corrects it, so subtract the virtual hotspot here
+		_mouseNextRect.w = _mouseCurState.vW;
+		_mouseNextRect.h = _mouseCurState.vH;
+		_mouseNextRect.x -= _mouseCurState.vHotX;
+		_mouseNextRect.y -= _mouseCurState.vHotY;
+	} else {
+		_mouseNextRect.w = _mouseCurState.rW;
+		_mouseNextRect.h = _mouseCurState.rH;
+		_mouseNextRect.x -= _mouseCurState.rHotX;
+		_mouseNextRect.y -= _mouseCurState.rHotY;
+	}
 
 	if (!_cursorVisible || !_mouseSurface) {
 		_mouseNextRect.x = _mouseNextRect.y = _mouseNextRect.w = _mouseNextRect.h = 0;
@@ -2535,14 +2544,14 @@ void SurfaceSdlGraphicsManager::undrawMouse() {
 	// alpha-blended cursors will happily blend into themselves if the surface
 	// under the cursor is not reset first
 	//
-	// The mouse is undrawn using real coordinates, i.e. they have already
-	// been scaled and aspect-ratio corrected.
+	// The mouse is undrawn using virtual coordinates, i.e. they may be
+	// scaled and aspect-ratio corrected.
 
 	if (_mouseLastRect.w != 0 && _mouseLastRect.h != 0)
-		addDirtyRect(_mouseLastRect.x, _mouseLastRect.y, _mouseLastRect.w, _mouseLastRect.h, true);
+		addDirtyRect(_mouseLastRect.x, _mouseLastRect.y, _mouseLastRect.w, _mouseLastRect.h, _overlayInGUI);
 
 	if (_mouseNextRect.w != 0 && _mouseNextRect.h != 0)
-		addDirtyRect(_mouseNextRect.x, _mouseNextRect.y, _mouseNextRect.w, _mouseNextRect.h, true);
+		addDirtyRect(_mouseNextRect.x, _mouseNextRect.y, _mouseNextRect.w, _mouseNextRect.h, _overlayInGUI);
 }
 
 void SurfaceSdlGraphicsManager::drawMouse() {


### PR DESCRIPTION
Since commit 925c8d3e1fa ("BACKENDS: Allow cursors to be scaled relative to the game screen"), the in-game cursor on the SurfaceSDL graphics manager is drawn hotspot * (scaleFactor - 1) pixels up and left of the position the engine receives from mouse events (e.g. 7px at 2x for a (7,7) hotspot, more on Y with aspect ratio correction). 

That commit dropped the !_overlayInGUI branch in undrawMouse(), so the scaled hotspot (rHotX) is now subtracted from the virtual (unscaled) cursor coordinates, and drawMouse() then multiplies the rect by the scale factor a second time. The cursor-scaling feature itself is untouched by this PR — it only restores the virtual-coordinate branch for the game cursor and passes the dirty rects in the coordinate space they are actually in (_overlayInGUI flag), as before the regression.

Found while testing CHAMBER: door hotspots are only a few pixels wide, so the offset made them nearly impossible to hit. Verified in-game by drawing a marker at the engine's logical cursor position and comparing it with the drawn cursor — they now coincide at all scale factors.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
