### PR TITLE
MM: XEEN: Fix cutscene subtitle rendering

### DIFF
--- a/engines/mm/xeen/font.cpp
+++ b/engines/mm/xeen/font.cpp
@@ -353,6 +353,31 @@ const char *FontSurface::writeString(const Common::String &s, const Common::Rect
 	return _displayString;
 }
 
+const char *FontSurface::fitToWidth(const char *s, int maxWidth) {
+	const char *strSave = _displayString;
+
+	for (;;) {
+		// Measure the rendered width of the string
+		_displayString = s;
+		int total = 0;
+		while (*_displayString && !getNextCharWidth(total)) {
+		}
+
+		// writeString wraps once its running position reaches the right
+		// edge, so the text only fits if it stays strictly narrower
+		if (total < maxWidth || !*s)
+			break;
+
+		// Too wide, so drop the leading character and remeasure
+		_displayString = s;
+		getNextChar();
+		s = _displayString;
+	}
+
+	_displayString = strSave;
+	return s;
+}
+
 void FontSurface::writeCharacter(uint16_t c, const Common::Rect &clipRect) {
 	Justify justify = _fontJustify;
 	_fontJustify = JUSTIFY_NONE;

--- a/engines/mm/xeen/font.cpp
+++ b/engines/mm/xeen/font.cpp
@@ -363,6 +363,32 @@ void FontSurface::writeCharacter(uint16_t c, const Common::Rect &clipRect) {
 	_fontJustify = justify;
 }
 
+// The French version stores accented characters as their code page 437
+// codes, while its font keeps the corresponding glyphs in repurposed ASCII
+// slots, so translate the former into the latter
+static uint16_t frenchChar(byte c) {
+	switch (c) {
+	case 0x81: return 0x5E;   // u with diaeresis
+	case 0x82: return 0x24;   // e with acute accent
+	case 0x83: return 0x26;   // a with circumflex
+	case 0x85: return 0x5D;   // a with grave accent
+	case 0x87: return 0x7D;   // c with cedilla
+	case 0x88: return 0x23;   // e with circumflex
+	case 0x8A: return 0x25;   // e with grave accent
+	case 0x8B: return 0x5F;   // i with diaeresis
+	case 0x8C: return 0x7B;   // i with circumflex
+	case 0x93: return 0x5B;   // o with circumflex
+	case 0x96: return 0x3D;   // u with circumflex
+	case 0x97: return 0x5C;   // u with grave accent
+	case 0x80: return 'C';    // capital C with cedilla, which has no glyph
+	case 0x90: return 'E';    // capital E with acute accent, which has no glyph
+	default:
+		// Never let an unknown high byte become a control code
+		c &= 0x7f;
+		return (c < ' ') ? ' ' : c;
+	}
+}
+
 uint16_t FontSurface::getNextChar() {
 	if (_isBig5) {
 		uint8_t lead = *_displayString++;
@@ -371,6 +397,8 @@ uint16_t FontSurface::getNextChar() {
 		return (lead << 8) | (*_displayString++ & 0xff);
 	} else if (Common::RU_RUS == lang)
 		return *_displayString++ & 0xff;
+	else if (Common::FR_FRA == lang && (*_displayString & 0x80))
+		return frenchChar(*_displayString++ & 0xff);
 	else
 		return *_displayString++ & 0x7f;
 }

--- a/engines/mm/xeen/font.h
+++ b/engines/mm/xeen/font.h
@@ -117,6 +117,16 @@ public:
 	 *		justification is set, the message will be written at _writePos
 	 */
 	const char *writeString(const Common::String &s, const Common::Rect &clipRect, bool ttsVoiceText = true, Common::String *ttsMessage = nullptr);
+
+	/**
+	 * Returns the tail of a plain text string, dropping as many leading
+	 * characters as necessary for the rendered text to be narrower than
+	 * the given pixel width, and so display without wrapping
+	 * @param s			String to fit; measuring stops at any control code
+	 * @param maxWidth	Pixel width the rendered string must stay below
+	 * @returns			Pointer within s to the portion that fits
+	 */
+	const char *fitToWidth(const char *s, int maxWidth);
 	bool isSpace(char c);
 	/**
 	 * Write a charcter to the window

--- a/engines/mm/xeen/subtitles.cpp
+++ b/engines/mm/xeen/subtitles.cpp
@@ -24,12 +24,16 @@
 #include "mm/xeen/subtitles.h"
 #include "mm/xeen/events.h"
 #include "mm/xeen/files.h"
+#include "mm/xeen/screen.h"
 #include "mm/xeen/xeen.h"
 
 namespace MM {
 namespace Xeen {
 
 static const char *SUBTITLE_LINE = "\f35\x3""c\v190\t000%s";
+
+// Bounds of the subtitle box (box.vga frame 0, an opaque 255x11 panel)
+static constexpr Common::Rect SUBTITLE_BOX(Common::Point(36, 189), 255, 11);
 
 Subtitles::Subtitles() : _lineNum(-1), _boxSprites(nullptr), _lineEnd(0), _lineSize(0) {
 }
@@ -145,19 +149,24 @@ void Subtitles::show() {
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
 		if (timeElapsed() && (_lineEnd != _lineSize || !ttsMan || !ttsMan->isSpeaking())) {
 			_lineEnd = (_lineEnd + 1) % (_lineSize + 1);
-			int count;
-			if (Common::RU_RUS == g_vm->getLanguage())
-				count = MAX(_lineEnd - 36, 0);
-			else
-				count = MAX(_lineEnd - 40, 0);
+			int count = MAX(_lineEnd - 40, 0);
 
 			// Get the portion of the line to display
 			char buffer[1000];
 			strncpy(buffer, _lines[_lineNum].c_str() + count, _lineEnd - count);
 			buffer[_lineEnd - count] = '\0';
 
+			// The character-based cap above doesn't bound the pixel width of
+			// the variable-width font, so drop further leading characters
+			// until the text fits within the subtitle box, whose opaque
+			// interior then erases the previous text on each redraw. The
+			// text is centered on the screen, so it stays inside the box as
+			// long as it doesn't reach the box's left edge
+			const char *text = windows[0].fitToWidth(buffer,
+				2 * (SCREEN_WIDTH / 2 - SUBTITLE_BOX.left));
+
 			// Form the display line
-			_displayLine = Common::String::format(SUBTITLE_LINE, buffer);
+			_displayLine = Common::String::format(SUBTITLE_LINE, text);
 			markTime();
 		}
 
@@ -165,10 +174,15 @@ void Subtitles::show() {
 		if (!_boxSprites)
 			// Not already loaded, so load it
 			_boxSprites = new SpriteResource("box.vga");
-		_boxSprites->draw(0, 0, Common::Point(36, 189));
+		_boxSprites->draw(0, 0, Common::Point(SUBTITLE_BOX.left, SUBTITLE_BOX.top));
 
 		// Write the subtitle line
 		windows[0].writeString(_displayLine, false);
+
+		// The subtitles are redrawn more often than the scenes showing them
+		// redraw the screen, so always push the whole box out, so that a
+		// partially drawn line never lingers over a more recent one
+		windows[0].addDirtyRect(SUBTITLE_BOX);
 
 		if (_lineEnd == 0 && (!ttsMan || !ttsMan->isSpeaking()))
 			reset();

--- a/engines/mm/xeen/subtitles.cpp
+++ b/engines/mm/xeen/subtitles.cpp
@@ -147,8 +147,15 @@ void Subtitles::show() {
 		reset();
 	} else {
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
-		if (timeElapsed() && (_lineEnd != _lineSize || !ttsMan || !ttsMan->isSpeaking())) {
-			_lineEnd = (_lineEnd + 1) % (_lineSize + 1);
+		bool speaking = sound.isSoundPlaying() || (ttsMan && ttsMan->isSpeaking());
+
+		if (timeElapsed() && (_lineEnd != _lineSize || !speaking)) {
+			// Advance the reveal. The original reveals one character per
+			// interval, which was tuned for the English lines; localized
+			// lines can be much longer, so scale the step with the length
+			// to keep long lines from lagging behind the voice
+			int step = 1 + _lineSize / 100;
+			_lineEnd = (_lineEnd == _lineSize) ? 0 : MIN(_lineEnd + step, _lineSize);
 			int count = MAX(_lineEnd - 40, 0);
 
 			// Get the portion of the line to display
@@ -184,7 +191,7 @@ void Subtitles::show() {
 		// partially drawn line never lingers over a more recent one
 		windows[0].addDirtyRect(SUBTITLE_BOX);
 
-		if (_lineEnd == 0 && (!ttsMan || !ttsMan->isSpeaking()))
+		if (_lineEnd == 0 && !speaking)
 			reset();
 	}
 }

--- a/engines/mm/xeen/subtitles.cpp
+++ b/engines/mm/xeen/subtitles.cpp
@@ -143,8 +143,8 @@ void Subtitles::show() {
 		reset();
 	} else {
 		Common::TextToSpeechManager *ttsMan = g_system->getTextToSpeechManager();
-		if (timeElapsed() && (_lineEnd != _lineSize - 1 || !ttsMan || !ttsMan->isSpeaking())) {
-			_lineEnd = (_lineEnd + 1) % _lineSize;
+		if (timeElapsed() && (_lineEnd != _lineSize || !ttsMan || !ttsMan->isSpeaking())) {
+			_lineEnd = (_lineEnd + 1) % (_lineSize + 1);
 			int count;
 			if (Common::RU_RUS == g_vm->getLanguage())
 				count = MAX(_lineEnd - 36, 0);


### PR DESCRIPTION
This fixes several issues with the cutscene subtitles, while
investigating garbled and misplaced subtitle text in the French DOS
version of World of Xeen. Main issue was with accented char in french:

- Translate the French CP437 accented characters (0x82 for e-acute,
  0x8A for e-grave, ...) to the repurposed ASCII slots where the
  French font keeps its accented glyphs. They previously fell into
  font control codes, garbling the line or pushing text below the
  subtitle box.

- Fix an off-by-one that kept the last character of every line from
  being revealed, and a division by zero on empty lines.

- Fit the visible portion of the line within the subtitle box by
  rendered pixel width instead of a fixed character count, so wide
  windows no longer word-wrap below the box or get truncated. 
This supersedes the Russian-specific 36-character cap.

- Scale the reveal speed with the line length (one extra character
  per 100 characters) so long localized lines don't lag behind the
  voice, and keep the fully revealed line on screen while the voice
  line is playing.

Tested by playing the intro cutscenes of the French DOS World of Xeen
with voice and subtitles enabled: the subtitles no longer overwrite
each other, accents render correctly and the text keeps pace with the
animation. 

The full engine builds and each commit compiles individually.

I could only test with the French and English data, 
so this would deserve a pass with the other localizations,
notably Russian, whose subtitle window now stays inside
the box where it previously spilled beyond it.