### PR TITLE
NANCY: Fix buffer overread in HamRadioPuzzle

### DIFF
--- a/engines/nancy/action/puzzle/hamradiopuzzle.cpp
+++ b/engines/nancy/action/puzzle/hamradiopuzzle.cpp
@@ -160,9 +160,13 @@ void HamRadioPuzzle::setFrequency(const Common::Array<uint16> &freq) {
 }
 
 void HamRadioPuzzle::CCSound::readData(Common::SeekableReadStream &stream) {
-	char buf[100];
-	stream.read(buf, 100);
-	assembleTextLine(buf, text, 100);
+	// One line, "Voice: Mensaje recibido.<n>..." fills all bytes, no NUL!
+	// Guarantee NUL-terminated buf, even up to `size` chars.
+	const uint size = 100;
+	char buf[size + 1];
+	stream.read(buf, size);
+	buf[size] = 0;
+	assembleTextLine(buf, text, size);
 	sound.readNormal(stream);
 }
 


### PR DESCRIPTION
The buffer could be entirely filled with characters, with no NUL terminator; eventually strlen() would run away.
Verified no change to in-game text. (One line does have a truncated `<n` but renders correctly in the game.)

```
Loading new scene 2874: description "LAB", frame 0, vertical scroll 0, kLoadSceneSound
=================================================================
==87807==ERROR: AddressSanitizer: stack-buffer-overflow on address 0x7fdac778fb84 at pc 0x557eb2e433f7 bp 0x7ffe1301b870 sp 0x7ffe1301b038
READ of size 103 at 0x7fdac778fb84 thread T0
    #0 0x557eb2e433f6 in strlen (scummvm+0x10d33f6) (BuildId: e9d028df1a27f8bb8e234551fa6b040670539d0d)
    #1 0x557eb48b9360 in Common::BaseString<char>::cStrLen(char const*) common/str-base.cpp:1151:9
    #2 0x557eb48b9360 in Common::BaseString<char>::BaseString(char const*) common/str-base.cpp:118:29
    #3 0x557eb37e428e in Common::String::String(char const*) ./common/str.h:72:28
    #4 0x557eb37e428e in Nancy::assembleTextLine(char*, Common::String&, unsigned int) engines/nancy/util.cpp:331:19
    #5 0x557eb34b4cf4 in Nancy::Action::HamRadioPuzzle::CCSound::readData(Common::SeekableReadStream&) engines/nancy/action/puzzle/hamradiopuzzle.cpp:165:2
    #6 0x557eb34b6a82 in Nancy::Action::HamRadioPuzzle::readData(Common::SeekableReadStream&) engines/nancy/action/puzzle/hamradiopuzzle.cpp:234:14
```
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
