### PR TITLE
DIRECTOR: Add detection for 鶴田謙二 CD教養画集「MADE IN CHINA」 (Kenji Tsuruta CD Art Collection: Made in China)

### DIFF
--- a/engines/director/detection_tables.h
+++ b/engines/director/detection_tables.h
@@ -1377,6 +1377,7 @@ static const PlainGameDescriptor directorGames[] = {
 	{ "jmac",				"J-MAC みんなの広場 Vol.1" },
 	{ "keiri",				"経理入門" },										// Introduction to Accounting
 	{ "llla",				"Live Love Life AIDS" },
+	{ "madeinchina",		"鶴田謙二 CD教養画集「MADE IN CHINA」" }, // Kenji Tsuruta CD Art Collection: Made in China
 	{ "mazebox",			"The Latest Works of MazeBox" },
 	{ "macintosho20",		"村上隆" }, // Macintosho exhibit disk #20 - Takashi Murakami's Hiropon
 	{ "microphonefiend",	"Microphone Fiend" },
@@ -2417,6 +2418,16 @@ static const DirectorGameDescription gameDescriptions[] = {
 	MACGAME1f_l("henachoco05r", "Patched version (later)", "rodem-tti", "e6165016b17961ac8616568301842c51", 4095754, Common::JA_JPN, 402, GF_DESKTOP|GF_640x480),
 	// From a 2000-dated game disc containing a prepatched game
 	MACGAME1f_l("henachoco05r", "Patched version (later)", "rodem-tti", "8aaf8baa98598362ab0accbbc8aae457", 292698, Common::JA_JPN, 402, GF_DESKTOP|GF_640x480),
+
+	// 鶴田謙二 CD教養画集「MADE IN CHINA」 (Kenji Tsuruta CD Art Collection: Made in China)
+	// published by Gainax, Tokyo (1995-10).
+	// Hybrid Mac/Windows disc. Only the Windows projector survives in the known dump.
+	// GF_DESKTOP: the boot movie reads `the stageTop` to choose between the 640x480
+	// build (MOVIE/MENU13.DXR) and the 800x600 one (MOVIE/MENU16.DXR). Without a
+	// desktop the stage sits at the origin, stageTop is 0, and the 800x600 build is
+	// unreachable. Note the title bails out to an error frame unless colorDepth is 8,
+	// so GF_TRUECOLOR must not be set here.
+	WINGAME1tf_l("madeinchina", "", "MENU.EXE", "3bd6cec01e8e576e80d8c4dcad56d1f6", 884291, Common::JA_JPN, 404, GF_DESKTOP),
 
 	// German release is D5
 	MACGAME1("majestic", "", "Majestic", "01be45e7241194dad07938e7059b88e3", 483518, 400),


### PR DESCRIPTION
Adds detection for 鶴田謙二 CD教養画集「MADE IN CHINA」 (Kenji Tsuruta CD Art Collection: Made in China), published by Gainax in October 1995. Director 4.0.4.

The disc is a hybrid Mac/Windows release, but only the Windows projector survives in the dump I have, so only a `WINGAME1tf_l` entry is added.

### Why `GF_DESKTOP`

The boot movie embedded in `MENU.EXE` picks its resolution by reading `the stageTop`:

```lingo
put the stageTop
if the stageTop = 0 then
  set size to 13
else
  set size to 16
end if
```

With `kWMModeNoDesktop` the stage sits at the origin, so `stageTop` is 0 and the movie always takes the 640x480 path (`MOVIE/MENU13.DXR`). With a desktop the stage is centred in the 1024x768 virtual screen, `stageTop` becomes 143, and the 800x600 build (`MOVIE/MENU16.DXR`) loads. Both builds ship on the disc; without `GF_DESKTOP` the 800x600 one is unreachable.

### Why not `GF_TRUECOLOR`

The same boot movie jumps to an error frame unless `the colorDepth` is 8:

```lingo
if the colorDepth <> 8 then
  set err to 1
  go("al2")
end if
```

On the Windows path it sets the depth to 8 itself, so the entry must stay 8bpp.

### Testing

Detected and booted to the 800x600 menu; the menu entries and the 16-inch gallery load. Verified on macOS (arm64) and in the Emscripten build.

The `MENU.EXE` hash is a tail MD5 (`ADGF_TAILMD5`, via `WINGAME1tf_l`), verified against the disc:

```
$ tail -c 5000 MENU.EXE | md5
3bd6cec01e8e576e80d8c4dcad56d1f6
$ stat -f %z MENU.EXE
884291
```
