### PR TITLE
LURE: Fix being unable to talk to characters after a one-sided conversation

### DIFF
--- a/engines/lure/hotspots.cpp
+++ b/engines/lure/hotspots.cpp
@@ -3651,13 +3651,6 @@ void HotspotTickHandlers::talkAnimHandler(Hotspot &h) {
 			responseNumber = Script::execute(_talkResponse->preSequenceId);
 			debugC(ERROR_DETAILED, kLureDebugAnimations, "Character response new response = %d",
 				responseNumber);
-
-			// FIXME: Fix for resetting the character being talked to
-			// after talking to Goewin whilst transformed
-			if (_talkResponse->preSequenceId == 10902) {
-				HotspotData *character = res.getHotspot(PLAYER_ID);
-				character->talkDestCharacterId = 0;
-			}
 		} while (responseNumber != TALK_RESPONSE_MAGIC_ID);
 
 		descId = _talkResponse->descId;
@@ -3721,7 +3714,12 @@ void HotspotTickHandlers::talkEndConversation() {
 	Hotspot *charHotspot = res.getActiveHotspot(talkDestCharacter);
 	assert(charHotspot);
 
-	res.getActiveHotspot(PLAYER_ID)->setTickProc(PLAYER_TICK_PROC_ID);
+	Hotspot *player = res.getActiveHotspot(PLAYER_ID);
+	player->setTickProc(PLAYER_TICK_PROC_ID);
+
+	// Clear the player's talk destination now that the conversation is over.
+	player->resource()->talkDestCharacterId = 0;
+
 	charHotspot->setUseHotspotId(0);
 	charHotspot->resource()->talkerId = 0;
 	charHotspot->setDelayCtr(24);


### PR DESCRIPTION
When a conversation consists solely of the other character speaking (I ran into this talking to Gwyn whilst transformed to Selena), the player's `talkDestCharacterId` was never cleared. In most other conversations, on the other hand, the player is also a speaker, and when `Resources::setTalkingCharacter()` cycles through him, his `talkDestCharacterId` is cleared as a side effect. After a one-sided conversation, however, this left a guard in `Hotspot::doTalkTo()` permanently blocking new conversations.

To resolve this clear `talkDestCharacterId` in `HotspotTickHandlers::talkEndConversation()`, so at the end of every conversation. This also subsumes an earlier workaround specific to the Goewin character (rather than Gwyn).

Fixes #16944, https://bugs.scummvm.org/ticket/16944

I tested this with the save attached to the bug report, where the player is transformed into Selena, and couldn't reproduce the problem anymore after talking to either Gwyn or Goewin. I also did some cursory testing with an earlier save as Diermot and didn't notice any issues.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
