### PR TITLE
LURE: Improve two cases of pathfinding

### DIFF
--- a/engines/lure/hotspots.cpp
+++ b/engines/lure/hotspots.cpp
@@ -4140,6 +4140,21 @@ void HotspotTickHandlers::npcRoomChange(Hotspot &h) {
 	RoomExitCoordinates &coords = res.coordinateList().getEntry(srcRoom);
 	RoomExitCoordinateData &exitData = coords.getData(destRoom);
 
+	// If the routing to an intermediate next-hop room leads straight back to srcRoom,
+	// the target is unreachable (routing cycle); give up and stay put in the current room.
+	uint16 nextHop = exitData.roomNumber & 0xff;
+	if ((nextHop != 0) && (nextHop != destRoom)) {
+		RoomExitCoordinates& nextHopCoords = res.coordinateList().getEntry(nextHop);
+		RoomExitCoordinateData& nextHopExitData = nextHopCoords.getData(destRoom);
+		uint16 backHop = nextHopExitData.roomNumber & 0xff;
+
+		if (backHop == srcRoom) {
+			h.currentActions().top().setRoomNumber(h.roomNumber());
+			h.setExitCtr(0);
+			return;
+		}
+	}
+
 	if (h.hotspotId() != RATPOUCH_ID) {
 		// Count up the number of characters in the room
 		HotspotList &list = res.activeHotspots();

--- a/engines/lure/hotspots.cpp
+++ b/engines/lure/hotspots.cpp
@@ -1721,8 +1721,14 @@ void Hotspot::doTalkTo(HotspotData *hotspot) {
 		}
 	}
 
+	// Only start a conversation if the character actually has one defined for the
+	// current talk index.
+	uint16 talkId = getTalkId(hotspot);
+	if (talkId == 0)
+		return;
+
 	// Start talking with character
-	startTalk(hotspot, getTalkId(hotspot));
+	startTalk(hotspot, talkId);
 }
 
 void Hotspot::doTell(HotspotData *hotspot) {

--- a/engines/lure/hotspots.cpp
+++ b/engines/lure/hotspots.cpp
@@ -56,6 +56,7 @@ Hotspot::Hotspot(HotspotData *res): _pathFinder(this) {
 	_destX = res->startX;
 	_destY = res->startY;
 	_destHotspotId = 0;
+	_walkToHotspotId = 0;
 	_frameWidth = res->width;
 	_frameStartsUsed = false;
 	_height = res->height;
@@ -101,6 +102,7 @@ Hotspot::Hotspot(Hotspot *character, uint16 objType): _pathFinder(this) {
 	_override = nullptr;
 	_colorOffset = 0;
 	_destHotspotId = character->hotspotId();
+	_walkToHotspotId = 0;
 	_blockedOffset = 0;
 	_exitCtr = 0;
 	_voiceCtr = 0;
@@ -172,6 +174,7 @@ Hotspot::Hotspot(): _pathFinder(nullptr) {
 	_override = nullptr;
 	_colorOffset = 0;
 	_destHotspotId = 0;
+	_walkToHotspotId = 0;
 	_blockedOffset = 0;
 	_exitCtr = 0;
 	_voiceCtr = 0;
@@ -492,6 +495,7 @@ void Hotspot::walkTo(int16 endPosX, int16 endPosY, uint16 destHotspot) {
 	_destX = endPosX;
 	_destY = endPosY;
 	_destHotspotId = destHotspot;
+	_walkToHotspotId = 0;
 	currentActions().addFront(START_WALKING, _roomNumber);
 }
 
@@ -606,6 +610,7 @@ void Hotspot::setRandomDest() {
 	else
 		currentActions().top().setAction(START_WALKING);
 	_walkFlag = true;
+	setWalkToHotspot(0);
 
 	// Try up to 20 times to find an unoccupied destination
 	for (int tryCtr = 0; tryCtr < 20; ++tryCtr) {
@@ -1100,6 +1105,7 @@ bool Hotspot::characterWalkingCheck(uint16 id) {
 	int16 xp, yp;
 	bool altFlag;
 	HotspotData *hotspot;
+	uint16 walkToHotspotId = 0;
 
 	// Note that several invalid hotspot Ids are used to identify special walk to
 	// coordinates used throughout the game
@@ -1137,6 +1143,7 @@ bool Hotspot::characterWalkingCheck(uint16 id) {
 			yp = hotspot->walkY & 0x7fff;
 			altFlag = (hotspot->walkY & 0x8000) != 0;
 		}
+		walkToHotspotId = id;
 		break;
 	}
 
@@ -1146,6 +1153,7 @@ bool Hotspot::characterWalkingCheck(uint16 id) {
 			((((y() + heightCopy()) >> 3) - 1) != (yp >> 3))) {
 			// Walk to the specified destination
 			walkTo(xp, yp);
+			setWalkToHotspot(walkToHotspotId);
 			return true;
 		} else {
 			return false;
@@ -1156,6 +1164,7 @@ bool Hotspot::characterWalkingCheck(uint16 id) {
 	if ((ABS(x() - xp) >= 8) ||
 		(ABS(y() + heightCopy() - yp - 1) >= 19)) {
 		walkTo(xp, yp);
+		setWalkToHotspot(walkToHotspotId);
 		return true;
 	}
 

--- a/engines/lure/hotspots.h
+++ b/engines/lure/hotspots.h
@@ -214,7 +214,8 @@ private:
 	uint16 _frameCtr;
 	uint8 _voiceCtr;
 	int16 _destX, _destY;
-	uint16 _destHotspotId;
+	uint16 _destHotspotId;     // 0: walking to a coordinate, 0xffff: invalid sentinel, else: room-exit hotspot
+	uint16 _walkToHotspotId;   // hotspot being approached for interaction; exempt from block-avoidance
 	uint16 _blockedOffset;
 	uint8 _exitCtr;
 	bool _walkFlag;
@@ -299,6 +300,7 @@ public:
 	int8 talkX() const { return _talkX; }
 	int8 talkY() const { return _talkY; }
 	uint16 destHotspotId() const { return _destHotspotId; }
+	uint16 walkToHotspot() const { return _walkToHotspotId; }
 	uint16 blockedOffset() const { return _blockedOffset; }
 	uint8 exitCtr() const { return _exitCtr; }
 	bool walkFlag() const { return _walkFlag; }
@@ -332,6 +334,7 @@ public:
 	void setPosition(int16 newX, int16 newY);
 	void setDestPosition(int16 newX, int16 newY) { _destX = newX; _destY = newY; }
 	void setDestHotspot(uint16 id) { _destHotspotId = id; }
+	void setWalkToHotspot(uint16 id) { _walkToHotspotId = id; }
 	void setExitCtr(uint8 value) { _exitCtr = value; }
 	BlockedState blockedState() const {
 		assert(_data);

--- a/engines/lure/res_struct.cpp
+++ b/engines/lure/res_struct.cpp
@@ -1129,6 +1129,11 @@ int PausedCharacterList::check(uint16 charId, int numImpinging, uint16 *impingin
 			// Entry is skipped if hotspot not present or is executing hotspot script
 			continue;
 
+		// Don't treat the hotspot we're deliberately walking up to as an obstacle
+		if (charHotspot->walkToHotspot() == hotspot->hotspotId()) {
+			continue;
+		}
+
 		// Scan through the pause list to see if there's a record for the
 		// calling character and the impinging list entry
 		bool foundEntry = false;


### PR DESCRIPTION
These are my attempts to fix two pathfinding-related issues that I encountered during my playthrough of Lure of the Temptress. This doesn't resolve all annoyances, but I was able to complete the game with my patches. Note that I'm not familiar with the original DOS version and haven't compared behaviors.

### 1) Player character wandering off instead of interacting with hotspot

This had been reported as a bug with a reproducer save: https://bugs.scummvm.org/ticket/14397

When the player character walks up to a hotspot in order to interact (e.g., talk to a person), a collision between the two hotspots may be detected. Then a block avoidance mechanism kicks in, sending Diermot off to wander to a random screen location.

The suggested fix is to make the hotspot we're deliberately walking up to exempt from this block avoidance mechanism.

| master | this PR |
|--------|--------|
| <img width="480" height="336" alt="lure - master - bar talk to" src="https://github.com/user-attachments/assets/632dbf65-8cb8-49cc-b6b9-c90601f99ffa" /> | <img width="480" height="336" alt="lure - pr - bar talk to" src="https://github.com/user-attachments/assets/99abb43c-ecf8-47e5-97a5-e38adf388dad" /> | 


### 2) Ratpouch stuck at an exit between two rooms

Here somehow the follower character had a set destination room that was unreachable from his current room. This lead to him looping in a cycle between two adjacent rooms, appearing to be stuck at the exit.

The suggested fix is to detect these short cycles that do not involve the ultimate destination room, then remain in the current room.

| master | this PR |
|--------|--------|
| <img width="480" height="336" alt="lure - master - ratpouch looping" src="https://github.com/user-attachments/assets/16f7b814-fb8a-468c-a8ff-5cced12213db" /> | <img width="480" height="336" alt="lure - pr - ratpouch exiting" src="https://github.com/user-attachments/assets/3cfb8f94-36f6-4bb0-a64b-1b67b0b3edaa" /> | 


### Caveat

Fix 1) led to one issue. Late in the game, in the castle dining room there's a skorl who will kill the player when approached. With my patch, when I set out to "talk to" him, this would crash the game with an error message `Talk failed - invalid offset: Character=437h, offset=0h!`. Apparently, the characters now got close enough to each other to launch `startTalk`, but no conversation was defined. This can be avoided by catching this early (`getTalkId(hotspot) == 0`) and skipping out before `startTalk()`. (A bit of a hack)

| problematic scene |
|--------|
| <img width="480" height="336" alt="lure - dining room" src="https://github.com/user-attachments/assets/0f2832bd-da12-4193-b96f-2f83f7e8dd9a" /> | 


[saves.zip](https://github.com/user-attachments/files/29765625/saves.zip)
