### PR TITLE
DIRECTOR: Yield to the backend during long Lingo repeat loops

### DIFF
--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -664,6 +664,8 @@ bool Lingo::execute(int targetFrame) {
 			if (g_system->getMillis() - lastUpdate > 20) {
 				lastUpdate = g_system->getMillis();
 				g_system->updateScreen();
+				// On Emscripten, updateScreen() may skip the swap, so force a yield here; a no-op elsewhere.
+				g_system->delayMillis(0);
 			}
 		}
 


### PR DESCRIPTION
A long Lingo `repeat while` loop freezes the browser tab: on Emscripten `updateScreen()` skips the buffer swap when nothing is dirty, so there is no yield point back to the event loop. `delayMillis(0)` next to it provides one and pumps the timer that drives the mixer; a no-op `SDL_Delay(0)` elsewhere.

Tested on macOS and Emscripten. Depends on #7643 for audio.
