### PR TITLE
GRAPHICS: Remove broken Font::drawAlphaString() implementation

### DIFF
--- a/engines/phoenixvr/phoenixvr.cpp
+++ b/engines/phoenixvr/phoenixvr.cpp
@@ -1313,7 +1313,7 @@ void PhoenixVREngine::rollover(int textId, RolloverType type) {
 	auto textColor = _text->format.RGBToColor(r, g, b);
 	for (int i = 0; i != numLines; ++i) {
 		int dw = (textW - widths[i]) / 2;
-		font->drawAlphaString(_text.get(), lines[i], dw, i * fontH, textW, textColor, Graphics::kTextAlignLeft);
+		font->drawString(_text.get(), lines[i], dw, i * fontH, textW, textColor, Graphics::kTextAlignLeft);
 	}
 	_textRect = dstRect;
 }

--- a/engines/wintermute/base/font/base_font_truetype.cpp
+++ b/engines/wintermute/base/font/base_font_truetype.cpp
@@ -256,7 +256,6 @@ BaseSurface *BaseFontTT::renderTextToTexture(const WideString &text, int width, 
 
 	// TODO: This debug call does not work with WideString because text.c_str() returns an uint32 array.
 	//debugC(kWintermuteDebugFont, "%s %d %d %d %d", text.c_str(), RGBCOLGetR(_layers[0]->_color), RGBCOLGetG(_layers[0]->_color), RGBCOLGetB(_layers[0]->_color), RGBCOLGetA(_layers[0]->_color));
-//	void drawAlphaString(Surface *dst, const Common::String &str, int x, int y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = true) const;
 	Graphics::Surface *surface = new Graphics::Surface();
 	surface->create((uint16)width, (uint16)(_lineHeight * lines.size()), _game->_renderer->getPixelFormat());
 	uint32 useColor = 0xffffffff;
@@ -269,7 +268,7 @@ BaseSurface *BaseFontTT::renderTextToTexture(const WideString &text, int width, 
 		} else {
 			str = Common::convertBiDiU32String(*it, Common::BIDI_PAR_LTR);
 		}
-		_font->drawAlphaString(surface, str, 0, heightOffset, width, useColor, alignment);
+		_font->drawString(surface, str, 0, heightOffset, width, useColor, alignment);
 		heightOffset += (int)_lineHeight;
 	}
 

--- a/engines/wintermute/base/font/base_font_truetype.cpp
+++ b/engines/wintermute/base/font/base_font_truetype.cpp
@@ -291,7 +291,7 @@ BaseSurface *BaseFontTT::renderTextToTexture(const WideString &text, int width, 
 		} else {
 			str = Common::convertBiDiU32String(lineStr, Common::BIDI_PAR_LTR);
 		}
-		_font->drawAlphaString(surface, str, 0, heightOffset, width, useColor, alignment);
+		_font->drawString(surface, str, 0, heightOffset, width, useColor, alignment);
 		heightOffset += (int)_lineHeight;
 	}
 

--- a/graphics/font.cpp
+++ b/graphics/font.cpp
@@ -110,7 +110,7 @@ int getStringWidthImpl(const Font &font, const StringType &str) {
 }
 
 template<class SurfaceType, class StringType>
-void drawStringImpl(const Font &font, SurfaceType *dst, const StringType &str, int x, int y, int w, uint32 color, TextAlign align, int deltax, bool alpha, bool allowCharClipping) {
+void drawStringImpl(const Font &font, SurfaceType *dst, const StringType &str, int x, int y, int w, uint32 color, TextAlign align, int deltax, bool allowCharClipping) {
 	// The logic in getBoundingImpl is the same as we use here. In case we
 	// ever change something here we will need to change it there too.
 	assert(dst != 0);
@@ -132,7 +132,7 @@ void drawStringImpl(const Font &font, SurfaceType *dst, const StringType &str, i
 
 		Common::Rect charBox = font.getBoundingBox(cur);
 
-		// This assumes that each drawChar/drawAlphaChar implementation
+		// This assumes that each drawChar implementation
 		// MUST perform boundary checks, to avoid writing out of bounds!
 		if (!allowCharClipping) {
 			if (x + charBox.right > rightX)
@@ -140,10 +140,7 @@ void drawStringImpl(const Font &font, SurfaceType *dst, const StringType &str, i
 		}
 
 		if (x + charBox.right >= leftX) {
-			if (alpha)
-				font.drawAlphaChar(dst, cur, x, y, color);
-			else
-				font.drawChar(dst, cur, x, y, color);
+			font.drawChar(dst, cur, x, y, color);
 		}
 
 		x += font.getCharWidth(cur);
@@ -483,40 +480,19 @@ void Font::drawChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color)
 	dst->addDirtyRect(charBox);
 }
 
-void Font::drawAlphaChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const {
-	// Generic implementation for 1bpp fonts. Fonts with alpha blending
-	// should override this function.
-
-	uint32 aMask = (0xFF >> dst->format.aLoss) << dst->format.aShift;
-
-	Common::Rect charBox = getBoundingBox(chr);
-	charBox.translate(x, y);
-	dst->fillRect(charBox, color & ~aMask);
-
-	drawChar(dst, chr, x, y, color | aMask);
-}
-
-void Font::drawAlphaChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const {
-	drawAlphaChar(dst->surfacePtr(), chr, x, y, color);
-
-	Common::Rect charBox = getBoundingBox(chr);
-	charBox.translate(x, y);
-	dst->addDirtyRect(charBox);
-}
-
 void Font::drawString(Surface *dst, const Common::String &str, int x, int y, int w, uint32 color, TextAlign align, int deltax, bool useEllipsis, bool allowCharClipping) const {
 	Common::String renderStr = useEllipsis ? handleEllipsis(*this, str, w) : str;
-	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax, false, allowCharClipping);
+	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax, allowCharClipping);
 }
 
 void Font::drawString(Surface *dst, const Common::U32String &str, int x, int y, int w, uint32 color, TextAlign align, int deltax, bool useEllipsis, bool allowCharClipping) const {
 	Common::U32String renderStr = useEllipsis ? handleEllipsis(*this, str, w) : str;
-	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax, false, allowCharClipping);
+	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax, allowCharClipping);
 }
 
 void Font::drawString(ManagedSurface *dst, const Common::String &str, int x, int y, int w, uint32 color, TextAlign align, int deltax, bool useEllipsis, bool allowCharClipping) const {
 	Common::String renderStr = useEllipsis ? handleEllipsis(*this, str, w) : str;
-	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax, false, allowCharClipping);
+	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax, allowCharClipping);
 
 	if (w != 0) {
 		dst->addDirtyRect(getBoundingBox(str, x, y, w, align, deltax, useEllipsis));
@@ -525,35 +501,7 @@ void Font::drawString(ManagedSurface *dst, const Common::String &str, int x, int
 
 void Font::drawString(ManagedSurface *dst, const Common::U32String &str, int x, int y, int w, uint32 color, TextAlign align, int deltax, bool useEllipsis, bool allowCharClipping) const {
 	Common::U32String renderStr = useEllipsis ? handleEllipsis(*this, str, w) : str;
-	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax, false, allowCharClipping);
-
-	if (w != 0) {
-		dst->addDirtyRect(getBoundingBox(str, x, y, w, align, useEllipsis));
-	}
-}
-
-void Font::drawAlphaString(Surface *dst, const Common::String &str, int x, int y, int w, uint32 color, TextAlign align, int deltax, bool useEllipsis, bool allowCharClipping) const {
-	Common::String renderStr = useEllipsis ? handleEllipsis(*this, str, w) : str;
-	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax, true, allowCharClipping);
-}
-
-void Font::drawAlphaString(Surface *dst, const Common::U32String &str, int x, int y, int w, uint32 color, TextAlign align, int deltax, bool useEllipsis, bool allowCharClipping) const {
-	Common::U32String renderStr = useEllipsis ? handleEllipsis(*this, str, w) : str;
-	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax, true, allowCharClipping);
-}
-
-void Font::drawAlphaString(ManagedSurface *dst, const Common::String &str, int x, int y, int w, uint32 color, TextAlign align, int deltax, bool useEllipsis, bool allowCharClipping) const {
-	Common::String renderStr = useEllipsis ? handleEllipsis(*this, str, w) : str;
-	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax, true, allowCharClipping);
-
-	if (w != 0) {
-		dst->addDirtyRect(getBoundingBox(str, x, y, w, align, deltax, useEllipsis));
-	}
-}
-
-void Font::drawAlphaString(ManagedSurface *dst, const Common::U32String &str, int x, int y, int w, uint32 color, TextAlign align, int deltax, bool useEllipsis, bool allowCharClipping) const {
-	Common::U32String renderStr = useEllipsis ? handleEllipsis(*this, str, w) : str;
-	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax, true, allowCharClipping);
+	drawStringImpl(*this, dst, renderStr, x, y, w, color, align, deltax, allowCharClipping);
 
 	if (w != 0) {
 		dst->addDirtyRect(getBoundingBox(str, x, y, w, align, useEllipsis));

--- a/graphics/font.h
+++ b/graphics/font.h
@@ -214,34 +214,6 @@ public:
 	virtual void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const = 0;
 	virtual void drawChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const;
 
-	/**
-	 * Draw a character at a specific point on the surface.
-	 *
-	 * Unlike drawChar(), this stores the alpha channel for fonts
-	 * that would normally blend characters with the contents of
-	 * the surface. This is useful for 3D games, or for games that
-	 * require text on a separate surface to be blitted later.
-	 *
-	 * Note that the point describes the top left edge point where to draw
-	 * the character. This can be different from the top left edge point of the
-	 * character's bounding box. For example, TTF fonts sometimes move
-	 * characters like 't' by one (or more) pixels to the left to create better
-	 * visual results. To query the actual bounding box of a character, use
-	 * getBoundingBox.
-	 * @see getBoundingBox
-	 *
-	 * The Font implementation should take care of not drawing outside of the
-	 * specified surface.
-	 *
-	 * @param dst   The surface to draw on.
-	 * @param chr   The character to draw.
-	 * @param x     The x coordinate where to draw the character.
-	 * @param y     The y coordinate where to draw the character.
-	 * @param color The color of the character.
-	 */
-	virtual void drawAlphaChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const;
-	virtual void drawAlphaChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const;
-
 	/** @overload */
 
 	/**
@@ -266,34 +238,6 @@ public:
 	void drawString(ManagedSurface *dst, const Common::String &str, int x, int _y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = false, bool allowCharClipping = false) const;
 	/** @overload */
 	void drawString(ManagedSurface *dst, const Common::U32String &str, int x, int y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = false, bool allowCharClipping = false) const;
-
-	/**
-	 * Draw the given @p str string to the given @p dst surface.
-	 *
-	 * Unlike drawString(), this stores the alpha channel for fonts
-	 * that would normally blend characters with the contents of
-	 * the surface. This is useful for 3D games, or for games that
-	 * require text on a separate surface to be blitted later.
-	 *
-	 * @param dst     The surface on which to draw the string.
-	 * @param str     The string to draw.
-	 * @param x       The x position where to start drawing.
-	 * @param y       The y position where to start drawing.
-	 * @param w       Width of the text area.
-	 * @param color   The color with which to draw the string.
-	 * @param align   Text alignment. This can be used to center the string in the given area or to align it to the right.
-	 * @param deltax  Offset to the x starting position of the string.
-	 * @param useEllipsis  Use ellipsis if needed to fit the string in the area.
-	 * @param allowCharClipping  Allows characters to extend beyond the right boundary.
-	 *
-	 */
-	void drawAlphaString(Surface *dst, const Common::String &str, int x, int y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = false, bool allowCharClipping = false) const;
-	/** @overload */
-	void drawAlphaString(Surface *dst, const Common::U32String &str, int x, int y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = false, bool allowCharClipping = false) const;
-	/** @overload */
-	void drawAlphaString(ManagedSurface *dst, const Common::String &str, int x, int _y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = false, bool allowCharClipping = false) const;
-	/** @overload */
-	void drawAlphaString(ManagedSurface *dst, const Common::U32String &str, int x, int y, int w, uint32 color, TextAlign align = kTextAlignLeft, int deltax = 0, bool useEllipsis = false, bool allowCharClipping = false) const;
 
 	/**
 	 * Compute and return the width of the string @p str when rendered using this font.

--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -183,8 +183,6 @@ public:
 
 	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const override;
 	void drawChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const override;
-	void drawAlphaChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const override;
-	void drawAlphaChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const override;
 
 private:
 	bool _initialized;
@@ -216,7 +214,7 @@ private:
 	int readPointSizeFromVDMXTable(int height) const;
 	int computePointSizeFromHeaders(int height) const;
 	void drawCharIntern(Surface *dst, uint32 chr, int x, int y, uint32 color,
-		const uint32 *transparentColor, bool alpha) const;
+		const uint32 *transparentColor) const;
 
 	FT_Int32 _loadFlags;
 	FT_Render_Mode _renderMode;
@@ -661,53 +659,19 @@ static void renderGlyph(uint8 *dstPos, const int dstPitch, const uint8 *srcPos,
 	}
 }
 
-template<typename ColorType>
-static void renderAlphaGlyph(uint8 *dstPos, const int dstPitch, const uint8 *srcPos,
-		const int srcPitch, const int w, const int h, ColorType color,
-		const PixelFormat &dstFormat) {
-	uint8 sR, sG, sB;
-	dstFormat.colorToRGB(color, sR, sG, sB);
-
-	for (int y = 0; y < h; ++y) {
-		ColorType *rDst = (ColorType *)dstPos;
-		const uint8 *src = srcPos;
-
-		for (int x = 0; x < w; ++x) {
-			*rDst = dstFormat.ARGBToColor(*src, sR, sG, sB);
-			++rDst;
-			++src;
-		}
-
-		dstPos += dstPitch;
-		srcPos += srcPitch;
-	}
-}
-
 } // End of anonymous namespace
 
 void TTFFont::drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const {
-	drawCharIntern(dst, chr, x, y, color, nullptr, false);
+	drawCharIntern(dst, chr, x, y, color, nullptr);
 }
 
 void TTFFont::drawChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const {
 	if (dst->hasTransparentColor()) {
 		uint32 transColor = dst->getTransparentColor();
-		drawCharIntern(dst->surfacePtr(), chr, x, y, color, &transColor, false);
+		drawCharIntern(dst->surfacePtr(), chr, x, y, color, &transColor);
 	} else {
-		drawCharIntern(dst->surfacePtr(), chr, x, y, color, nullptr, false);
+		drawCharIntern(dst->surfacePtr(), chr, x, y, color, nullptr);
 	}
-
-	Common::Rect charBox = getBoundingBox(chr);
-	charBox.translate(x, y);
-	dst->addDirtyRect(charBox);
-}
-
-void TTFFont::drawAlphaChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const {
-	drawCharIntern(dst, chr, x, y, color, nullptr, true);
-}
-
-void TTFFont::drawAlphaChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const {
-	drawCharIntern(dst->surfacePtr(), chr, x, y, color, nullptr, true);
 
 	Common::Rect charBox = getBoundingBox(chr);
 	charBox.translate(x, y);
@@ -715,7 +679,7 @@ void TTFFont::drawAlphaChar(ManagedSurface *dst, uint32 chr, int x, int y, uint3
 }
 
 void TTFFont::drawCharIntern(Surface * dst, uint32 chr, int x, int y, uint32 color,
-		const uint32 *transparentColor, bool alpha) const {
+		const uint32 *transparentColor) const {
 	assureCached(chr);
 	GlyphCache::const_iterator glyphEntry = _glyphs.find(chr);
 	if (glyphEntry == _glyphs.end())
@@ -763,40 +727,30 @@ void TTFFont::drawCharIntern(Surface * dst, uint32 chr, int x, int y, uint32 col
 
 	uint8 *dstPos = (uint8 *)dst->getBasePtr(x, y);
 
-	if (alpha) {
-		if (dst->format.bytesPerPixel == 1) {
-			renderAlphaGlyph<uint8>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format);
-		} else if (dst->format.bytesPerPixel == 2) {
-			renderAlphaGlyph<uint16>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format);
-		} else if (dst->format.bytesPerPixel == 4) {
-			renderAlphaGlyph<uint32>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format);
-		}
-	} else {
-		if (dst->format.isCLUT8()) {
-			for (int cy = 0; cy < h; ++cy) {
-				uint8 *rDst = dstPos;
-				const uint8 *src = srcPos;
+	if (dst->format.isCLUT8()) {
+		for (int cy = 0; cy < h; ++cy) {
+			uint8 *rDst = dstPos;
+			const uint8 *src = srcPos;
 
-				for (int cx = 0; cx < w; ++cx) {
-					// We assume a 1Bpp mode is a color indexed mode, thus we can
-					// not take advantage of anti-aliasing here.
-					if (*src >= 0x80)
-						*rDst = color;
+			for (int cx = 0; cx < w; ++cx) {
+				// We assume a 1Bpp mode is a color indexed mode, thus we can
+				// not take advantage of anti-aliasing here.
+				if (*src >= 0x80)
+					*rDst = color;
 
-					++rDst;
-					++src;
-				}
-
-				dstPos += dst->pitch;
-				srcPos += glyph.image.pitch;
+				++rDst;
+				++src;
 			}
-		} else if (dst->format.bytesPerPixel == 1) {
-			renderGlyph<uint8>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
-		} else if (dst->format.bytesPerPixel == 2) {
-			renderGlyph<uint16>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
-		} else if (dst->format.bytesPerPixel == 4) {
-			renderGlyph<uint32>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
+
+			dstPos += dst->pitch;
+			srcPos += glyph.image.pitch;
 		}
+	} else if (dst->format.bytesPerPixel == 1) {
+		renderGlyph<uint8>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
+	} else if (dst->format.bytesPerPixel == 2) {
+		renderGlyph<uint16>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
+	} else if (dst->format.bytesPerPixel == 4) {
+		renderGlyph<uint32>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
 	}
 }
 

--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -183,8 +183,6 @@ public:
 
 	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const override;
 	void drawChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const override;
-	void drawAlphaChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const override;
-	void drawAlphaChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const override;
 
 private:
 	bool _initialized;
@@ -216,7 +214,7 @@ private:
 	int readPointSizeFromVDMXTable(int height) const;
 	int computePointSizeFromHeaders(int height) const;
 	void drawCharIntern(Surface *dst, uint32 chr, int x, int y, uint32 color,
-		const uint32 *transparentColor, bool alpha) const;
+		const uint32 *transparentColor) const;
 
 	FT_Int32 _loadFlags;
 	FT_Render_Mode _renderMode;
@@ -666,53 +664,19 @@ static void renderGlyph(uint8 *dstPos, const int dstPitch, const uint8 *srcPos,
 	}
 }
 
-template<typename ColorType>
-static void renderAlphaGlyph(uint8 *dstPos, const int dstPitch, const uint8 *srcPos,
-		const int srcPitch, const int w, const int h, ColorType color,
-		const PixelFormat &dstFormat) {
-	uint8 sR, sG, sB;
-	dstFormat.colorToRGB(color, sR, sG, sB);
-
-	for (int y = 0; y < h; ++y) {
-		ColorType *rDst = (ColorType *)dstPos;
-		const uint8 *src = srcPos;
-
-		for (int x = 0; x < w; ++x) {
-			*rDst = dstFormat.ARGBToColor(*src, sR, sG, sB);
-			++rDst;
-			++src;
-		}
-
-		dstPos += dstPitch;
-		srcPos += srcPitch;
-	}
-}
-
 } // End of anonymous namespace
 
 void TTFFont::drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const {
-	drawCharIntern(dst, chr, x, y, color, nullptr, false);
+	drawCharIntern(dst, chr, x, y, color, nullptr);
 }
 
 void TTFFont::drawChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const {
 	if (dst->hasTransparentColor()) {
 		uint32 transColor = dst->getTransparentColor();
-		drawCharIntern(dst->surfacePtr(), chr, x, y, color, &transColor, false);
+		drawCharIntern(dst->surfacePtr(), chr, x, y, color, &transColor);
 	} else {
-		drawCharIntern(dst->surfacePtr(), chr, x, y, color, nullptr, false);
+		drawCharIntern(dst->surfacePtr(), chr, x, y, color, nullptr);
 	}
-
-	Common::Rect charBox = getBoundingBox(chr);
-	charBox.translate(x, y);
-	dst->addDirtyRect(charBox);
-}
-
-void TTFFont::drawAlphaChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const {
-	drawCharIntern(dst, chr, x, y, color, nullptr, true);
-}
-
-void TTFFont::drawAlphaChar(ManagedSurface *dst, uint32 chr, int x, int y, uint32 color) const {
-	drawCharIntern(dst->surfacePtr(), chr, x, y, color, nullptr, true);
 
 	Common::Rect charBox = getBoundingBox(chr);
 	charBox.translate(x, y);
@@ -720,7 +684,7 @@ void TTFFont::drawAlphaChar(ManagedSurface *dst, uint32 chr, int x, int y, uint3
 }
 
 void TTFFont::drawCharIntern(Surface * dst, uint32 chr, int x, int y, uint32 color,
-		const uint32 *transparentColor, bool alpha) const {
+		const uint32 *transparentColor) const {
 	assureCached(chr);
 	GlyphCache::const_iterator glyphEntry = _glyphs.find(chr);
 	if (glyphEntry == _glyphs.end())
@@ -768,40 +732,30 @@ void TTFFont::drawCharIntern(Surface * dst, uint32 chr, int x, int y, uint32 col
 
 	uint8 *dstPos = (uint8 *)dst->getBasePtr(x, y);
 
-	if (alpha) {
-		if (dst->format.bytesPerPixel == 1) {
-			renderAlphaGlyph<uint8>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format);
-		} else if (dst->format.bytesPerPixel == 2) {
-			renderAlphaGlyph<uint16>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format);
-		} else if (dst->format.bytesPerPixel == 4) {
-			renderAlphaGlyph<uint32>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format);
-		}
-	} else {
-		if (dst->format.isCLUT8()) {
-			for (int cy = 0; cy < h; ++cy) {
-				uint8 *rDst = dstPos;
-				const uint8 *src = srcPos;
+	if (dst->format.isCLUT8()) {
+		for (int cy = 0; cy < h; ++cy) {
+			uint8 *rDst = dstPos;
+			const uint8 *src = srcPos;
 
-				for (int cx = 0; cx < w; ++cx) {
-					// We assume a 1Bpp mode is a color indexed mode, thus we can
-					// not take advantage of anti-aliasing here.
-					if (*src >= 0x80)
-						*rDst = color;
+			for (int cx = 0; cx < w; ++cx) {
+				// We assume a 1Bpp mode is a color indexed mode, thus we can
+				// not take advantage of anti-aliasing here.
+				if (*src >= 0x80)
+					*rDst = color;
 
-					++rDst;
-					++src;
-				}
-
-				dstPos += dst->pitch;
-				srcPos += glyph.image.pitch;
+				++rDst;
+				++src;
 			}
-		} else if (dst->format.bytesPerPixel == 1) {
-			renderGlyph<uint8>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
-		} else if (dst->format.bytesPerPixel == 2) {
-			renderGlyph<uint16>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
-		} else if (dst->format.bytesPerPixel == 4) {
-			renderGlyph<uint32>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
+
+			dstPos += dst->pitch;
+			srcPos += glyph.image.pitch;
 		}
+	} else if (dst->format.bytesPerPixel == 1) {
+		renderGlyph<uint8>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
+	} else if (dst->format.bytesPerPixel == 2) {
+		renderGlyph<uint16>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
+	} else if (dst->format.bytesPerPixel == 4) {
+		renderGlyph<uint32>(dstPos, dst->pitch, srcPos, glyph.image.pitch, w, h, color, dst->format, transparentColor);
 	}
 }
 


### PR DESCRIPTION
The current implementation doesn't properly account for overlapping glyphs - fixing it would result in the code being identical to the non-alpha variant.