### PR TITLE
Support "obfuscated" version of Nancy 10

### DIFF
--- a/common/compression/installshield_cab.cpp
+++ b/common/compression/installshield_cab.cpp
@@ -83,6 +83,41 @@ bool inflateZlibInstallShield(byte *dst, uint dstLen, const byte *src, uint srcL
 	return true;
 }
 
+class SeekableDeobfuscationReadStream : public SeekableReadStream {
+protected:
+	DisposablePtr<SeekableReadStream> _parentStream;
+
+public:
+	SeekableDeobfuscationReadStream(SeekableReadStream *parentStream)
+		: _parentStream(parentStream, DisposeAfterUse::YES) {
+		assert(parentStream);
+	}
+
+	bool err() const override { return _parentStream->err(); }
+	void clearErr() override { _parentStream->clearErr(); }
+
+	bool eos() const override { return _parentStream->eos(); }
+
+	int64 pos() const override { return _parentStream->pos(); }
+	int64 size() const override { return _parentStream->size(); }
+	bool seek(int64 offset, int whence = SEEK_SET) { return _parentStream->seek(offset, whence); }
+
+#define ror8(x,n)   (((x) >> ((int)(n))) | ((x) << (8 - (int)(n))))
+
+	uint32 read(void *dataPtr, uint32 dataSize) override {
+		uint32 seed = _parentStream->pos();
+		uint32 res = _parentStream->read(dataPtr, dataSize);
+
+		byte *ptr = (byte *)dataPtr;
+
+		for (uint32 i = 0; i < dataSize; i++) {
+			ptr[i] = ror8(ptr[i] ^ 0xD5, 2) - ((seed + i) % 0x47);
+		}
+
+		return res;
+	}
+};
+
 class InstallShieldCabinet : public Archive {
 public:
 	InstallShieldCabinet();
@@ -133,6 +168,7 @@ private:
 
 	Path getHeaderName() const;
 	Path getVolumeName(uint volume) const;
+	SeekableReadStream *createReadStreamForMemberHelper(const Path &path) const;
 };
 
 InstallShieldCabinet::InstallShieldCabinet() : _version(0), _archive(nullptr) {
@@ -351,12 +387,17 @@ SeekableReadStream *InstallShieldCabinet::createReadStreamForMember(const Path &
 	if (!_map.contains(path))
 		return nullptr;
 
-	const FileEntry &entry = _map[path];
+	SeekableReadStream *stream = createReadStreamForMemberHelper(path);
 
-	if (entry.flags & kObfuscated) {
-		warning("Cannot extract obfuscated file %s", path.toString().c_str());
-		return nullptr;
-	}
+	const FileEntry &entry = _map[path];
+	if (entry.flags & kObfuscated)
+		stream = new SeekableDeobfuscationReadStream(stream);
+
+	return stream;
+}
+
+SeekableReadStream *InstallShieldCabinet::createReadStreamForMemberHelper(const Path &path) const {
+	const FileEntry &entry = _map[path];
 
 	ScopedPtr<SeekableReadStream> stream;
 	if (_archive) {
@@ -449,7 +490,7 @@ bool InstallShieldCabinet::readVolumeHeader(SeekableReadStream *volumeStream, In
 		return false;
 	}
 
-	// We support cabinet versions 5 - 13, but do not deobfuscate obfuscated files
+	// We support cabinet versions 5 - 13
 
 	uint32 magicBytes = volumeStream->readUint32LE();
 	int shift = magicBytes >> 24;

--- a/engines/nancy/detection_tables.h
+++ b/engines/nancy/detection_tables.h
@@ -755,7 +755,7 @@ static const NancyGameDescription gameDescriptions[] = {
 			},
 			Common::EN_ANY,
 			Common::kPlatformWindows,
-			ADGF_UNSTABLE | ADGF_DROPPLATFORM,
+			ADGF_UNSTABLE | ADGF_DROPPLATFORM | GF_COMPRESSED,
 			NANCY8_GUIOPTIONS
 		},
 		kGameTypeNancy10


### PR DESCRIPTION
My copy of Nancy 10 (The Secret of Shadow Ranch) is currently detected by ScummVM as v1.01 from Nancy Drew: Ultimate Dare, MD5 by eientei95. However, it doesn't start because it can't find the boot script. The reason for this is twofold:

* A lot (most? all?) of the files in the InstallShield cabinet files have the "obfuscated" flag, which our InstallShield unpacker detects by doesn't handle.

* The detection entry is missing the `GF_COMPRESSION` flag, which means it won't try to read data from the cabinet files.

This pull request splits `InstallShieldCabinet::createReadStreamForMember()` into a helper method (which is almost identical to the old method) and a main method which will wrap the created stream in a `SeekableDeobfuscationReadStream` if necessary. I _think_ this is a clean approach to the problem, but I could have messed up in my implementation of it of course.

Note that I'm not familiar with the game at all. I have started it and walked around a bit. Many of the files it's reading are obfuscated, and since the game didn't crash I assume it worked. I've also started one of the non-obfuscated Nancy games, and didn't notice any regression.