### PR TITLE
CHEWY: Fix #16946 (Cannot interact at all after leaving first room)

### DIFF
--- a/engines/chewy/rooms/room00.cpp
+++ b/engines/chewy/rooms/room00.cpp
@@ -97,9 +97,9 @@ bool Room0::timer(int16 timerNr, int16 aniNr) {
 				eyeAnim();
 			} else if (!_G(gameState).R0PillowThrow) {
 				startAadWait(42);
-				start_spz(CH_TALK3, 255, false, P_CHEWY);
 
 				if (_G(gameState).R0FueterLab < 3) {
+					start_spz(CH_TALK3, 255, false, P_CHEWY);
 					startAadWait(43);
 					++_G(gameState).R0FueterLab;
 				}


### PR DESCRIPTION
In case the player had seen the feeding hose multiple times (such that R0FueterLab >=3) before throwing the pillow, the talking animation would trigger, but the corresponding dialog (`startAadWait(43)`) wouldn't run. This led to the game being stuck in the talking animation even after the cutscene in the next room.

I tested the fix with the savegame from my bug report (https://bugs.scummvm.org/ticket/16946), where `R0FueterLab >= 3`, as well as with a new game where I progressed much more quickly. In both cases I was able to properly transition to the next room.