### PR TITLE
CHEWY: Fix losing active inventory item, bug #16622

### DIFF
--- a/engines/chewy/events.cpp
+++ b/engines/chewy/events.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "common/system.h"
+#include "chewy/cursor.h"
 #include "chewy/events.h"
 #include "chewy/globals.h"
 
@@ -75,6 +76,13 @@ void EventsManager::handleEvent(const Common::Event &event) {
 		handleKbdEvent(event);
 }
 
+static void returnInventoryCursorToSlot() {
+	if (_G(cur)->usingInventoryCursor()) {
+		invent_2_slot(_G(cur)->getInventoryCursor());
+		_G(cur)->setInventoryCursor(-1);
+	}
+}
+
 void EventsManager::handleMouseEvent(const Common::Event &event) {
 	_pendingEvents.push(event);
 
@@ -99,6 +107,7 @@ void EventsManager::handleMouseEvent(const Common::Event &event) {
 	case Common::EVENT_WHEELUP:
 		// Cycle backwards through cursors
 		if (isWheelEnabled) {
+			returnInventoryCursorToSlot();
 			if (--_G(menu_item) < 0)
 				_G(menu_item) = CUR_TALK;
 			cursorChoice(_G(menu_item));
@@ -108,6 +117,7 @@ void EventsManager::handleMouseEvent(const Common::Event &event) {
 	case Common::EVENT_WHEELDOWN:
 		// Cycle forwards through cursors
 		if (isWheelEnabled) {
+			returnInventoryCursorToSlot();
 			if (++_G(menu_item) > CUR_TALK)
 				_G(menu_item) = CUR_WALK;
 			cursorChoice(_G(menu_item));
@@ -117,6 +127,7 @@ void EventsManager::handleMouseEvent(const Common::Event &event) {
 	case Common::EVENT_MBUTTONDOWN:
 		// Toggle between walk and look cursor
 		if (isWheelEnabled) {
+			returnInventoryCursorToSlot();
 			_G(menu_item) = (_G(menu_item) == CUR_WALK) ? CUR_LOOK : CUR_WALK;
 			cursorChoice(_G(menu_item));
 		}

--- a/engines/chewy/main.cpp
+++ b/engines/chewy/main.cpp
@@ -807,6 +807,7 @@ void mouseAction() {
 				else if (_G(cur)->usingInventoryCursor()) {
 					if (_G(inv_disp_ok)) {
 						if (_G(cur)->usingInventoryCursor()) {
+							invent_2_slot(_G(cur)->getInventoryCursor());
 							_G(menu_item) = CUR_USE;
 							cursorChoice(_G(menu_item));
 							_G(cur)->setInventoryCursor(-1);


### PR DESCRIPTION
When clicking an item in the "stand-by window" or by turning the mouse wheel while an item is present in the stand-by window (= the active item), the item would vanish from the game. With this change the item is returned to the main inventory instead.

This fixes the main problem reported in https://bugs.scummvm.org/ticket/16622. As explained in a comment there, however, the standby window functionality of the original game is not functional with the ScummVM engine.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
