### PR TITLE
ALL: Use override keyword where appropriate

### DIFF
--- a/audio/alsa_opl.cpp
+++ b/audio/alsa_opl.cpp
@@ -69,12 +69,12 @@ public:
 	OPL(Config::OplType type);
 	~OPL();
 
-	bool init();
-	void reset();
+	bool init() override;
+	void reset() override;
 
-	void write(int a, int v);
+	void write(int a, int v) override;
 
-	void writeReg(int r, int v);
+	void writeReg(int r, int v) override;
 };
 
 const int OPL::voiceToOper0[OPL::kVoices] =

--- a/audio/audiostream.h
+++ b/audio/audiostream.h
@@ -171,15 +171,15 @@ public:
 	 */
 	LoopingAudioStream(Common::DisposablePtr<RewindableAudioStream>&& stream, uint loops, bool rewind = true);
 
-	int readBuffer(int16 *buffer, const int numSamples);
-	bool endOfData() const;
-	bool endOfStream() const;
+	int readBuffer(int16 *buffer, const int numSamples) override;
+	bool endOfData() const override;
+	bool endOfStream() const override;
 
-	bool isStereo() const { return _parent->isStereo(); }
-	int getRate() const { return _parent->getRate(); }
+	bool isStereo() const override { return _parent->isStereo(); }
+	int getRate() const override { return _parent->getRate(); }
 
-	uint getCompleteIterations() const { return _completeIterations; }
-	void setRemainingIterations(uint loops) { _loops = _completeIterations + loops; }
+	uint getCompleteIterations() const override { return _completeIterations; }
+	void setRemainingIterations(uint loops) override { _loops = _completeIterations + loops; }
 private:
 	Common::DisposablePtr<RewindableAudioStream> _parent;
 
@@ -251,7 +251,7 @@ public:
 	 */
 	virtual Timestamp getLength() const = 0;
 
-	virtual bool rewind() { return seek(0); }
+	bool rewind() override { return seek(0); }
 };
 
 /**
@@ -304,15 +304,15 @@ public:
 	                      const Timestamp loopEnd,
 	                      DisposeAfterUse::Flag disposeAfterUse = DisposeAfterUse::YES);
 
-	int readBuffer(int16 *buffer, const int numSamples);
-	bool endOfData() const;
-	bool endOfStream() const;
+	int readBuffer(int16 *buffer, const int numSamples) override;
+	bool endOfData() const override;
+	bool endOfStream() const override;
 
-	bool isStereo() const { return _parent->isStereo(); }
-	int getRate() const { return _parent->getRate(); }
+	bool isStereo() const override { return _parent->isStereo(); }
+	int getRate() const override { return _parent->getRate(); }
 
-	uint getCompleteIterations() const { return _completeIterations; }
-	void setRemainingIterations(uint loops) { _loops = _completeIterations + loops; }
+	uint getCompleteIterations() const override { return _completeIterations; }
+	void setRemainingIterations(uint loops) override { _loops = _completeIterations + loops; }
 private:
 	Common::DisposablePtr<SeekableAudioStream> _parent;
 
@@ -343,18 +343,18 @@ public:
 	 */
 	SubSeekableAudioStream(SeekableAudioStream *parent, const Timestamp start, const Timestamp end, DisposeAfterUse::Flag disposeAfterUse = DisposeAfterUse::YES);
 
-	int readBuffer(int16 *buffer, const int numSamples);
+	int readBuffer(int16 *buffer, const int numSamples) override;
 
-	bool isStereo() const { return _parent->isStereo(); }
+	bool isStereo() const override { return _parent->isStereo(); }
 
-	int getRate() const { return _parent->getRate(); }
+	int getRate() const override { return _parent->getRate(); }
 
-	bool endOfData() const { return (_pos >= _length) || _parent->endOfData(); }
-	bool endOfStream() const { return (_pos >= _length) || _parent->endOfStream(); }
+	bool endOfData() const override { return (_pos >= _length) || _parent->endOfData(); }
+	bool endOfStream() const override { return (_pos >= _length) || _parent->endOfStream(); }
 
-	bool seek(const Timestamp &where);
+	bool seek(const Timestamp &where) override;
 
-	Timestamp getLength() const { return _length; }
+	Timestamp getLength() const override { return _length; }
 private:
 	Common::DisposablePtr<SeekableAudioStream> _parent;
 
@@ -479,18 +479,17 @@ public:
 	virtual ~StatelessPacketizedAudioStream() {}
 
 	// AudioStream API
-	bool isStereo() const { return _channels == 2; }
-	int getRate() const { return _rate; }
-	int readBuffer(int16 *data, const int numSamples) { return _stream->readBuffer(data, numSamples); }
-	bool endOfData() const { return _stream->endOfData(); }
-	bool endOfStream() const { return _stream->endOfStream(); }
+	bool isStereo() const override { return _channels == 2; }
+	int getRate() const override { return _rate; }
+	int readBuffer(int16 *data, const int numSamples) override { return _stream->readBuffer(data, numSamples); }
+	bool endOfData() const override { return _stream->endOfData(); }
+	bool endOfStream() const override { return _stream->endOfStream(); }
 
-	// QueuingAudioStream API
 	uint32 numQueuedStreams() const { return _stream->numQueuedStreams(); }
 
 	// PacketizedAudioStream API
-	void queuePacket(Common::SeekableReadStream *data) { _stream->queueAudioStream(makeStream(data)); }
-	void finish() { _stream->finish(); }
+	void queuePacket(Common::SeekableReadStream *data) override { _stream->queueAudioStream(makeStream(data)); }
+	void finish() override { _stream->finish(); }
 
 	/**
 	 * Return how many channels this stream is using.

--- a/audio/chip.h
+++ b/audio/chip.h
@@ -84,12 +84,12 @@ public:
 	virtual ~RealChip();
 
 	// Chip API
-	void setCallbackFrequency(int timerFrequency);
+	void setCallbackFrequency(int timerFrequency) override;
 
 protected:
 	// Chip API
-	void startCallbacks(int timerFrequency);
-	void stopCallbacks();
+	void startCallbacks(int timerFrequency) override;
+	void stopCallbacks() override;
 	virtual void onTimer();
 
 private:

--- a/audio/decoders/3do.h
+++ b/audio/decoders/3do.h
@@ -62,12 +62,12 @@ protected:
 	int32 _streamBytesLeft;
 
 	void reset();
-	bool rewind();
-	bool endOfData() const { return (_stream->pos() >= _stream->size()); }
-	bool isStereo() const { return _stereo; }
-	int getRate() const { return _sampleRate; }
+	bool rewind() override;
+	bool endOfData() const override { return (_stream->pos() >= _stream->size()); }
+	bool isStereo() const override { return _stereo; }
+	int getRate() const override { return _sampleRate; }
 
-	int readBuffer(int16 *buffer, const int numSamples);
+	int readBuffer(int16 *buffer, const int numSamples) override;
 
 	bool _initialRead;
 	audio_3DO_ADP4_PersistentSpace *_callerDecoderData;
@@ -90,12 +90,12 @@ protected:
 	int32 _streamBytesLeft;
 
 	void reset();
-	bool rewind();
-	bool endOfData() const { return (_stream->pos() >= _stream->size()); }
-	bool isStereo() const { return _stereo; }
-	int getRate() const { return _sampleRate; }
+	bool rewind() override;
+	bool endOfData() const override { return (_stream->pos() >= _stream->size()); }
+	bool isStereo() const override { return _stereo; }
+	int getRate() const override { return _sampleRate; }
 
-	int readBuffer(int16 *buffer, const int numSamples);
+	int readBuffer(int16 *buffer, const int numSamples) override;
 
 	bool _initialRead;
 	audio_3DO_SDX2_PersistentSpace *_callerDecoderData;

--- a/audio/decoders/adpcm_intern.h
+++ b/audio/decoders/adpcm_intern.h
@@ -63,13 +63,13 @@ protected:
 public:
 	ADPCMStream(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, uint32 size, int rate, int channels, uint32 blockAlign);
 
-	virtual bool endOfData() const { return (_stream->eos() || _stream->pos() >= _endpos); }
-	virtual bool isStereo() const { return _channels == 2; }
-	virtual int getRate() const { return _rate; }
+	bool endOfData() const override { return (_stream->eos() || _stream->pos() >= _endpos); }
+	bool isStereo() const override { return _channels == 2; }
+	int getRate() const override { return _rate; }
 
-	virtual bool rewind();
-	virtual bool seek(const Timestamp &where) { return false; }
-	virtual Timestamp getLength() const { return Timestamp(); }
+	bool rewind() override;
+	bool seek(const Timestamp &where) override { return false; }
+	Timestamp getLength() const override { return Timestamp(); }
 
 	/**
 	 * This table is used by some ADPCM variants (IMA and OKI) to adjust the
@@ -86,9 +86,9 @@ public:
 	Oki_ADPCMStream(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, uint32 size, int rate, int channels, uint32 blockAlign)
 		: ADPCMStream(stream, disposeAfterUse, size, rate, channels, blockAlign) { _decodedSampleCount = 0; }
 
-	virtual bool endOfData() const { return (_stream->eos() || _stream->pos() >= _endpos) && (_decodedSampleCount == 0); }
+	bool endOfData() const override { return (_stream->eos() || _stream->pos() >= _endpos) && (_decodedSampleCount == 0); }
 
-	virtual int readBuffer(int16 *buffer, const int numSamples);
+	int readBuffer(int16 *buffer, const int numSamples) override;
 
 protected:
 	int16 decodeOKI(byte);
@@ -103,9 +103,9 @@ public:
 	XA_ADPCMStream(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, uint32 size, int rate, int channels, uint32 blockAlign)
 		: ADPCMStream(stream, disposeAfterUse, size, rate, channels, blockAlign) { _decodedSampleCount = 0; }
 
-	virtual bool endOfData() const { return (_stream->eos() || _stream->pos() >= _endpos) && (_decodedSampleCount == 0); }
+	bool endOfData() const override { return (_stream->eos() || _stream->pos() >= _endpos) && (_decodedSampleCount == 0); }
 
-	virtual int readBuffer(int16 *buffer, const int numSamples);
+	int readBuffer(int16 *buffer, const int numSamples) override;
 
 protected:
 	void decodeXA(const byte *src);
@@ -135,9 +135,9 @@ public:
 	DVI_ADPCMStream(Common::SeekableReadStream *stream, DisposeAfterUse::Flag disposeAfterUse, uint32 size, int rate, int channels, uint32 blockAlign)
 		: Ima_ADPCMStream(stream, disposeAfterUse, size, rate, channels, blockAlign) { _decodedSampleCount = 0; }
 
-	virtual bool endOfData() const { return (_stream->eos() || _stream->pos() >= _endpos) && (_decodedSampleCount == 0); }
+	bool endOfData() const override { return (_stream->eos() || _stream->pos() >= _endpos) && (_decodedSampleCount == 0); }
 
-	virtual int readBuffer(int16 *buffer, const int numSamples);
+	int readBuffer(int16 *buffer, const int numSamples) override;
 
 private:
 	uint8 _decodedSampleCount;
@@ -151,7 +151,7 @@ protected:
 	int16 _buffer[2][2];
 	uint8 _chunkPos[2];
 
-	void reset() {
+	void reset() override {
 		Ima_ADPCMStream::reset();
 		_chunkPos[0] = 0;
 		_chunkPos[1] = 0;
@@ -168,7 +168,7 @@ public:
 		_streamPos[1] = _blockAlign;
 	}
 
-	virtual int readBuffer(int16 *buffer, const int numSamples);
+	int readBuffer(int16 *buffer, const int numSamples) override;
 };
 
 class MSIma_ADPCMStream : public Ima_ADPCMStream {
@@ -186,9 +186,9 @@ public:
 		_samplesLeft[1] = 0;
 	}
 
-	virtual int readBuffer(int16 *buffer, const int numSamples);
+	int readBuffer(int16 *buffer, const int numSamples) override;
 
-	void reset() {
+	void reset() override {
 		Ima_ADPCMStream::reset();
 		_samplesLeft[0] = 0;
 		_samplesLeft[1] = 0;
@@ -215,7 +215,7 @@ protected:
 		ADPCMChannelStatus ch[2];
 	} _status;
 
-	void reset() {
+	void reset() override {
 		ADPCMStream::reset();
 		memset(&_status, 0, sizeof(_status));
 	}
@@ -230,9 +230,9 @@ public:
 		_decodedSampleIndex = 0;
 	}
 
-	virtual bool endOfData() const { return (_stream->eos() || _stream->pos() >= _endpos) && (_decodedSampleCount == 0); }
+	bool endOfData() const override { return (_stream->eos() || _stream->pos() >= _endpos) && (_decodedSampleCount == 0); }
 
-	virtual int readBuffer(int16 *buffer, const int numSamples);
+	int readBuffer(int16 *buffer, const int numSamples) override;
 
 protected:
 	int16 decodeMS(ADPCMChannelStatus *c, byte);
@@ -255,7 +255,7 @@ public:
 		assert(channels == 2);
 	}
 
-	virtual int readBuffer(int16 *buffer, const int numSamples);
+	int readBuffer(int16 *buffer, const int numSamples) override;
 
 private:
 	byte _nibble, _lastByte;

--- a/audio/decoders/qdm2.cpp
+++ b/audio/decoders/qdm2.cpp
@@ -106,7 +106,7 @@ public:
 	QDM2Stream(Common::SeekableReadStream *extraData, DisposeAfterUse::Flag disposeExtraData);
 	~QDM2Stream();
 
-	AudioStream *decodeFrame(Common::SeekableReadStream &stream);
+	AudioStream *decodeFrame(Common::SeekableReadStream &stream) override;
 
 private:
 	// Parameters from codec header, do not change during playback

--- a/audio/decoders/quicktime_intern.h
+++ b/audio/decoders/quicktime_intern.h
@@ -68,14 +68,14 @@ protected:
 		~QuickTimeAudioTrack();
 
 		// AudioStream API
-		int readBuffer(int16 *buffer, const int numSamples);
-		bool isStereo() const { return _queue->isStereo(); }
-		int getRate() const { return _queue->getRate(); }
-		bool endOfData() const;
+		int readBuffer(int16 *buffer, const int numSamples) override;
+		bool isStereo() const override { return _queue->isStereo(); }
+		int getRate() const override { return _queue->getRate(); }
+		bool endOfData() const override;
 
 		// SeekableAudioStream API
-		bool seek(const Timestamp &where);
-		Timestamp getLength() const;
+		bool seek(const Timestamp &where) override;
+		Timestamp getLength() const override;
 
 		// Queue *at least* "length" audio
 		// If length is zero, it queues the next logical block of audio whether
@@ -130,7 +130,7 @@ protected:
 	};
 
 	// Common::QuickTimeParser API
-	virtual Common::QuickTimeParser::SampleDesc *readSampleDesc(Track *track, uint32 format, uint32 descSize);
+	Common::QuickTimeParser::SampleDesc *readSampleDesc(Track *track, uint32 format, uint32 descSize) override;
 
 	void init();
 

--- a/audio/decoders/wma.h
+++ b/audio/decoders/wma.h
@@ -49,7 +49,7 @@ public:
 	         uint32 bitRate, uint32 blockAlign, Common::SeekableReadStream *extraData = 0);
 	~WMACodec();
 
-	AudioStream *decodeFrame(Common::SeekableReadStream &data);
+	AudioStream *decodeFrame(Common::SeekableReadStream &data) override;
 
 private:
 	static const int kChannelsMax = 2; ///< Max number of channels we support.

--- a/audio/mods/infogrames.h
+++ b/audio/mods/infogrames.h
@@ -139,7 +139,7 @@ protected:
 	void reset();
 	void getNextSample(Channel &chn);
 	int16 tune(Slide &slide, int16 start) const;
-	virtual void interrupt();
+	void interrupt() override;
 };
 
 } // End of namespace Audio

--- a/audio/mods/maxtrax.h
+++ b/audio/mods/maxtrax.h
@@ -50,7 +50,7 @@ public:
 	void setSignalCallback(void (*callback) (int));
 
 protected:
-	void interrupt();
+	void interrupt() override;
 
 private:
 	enum { kNumPatches = 64, kNumVoices = 4, kNumChannels = 16, kNumExtraChannels = 1 };

--- a/audio/mods/paula.h
+++ b/audio/mods/paula.h
@@ -99,10 +99,10 @@ public:
 	void pausePlay(bool pause) { _playing = !pause; }
 
 // AudioStream API
-	int readBuffer(int16 *buffer, const int numSamples);
-	bool isStereo() const { return _stereo; }
-	bool endOfData() const { return _end; }
-	int getRate() const { return _rate; }
+	int readBuffer(int16 *buffer, const int numSamples) override;
+	bool isStereo() const override { return _stereo; }
+	bool endOfData() const override { return _end; }
+	int getRate() const override { return _rate; }
 
 protected:
 	struct Channel {

--- a/audio/mods/tfmx.h
+++ b/audio/mods/tfmx.h
@@ -75,7 +75,7 @@ public:
 	void setModuleData(Tfmx &otherPlayer);
 
 protected:
-	void interrupt();
+	void interrupt() override;
 
 private:
 	enum { kPalDefaultCiaVal = 11822, kNtscDefaultCiaVal = 14320, kCiaBaseInterval = 0x1B51F8 };

--- a/audio/mpu401.h
+++ b/audio/mpu401.h
@@ -38,24 +38,24 @@ private:
 	byte _channel;
 
 public:
-	MidiDriver *device();
-	byte getNumber() { return _channel; }
-	virtual void release() { _allocated = false; }
+	MidiDriver *device() override;
+	byte getNumber() override { return _channel; }
+	void release() override { _allocated = false; }
 
-	virtual void send(uint32 b);
+	void send(uint32 b) override;
 
 	// Regular messages
-	virtual void noteOff(byte note);
-	virtual void noteOn(byte note, byte velocity);
-	virtual void programChange(byte program);
-	virtual void pitchBend(int16 bend);
+	void noteOff(byte note) override;
+	void noteOn(byte note, byte velocity) override;
+	void programChange(byte program) override;
+	void pitchBend(int16 bend) override;
 
 	// Control Change messages
-	virtual void controlChange(byte control, byte value);
-	virtual void pitchBendFactor(byte value);
+	void controlChange(byte control, byte value) override;
+	void pitchBendFactor(byte value) override;
 
 	// SysEx messages
-	virtual void sysEx_customInstrument(uint32 type, const byte *instr, uint32 datasize) {}
+	void sysEx_customInstrument(uint32 type, const byte *instr, uint32 datasize) override {}
 
 	// Only to be called by the owner
 	void init(MidiDriver *owner, byte channel);
@@ -74,13 +74,13 @@ public:
 	MidiDriver_MPU401();
 	virtual ~MidiDriver_MPU401();
 
-	virtual void close();
-	virtual void setTimerCallback(void *timer_param, Common::TimerManager::TimerProc timer_proc);
-	virtual uint32 getBaseTempo(void) { return 10000; }
-	virtual uint32 property(int prop, uint32 param);
+	void close() override;
+	void setTimerCallback(void *timer_param, Common::TimerManager::TimerProc timer_proc) override;
+	uint32 getBaseTempo(void) override { return 10000; }
+	uint32 property(int prop, uint32 param) override;
 
-	virtual MidiChannel *allocateChannel();
-	virtual MidiChannel *getPercussionChannel() { return &_midi_channels[9]; }
+	MidiChannel *allocateChannel() override;
+	MidiChannel *getPercussionChannel() override { return &_midi_channels[9]; }
 };
 
 

--- a/audio/nfmopl.h
+++ b/audio/nfmopl.h
@@ -86,7 +86,7 @@ public:
 
 protected:
 
-	virtual void onTimer() override final;
+	void onTimer() override final;
 };
 };  // End of namespace RealChip
 

--- a/audio/null.h
+++ b/audio/null.h
@@ -28,9 +28,9 @@
 /* NULL driver */
 class MidiDriver_NULL : public MidiDriver_MPU401 {
 public:
-	int open() { return 0; }
- 	bool isOpen() const { return true; }
-	void send(uint32 b) { }
+	int open() override { return 0; }
+ 	bool isOpen() const override { return true; }
+	void send(uint32 b) override { }
 };
 
 
@@ -38,14 +38,14 @@ public:
 
 class NullMusicPlugin : public MusicPluginObject {
 public:
-	virtual const char *getName() const;
+	const char *getName() const override;
 
-	virtual const char *getId() const {
+	const char *getId() const override {
 		return "null";
 	}
 
-	virtual MusicDevices getDevices() const;
-	Common::Error createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle = 0) const;
+	MusicDevices getDevices() const override;
+	Common::Error createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle = 0) const override;
 };
 
 #endif

--- a/audio/softsynth/emumidi.h
+++ b/audio/softsynth/emumidi.h
@@ -61,7 +61,7 @@ public:
 	}
 
 	// MidiDriver API
-	virtual int open() {
+	int open() override {
 		_isOpen = true;
 
 		int d = getRate() / _baseFreq;
@@ -75,19 +75,19 @@ public:
 		return 0;
 	}
 
-	bool isOpen() const { return _isOpen; }
+	bool isOpen() const override { return _isOpen; }
 
-	virtual void setTimerCallback(void *timer_param, Common::TimerManager::TimerProc timer_proc) {
+	void setTimerCallback(void *timer_param, Common::TimerManager::TimerProc timer_proc) override {
 		_timerProc = timer_proc;
 		_timerParam = timer_param;
 	}
 
-	virtual uint32 getBaseTempo() {
+	uint32 getBaseTempo() override {
 		return 1000000 / _baseFreq;
 	}
 
 	// AudioStream API
-	virtual int readBuffer(int16 *data, const int numSamples) {
+	int readBuffer(int16 *data, const int numSamples) override {
 		const int stereoFactor = isStereo() ? 2 : 1;
 		int len = numSamples / stereoFactor;
 		int step;
@@ -116,7 +116,7 @@ public:
 		return numSamples;
 	}
 
-	virtual bool endOfData() const {
+	bool endOfData() const override {
 		return false;
 	}
 };

--- a/audio/softsynth/fmtowns_pc98/towns_euphony.h
+++ b/audio/softsynth/fmtowns_pc98/towns_euphony.h
@@ -49,12 +49,12 @@ public:
 	EuphonyDriver(Audio::Mixer *mixer, EuphonyPlayer *pl);
 	~EuphonyDriver();
 
-	bool init();
+	bool init() override;
 	void reset();
 
 	int assignPartToChannel(int chan, int part);
 
-	void send(uint8 command);
+	void send(uint8 command) override;
 
 	void setTimerA(bool enable, int tempo);
 	void setTimerB(bool enable, int tempo);
@@ -107,9 +107,9 @@ public:
 	Type0Driver(EuphonyPlayer *pl);
 	~Type0Driver();
 
-	bool init();
+	bool init() override;
 
-	void send(uint8 command);
+	void send(uint8 command) override;
 };
 
 class EuphonyPlayer : public TownsAudioInterfacePluginDriver {
@@ -135,7 +135,7 @@ public:
 	int configPart_adjustVolume(int part, int val);
 	int configPart_setTranspose(int part, int val);
 
-	void timerCallback(int timerId);
+	void timerCallback(int timerId) override;
 
 	EuphonyDriver *driver() { return _eupDriver; }
 

--- a/audio/softsynth/fmtowns_pc98/towns_pc98_driver.h
+++ b/audio/softsynth/fmtowns_pc98/towns_pc98_driver.h
@@ -63,8 +63,8 @@ private:
 	void writeReg(uint8 part, uint8 reg, uint8 val);
 	void preventRegisterWrite(bool prevent);
 
-	void timerCallbackA();
-	void timerCallbackB();
+	void timerCallbackA() override;
+	void timerCallbackB() override;
 
 	void startSoundEffect();
 

--- a/audio/softsynth/fmtowns_pc98/towns_pc98_fmsynth.h
+++ b/audio/softsynth/fmtowns_pc98/towns_pc98_fmsynth.h
@@ -82,10 +82,10 @@ public:
 	uint8 readReg(uint8 part, uint8 regAddress);
 
 	// AudioStream interface
-	int readBuffer(int16 *buffer, const int numSamples);
-	bool isStereo() const;
-	bool endOfData() const;
-	int getRate() const;
+	int readBuffer(int16 *buffer, const int numSamples) override;
+	bool isStereo() const override;
+	bool endOfData() const override;
+	int getRate() const override;
 
 protected:
 	void deinit();

--- a/audio/softsynth/mt32/Analog.cpp
+++ b/audio/softsynth/mt32/Analog.cpp
@@ -127,7 +127,7 @@ public:
 template <class SampleEx>
 class NullLowPassFilter : public AbstractLowPassFilter<SampleEx> {
 public:
-	SampleEx process(const SampleEx sample) {
+	SampleEx process(const SampleEx sample) override {
 		return sample;
 	}
 };
@@ -150,7 +150,7 @@ public:
 		Synth::muteSampleBuffer(ringBuffer, COARSE_LPF_DELAY_LINE_LENGTH);
 	}
 
-	SampleEx process(const SampleEx inSample) {
+	SampleEx process(const SampleEx inSample) override {
 		static const unsigned int DELAY_LINE_MASK = COARSE_LPF_DELAY_LINE_LENGTH - 1;
 
 		SampleEx sample = lpfTaps[COARSE_LPF_DELAY_LINE_LENGTH] * ringBuffer[ringBufferPosition];
@@ -179,12 +179,12 @@ private:
 
 public:
 	AccurateLowPassFilter(const bool oldMT32AnalogLPF, const bool oversample);
-	FloatSample process(const FloatSample sample);
-	IntSampleEx process(const IntSampleEx sample);
-	bool hasNextSample() const;
-	unsigned int getOutputSampleRate() const;
-	unsigned int estimateInSampleCount(const unsigned int outSamples) const;
-	void addPositionIncrement(const unsigned int positionIncrement);
+	FloatSample process(const FloatSample sample) override;
+	IntSampleEx process(const IntSampleEx sample) override;
+	bool hasNextSample() const override;
+	unsigned int getOutputSampleRate() const override;
+	unsigned int estimateInSampleCount(const unsigned int outSamples) const override;
+	void addPositionIncrement(const unsigned int positionIncrement) override;
 };
 
 static inline IntSampleEx normaliseSample(const IntSampleEx sample) {
@@ -223,19 +223,19 @@ public:
 		delete &rightChannelLPF;
 	}
 
-	unsigned int getOutputSampleRate() const {
+	unsigned int getOutputSampleRate() const override {
 		return leftChannelLPF.getOutputSampleRate();
 	}
 
-	Bit32u getDACStreamsLength(const Bit32u outputLength) const {
+	Bit32u getDACStreamsLength(const Bit32u outputLength) const override {
 		return leftChannelLPF.estimateInSampleCount(outputLength);
 	}
 
-	void setSynthOutputGain(const float synthGain);
-	void setReverbOutputGain(const float reverbGain, const bool mt32ReverbCompatibilityMode);
+	void setSynthOutputGain(const float synthGain) override;
+	void setReverbOutputGain(const float reverbGain, const bool mt32ReverbCompatibilityMode) override;
 
-	bool process(IntSample *outStream, const IntSample *nonReverbLeft, const IntSample *nonReverbRight, const IntSample *reverbDryLeft, const IntSample *reverbDryRight, const IntSample *reverbWetLeft, const IntSample *reverbWetRight, Bit32u outLength);
-	bool process(FloatSample *outStream, const FloatSample *nonReverbLeft, const FloatSample *nonReverbRight, const FloatSample *reverbDryLeft, const FloatSample *reverbDryRight, const FloatSample *reverbWetLeft, const FloatSample *reverbWetRight, Bit32u outLength);
+	bool process(IntSample *outStream, const IntSample *nonReverbLeft, const IntSample *nonReverbRight, const IntSample *reverbDryLeft, const IntSample *reverbDryRight, const IntSample *reverbWetLeft, const IntSample *reverbWetRight, Bit32u outLength) override;
+	bool process(FloatSample *outStream, const FloatSample *nonReverbLeft, const FloatSample *nonReverbRight, const FloatSample *reverbDryLeft, const FloatSample *reverbDryRight, const FloatSample *reverbWetLeft, const FloatSample *reverbWetRight, Bit32u outLength) override;
 
 	template <class Sample>
 	void produceOutput(Sample *outStream, const Sample *nonReverbLeft, const Sample *nonReverbRight, const Sample *reverbDryLeft, const Sample *reverbDryRight, const Sample *reverbWetLeft, const Sample *reverbWetRight, Bit32u outLength) {

--- a/audio/softsynth/mt32/BReverbModel.cpp
+++ b/audio/softsynth/mt32/BReverbModel.cpp
@@ -455,11 +455,11 @@ public:
 		close();
 	}
 
-	bool isOpen() const {
+	bool isOpen() const override {
 		return combs != NULL;
 	}
 
-	void open() {
+	void open() override {
 		if (isOpen()) return;
 		if (currentSettings.numberOfAllpasses > 0) {
 			allpasses = new AllpassFilter<Sample>*[currentSettings.numberOfAllpasses];
@@ -479,7 +479,7 @@ public:
 		mute();
 	}
 
-	void close() {
+	void close() override {
 		if (allpasses != NULL) {
 			for (Bit32u i = 0; i < currentSettings.numberOfAllpasses; i++) {
 				if (allpasses[i] != NULL) {
@@ -502,7 +502,7 @@ public:
 		}
 	}
 
-	void mute() {
+	void mute() override {
 		if (allpasses != NULL) {
 			for (Bit32u i = 0; i < currentSettings.numberOfAllpasses; i++) {
 				allpasses[i]->mute();
@@ -515,7 +515,7 @@ public:
 		}
 	}
 
-	void setParameters(Bit8u time, Bit8u level) {
+	void setParameters(Bit8u time, Bit8u level) override {
 		if (!isOpen()) return;
 		level &= 7;
 		time &= 7;
@@ -542,7 +542,7 @@ public:
 		}
 	}
 
-	bool isActive() const {
+	bool isActive() const override {
 		if (!isOpen()) return false;
 		for (Bit32u i = 0; i < currentSettings.numberOfAllpasses; i++) {
 			if (!allpasses[i]->isEmpty()) return true;
@@ -553,7 +553,7 @@ public:
 		return false;
 	}
 
-	bool isMT32Compatible(const ReverbMode mode) const {
+	bool isMT32Compatible(const ReverbMode mode) const override {
 		return &currentSettings == &getMT32Settings(mode);
 	}
 
@@ -622,8 +622,8 @@ public:
 		} // while ((numSamples--) > 0)
 	} // produceOutput
 
-	bool process(const IntSample *inLeft, const IntSample *inRight, IntSample *outLeft, IntSample *outRight, Bit32u numSamples);
-	bool process(const FloatSample *inLeft, const FloatSample *inRight, FloatSample *outLeft, FloatSample *outRight, Bit32u numSamples);
+	bool process(const IntSample *inLeft, const IntSample *inRight, IntSample *outLeft, IntSample *outRight, Bit32u numSamples) override;
+	bool process(const FloatSample *inLeft, const FloatSample *inRight, FloatSample *outLeft, FloatSample *outRight, Bit32u numSamples) override;
 };
 
 BReverbModel *BReverbModel::createBReverbModel(const ReverbMode mode, const bool mt32CompatibleModel, const RendererType rendererType) {

--- a/audio/softsynth/mt32/File.h
+++ b/audio/softsynth/mt32/File.h
@@ -40,7 +40,7 @@ public:
 
 class MT32EMU_EXPORT AbstractFile : public File {
 public:
-	const SHA1Digest &getSHA1();
+	const SHA1Digest &getSHA1() override;
 
 protected:
 	AbstractFile();
@@ -59,9 +59,9 @@ public:
 	ArrayFile(const Bit8u *data, size_t size);
 	ArrayFile(const Bit8u *data, size_t size, const SHA1Digest &sha1Digest);
 
-	size_t getSize();
-	const Bit8u *getData();
-	void close() {}
+	size_t getSize() override;
+	const Bit8u *getData() override;
+	void close() override {}
 
 private:
 	const Bit8u *data;

--- a/audio/softsynth/mt32/FileStream.h
+++ b/audio/softsynth/mt32/FileStream.h
@@ -30,10 +30,10 @@ class FileStream : public AbstractFile {
 public:
 	MT32EMU_EXPORT FileStream();
 	MT32EMU_EXPORT ~FileStream();
-	MT32EMU_EXPORT size_t getSize();
-	MT32EMU_EXPORT const Bit8u *getData();
+	MT32EMU_EXPORT size_t getSize() override;
+	MT32EMU_EXPORT const Bit8u *getData() override;
 	MT32EMU_EXPORT bool open(const char *filename);
-	MT32EMU_EXPORT void close();
+	MT32EMU_EXPORT void close() override;
 
 private:
 	std::ifstream &ifsp;

--- a/audio/softsynth/mt32/LA32FloatWaveGenerator.h
+++ b/audio/softsynth/mt32/LA32FloatWaveGenerator.h
@@ -106,13 +106,13 @@ public:
 	// ringModulated should be set to false for the structures with mixing or stereo output
 	// ringModulated should be set to true for the structures with ring modulation
 	// mixed is used for the structures with ring modulation and indicates whether the master partial output is mixed to the ring modulator output
-	void init(const bool ringModulated, const bool mixed);
+	void init(const bool ringModulated, const bool mixed) override;
 
 	// Initialise the WG engine for generation of synth partial samples and set up the invariant parameters
-	void initSynth(const PairType master, const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance);
+	void initSynth(const PairType master, const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance) override;
 
 	// Initialise the WG engine for generation of PCM partial samples and set up the invariant parameters
-	void initPCM(const PairType master, const Bit16s * const pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped);
+	void initPCM(const PairType master, const Bit16s * const pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped) override;
 
 	// Update parameters with respect to TVP, TVA and TVF, and generate next sample
 	void generateNextSample(const PairType master, const Bit32u amp, const Bit16u pitch, const Bit32u cutoff);
@@ -121,7 +121,7 @@ public:
 	float nextOutSample();
 
 	// Deactivate the WG engine
-	void deactivate(const PairType master);
+	void deactivate(const PairType master) override;
 
 	// Return active state of the WG engine
 	bool isActive(const PairType master) const;

--- a/audio/softsynth/mt32/LA32WaveGenerator.h
+++ b/audio/softsynth/mt32/LA32WaveGenerator.h
@@ -239,13 +239,13 @@ public:
 	// ringModulated should be set to false for the structures with mixing or stereo output
 	// ringModulated should be set to true for the structures with ring modulation
 	// mixed is used for the structures with ring modulation and indicates whether the master partial output is mixed to the ring modulator output
-	void init(const bool ringModulated, const bool mixed);
+	void init(const bool ringModulated, const bool mixed) override;
 
 	// Initialise the WG engine for generation of synth partial samples and set up the invariant parameters
-	void initSynth(const PairType master, const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance);
+	void initSynth(const PairType master, const bool sawtoothWaveform, const Bit8u pulseWidth, const Bit8u resonance) override;
 
 	// Initialise the WG engine for generation of PCM partial samples and set up the invariant parameters
-	void initPCM(const PairType master, const Bit16s * const pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped);
+	void initPCM(const PairType master, const Bit16s * const pcmWaveAddress, const Bit32u pcmWaveLength, const bool pcmWaveLooped) override;
 
 	// Update parameters with respect to TVP, TVA and TVF, and generate next sample
 	void generateNextSample(const PairType master, const Bit32u amp, const Bit16u pitch, const Bit32u cutoff);
@@ -255,7 +255,7 @@ public:
 	Bit16s nextOutSample();
 
 	// Deactivate the WG engine
-	void deactivate(const PairType master);
+	void deactivate(const PairType master) override;
 
 	// Return active state of the WG engine
 	bool isActive(const PairType master) const;

--- a/audio/softsynth/mt32/MidiStreamParser.h
+++ b/audio/softsynth/mt32/MidiStreamParser.h
@@ -108,10 +108,10 @@ public:
 	void resetTimestamp();
 
 protected:
-	void handleShortMessage(const Bit32u message);
-	void handleSysex(const Bit8u *stream, const Bit32u length);
-	void handleSystemRealtimeMessage(const Bit8u realtime);
-	void printDebug(const char *debugMessage);
+	void handleShortMessage(const Bit32u message) override;
+	void handleSysex(const Bit8u *stream, const Bit32u length) override;
+	void handleSystemRealtimeMessage(const Bit8u realtime) override;
+	void printDebug(const char *debugMessage) override;
 
 private:
 	Synth &synth;

--- a/audio/softsynth/mt32/Part.h
+++ b/audio/softsynth/mt32/Part.h
@@ -144,15 +144,15 @@ class RhythmPart: public Part {
 	PatchCache drumCache[85][4];
 public:
 	RhythmPart(Synth *synth, unsigned int usePartNum);
-	void refresh();
-	void refreshTimbre(unsigned int timbreNum);
-	void setTimbre(TimbreParam *timbre);
-	void noteOn(unsigned int key, unsigned int velocity);
-	void noteOff(unsigned int midiKey);
-	unsigned int getAbsTimbreNum() const;
-	void setPan(unsigned int midiPan);
-	void setProgram(unsigned int patchNum);
-	void polyStateChanged(PolyState oldState, PolyState newState);
+	void refresh() override;
+	void refreshTimbre(unsigned int timbreNum) override;
+	void setTimbre(TimbreParam *timbre) override;
+	void noteOn(unsigned int key, unsigned int velocity) override;
+	void noteOff(unsigned int midiKey) override;
+	unsigned int getAbsTimbreNum() const override;
+	void setPan(unsigned int midiPan) override;
+	void setProgram(unsigned int patchNum) override;
+	void polyStateChanged(PolyState oldState, PolyState newState) override;
 };
 
 } // namespace MT32Emu

--- a/audio/softsynth/mt32/Synth.cpp
+++ b/audio/softsynth/mt32/Synth.cpp
@@ -216,10 +216,10 @@ public:
 		tmpBuffers(createTmpBuffers())
 	{}
 
-	void render(IntSample *stereoStream, Bit32u len);
-	void render(FloatSample *stereoStream, Bit32u len);
-	void renderStreams(const DACOutputStreams<IntSample> &streams, Bit32u len);
-	void renderStreams(const DACOutputStreams<FloatSample> &streams, Bit32u len);
+	void render(IntSample *stereoStream, Bit32u len) override;
+	void render(FloatSample *stereoStream, Bit32u len) override;
+	void renderStreams(const DACOutputStreams<IntSample> &streams, Bit32u len) override;
+	void renderStreams(const DACOutputStreams<FloatSample> &streams, Bit32u len) override;
 
 	template <class O>
 	void doRenderAndConvert(O *stereoStream, Bit32u len);
@@ -1981,13 +1981,13 @@ public:
 /** Storage space for SysEx data is allocated dynamically on demand and is disposed lazily. */
 class DynamicSysexDataStorage : public MidiEventQueue::SysexDataStorage {
 public:
-	Bit8u *allocate(Bit32u sysexLength) {
+	Bit8u *allocate(Bit32u sysexLength) override {
 		return new Bit8u[sysexLength];
 	}
 
-	void reclaimUnused(const Bit8u *, Bit32u) {}
+	void reclaimUnused(const Bit8u *, Bit32u) override {}
 
-	void dispose(const Bit8u *sysexData, Bit32u) {
+	void dispose(const Bit8u *sysexData, Bit32u) override {
 		delete[] sysexData;
 	}
 };
@@ -2010,7 +2010,7 @@ public:
 		delete[] storageBuffer;
 	}
 
-	Bit8u *allocate(Bit32u sysexLength) {
+	Bit8u *allocate(Bit32u sysexLength) override {
 		Bit32u myStartPosition = startPosition;
 		Bit32u myEndPosition = endPosition;
 
@@ -2036,7 +2036,7 @@ public:
 		return storageBuffer + myEndPosition;
 	}
 
-	void reclaimUnused(const Bit8u *sysexData, Bit32u sysexLength) {
+	void reclaimUnused(const Bit8u *sysexData, Bit32u sysexLength) override {
 		if (sysexData == NULL) return;
 		Bit32u allocatedPosition = startPosition;
 		if (storageBuffer + allocatedPosition == sysexData) {
@@ -2047,7 +2047,7 @@ public:
 		}
 	}
 
-	void dispose(const Bit8u *, Bit32u) {}
+	void dispose(const Bit8u *, Bit32u) override {}
 
 private:
 	Bit8u * const storageBuffer;

--- a/audio/softsynth/mt32/c_interface/c_interface.cpp
+++ b/audio/softsynth/mt32/c_interface/c_interface.cpp
@@ -169,7 +169,7 @@ private:
 		return delegate.v0->getVersionID(delegate) < versionID;
 	}
 
-	void printDebug(const char *fmt, va_list list) {
+	void printDebug(const char *fmt, va_list list) override {
 		if (delegate.v0->printDebug == NULL) {
 			ReportHandler::printDebug(fmt, list);
 		} else {
@@ -177,7 +177,7 @@ private:
 		}
 	}
 
-	void onErrorControlROM() {
+	void onErrorControlROM() override {
 		if (delegate.v0->onErrorControlROM == NULL) {
 			ReportHandler::onErrorControlROM();
 		} else {
@@ -185,7 +185,7 @@ private:
 		}
 	}
 
-	void onErrorPCMROM() {
+	void onErrorPCMROM() override {
 		if (delegate.v0->onErrorPCMROM == NULL) {
 			ReportHandler::onErrorPCMROM();
 		} else {
@@ -193,7 +193,7 @@ private:
 		}
 	}
 
-	void showLCDMessage(const char *message) {
+	void showLCDMessage(const char *message) override {
 		if (delegate.v0->showLCDMessage == NULL) {
 			ReportHandler::showLCDMessage(message);
 		} else {
@@ -201,7 +201,7 @@ private:
 		}
 	}
 
-	void onMIDIMessagePlayed() {
+	void onMIDIMessagePlayed() override {
 		if (delegate.v0->onMIDIMessagePlayed == NULL) {
 			ReportHandler::onMIDIMessagePlayed();
 		} else {
@@ -209,14 +209,14 @@ private:
 		}
 	}
 
-	bool onMIDIQueueOverflow() {
+	bool onMIDIQueueOverflow() override {
 		if (delegate.v0->onMIDIQueueOverflow == NULL) {
 			return ReportHandler::onMIDIQueueOverflow();
 		}
 		return delegate.v0->onMIDIQueueOverflow(instanceData) != MT32EMU_BOOL_FALSE;
 	}
 
-	void onMIDISystemRealtime(Bit8u systemRealtime) {
+	void onMIDISystemRealtime(Bit8u systemRealtime) override {
 		if (delegate.v0->onMIDISystemRealtime == NULL) {
 			ReportHandler::onMIDISystemRealtime(systemRealtime);
 		} else {
@@ -224,7 +224,7 @@ private:
 		}
 	}
 
-	void onDeviceReset() {
+	void onDeviceReset() override {
 		if (delegate.v0->onDeviceReset == NULL) {
 			ReportHandler::onDeviceReset();
 		} else {
@@ -232,7 +232,7 @@ private:
 		}
 	}
 
-	void onDeviceReconfig() {
+	void onDeviceReconfig() override {
 		if (delegate.v0->onDeviceReconfig == NULL) {
 			ReportHandler::onDeviceReconfig();
 		} else {
@@ -240,7 +240,7 @@ private:
 		}
 	}
 
-	void onNewReverbMode(Bit8u mode) {
+	void onNewReverbMode(Bit8u mode) override {
 		if (delegate.v0->onNewReverbMode == NULL) {
 			ReportHandler::onNewReverbMode(mode);
 		} else {
@@ -248,7 +248,7 @@ private:
 		}
 	}
 
-	void onNewReverbTime(Bit8u time) {
+	void onNewReverbTime(Bit8u time) override {
 		if (delegate.v0->onNewReverbTime == NULL) {
 			ReportHandler::onNewReverbTime(time);
 		} else {
@@ -256,7 +256,7 @@ private:
 		}
 	}
 
-	void onNewReverbLevel(Bit8u level) {
+	void onNewReverbLevel(Bit8u level) override {
 		if (delegate.v0->onNewReverbLevel == NULL) {
 			ReportHandler::onNewReverbLevel(level);
 		} else {
@@ -264,7 +264,7 @@ private:
 		}
 	}
 
-	void onPolyStateChanged(Bit8u partNum) {
+	void onPolyStateChanged(Bit8u partNum) override {
 		if (delegate.v0->onPolyStateChanged == NULL) {
 			ReportHandler::onPolyStateChanged(partNum);
 		} else {
@@ -272,7 +272,7 @@ private:
 		}
 	}
 
-	void onProgramChanged(Bit8u partNum, const char *soundGroupName, const char *patchName) {
+	void onProgramChanged(Bit8u partNum, const char *soundGroupName, const char *patchName) override {
 		if (delegate.v0->onProgramChanged == NULL) {
 			ReportHandler::onProgramChanged(partNum, soundGroupName, patchName);
 		} else {
@@ -280,7 +280,7 @@ private:
 		}
 	}
 
-	void onLCDStateUpdated() {
+	void onLCDStateUpdated() override {
 		if (isVersionLess(MT32EMU_REPORT_HANDLER_VERSION_1) || delegate.v1->onLCDStateUpdated == NULL) {
 			ReportHandler2::onLCDStateUpdated();
 		} else {
@@ -288,7 +288,7 @@ private:
 		}
 	}
 
-	void onMidiMessageLEDStateUpdated(bool ledState) {
+	void onMidiMessageLEDStateUpdated(bool ledState) override {
 		if (isVersionLess(MT32EMU_REPORT_HANDLER_VERSION_1) || delegate.v1->onMidiMessageLEDStateUpdated == NULL) {
 			ReportHandler2::onMidiMessageLEDStateUpdated(ledState);
 		} else {
@@ -307,7 +307,7 @@ protected:
 	void *instanceData;
 
 private:
-	void handleShortMessage(const Bit32u message) {
+	void handleShortMessage(const Bit32u message) override {
 		if (delegate.v0->handleShortMessage == NULL) {
 			DefaultMidiStreamParser::handleShortMessage(message);
 		} else {
@@ -315,7 +315,7 @@ private:
 		}
 	}
 
-	void handleSysex(const Bit8u *stream, const Bit32u length) {
+	void handleSysex(const Bit8u *stream, const Bit32u length) override {
 		if (delegate.v0->handleSysex == NULL) {
 			DefaultMidiStreamParser::handleSysex(stream, length);
 		} else {
@@ -323,7 +323,7 @@ private:
 		}
 	}
 
-	void handleSystemRealtimeMessage(const Bit8u realtime) {
+	void handleSystemRealtimeMessage(const Bit8u realtime) override {
 		if (delegate.v0->handleSystemRealtimeMessage == NULL) {
 			DefaultMidiStreamParser::handleSystemRealtimeMessage(realtime);
 		} else {

--- a/audio/softsynth/mt32/srchelper/InternalResampler.cpp
+++ b/audio/softsynth/mt32/srchelper/InternalResampler.cpp
@@ -32,7 +32,7 @@ public:
 	SynthWrapper(Synth &useSynth) : synth(useSynth)
 	{}
 
-	void getOutputSamples(FloatSample *outBuffer, unsigned int size) {
+	void getOutputSamples(FloatSample *outBuffer, unsigned int size) override {
 		synth.render(outBuffer, size);
 	}
 };

--- a/audio/softsynth/mt32/srchelper/srctools/include/FIRResampler.h
+++ b/audio/softsynth/mt32/srchelper/srctools/include/FIRResampler.h
@@ -30,8 +30,8 @@ public:
 	FIRResampler(const unsigned int upsampleFactor, const double downsampleFactor, const FIRCoefficient kernel[], const unsigned int kernelLength);
 	~FIRResampler();
 
-	void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength);
-	unsigned int estimateInLength(const unsigned int outLength) const;
+	void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength) override;
+	unsigned int estimateInLength(const unsigned int outLength) const override;
 
 private:
 	const struct Constants {

--- a/audio/softsynth/mt32/srchelper/srctools/include/IIR2xResampler.h
+++ b/audio/softsynth/mt32/srchelper/srctools/include/IIR2xResampler.h
@@ -78,8 +78,8 @@ public:
 	explicit IIR2xInterpolator(const Quality quality);
 	explicit IIR2xInterpolator(const unsigned int useSectionsCount, const IIRCoefficient useFIR, const IIRSection useSections[]);
 
-	void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength);
-	unsigned int estimateInLength(const unsigned int outLength) const;
+	void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength) override;
+	unsigned int estimateInLength(const unsigned int outLength) const override;
 
 private:
 	FloatSample lastInputSamples[IIR_RESAMPER_CHANNEL_COUNT];
@@ -91,8 +91,8 @@ public:
 	explicit IIR2xDecimator(const Quality quality);
 	explicit IIR2xDecimator(const unsigned int useSectionsCount, const IIRCoefficient useFIR, const IIRSection useSections[]);
 
-	void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength);
-	unsigned int estimateInLength(const unsigned int outLength) const;
+	void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength) override;
+	unsigned int estimateInLength(const unsigned int outLength) const override;
 };
 
 } // namespace SRCTools

--- a/audio/softsynth/mt32/srchelper/srctools/include/LinearResampler.h
+++ b/audio/softsynth/mt32/srchelper/srctools/include/LinearResampler.h
@@ -28,8 +28,8 @@ public:
 	LinearResampler(double sourceSampleRate, double targetSampleRate);
 	~LinearResampler() {}
 
-	unsigned int estimateInLength(const unsigned int outLength) const;
-	void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength);
+	unsigned int estimateInLength(const unsigned int outLength) const override;
+	void process(const FloatSample *&inSamples, unsigned int &inLength, FloatSample *&outSamples, unsigned int &outLength) override;
 
 private:
 	const double inputToOutputRatio;

--- a/audio/softsynth/mt32/srchelper/srctools/src/ResamplerModel.cpp
+++ b/audio/softsynth/mt32/srchelper/srctools/src/ResamplerModel.cpp
@@ -36,7 +36,7 @@ friend void freeResamplerModel(FloatSampleProvider &model, FloatSampleProvider &
 public:
 	CascadeStage(FloatSampleProvider &source, ResamplerStage &resamplerStage);
 
-	void getOutputSamples(FloatSample *outBuffer, unsigned int size);
+	void getOutputSamples(FloatSample *outBuffer, unsigned int size) override;
 
 protected:
 	ResamplerStage &resamplerStage;

--- a/audio/softsynth/opl/dosbox.h
+++ b/audio/softsynth/opl/dosbox.h
@@ -86,17 +86,17 @@ public:
 	OPL(Config::OplType type);
 	~OPL();
 
-	bool init();
-	void reset();
+	bool init() override;
+	void reset() override;
 
-	void write(int a, int v);
+	void write(int a, int v) override;
 
-	void writeReg(int r, int v);
+	void writeReg(int r, int v) override;
 
-	bool isStereo() const { return _type != Config::kOpl2; }
+	bool isStereo() const override { return _type != Config::kOpl2; }
 
 protected:
-	void generateSamples(int16 *buffer, int length);
+	void generateSamples(int16 *buffer, int length) override;
 };
 
 } // End of namespace DOSBox

--- a/audio/softsynth/opl/mame.h
+++ b/audio/softsynth/opl/mame.h
@@ -182,17 +182,17 @@ public:
 	OPL() : _opl(0) {}
 	~OPL();
 
-	bool init();
-	void reset();
+	bool init() override;
+	void reset() override;
 
-	void write(int a, int v);
+	void write(int a, int v) override;
 
-	void writeReg(int r, int v);
+	void writeReg(int r, int v) override;
 
-	bool isStereo() const { return false; }
+	bool isStereo() const override { return false; }
 
 protected:
-	void generateSamples(int16 *buffer, int length);
+	void generateSamples(int16 *buffer, int length) override;
 };
 
 } // End of namespace MAME

--- a/audio/softsynth/opl/nuked.h
+++ b/audio/softsynth/opl/nuked.h
@@ -217,17 +217,17 @@ public:
 	OPL(Config::OplType type);
 	~OPL();
 
-	bool init();
-	void reset();
+	bool init() override;
+	void reset() override;
 
-	void write(int a, int v);
+	void write(int a, int v) override;
 
-	void writeReg(int r, int v);
+	void writeReg(int r, int v) override;
 
-	bool isStereo() const { return true; }
+	bool isStereo() const override { return true; }
 
 protected:
-	void generateSamples(int16 *buffer, int length);
+	void generateSamples(int16 *buffer, int length) override;
 };
 
 }

--- a/audio/softsynth/pcspk.h
+++ b/audio/softsynth/pcspk.h
@@ -129,12 +129,12 @@ public:
 
 	bool isPlaying() const;
 
-	int readBuffer(int16 *buffer, const int numSamples);
+	int readBuffer(int16 *buffer, const int numSamples) override;
 
-	bool isStereo() const	{ return false; }
-	bool endOfData() const	{ return false; }
-	bool endOfStream() const { return false; }
-	int getRate() const	{ return _rate; }
+	bool isStereo() const override    { return false; }
+	bool endOfData() const override   { return false; }
+	bool endOfStream() const override { return false; }
+	int getRate() const override      { return _rate; }
 
 protected:
 	Common::Mutex _mutex;

--- a/audio/soundfont/rifffile.h
+++ b/audio/soundfont/rifffile.h
@@ -83,8 +83,8 @@ public:
 
 	Chunk *AddChildChunk(Chunk *ck);
 
-	virtual uint32 GetSize();  //  Returns the size of the chunk in bytes, including any pad byte.
-	virtual void Write(uint8 *buffer);
+	uint32 GetSize() override;  //  Returns the size of the chunk in bytes, including any pad byte.
+	void Write(uint8 *buffer) override;
 };
 
 ////////////////////////////////////////////////////////////////////////////

--- a/audio/soundfont/vab/psxspu.h
+++ b/audio/soundfont/vab/psxspu.h
@@ -396,8 +396,8 @@ public:
 	PSXSampColl(VGMInstrSet *instrset, uint32 offset, uint32 length,
 				const Common::Array<SizeOffsetPair> &vagLocations);
 
-	virtual bool
-	GetSampleInfo();  // retrieve sample info, including pointers to data, # channels, rate, etc.
+	// retrieve sample info, including pointers to data, # channels, rate, etc.
+	bool GetSampleInfo() override;
 
 protected:
 	Common::Array<SizeOffsetPair> _vagLocations;

--- a/audio/soundfont/vab/vab.h
+++ b/audio/soundfont/vab/vab.h
@@ -36,8 +36,8 @@ public:
 	Vab(RawFile *file, uint32 offset);
 	virtual ~Vab(void);
 
-	virtual bool GetHeaderInfo();
-	virtual bool GetInstrPointers();
+	bool GetHeaderInfo() override;
+	bool GetInstrPointers() override;
 };
 
 // ********
@@ -50,7 +50,7 @@ public:
 			 uint32 theInstrNum, const Common::String &name = "Instrument");
 	virtual ~VabInstr();
 
-	virtual bool LoadInstr();
+	bool LoadInstr() override;
 
 public:
 	uint8 _tones;
@@ -65,7 +65,7 @@ class VabRgn : public VGMRgn {
 public:
 	VabRgn(VabInstr *instr, uint32 offset);
 
-	virtual bool LoadRgn();
+	bool LoadRgn() override;
 
 public:
 	uint16 _ADSR1;  // raw ps2 ADSR1 value (articulation data)

--- a/audio/soundfont/vgminstrset.h
+++ b/audio/soundfont/vgminstrset.h
@@ -49,7 +49,7 @@ public:
 				Common::String name = "VGMInstrSet", VGMSampColl *theSampColl = NULL);
 	virtual ~VGMInstrSet(void);
 
-	virtual bool Load();
+	bool Load() override;
 	virtual bool GetHeaderInfo();
 	virtual bool GetInstrPointers();
 	virtual bool LoadInstrs();

--- a/audio/soundfont/vgmsamp.h
+++ b/audio/soundfont/vgmsamp.h
@@ -82,7 +82,7 @@ public:
 				uint32 length = 0, Common::String theName = "VGMSampColl");
 	virtual ~VGMSampColl(void);
 
-	virtual bool Load();
+	bool Load() override;
 	virtual bool GetHeaderInfo() { return true; }  // retrieve any header data
 	virtual bool GetSampleInfo() { return true; }  // retrieve sample info, including pointers to data, # channels, rate, etc.
 

--- a/backends/audiocd/audiocd-stream.h
+++ b/backends/audiocd/audiocd-stream.h
@@ -53,12 +53,12 @@ public:
 	AudioCDStream();
 	~AudioCDStream();
 
-	int readBuffer(int16 *buffer, const int numSamples);
-	bool isStereo() const { return true; }
-	int getRate() const { return 44100; }
-	bool endOfData() const;
-	bool seek(const Audio::Timestamp &where);
-	Audio::Timestamp getLength() const;
+	int readBuffer(int16 *buffer, const int numSamples) override;
+	bool isStereo() const override { return true; }
+	int getRate() const override { return 44100; }
+	bool endOfData() const override;
+	bool seek(const Audio::Timestamp &where) override;
+	Audio::Timestamp getLength() const override;
 
 protected:
 	virtual uint getStartFrame() const = 0;

--- a/backends/audiocd/default/default-audiocd.h
+++ b/backends/audiocd/default/default-audiocd.h
@@ -37,20 +37,20 @@ public:
 	DefaultAudioCDManager();
 	virtual ~DefaultAudioCDManager();
 
-	virtual bool open();
-	virtual void close();
-	virtual bool play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate = false,
-		Audio::Mixer::SoundType soundType = Audio::Mixer::kMusicSoundType);
-	virtual bool playAbsolute(int startFrame, int numLoops, int duration, bool onlyEmulate = false,
-		Audio::Mixer::SoundType soundType = Audio::Mixer::kMusicSoundType, const char *cuesheet = "disc.cue");
-	virtual void stop();
-	virtual bool isPlaying() const;
-	virtual void setVolume(byte volume);
-	virtual void setBalance(int8 balance);
-	virtual void update();
-	virtual Status getStatus() const; // Subclasses should override for better status results
-	virtual bool existExtractedCDAudioFiles(uint track);
-	virtual bool isDataAndCDAudioReadFromSameCD() { return false; }
+	bool open() override;
+	void close() override;
+	bool play(int track, int numLoops, int startFrame, int duration, bool onlyEmulate = false,
+		Audio::Mixer::SoundType soundType = Audio::Mixer::kMusicSoundType) override;
+	bool playAbsolute(int startFrame, int numLoops, int duration, bool onlyEmulate = false,
+		Audio::Mixer::SoundType soundType = Audio::Mixer::kMusicSoundType, const char *cuesheet = "disc.cue") override;
+	void stop() override;
+	bool isPlaying() const override;
+	void setVolume(byte volume) override;
+	void setBalance(int8 balance) override;
+	void update() override;
+	Status getStatus() const override; // Subclasses should override for better status results
+	bool existExtractedCDAudioFiles(uint track) override;
+	bool isDataAndCDAudioReadFromSameCD() override { return false; }
 
 private:
 	void fillPotentialTrackNames(Common::Array<Common::String> &trackNames, int track) const;

--- a/backends/audiocd/linux/linux-audiocd.cpp
+++ b/backends/audiocd/linux/linux-audiocd.cpp
@@ -111,9 +111,9 @@ public:
 	~LinuxAudioCDStream();
 
 protected:
-	uint getStartFrame() const;
-	uint getEndFrame() const;
-	bool readFrame(int frame, int16 *buffer);
+	uint getStartFrame() const override;
+	uint getEndFrame() const override;
+	bool readFrame(int frame, int16 *buffer) override;
 
 private:
 	int _fd;

--- a/backends/cloud/id/idstorage.h
+++ b/backends/cloud/id/idstorage.h
@@ -70,7 +70,7 @@ public:
 
 	/** Returns pointer to Networking::NetworkReadStream. */
 	Networking::Request *streamFile(const Common::String &path, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) override;
-	virtual Networking::Request *streamFileById(const Common::String &id, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) override = 0;
+	Networking::Request *streamFileById(const Common::String &id, Networking::NetworkReadStreamCallback callback, Networking::ErrorCallback errorCallback) override = 0;
 
 	/** Calls the callback when finished. */
 	Networking::Request *download(const Common::String &remotePath, const Common::Path &localPath, BoolCallback callback, Networking::ErrorCallback errorCallback) override;

--- a/backends/dlc/scummvmcloud.h
+++ b/backends/dlc/scummvmcloud.h
@@ -44,11 +44,11 @@ public:
 	ScummVMCloud() {}
 	virtual ~ScummVMCloud() {}
 
-	virtual void getAllDLCs() override;
+	void getAllDLCs() override;
 
-	virtual void startDownloadAsync(const Common::String &id, const Common::String &url) override;
+	void startDownloadAsync(const Common::String &id, const Common::String &url) override;
 
-	virtual void removeCacheFile(const Common::Path &file) override;
+	void removeCacheFile(const Common::Path &file) override;
 
 	// extracts the provided zip in the provided destination path
 	Common::Error extractZip(const Common::Path &file, const Common::Path &destPath);

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -47,7 +47,7 @@ public:
 	/**
 	 * Gets and processes SDL events.
 	 */
-	virtual bool pollEvent(Common::Event &event);
+	bool pollEvent(Common::Event &event) override;
 
 	/**
 	 * Emulates a mouse movement that would normally be caused by a mouse warp

--- a/backends/graphics/graphics.h
+++ b/backends/graphics/graphics.h
@@ -83,8 +83,8 @@ public:
 
 	virtual int16 getHeight() const = 0;
 	virtual int16 getWidth() const = 0;
-	virtual void setPalette(const byte *colors, uint start, uint num) = 0;
-	virtual void grabPalette(byte *colors, uint start, uint num) const = 0;
+	void setPalette(const byte *colors, uint start, uint num) override = 0;
+	void grabPalette(byte *colors, uint start, uint num) const override = 0;
 	virtual void copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) = 0;
 	virtual Graphics::Surface *lockScreen() = 0;
 	virtual void unlockScreen() = 0;

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -91,7 +91,7 @@ public:
 	 */
 	virtual bool notifyMousePosition(Common::Point &mouse);
 
-	virtual bool showMouse(bool visible) override;
+	bool showMouse(bool visible) override;
 	bool lockMouse(bool lock) override;
 
 	virtual bool saveScreenshot(const Common::Path &filename) const { return false; }

--- a/backends/keymapper/keymapper.h
+++ b/backends/keymapper/keymapper.h
@@ -48,7 +48,7 @@ public:
 	~Keymapper();
 
 	// EventMapper interface
-	virtual bool mapEvent(const Event &ev, List<Event> &mappedEvents);
+	bool mapEvent(const Event &ev, List<Event> &mappedEvents) override;
 
 	/**
 	 * Registers a HardwareInputSet and platform-specific default mappings with the Keymapper

--- a/backends/midi/alsa.cpp
+++ b/backends/midi/alsa.cpp
@@ -339,17 +339,17 @@ int AlsaDevice::getClient() {
 
 class AlsaMusicPlugin : public MusicPluginObject {
 public:
-	const char *getName() const {
+	const char *getName() const override {
 		return "ALSA";
 	}
 
-	const char *getId() const {
+	const char *getId() const override {
 		return "alsa";
 	}
 
 	AlsaDevices getAlsaDevices() const;
-	MusicDevices getDevices() const;
-	Common::Error createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle = 0) const;
+	MusicDevices getDevices() const override;
+	Common::Error createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle = 0) const override;
 
 private:
 	static int parse_addr(const char *arg, int *client, int *port);

--- a/backends/midi/seq.cpp
+++ b/backends/midi/seq.cpp
@@ -272,17 +272,17 @@ const char *MidiDriver_SEQ::getDeviceName() {
 
 class SeqMusicPlugin : public MusicPluginObject {
 public:
-	const char *getName() const {
+	const char *getName() const override {
 		return "SEQ";
 	}
 
-	const char *getId() const {
+	const char *getId() const override {
 		return "seq";
 	}
 
-	MusicDevices getDevices() const;
-	Common::Error createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle = 0) const;
-	bool checkDevice(MidiDriver::DeviceHandle hdl, int checkFlags, bool quiet) const;
+	MusicDevices getDevices() const override;
+	Common::Error createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle = 0) const override;
+	bool checkDevice(MidiDriver::DeviceHandle hdl, int checkFlags, bool quiet) const override;
 
 private:
 	void addMidiDevices(int deviceFD, MusicDevices &devices, Common::Array<int> *portIDs) const;

--- a/backends/midi/sndio.cpp
+++ b/backends/midi/sndio.cpp
@@ -123,16 +123,16 @@ void MidiDriver_Sndio::sysEx(const byte *msg, uint16 length) {
 
 class SndioMusicPlugin : public MusicPluginObject {
 public:
-	const char *getName() const {
+	const char *getName() const override {
 		return "Sndio";
 	}
 
-	const char *getId() const {
+	const char *getId() const override {
 		return "sndio";
 	}
 
-	MusicDevices getDevices() const;
-	Common::Error createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle = 0) const;
+	MusicDevices getDevices() const override;
+	Common::Error createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle = 0) const override;
 };
 
 MusicDevices SndioMusicPlugin::getDevices() const {

--- a/backends/midi/timidity.cpp
+++ b/backends/midi/timidity.cpp
@@ -516,16 +516,16 @@ void MidiDriver_TIMIDITY::sysEx(const byte *msg, uint16 length) {
 
 class TimidityMusicPlugin : public MusicPluginObject {
 public:
-	const char *getName() const {
+	const char *getName() const override {
 		return "TiMidity";
 	}
 
-	const char *getId() const {
+	const char *getId() const override {
 		return "timidity";
 	}
 
-	MusicDevices getDevices() const;
-	Common::Error createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle = 0) const;
+	MusicDevices getDevices() const override;
+	Common::Error createInstance(MidiDriver **mididriver, MidiDriver::DeviceHandle = 0) const override;
 };
 
 MusicDevices TimidityMusicPlugin::getDevices() const {

--- a/backends/mixer/atari/atari-mixer.h
+++ b/backends/mixer/atari/atari-mixer.h
@@ -34,7 +34,7 @@ public:
 	AtariMixerManager();
 	virtual ~AtariMixerManager();
 
-	virtual void init() override;
+	void init() override;
 	void update();
 
 	void suspendAudio() override;

--- a/backends/mixer/sdl/sdl-mixer.h
+++ b/backends/mixer/sdl/sdl-mixer.h
@@ -39,19 +39,19 @@ public:
 	/**
 	 * Initialize and setups the mixer
 	 */
-	virtual void init();
+	void init() override;
 
 	// Used by Event recorder
 
 	/**
 	 * Pauses the audio system
 	 */
-	virtual void suspendAudio();
+	void suspendAudio() override;
 
 	/**
 	 * Resumes the audio system
 	 */
-	virtual int resumeAudio();
+	int resumeAudio() override;
 
 protected:
 	/**

--- a/backends/platform/android/android.h
+++ b/backends/platform/android/android.h
@@ -272,7 +272,7 @@ public:
 	bool isRunningInMainThread() { return pthread_self() == _main_thread; }
 #endif
 
-	virtual const char * const *buildHelpDialogData() override;
+	const char * const *buildHelpDialogData() override;
 };
 
 #endif

--- a/backends/platform/ios7/ios7_osys_main.h
+++ b/backends/platform/ios7/ios7_osys_main.h
@@ -158,11 +158,11 @@ public:
 	void virtualController(bool connect);
 	bool isiOSAppOnMac() const;
 
-	virtual Common::Path getDefaultLogFileName() override { return Common::Path("/scummvm.log"); }
+	Common::Path getDefaultLogFileName() override { return Common::Path("/scummvm.log"); }
 
-	virtual GUI::OptionsContainerWidget* buildBackendOptionsWidget(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
-	virtual void applyBackendSettings() override;
-	virtual void registerDefaultSettings(const Common::String &target) const override;
+	GUI::OptionsContainerWidget* buildBackendOptionsWidget(GUI::GuiObject *boss, const Common::String &name, const Common::String &target) const override;
+	void applyBackendSettings() override;
+	void registerDefaultSettings(const Common::String &target) const override;
 
 protected:
 	void updateOutputSurface();

--- a/backends/platform/sdl/sdl-window.h
+++ b/backends/platform/sdl/sdl-window.h
@@ -209,7 +209,7 @@ private:
 
 class SdlIconlessWindow : public SdlWindow {
 public:
-	virtual void setupIcon() {}
+	void setupIcon() override {}
 };
 
 #endif

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -205,7 +205,7 @@ protected:
 #endif
 
 	virtual uint32 getOSDoubleClickTime() const { return 0; }
-	virtual const char * const *buildHelpDialogData() override;
+	const char * const *buildHelpDialogData() override;
 };
 
 #endif

--- a/backends/timer/default/default-timer.h
+++ b/backends/timer/default/default-timer.h
@@ -59,8 +59,8 @@ protected:
 public:
 	DefaultTimerManager();
 	virtual ~DefaultTimerManager();
-	virtual bool installTimerProc(TimerProc proc, int32 interval, void *refCon, const Common::String &id);
-	virtual void removeTimerProc(TimerProc proc);
+	bool installTimerProc(TimerProc proc, int32 interval, void *refCon, const Common::String &id) override;
+	void removeTimerProc(TimerProc proc) override;
 
 	/**
 	 * Timer callback, to be invoked at regular time intervals by the backend.

--- a/base/detection/detection.h
+++ b/base/detection/detection.h
@@ -26,6 +26,6 @@ public:
 	Detection() {}
 	virtual ~Detection() {}
 
-	virtual const char *getName() const = 0;
+	const char *getName() const override = 0;
 	virtual PluginList getPlugins() const = 0;
 };

--- a/base/plugins.h
+++ b/base/plugins.h
@@ -198,8 +198,8 @@ class StaticPlugin : public Plugin {
 public:
 	StaticPlugin(PluginObject *pluginobject, PluginType type);
 	~StaticPlugin();
-	virtual bool loadPlugin();
-	virtual void unloadPlugin();
+	bool loadPlugin() override;
+	void unloadPlugin() override;
 };
 
 

--- a/common/archive.h
+++ b/common/archive.h
@@ -287,8 +287,8 @@ private:
 class MemcachingCaseInsensitiveArchive : public Archive {
 public:
 	MemcachingCaseInsensitiveArchive(uint32 maxStronglyCachedSize = 512) : _maxStronglyCachedSize(maxStronglyCachedSize) {}
-	SeekableReadStream *createReadStreamForMember(const Path &path) const;
-	SeekableReadStream *createReadStreamForMemberAltStream(const Path &path, Common::AltStreamType altStreamType) const;
+	SeekableReadStream *createReadStreamForMember(const Path &path) const override;
+	SeekableReadStream *createReadStreamForMemberAltStream(const Path &path, Common::AltStreamType altStreamType) const override;
 
 	virtual Path translatePath(const Path &path) const {
 		return path.normalize();
@@ -487,7 +487,7 @@ public:
 	 * Reset the Search Manager to the default list of search paths (system
 	 * specific dirs + current dir).
 	 */
-	virtual void clear();
+	void clear() override;
 
 private:
 	friend class Singleton<SingletonBaseType>;

--- a/common/callback.h
+++ b/common/callback.h
@@ -96,7 +96,7 @@ protected:
 public:
 	Callback(T *object, TMethod method): _object(object), _method(method) {}
 	virtual ~Callback() {}
-	void operator()(S data) { (_object->*_method)(data); } /*!< Type of the object passed to the operator. */
+	void operator()(S data) override { (_object->*_method)(data); } /*!< Type of the object passed to the operator. */
 };
 
 /**
@@ -139,7 +139,7 @@ public:
 	CallbackBridge(T *object, TCallbackMethod method, BaseCallback<OS> *outerCallback):
 		_object(object), _method(method), _outerCallback(outerCallback) {}
 	virtual ~CallbackBridge() {}
-	void operator()(S data) { (_object->*_method)(_outerCallback, data); } /*!< Type of the object passed to the operator. */
+	void operator()(S data) override { (_object->*_method)(_outerCallback, data); } /*!< Type of the object passed to the operator. */
 };
 
 /** @} */

--- a/common/events.h
+++ b/common/events.h
@@ -305,7 +305,7 @@ public:
 		_artificialEventQueue.push(ev);
 	}
 
-	bool pollEvent(Event &ev) {
+	bool pollEvent(Event &ev) override {
 		if (!_artificialEventQueue.empty()) {
 			ev = _artificialEventQueue.pop();
 			return true;
@@ -318,7 +318,7 @@ public:
 	 * By default, an artificial event source prevents its events
 	 * from being mapped.
 	 */
-	virtual bool allowMapping() const { return false; }
+	bool allowMapping() const override { return false; }
 };
 
 /**

--- a/common/formats/iff_container.h
+++ b/common/formats/iff_container.h
@@ -212,11 +212,11 @@ class IFFParser {
 			}
 		}
 		// ReadStream implementation
-		bool eos() const { return _input->eos(); }
-		bool err() const { return _input->err(); }
-		void clearErr() { _input->clearErr(); }
+		bool eos() const override { return _input->eos(); }
+		bool err() const override { return _input->err(); }
+		void clearErr() override { _input->clearErr(); }
 
-		uint32 read(void *dataPtr, uint32 dataSize) {
+		uint32 read(void *dataPtr, uint32 dataSize) override {
 			incBytesRead(dataSize);
 			return _input->read(dataPtr, dataSize);
 		}
@@ -272,9 +272,9 @@ public:
 	PackBitsReadStream(Common::ReadStream &input);
 	~PackBitsReadStream();
 
-	virtual bool eos() const;
+	bool eos() const override;
 
-	uint32 read(void *dataPtr, uint32 dataSize);
+	uint32 read(void *dataPtr, uint32 dataSize) override;
 };
 
 /** @} */

--- a/common/formats/winexe_ne.h
+++ b/common/formats/winexe_ne.h
@@ -52,25 +52,25 @@ public:
 	~NEResources();
 
 	/** Clear all information. */
-	void clear();
+	void clear() override;
 
 	/** Load from an EXE file. */
 	using WinResources::loadFromEXE;
 
 	/** Load from a stream. */
-	bool loadFromEXE(SeekableReadStream *stream, DisposeAfterUse::Flag disposeFileHandle = DisposeAfterUse::YES);
+	bool loadFromEXE(SeekableReadStream *stream, DisposeAfterUse::Flag disposeFileHandle = DisposeAfterUse::YES) override;
 
 	/** Return a list of resources for a given type. */
-	const Array<WinResourceID> getIDList(const WinResourceID &type) const;
+	const Array<WinResourceID> getIDList(const WinResourceID &type) const override;
 
 	/** Return a stream to the specified resource (or 0 if non-existent). */
-	SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &id);
+	SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &id) override;
 
 	/** Get a string from a string resource. */
-	String loadString(uint32 stringID);
+	String loadString(uint32 stringID) override;
 
 protected:
-	VersionInfo *parseVersionInfo(SeekableReadStream *stream);
+	VersionInfo *parseVersionInfo(SeekableReadStream *stream) override;
 
 private:
 	/** A resource. */

--- a/common/formats/winexe_pe.h
+++ b/common/formats/winexe_pe.h
@@ -51,34 +51,34 @@ public:
 	~PEResources();
 
 	/** Clear all information. */
-	void clear();
+	void clear() override;
 
 	/** Load from an EXE file. */
 	using WinResources::loadFromEXE;
 
 	/** Load from a stream. */
-	bool loadFromEXE(SeekableReadStream *stream, DisposeAfterUse::Flag disposeFileHandle = DisposeAfterUse::YES);
+	bool loadFromEXE(SeekableReadStream *stream, DisposeAfterUse::Flag disposeFileHandle = DisposeAfterUse::YES) override;
+
+	/** Return a list of IDs for a given type. */
+	const Array<WinResourceID> getIDList(const WinResourceID &type) const override;
+
+	/** Return a list of languages for a given type and ID. */
+	const Array<WinResourceID> getLangList(const WinResourceID &type, const WinResourceID &id) const override;
+
+	/** Return a stream to the specified resource, taking the first language found (or 0 if non-existent). */
+	SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &id) override;
+
+	/** Return a stream to the specified resource (or 0 if non-existent). */
+	SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &id, const WinResourceID &lang) override;
+
+	/** Get a string from a string resource. */
+	String loadString(uint32 stringID) override;
 
 	/** Return a list of resource types. */
 	const Array<WinResourceID> getTypeList() const;
 
-	/** Return a list of IDs for a given type. */
-	const Array<WinResourceID> getIDList(const WinResourceID &type) const;
-
-	/** Return a list of languages for a given type and ID. */
-	const Array<WinResourceID> getLangList(const WinResourceID &type, const WinResourceID &id) const;
-
-	/** Return a stream to the specified resource, taking the first language found (or 0 if non-existent). */
-	SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &id);
-
-	/** Return a stream to the specified resource (or 0 if non-existent). */
-	SeekableReadStream *getResource(const WinResourceID &type, const WinResourceID &id, const WinResourceID &lang);
-
-	/** Get a string from a string resource. */
-	String loadString(uint32 stringID);
-
 protected:
-	VersionInfo *parseVersionInfo(SeekableReadStream *stream);
+	VersionInfo *parseVersionInfo(SeekableReadStream *stream) override;
 
 private:
 	struct Section {

--- a/common/formats/xmlparser.h
+++ b/common/formats/xmlparser.h
@@ -76,7 +76,7 @@ class SeekableReadStream;
 	struct CustomXMLKeyLayout : public XMLKeyLayout {\
 		typedef bool (parserName::*ParserCallback)(ParserNode *node);\
 		ParserCallback callback;\
-		bool doCallback(XMLParser *parent, ParserNode *node) {return ((kLocalParserName *)parent->*callback)(node);} };\
+		bool doCallback(XMLParser *parent, ParserNode *node) override {return ((kLocalParserName *)parent->*callback)(node);} };\
 	void buildLayout() override { \
 		Common::Stack<XMLKeyLayout *> layout; \
 		CustomXMLKeyLayout *lay = 0; \

--- a/common/func.h
+++ b/common/func.h
@@ -392,8 +392,8 @@ public:
 
 	Functor0Mem(T *t, const FuncType &func) : _t(t), _func(func) {}
 
-	bool isValid() const { return _func != 0 && _t != 0; }
-	Res operator()() const {
+	bool isValid() const override { return _func != 0 && _t != 0; }
+	Res operator()() const override {
 		return (_t->*_func)();
 	}
 private:
@@ -455,8 +455,8 @@ public:
 
 	Functor1Mem(T *t, const FuncType &func) : _t(t), _func(func) {}
 
-	bool isValid() const { return _func != 0 && _t != 0; }
-	Res operator()(Arg v1) const {
+	bool isValid() const override { return _func != 0 && _t != 0; }
+	Res operator()(Arg v1) const override {
 		return (_t->*_func)(v1);
 	}
 private:
@@ -511,8 +511,8 @@ public:
 
 	Functor2Mem(T *t, const FuncType &func) : _t(t), _func(func) {}
 
-	bool isValid() const { return _func != 0 && _t != 0; }
-	Res operator()(Arg1 v1, Arg2 v2) const {
+	bool isValid() const override { return _func != 0 && _t != 0; }
+	Res operator()(Arg1 v1, Arg2 v2) const override {
 		return (_t->*_func)(v1, v2);
 	}
 private:

--- a/common/memstream.h
+++ b/common/memstream.h
@@ -84,15 +84,15 @@ public:
 		_pos(0),
 		_eos(false) {}
 
-	uint32 read(void *dataPtr, uint32 dataSize);
+	uint32 read(void *dataPtr, uint32 dataSize) override;
 
-	bool eos() const { return _eos; }
-	void clearErr() { _eos = false; }
+	bool eos() const override { return _eos; }
+	void clearErr() override { _eos = false; }
 
-	int64 pos() const { return _pos; }
-	int64 size() const { return _size; }
+	int64 pos() const override { return _pos; }
+	int64 size() const override { return _size; }
 
-	bool seek(int64 offs, int whence = SEEK_SET);
+	bool seek(int64 offs, int whence = SEEK_SET) override;
 };
 
 

--- a/common/substream.h
+++ b/common/substream.h
@@ -61,10 +61,10 @@ public:
 		assert(parentStream);
 	}
 
-	virtual bool eos() const { return _eos || _parentStream->eos(); }
-	virtual bool err() const { return _parentStream->err(); }
-	virtual void clearErr() { _eos = false; _parentStream->clearErr(); }
-	virtual uint32 read(void *dataPtr, uint32 dataSize);
+	bool eos() const override { return _eos || _parentStream->eos(); }
+	bool err() const override { return _parentStream->err(); }
+	void clearErr() override { _eos = false; _parentStream->clearErr(); }
+	uint32 read(void *dataPtr, uint32 dataSize) override;
 };
 
 /*
@@ -82,10 +82,10 @@ protected:
 public:
 	SeekableSubReadStream(SeekableReadStream *parentStream, uint32 begin, uint32 end, DisposeAfterUse::Flag disposeParentStream = DisposeAfterUse::NO);
 
-	virtual int64 pos() const { return _pos - _begin; }
-	virtual int64 size() const { return _end - _begin; }
+	int64 pos() const override { return _pos - _begin; }
+	int64 size() const override { return _end - _begin; }
 
-	virtual bool seek(int64 offset, int whence = SEEK_SET);
+	bool seek(int64 offset, int whence = SEEK_SET) override;
 };
 
 /**
@@ -107,7 +107,7 @@ public:
 		: SeekableSubReadStream(parentStream, begin, end, disposeParentStream) {
 	}
 
-	virtual uint32 read(void *dataPtr, uint32 dataSize);
+	uint32 read(void *dataPtr, uint32 dataSize) override;
 };
 
 /**

--- a/graphics/VectorRendererSpec.h
+++ b/graphics/VectorRendererSpec.h
@@ -354,7 +354,7 @@ protected:
 	 *
 	 * @see VectorRenderer::drawLineAlg()
 	 */
-	virtual void drawLineAlg(int x1, int y1, int x2, int y2, uint dx, uint dy, PixelType color);
+	void drawLineAlg(int x1, int y1, int x2, int y2, uint dx, uint dy, PixelType color) override;
 
 	/**
 	 * "Wu's Circle Antialiasing Algorithm" as published by Xiaolin Wu, July 1991
@@ -365,7 +365,7 @@ protected:
 	 *
 	 * @see VectorRenderer::drawCircleAlg()
 	 */
-	virtual void drawCircleAlg(int x, int y, int r, PixelType color, VectorRenderer::FillMode fill_m);
+	void drawCircleAlg(int x, int y, int r, PixelType color, VectorRenderer::FillMode fill_m) override;
 
 	/**
 	 * "Wu's Circle Antialiasing Algorithm" as published by Xiaolin Wu, July 1991,
@@ -374,19 +374,19 @@ protected:
 	 *
 	 * @see VectorRenderer::drawRoundedAlg()
 	 */
-	virtual void drawRoundedSquareAlg(int x1, int y1, int r, int w, int h, PixelType color, VectorRenderer::FillMode fill_m);
+	void drawRoundedSquareAlg(int x1, int y1, int r, int w, int h, PixelType color, VectorRenderer::FillMode fill_m) override;
 
-	virtual void drawBorderRoundedSquareAlg(int x1, int y1, int r, int w, int h, PixelType color, VectorRenderer::FillMode fill_m, uint8 alpha_t, uint8 alpha_l, uint8 alpha_r, uint8 alpha_b);
+	void drawBorderRoundedSquareAlg(int x1, int y1, int r, int w, int h, PixelType color, VectorRenderer::FillMode fill_m, uint8 alpha_t, uint8 alpha_l, uint8 alpha_r, uint8 alpha_b) override;
 
-	virtual void drawInteriorRoundedSquareAlg(int x1, int y1, int r, int w, int h, PixelType color, VectorRenderer::FillMode fill_m);
+	void drawInteriorRoundedSquareAlg(int x1, int y1, int r, int w, int h, PixelType color, VectorRenderer::FillMode fill_m) override;
 
-	virtual void drawRoundedSquareShadow(int x, int y, int r, int w, int h, int offset, uint32 shadowIntensity) {
+	void drawRoundedSquareShadow(int x, int y, int r, int w, int h, int offset, uint32 shadowIntensity) override {
 		Base::drawRoundedSquareShadow(x, y, r, w, h, offset, shadowIntensity);
 	}
 
-	virtual void drawTabAlg(int x, int y, int w, int h, int r,
+	void drawTabAlg(int x, int y, int w, int h, int r,
 	    PixelType color, VectorRenderer::FillMode fill_m,
-	    int baseLeft, int baseRight, bool vFlip);
+	    int baseLeft, int baseRight, bool vFlip) override;
 };
 #endif
 /** @} */

--- a/graphics/fonts/amigafont.h
+++ b/graphics/fonts/amigafont.h
@@ -94,16 +94,16 @@ public:
 	AmigaFont(Topaz9Builtin);
 	virtual ~AmigaFont();
 
-	virtual int getFontHeight() const;
-	virtual int getCharWidth(uint32 chr) const;
-	virtual int getMaxCharWidth() const;
-	virtual int getKerningOffset(uint32 left, uint32 right) const;
+	int getFontHeight() const override;
+	int getCharWidth(uint32 chr) const override;
+	int getMaxCharWidth() const override;
+	int getKerningOffset(uint32 left, uint32 right) const override;
 	int getCharAdvanceWidth(uint32 chr) const;
 	int getCharDrawOffset(uint32 chr) const;
 	int getCharInkWidth(uint32 chr) const;
 	int getCharRenderWidth(uint32 chr) const;
 	void drawCharDoubleHeight(Surface *dst, uint32 chr, int x, int y, uint32 color) const;
-	virtual void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const;
+	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const override;
 
 	int getLoChar() const { return _font->_loChar; }
 	int getHiChar() const { return _font->_hiChar; }

--- a/graphics/fonts/bdf.h
+++ b/graphics/fonts/bdf.h
@@ -62,12 +62,12 @@ public:
 	BdfFont(const BdfFontData &data, DisposeAfterUse::Flag dispose);
 	~BdfFont();
 
-	virtual int getFontHeight() const;
-	virtual int getFontAscent() const;
-	virtual int getMaxCharWidth() const;
+	int getFontHeight() const override;
+	int getFontAscent() const override;
+	int getMaxCharWidth() const override;
 
-	virtual int getCharWidth(uint32 chr) const;
-	virtual void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const;
+	int getCharWidth(uint32 chr) const override;
+	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const override;
 
 	const char *getFamilyName() const;
 	const char *getFontSlant() const;

--- a/graphics/fonts/bgifont.h
+++ b/graphics/fonts/bgifont.h
@@ -43,10 +43,10 @@ public:
 
 	void close();
 
-	int getFontHeight() const { return _totalHeight; }
-	int getCharWidth(uint32 chr) const;
-	int getMaxCharWidth() const { return _maxWidth; }
-	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const;
+	int getFontHeight() const override { return _totalHeight; }
+	int getCharWidth(uint32 chr) const override;
+	int getMaxCharWidth() const override { return _maxWidth; }
+	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const override;
 
 private:
 	struct DrawingInstruction {

--- a/graphics/fonts/macfont.h
+++ b/graphics/fonts/macfont.h
@@ -168,17 +168,17 @@ public:
 	MacFONTFont(const MacFONTdata &data);
 	virtual ~MacFONTFont();
 
-	virtual int getFontHeight() const { return _data._fRectHeight + getFontLeading(); }
-	virtual int getFontAscent() const { return _data._ascent; }
-	virtual int getFontDescent() const { return _data._descent; }
-	virtual int getFontLeading() const { return _data._leading; }
-	virtual int getMaxCharWidth() const { return _data._maxWidth; }
-	virtual int getCharWidth(uint32 chr) const;
-	virtual void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const;
+	int getFontHeight() const override { return _data._fRectHeight + getFontLeading(); }
+	int getFontAscent() const override { return _data._ascent; }
+	int getFontDescent() const override { return _data._descent; }
+	int getFontLeading() const override { return _data._leading; }
+	int getMaxCharWidth() const override { return _data._maxWidth; }
+	int getCharWidth(uint32 chr) const override;
+	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const override;
 
 	bool loadFont(Common::SeekableReadStream &stream, MacFontFamily *family = nullptr, int size = 12, int style = 0);
 
-	virtual int getKerningOffset(uint32 left, uint32 right) const;
+	int getKerningOffset(uint32 left, uint32 right) const override;
 
 	int getFontSize() const { return _data._size; }
 

--- a/graphics/fonts/winfont.h
+++ b/graphics/fonts/winfont.h
@@ -63,12 +63,12 @@ public:
 	void close();
 
 	// Font API
-	int getFontHeight() const { return _pixHeight; }	//< pixels, not points - for points, see getFontSizeInPointsAtDPI()
-	int getFontAscent() const { return _ascent; }
-	int getMaxCharWidth() const { return _maxWidth; }
+	int getFontHeight() const override { return _pixHeight; }	//< pixels, not points - for points, see getFontSizeInPointsAtDPI()
+	int getFontAscent() const override { return _ascent; }
+	int getMaxCharWidth() const override { return _maxWidth; }
 	Common::String getName() const { return _name; }
-	int getCharWidth(uint32 chr) const;
-	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const;
+	int getCharWidth(uint32 chr) const override;
+	void drawChar(Surface *dst, uint32 chr, int x, int y, uint32 color) const override;
 	int getStyle() const;
 
 	int getFontSizeInPointsAtDPI(const int dpi) const;

--- a/graphics/korfont.h
+++ b/graphics/korfont.h
@@ -124,17 +124,17 @@ class FontKoreanBase : public FontKorean {
 public:
 	FontKoreanBase();
 
-	virtual void setDrawingMode(DrawingMode mode);
+	void setDrawingMode(DrawingMode mode) override;
 
-	virtual void toggleFlippedMode(bool enable);
+	void toggleFlippedMode(bool enable) override;
 
-	virtual uint getFontHeight() const;
+	uint getFontHeight() const override;
 
-	virtual uint getMaxFontWidth() const;
+	uint getMaxFontWidth() const override;
 
-	virtual uint getCharWidth(uint16 ch) const;
+	uint getCharWidth(uint16 ch) const override;
 
-	virtual void drawChar(void *dst, uint16 ch, int pitch, int bpp, uint32 c1, uint32 c2, int maxW, int maxH) const;
+	void drawChar(void *dst, uint16 ch, int pitch, int bpp, uint32 c1, uint32 c2, int maxW, int maxH) const override;
 private:
 	template<typename Color>
 	void blitCharacter(const uint8 *glyph, const int w, const int h, uint8 *dst, int pitch, Color c) const;
@@ -171,7 +171,7 @@ public:
 	/**
 	 * Load the font data from "KOREAN.FNT".
 	 */
-	bool loadData(const char *fontFile);
+	bool loadData(const char *fontFile) override;
 private:
 	uint8 *_fontData16x16;
 	uint _fontData16x16Size;
@@ -182,9 +182,9 @@ private:
 	uint8 *_fontData8x8;
 	uint _fontData8x8Size;
 
-	virtual const uint8 *getCharData(uint16 c) const;
+	const uint8 *getCharData(uint16 c) const override;
 
-	bool hasFeature(int feat) const;
+	bool hasFeature(int feat) const override;
 
 	const uint8 *getCharDataPCE(uint16 c) const;
 	const uint8 *getCharDataDefault(uint16 c) const;
@@ -204,7 +204,7 @@ public:
 	/**
 	 * Loads the ROM data from "KOREAN#.FNT".
 	 */
-	bool loadData(const char *fontFile);
+	bool loadData(const char *fontFile) override;
 private:
 	enum {
 		eFontNumChars = 256,
@@ -221,9 +221,9 @@ private:
 	uint _englishFontDataSize;
 
 
-	virtual const uint8 *getCharData(uint16 c) const;
+	const uint8 *getCharData(uint16 c) const override;
 
-	bool hasFeature(int feat) const;
+	bool hasFeature(int feat) const override;
 
 	bool englishLoadData(const char *fontFile);
 };

--- a/graphics/maccursor.h
+++ b/graphics/maccursor.h
@@ -51,21 +51,21 @@ public:
 	~MacCursor();
 
 	/** Return the cursor's width. */
-	uint16 getWidth() const { return 16; }
+	uint16 getWidth() const override { return 16; }
 	/** Return the cursor's height. */
-	uint16 getHeight() const { return 16; }
+	uint16 getHeight() const override { return 16; }
 	/** Return the cursor's hotspot's x coordinate. */
-	uint16 getHotspotX() const { return _hotspotX; }
+	uint16 getHotspotX() const override { return _hotspotX; }
 	/** Return the cursor's hotspot's y coordinate. */
-	uint16 getHotspotY() const { return _hotspotY; }
+	uint16 getHotspotY() const override { return _hotspotY; }
 	/** Return the cursor's transparent key. */
-	virtual byte getKeyColor() const { return 0xFF; }
+	byte getKeyColor() const override { return 0xFF; }
 
-	const byte *getSurface() const { return _surface; }
+	const byte *getSurface() const override { return _surface; }
 
-	virtual const byte *getPalette() const { return _palette; }
-	byte getPaletteStartIndex() const { return 0; }
-	uint16 getPaletteCount() const { return 256; }
+	const byte *getPalette() const override { return _palette; }
+	byte getPaletteStartIndex() const override { return 0; }
+	uint16 getPaletteCount() const override { return 256; }
 
 	/** Read the cursor's data out of a stream. */
 	bool readFromStream(Common::SeekableReadStream &stream, bool forceMonochrome = false, byte monochromeInvertedPixelColor = 0xff, bool forceCURSFormat = false);

--- a/graphics/macgui/mactextwindow.h
+++ b/graphics/macgui/mactextwindow.h
@@ -33,14 +33,14 @@ public:
 	MacTextWindow(MacWindowManager *wm, const Font *font, int fgcolor, int bgcolor, int maxWidth, TextAlign textAlignment, MacMenu *menu, int padding = 0);
 	virtual ~MacTextWindow();
 
-	virtual void resize(int w, int h) override;
+	void resize(int w, int h) override;
 	void setDimensions(const Common::Rect &r) override;
 
-	virtual bool processEvent(Common::Event &event) override;
+	bool processEvent(Common::Event &event) override;
 
-	virtual bool draw(ManagedSurface *g, bool forceRedraw = false) override;
-	virtual bool draw(bool forceRedraw = false) override;
-	virtual void blit(ManagedSurface *g, Common::Rect &dest) override;
+	bool draw(ManagedSurface *g, bool forceRedraw = false) override;
+	bool draw(bool forceRedraw = false) override;
+	void blit(ManagedSurface *g, Common::Rect &dest) override;
 
 	void setTextWindowFont(const MacFont *macFont);
 	const MacFont *getTextWindowFont();
@@ -88,7 +88,7 @@ public:
 
 	int getMouseLine(int x, int y);
 
-	virtual void setBorderColor(uint32 color) override { _mactext->setBorderColor(color); }
+	void setBorderColor(uint32 color) override { _mactext->setBorderColor(color); }
 	/**
 	 * if we want to draw the text which color is not black, then we need to set _textColorRGB
 	 * @param rgb text color you want to draw

--- a/graphics/macgui/macwindow.h
+++ b/graphics/macgui/macwindow.h
@@ -105,7 +105,7 @@ public:
 	 * Accessor method to check whether the window is editable (e.g. for resizing).
 	 * @return True if the window is editable as indicated in the constructor.
 	 */
-	bool isEditable() { return _editable; }
+	bool isEditable() override { return _editable; }
 
 	/**
 	 * Mutator to change the visible state of the window.
@@ -144,7 +144,7 @@ public:
 	 * being marked as dirty unless otherwise specified.
 	 * @param forceRedraw Its behavior depends on the subclass.
 	 */
-	virtual bool draw(bool forceRedraw = false) = 0;
+	bool draw(bool forceRedraw = false) override = 0;
 
 	/**
 	 * Method called to draw the window into the target surface.
@@ -153,7 +153,7 @@ public:
 	 * @param g Surface on which to draw the window.
 	 * @param forceRedraw It's behavior depends on the subclass.
 	 */
-	virtual bool draw(ManagedSurface *g, bool forceRedraw = false) = 0;
+	bool draw(ManagedSurface *g, bool forceRedraw = false) override = 0;
 
 	/**
 	 * Method called by the WM when there is an event concerning the window.
@@ -162,7 +162,7 @@ public:
 	 * @param event Event to be processed.
 	 * @return true If the event was successfully consumed and processed.
 	 */
-	virtual bool processEvent(Common::Event &event) = 0;
+	bool processEvent(Common::Event &event) override = 0;
 
 	/**
 	 * Method that checks if the window is needs redrawing.

--- a/graphics/mfc/afx.h
+++ b/graphics/mfc/afx.h
@@ -36,7 +36,7 @@ class CFileException;
 #define DECLARE_DYNAMIC(class_name) \
 	public: \
 	static const CRuntimeClass class##class_name; \
-	virtual const CRuntimeClass *GetRuntimeClass() const override; \
+	const CRuntimeClass *GetRuntimeClass() const override; \
 
 
 #define RUNTIME_CLASS(class_name) ((const CRuntimeClass *)(&class_name::class##class_name))

--- a/graphics/mfc/afxwin.h
+++ b/graphics/mfc/afxwin.h
@@ -1800,7 +1800,7 @@ class CView : public CWnd {
 	DECLARE_DYNAMIC(CView)
 
 protected:
-	virtual bool PreCreateWindow(CREATESTRUCT &cCs) override;
+	bool PreCreateWindow(CREATESTRUCT &cCs) override;
 	virtual void OnDraw(CDC *pDC) {}
 	void OnPaint();
 	void OnNcDestroy();

--- a/graphics/sjis.h
+++ b/graphics/sjis.h
@@ -157,19 +157,19 @@ class FontSJISBase : public FontSJIS {
 public:
 	FontSJISBase();
 
-	virtual void setDrawingMode(DrawingMode mode);
+	void setDrawingMode(DrawingMode mode) override;
 
-	virtual void toggleFlippedMode(bool enable);
+	void toggleFlippedMode(bool enable) override;
 
-	virtual void toggleFatPrint(bool enable);
+	void toggleFatPrint(bool enable) override;
 
-	virtual uint getFontHeight() const;
+	uint getFontHeight() const override;
 
-	virtual uint getMaxFontWidth() const;
+	uint getMaxFontWidth() const override;
 
-	virtual uint getCharWidth(uint16 ch) const;
+	uint getCharWidth(uint16 ch) const override;
 
-	virtual void drawChar(void *dst, uint16 ch, int pitch, int bpp, uint32 c1, uint32 c2, int maxW, int maxH) const;
+	void drawChar(void *dst, uint16 ch, int pitch, int bpp, uint32 c1, uint32 c2, int maxW, int maxH) const override;
 private:
 	template<typename Color>
 	void blitCharacter(const uint8 *glyph, const int w, const int h, uint8 *dst, int pitch, Color c) const;
@@ -215,7 +215,7 @@ public:
 	/**
 	 * Loads the ROM data from "FMT_FNT.ROM".
 	 */
-	bool loadData();
+	bool loadData() override;
 
 	static int getCharFMTChunk(uint16 ch);
 
@@ -228,9 +228,9 @@ private:
 	uint8 _fontData16x16[kFont16x16Chars * 32];
 	uint8 _fontData8x16[kFont8x16Chars * 32];
 
-	virtual const uint8 *getCharData(uint16 c) const;
+	const uint8 *getCharData(uint16 c) const override;
 
-	bool hasFeature(int feat) const;
+	bool hasFeature(int feat) const override;
 };
 
 /**
@@ -275,7 +275,7 @@ public:
 	/**
 	 * Loads the ROM data from "pce.cdbios".
 	 */
-	bool loadData();
+	bool loadData() override;
 private:
 	enum {
 		kFont12x12Chars = 3418
@@ -283,9 +283,9 @@ private:
 
 	uint8 _fontData12x12[kFont12x12Chars * 18];
 
-	virtual const uint8 *getCharData(uint16 c) const;
+	const uint8 *getCharData(uint16 c) const override;
 
-	bool hasFeature(int feat) const;
+	bool hasFeature(int feat) const override;
 };
 
 /**
@@ -299,7 +299,7 @@ public:
 	/**
 	 * Load the font data from "SJIS.FNT".
 	 */
-	bool loadData();
+	bool loadData() override;
 private:
 	uint8 *_fontData16x16;
 	uint _fontData16x16Size;
@@ -310,9 +310,9 @@ private:
 	uint8 *_fontData12x12;
 	uint _fontData12x12Size;
 
-	virtual const uint8 *getCharData(uint16 c) const;
+	const uint8 *getCharData(uint16 c) const override;
 
-	bool hasFeature(int feat) const;
+	bool hasFeature(int feat) const override;
 
 	const uint8 *getCharDataPCE(uint16 c) const;
 	const uint8 *getCharDataDefault(uint16 c) const;

--- a/graphics/tinygl/zdirtyrect.h
+++ b/graphics/tinygl/zdirtyrect.h
@@ -86,7 +86,7 @@ public:
 	ClearBufferDrawCall(bool clearZBuffer, int zValue, bool clearColorBuffer, int rValue, int gValue, int bValue, bool clearStencilBuffer, int stencilValue);
 	virtual ~ClearBufferDrawCall() { }
 	bool operator==(const ClearBufferDrawCall &other) const;
-	virtual void execute(bool restoreState, const Common::Rect *clippingRectangle = nullptr) const;
+	void execute(bool restoreState, const Common::Rect *clippingRectangle = nullptr) const override;
 
 	void *operator new(size_t size) {
 		return Internal::allocateFrame(size);
@@ -122,7 +122,7 @@ public:
 	RasterizationDrawCall();
 	virtual ~RasterizationDrawCall() { }
 	bool operator==(const RasterizationDrawCall &other) const;
-	virtual void execute(bool restoreState, const Common::Rect *clippingRectangle = nullptr) const;
+	void execute(bool restoreState, const Common::Rect *clippingRectangle = nullptr) const override;
 
 	void *operator new(size_t size) {
 		return Internal::allocateFrame(size);
@@ -207,7 +207,7 @@ public:
 	BlittingDrawCall(BlitImage *image, const BlitTransform &transform, BlittingMode blittingMode);
 	virtual ~BlittingDrawCall();
 	bool operator==(const BlittingDrawCall &other) const;
-	virtual void execute(bool restoreState, const Common::Rect *clippingRectangle = nullptr) const;
+	void execute(bool restoreState, const Common::Rect *clippingRectangle = nullptr) const override;
 
 	BlittingMode getBlittingMode() const { return _mode; }
 

--- a/gui/animation/RepeatAnimationWrapper.h
+++ b/gui/animation/RepeatAnimationWrapper.h
@@ -40,12 +40,12 @@ public:
 
 	virtual ~RepeatAnimationWrapper() {}
 
-	virtual void update(Drawable* drawable, long currentTime);
+	void update(Drawable* drawable, long currentTime) override;
 
 	/**
 	 * Set start time in millis
 	 */
-	virtual void start(long currentTime);
+	void start(long currentTime) override;
 
 private:
 	uint16 _timesToRepeat;

--- a/gui/animation/SequenceAnimationComposite.h
+++ b/gui/animation/SequenceAnimationComposite.h
@@ -36,9 +36,9 @@ public:
 
 	virtual void addAnimation(AnimationPtr animation);
 
-	virtual void update(Drawable* drawable, long currentTime);
+	void update(Drawable* drawable, long currentTime) override;
 
-	virtual void start(long currentTime);
+	void start(long currentTime) override;
 
 private:
 	uint16 _index;

--- a/image/bmp.h
+++ b/image/bmp.h
@@ -73,7 +73,7 @@ public:
 
 	// ImageDecoder API
 	void destroy() override;
-	virtual bool loadStream(Common::SeekableReadStream &stream) override;
+	bool loadStream(Common::SeekableReadStream &stream) override;
 	const Graphics::Surface *getSurface() const override { return _surface; }
 	const Graphics::Palette &getPalette() const override { return _palette; }
 

--- a/image/cel_3do.h
+++ b/image/cel_3do.h
@@ -55,7 +55,7 @@ public:
 
 	// ImageDecoder API
 	void destroy() override;
-	virtual bool loadStream(Common::SeekableReadStream &stream) override;
+	bool loadStream(Common::SeekableReadStream &stream) override;
 	const Graphics::Surface *getSurface() const override { return _surface; }
 	const Graphics::Palette &getPalette() const override { return _palette; }
 

--- a/image/neo.h
+++ b/image/neo.h
@@ -49,10 +49,10 @@ public:
 	virtual ~NeoDecoder();
 
 	// ImageDecoder API
-	void destroy();
-	virtual bool loadStream(Common::SeekableReadStream &stream);
-	virtual const Graphics::Surface *getSurface() const { return _surface; }
-	const Graphics::Palette &getPalette() const { return _palette; }
+	void destroy() override;
+	bool loadStream(Common::SeekableReadStream &stream) override;
+	const Graphics::Surface *getSurface() const override { return _surface; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 	uint16 getPaletteColorCount() const { return _palette.size(); }
 
 private:

--- a/image/pcx.h
+++ b/image/pcx.h
@@ -55,7 +55,7 @@ public:
 
 	// ImageDecoder API
 	void destroy() override;
-	virtual bool loadStream(Common::SeekableReadStream &stream) override;
+	bool loadStream(Common::SeekableReadStream &stream) override;
 	const Graphics::Surface *getSurface() const override { return _surface; }
 	const Graphics::Palette &getPalette() const override { return _palette; }
 

--- a/image/scr.h
+++ b/image/scr.h
@@ -50,10 +50,10 @@ public:
 	virtual ~ScrDecoder();
 
 	// ImageDecoder API
-	void destroy();
-	virtual bool loadStream(Common::SeekableReadStream &stream);
-	virtual const Graphics::Surface *getSurface() const { return _surface; }
-	const Graphics::Palette &getPalette() const { return _palette; }
+	void destroy() override;
+	bool loadStream(Common::SeekableReadStream &stream) override;
+	const Graphics::Surface *getSurface() const override { return _surface; }
+	const Graphics::Palette &getPalette() const override { return _palette; }
 private:
 	Graphics::Surface *_surface;
 	Graphics::Palette _palette;

--- a/image/tga.h
+++ b/image/tga.h
@@ -68,10 +68,10 @@ class TGADecoder : public ImageDecoder {
 public:
 	TGADecoder();
 	virtual ~TGADecoder();
-	virtual void destroy() override;
+	void destroy() override;
 	const Graphics::Surface *getSurface() const override { return &_surface; }
 	const Graphics::Palette &getPalette() const override { return _colorMap; }
-	virtual bool loadStream(Common::SeekableReadStream &stream) override;
+	bool loadStream(Common::SeekableReadStream &stream) override;
 private:
 	// Format-spec from:
 	// https://www.ludorg.net/amnesia/TGA_File_Format_Spec.html

--- a/video/avi_decoder.h
+++ b/video/avi_decoder.h
@@ -68,14 +68,14 @@ public:
 	AVIDecoder(const Common::Rational &frameRateOverride);
 	virtual ~AVIDecoder();
 
-	bool loadStream(Common::SeekableReadStream *stream);
-	void close();
-	uint16 getWidth() const { return _header.width; }
-	uint16 getHeight() const { return _header.height; }
+	bool loadStream(Common::SeekableReadStream *stream) override;
+	void close() override;
+	uint16 getWidth() const override { return _header.width; }
+	uint16 getHeight() const override { return _header.height; }
 
-	bool rewind();
-	bool isRewindable() const { return true; }
-	bool isSeekable() const;
+	bool rewind() override;
+	bool isRewindable() const override { return true; }
+	bool isSeekable() const override;
 
 	/**
 	 * Decode the next frame into a surface and return the latter.
@@ -92,7 +92,7 @@ public:
 	 *       hence the caller must *not* free it.
 	 * @note this may return 0, in which case the last frame should be kept on screen
 	 */
-	virtual const Graphics::Surface *decodeNextFrame();
+	const Graphics::Surface *decodeNextFrame() override;
 
 	/**
 	 * Decodes the next transparency track frame
@@ -100,10 +100,10 @@ public:
 	const Graphics::Surface *decodeNextTransparency();
 protected:
 	// VideoDecoder API
-	void readNextPacket();
-	bool seekIntern(const Audio::Timestamp &time);
-	bool supportsAudioTrackSwitching() const { return true; }
-	AudioTrack *getAudioTrack(int index);
+	void readNextPacket() override;
+	bool seekIntern(const Audio::Timestamp &time) override;
+	bool supportsAudioTrackSwitching() const override { return true; }
+	AudioTrack *getAudioTrack(int index) override;
 
 	/**
 	 * Define a track to be used by this class.
@@ -209,32 +209,32 @@ protected:
 		void decodeFrame(Common::SeekableReadStream *stream);
 		void forceTrackEnd();
 
-		uint16 getWidth() const { return _bmInfo.width; }
-		uint16 getHeight() const { return _bmInfo.height; }
+		uint16 getWidth() const override { return _bmInfo.width; }
+		uint16 getHeight() const override { return _bmInfo.height; }
 		uint16 getBitCount() const { return _bmInfo.bitCount; }
-		Graphics::PixelFormat getPixelFormat() const;
-		bool setOutputPixelFormat(const Graphics::PixelFormat &format);
-		void setCodecAccuracy(Image::CodecAccuracy accuracy);
-		int getCurFrame() const { return _curFrame; }
-		int getFrameCount() const { return _frameCount; }
+		Graphics::PixelFormat getPixelFormat() const override;
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) override;
+		void setCodecAccuracy(Image::CodecAccuracy accuracy) override;
+		int getCurFrame() const override { return _curFrame; }
+		int getFrameCount() const override { return _frameCount; }
 		Common::String &getName() { return _vidsHeader.name; }
-		const Graphics::Surface *decodeNextFrame() { return _lastFrame; }
+		const Graphics::Surface *decodeNextFrame() override { return _lastFrame; }
 
-		const byte *getPalette() const;
-		bool hasDirtyPalette() const;
+		const byte *getPalette() const override;
+		bool hasDirtyPalette() const override;
 		void setCurFrame(int frame) { _curFrame = frame; }
 		void loadPaletteFromChunk(Common::SeekableReadStream *chunk);
 		void loadPaletteFromChunkRaw(Common::SeekableReadStream *chunk, int firstEntry, int numEntries);
 		void useInitialPalette();
-		bool canDither() const;
-		void setDither(const byte *palette);
+		bool canDither() const override;
+		void setDither(const byte *palette) override;
 		bool isValid() const { return _videoCodec != nullptr; }
 
 		bool isTruemotion1() const;
 		void forceDimensions(uint16 width, uint16 height);
 
-		bool isRewindable() const { return true; }
-		bool rewind();
+		bool isRewindable() const override { return true; }
+		bool rewind() override;
 
 		/**
 		 * Set the video track to play in reverse or forward.
@@ -244,22 +244,22 @@ protected:
 		 * @param reverse true for reverse, false for forward
 		 * @return true for success, false for failure
 		 */
-		virtual bool setReverse(bool reverse);
+		bool setReverse(bool reverse) override;
 
 		/**
 		 * Is the video track set to play in reverse?
 		 */
-		virtual bool isReversed() const { return _reversed; }
+		bool isReversed() const override { return _reversed; }
 
 		/**
 		 * Returns true if at the end of the video track
 		 */
-		virtual bool endOfTrack() const;
+		bool endOfTrack() const override;
 
 		/**
 		 * Get track frame rate
 		 */
-		Common::Rational getFrameRate() const { return Common::Rational(_vidsHeader.rate, _vidsHeader.scale); }
+		Common::Rational getFrameRate() const override { return Common::Rational(_vidsHeader.rate, _vidsHeader.scale); }
 
 		/**
 		 * Force sets a new frame rate
@@ -297,11 +297,11 @@ protected:
 		Common::String &getName() { return _audsHeader.name; }
 		void setCurChunk(uint32 chunk) { _curChunk = chunk; }
 
-		bool isRewindable() const { return true; }
-		bool rewind();
+		bool isRewindable() const override { return true; }
+		bool rewind() override;
 
 	protected:
-		Audio::AudioStream *getAudioStream() const { return _audioStream; }
+		Audio::AudioStream *getAudioStream() const override { return _audioStream; }
 
 		AVIStreamHeader _audsHeader;
 		PCMWaveFormat _wvInfo;
@@ -367,7 +367,7 @@ public:
 	 * This only works when the video track(s) supports getFrameTime().
 	 * This calls seek() internally.
 	 */
-	virtual bool seekToFrame(uint frame);
+	bool seekToFrame(uint frame) override;
 };
 
 } // End of namespace Video

--- a/video/bink_decoder.h
+++ b/video/bink_decoder.h
@@ -71,16 +71,16 @@ public:
 	BinkDecoder();
 	~BinkDecoder();
 
-	bool loadStream(Common::SeekableReadStream *stream);
-	void close();
+	bool loadStream(Common::SeekableReadStream *stream) override;
+	void close() override;
 
 	Common::Rational getFrameRate();
 
 protected:
-	void readNextPacket();
-	bool supportsAudioTrackSwitching() const { return true; }
-	AudioTrack *getAudioTrack(int index);
-	bool seekIntern(const Audio::Timestamp &time);
+	void readNextPacket() override;
+	bool supportsAudioTrackSwitching() const override { return true; }
+	AudioTrack *getAudioTrack(int index) override;
+	bool seekIntern(const Audio::Timestamp &time) override;
 	uint32 findKeyFrame(uint32 frame) const;
 
 private:
@@ -351,13 +351,13 @@ private:
 		/** Decode an audio packet. */
 		void decodePacket();
 
-		bool seek(const Audio::Timestamp &time);
-		bool isSeekable() const { return true; }
+		bool seek(const Audio::Timestamp &time) override;
+		bool isSeekable() const override { return true; }
 		void skipSamples(const Audio::Timestamp &length);
 		int getRate();
 
 	protected:
-		Audio::AudioStream *getAudioStream() const;
+		Audio::AudioStream *getAudioStream() const override;
 
 	private:
 		AudioInfo *_audioInfo;

--- a/video/coktel_decoder.cpp
+++ b/video/coktel_decoder.cpp
@@ -1621,10 +1621,10 @@ public:
 		delete _stream;
 	}
 
-	int readBuffer(int16 *buffer, const int numSamples);
-	bool isStereo() const { return _channels == 2; }
-	int getRate() const { return _rate; }
-	bool endOfData() const { return _stream->pos() >= _stream->size() || _stream->eos() || _stream->err(); }
+	int readBuffer(int16 *buffer, const int numSamples) override;
+	bool isStereo() const override { return _channels == 2; }
+	int getRate() const override { return _rate; }
+	bool endOfData() const override { return _stream->pos() >= _stream->size() || _stream->eos() || _stream->err(); }
 
 private:
 	Common::SeekableReadStream *_stream;
@@ -2797,7 +2797,7 @@ public:
 	}
 
 protected:
-	virtual void reset() {
+	void reset() override {
 		Audio::DVI_ADPCMStream::reset();
 		_status.ima_ch[0].last = _startPredictorValue;
 		_status.ima_ch[0].stepIndex = _startIndexValue;

--- a/video/coktel_decoder.h
+++ b/video/coktel_decoder.h
@@ -292,22 +292,22 @@ public:
 			Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType);
 	~PreIMDDecoder();
 
-	bool reloadStream(Common::SeekableReadStream *stream);
+	bool reloadStream(Common::SeekableReadStream *stream) override;
 
-	bool seek(int32 frame, int whence = SEEK_SET, bool restart = false);
+	bool seek(int32 frame, int whence = SEEK_SET, bool restart = false) override;
 
-	bool loadStream(Common::SeekableReadStream *stream);
+	bool loadStream(Common::SeekableReadStream *stream) override;
 	void close();
 
-	bool isVideoLoaded() const;
+	bool isVideoLoaded() const override;
 
-	const Graphics::Surface *decodeNextFrame();
+	const Graphics::Surface *decodeNextFrame() override;
 
-	uint32 getFlags() const;
-	uint16 getSoundFlags() const;
-	uint32 getVideoBufferSize() const;
+	uint32 getFlags() const override;
+	uint16 getSoundFlags() const override;
+	uint32 getVideoBufferSize() const override;
 
-	Graphics::PixelFormat getPixelFormat() const;
+	Graphics::PixelFormat getPixelFormat() const override;
 
 private:
 	Common::SeekableReadStream *_stream;
@@ -326,24 +326,24 @@ public:
 	IMDDecoder(Audio::Mixer *mixer, Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType);
 	~IMDDecoder();
 
-	bool reloadStream(Common::SeekableReadStream *stream);
+	bool reloadStream(Common::SeekableReadStream *stream) override;
 
-	bool seek(int32 frame, int whence = SEEK_SET, bool restart = false);
+	bool seek(int32 frame, int whence = SEEK_SET, bool restart = false) override;
 
-	void setXY(uint16 x, uint16 y);
+	void setXY(uint16 x, uint16 y) override;
 
-	bool loadStream(Common::SeekableReadStream *stream);
+	bool loadStream(Common::SeekableReadStream *stream) override;
 	void close();
 
-	bool isVideoLoaded() const;
+	bool isVideoLoaded() const override;
 
-	const Graphics::Surface *decodeNextFrame();
+	const Graphics::Surface *decodeNextFrame() override;
 
-	uint32 getFlags() const;
-	uint16 getSoundFlags() const;
-	uint32 getVideoBufferSize() const;
+	uint32 getFlags() const override;
+	uint16 getSoundFlags() const override;
+	uint32 getVideoBufferSize() const override;
 
-	Graphics::PixelFormat getPixelFormat() const;
+	Graphics::PixelFormat getPixelFormat() const override;
 
 private:
 	enum Command {
@@ -422,38 +422,38 @@ public:
 	VMDDecoder(Audio::Mixer *mixer, Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType);
 	~VMDDecoder();
 
-	bool reloadStream(Common::SeekableReadStream *stream);
+	bool reloadStream(Common::SeekableReadStream *stream) override;
 
-	bool seek(int32 frame, int whence = SEEK_SET, bool restart = false);
+	bool seek(int32 frame, int whence = SEEK_SET, bool restart = false) override;
 
-	void setXY(uint16 x, uint16 y);
+	void setXY(uint16 x, uint16 y) override;
 
-	void colorModeChanged();
+	void colorModeChanged() override;
 
-	bool getFrameCoords(int16 frame, int16 &x, int16 &y, int16 &width, int16 &height);
+	bool getFrameCoords(int16 frame, int16 &x, int16 &y, int16 &width, int16 &height) override;
 
-	bool hasEmbeddedFiles() const;
-	bool hasEmbeddedFile(const Common::String &fileName) const;
-	Common::SeekableReadStream *getEmbeddedFile(const Common::String &fileName) const;
+	bool hasEmbeddedFiles() const override;
+	bool hasEmbeddedFile(const Common::String &fileName) const override;
+	Common::SeekableReadStream *getEmbeddedFile(const Common::String &fileName) const override;
 
-	int32 getSubtitleIndex() const;
+	int32 getSubtitleIndex() const override;
 
-	bool hasVideo() const;
-	bool hasVideoData() const;
-	bool isPaletted() const;
+	bool hasVideo() const override;
+	bool hasVideoData() const override;
+	bool isPaletted() const override;
 
-	bool loadStream(Common::SeekableReadStream *stream);
+	bool loadStream(Common::SeekableReadStream *stream) override;
 	void close();
 
-	bool isVideoLoaded() const;
+	bool isVideoLoaded() const override;
 
-	const Graphics::Surface *decodeNextFrame();
+	const Graphics::Surface *decodeNextFrame() override;
 
-	uint32 getFlags() const;
-	uint16 getSoundFlags() const;
-	uint32 getVideoBufferSize() const;
+	uint32 getFlags() const override;
+	uint16 getSoundFlags() const override;
+	uint32 getVideoBufferSize() const override;
 
-	Graphics::PixelFormat getPixelFormat() const;
+	Graphics::PixelFormat getPixelFormat() const override;
 
 protected:
 	void setAutoStartSound(bool autoStartSound);
@@ -606,8 +606,8 @@ public:
 	AdvancedVMDDecoder(Audio::Mixer::SoundType soundType = Audio::Mixer::kPlainSoundType);
 	~AdvancedVMDDecoder();
 
-	bool loadStream(Common::SeekableReadStream *stream);
-	void close();
+	bool loadStream(Common::SeekableReadStream *stream) override;
+	void close() override;
 
 	void setSurfaceMemory(void *mem, uint16 width, uint16 height, uint8 bpp);
 
@@ -616,17 +616,17 @@ private:
 	public:
 		VMDVideoTrack(VMDDecoder *decoder);
 
-		uint16 getWidth() const;
-		uint16 getHeight() const;
-		Graphics::PixelFormat getPixelFormat() const;
-		int getCurFrame() const;
-		int getFrameCount() const;
-		const Graphics::Surface *decodeNextFrame();
-		const byte *getPalette() const;
-		bool hasDirtyPalette() const;
+		uint16 getWidth() const override;
+		uint16 getHeight() const override;
+		Graphics::PixelFormat getPixelFormat() const override;
+		int getCurFrame() const override;
+		int getFrameCount() const override;
+		const Graphics::Surface *decodeNextFrame() override;
+		const byte *getPalette() const override;
+		bool hasDirtyPalette() const override;
 
 	protected:
-		Common::Rational getFrameRate() const;
+		Common::Rational getFrameRate() const override;
 
 	private:
 		VMDDecoder *_decoder;
@@ -637,7 +637,7 @@ private:
 		VMDAudioTrack(VMDDecoder *decoder);
 
 	protected:
-		virtual Audio::AudioStream *getAudioStream() const;
+		Audio::AudioStream *getAudioStream() const override;
 
 	private:
 		VMDDecoder *_decoder;

--- a/video/dxa_decoder.h
+++ b/video/dxa_decoder.h
@@ -46,7 +46,7 @@ public:
 	DXADecoder();
 	virtual ~DXADecoder();
 
-	bool loadStream(Common::SeekableReadStream *stream);
+	bool loadStream(Common::SeekableReadStream *stream) override;
 
 protected:
 	/**
@@ -60,22 +60,22 @@ private:
 		DXAVideoTrack(Common::SeekableReadStream *stream);
 		~DXAVideoTrack();
 
-		bool isRewindable() const { return true; }
-		bool rewind();
+		bool isRewindable() const override { return true; }
+		bool rewind() override;
 
-		uint16 getWidth() const { return _width; }
-		uint16 getHeight() const { return _height; }
-		Graphics::PixelFormat getPixelFormat() const;
-		int getCurFrame() const { return _curFrame; }
-		int getFrameCount() const { return _frameCount; }
-		const Graphics::Surface *decodeNextFrame();
-		const byte *getPalette() const { _dirtyPalette = false; return _palette.data(); }
-		bool hasDirtyPalette() const { return _dirtyPalette; }
+		uint16 getWidth() const override { return _width; }
+		uint16 getHeight() const override { return _height; }
+		Graphics::PixelFormat getPixelFormat() const override;
+		int getCurFrame() const override { return _curFrame; }
+		int getFrameCount() const override { return _frameCount; }
+		const Graphics::Surface *decodeNextFrame() override;
+		const byte *getPalette() const override { _dirtyPalette = false; return _palette.data(); }
+		bool hasDirtyPalette() const override { return _dirtyPalette; }
 
 		void setFrameStartPos();
 
 	protected:
-		Common::Rational getFrameRate() const { return _frameRate; }
+		Common::Rational getFrameRate() const override { return _frameRate; }
 
 	private:
 		void decodeZlib(byte *data, int size, int totalSize);

--- a/video/flic_decoder.h
+++ b/video/flic_decoder.h
@@ -52,7 +52,7 @@ public:
 	FlicDecoder();
 	virtual ~FlicDecoder();
 
-	virtual bool loadStream(Common::SeekableReadStream *stream);
+	bool loadStream(Common::SeekableReadStream *stream) override;
 
 	const Common::List<Common::Rect> *getDirtyRects() const;
 	void clearDirtyRects();
@@ -67,8 +67,8 @@ protected:
 		virtual void readHeader();
 
 		bool endOfTrack() const override;
-		virtual bool isRewindable() const override{ return true; }
-		virtual bool rewind() override;
+		bool isRewindable() const override{ return true; }
+		bool rewind() override;
 
 		uint16 getWidth() const override;
 		uint16 getHeight() const override;
@@ -77,7 +77,7 @@ protected:
 		int getCurFrameDelay() const override { return _frameDelay; }
 		int getFrameCount() const override { return _frameCount; }
 		uint32 getNextFrameStartTime() const override { return _nextFrameStartTime; }
-		virtual const Graphics::Surface *decodeNextFrame() override;
+		const Graphics::Surface *decodeNextFrame() override;
 		virtual void handleFrame();
 		const byte *getPalette() const override{ _dirtyPalette = false; return _palette.data(); }
 		bool hasDirtyPalette() const override { return _dirtyPalette; }

--- a/video/hnm_decoder.h
+++ b/video/hnm_decoder.h
@@ -100,7 +100,7 @@ private:
 		const byte *getPalette() const override { _dirtyPalette = false; return _palette.data(); }
 		bool hasDirtyPalette() const override { return _dirtyPalette; }
 
-		virtual void newFrame(uint32 frameDelay) override;
+		void newFrame(uint32 frameDelay) override;
 
 	protected:
 		HNM45VideoTrack(uint32 width, uint32 height, uint32 frameSize, uint32 frameCount,
@@ -170,7 +170,7 @@ private:
 		bool setOutputPixelFormat(const Graphics::PixelFormat &format) override;
 		const Graphics::Surface *decodeNextFrame() override { return _surface; }
 
-		virtual void newFrame(uint32 frameDelay) override;
+		void newFrame(uint32 frameDelay) override;
 		/** Decode a video chunk. */
 		void decodeChunk(byte *data, uint32 size,
 		                 uint16 chunkType, uint16 flags) override;

--- a/video/mkv/mkvparser.h
+++ b/video/mkv/mkvparser.h
@@ -147,8 +147,8 @@ class SimpleBlock : public BlockEntry {
   SimpleBlock(Cluster*, long index, long long start, long long size);
   long Parse();
 
-  Kind GetKind() const;
-  const Block* GetBlock() const;
+  Kind GetKind() const override;
+  const Block* GetBlock() const override;
 
  protected:
   Block m_block;
@@ -167,8 +167,8 @@ class BlockGroup : public BlockEntry {
 
   long Parse();
 
-  Kind GetKind() const;
-  const Block* GetBlock() const;
+  Kind GetKind() const override;
+  const Block* GetBlock() const override;
 
   long long GetPrevTimeCode() const;  // relative to block's time
   long long GetNextTimeCode() const;  // as above
@@ -378,8 +378,8 @@ class Track {
    public:
     EOSBlock();
 
-    Kind GetKind() const;
-    const Block* GetBlock() const;
+    Kind GetKind() const override;
+    const Block* GetBlock() const override;
   };
 
   EOSBlock m_eos;
@@ -520,8 +520,8 @@ class VideoTrack : public Track {
   long long GetStereoMode() const;
   double GetFrameRate() const;
 
-  bool VetEntry(const BlockEntry*) const;
-  long Seek(long long time_ns, const BlockEntry*&) const;
+  bool VetEntry(const BlockEntry*) const override;
+  long Seek(long long time_ns, const BlockEntry*&) const override;
 
   Colour* GetColour() const;
 

--- a/video/mkv_decoder.h
+++ b/video/mkv_decoder.h
@@ -79,11 +79,11 @@ public:
 	 * Load a video file
 	 * @param stream  the stream to load
 	 */
-	bool loadStream(Common::SeekableReadStream *stream);
-	void close();
+	bool loadStream(Common::SeekableReadStream *stream) override;
+	void close() override;
 
 protected:
-	void readNextPacket();
+	void readNextPacket() override;
 
 private:
 	class VPXVideoTrack : public VideoTrack {
@@ -91,20 +91,20 @@ private:
 		VPXVideoTrack(const mkvparser::Track *const pTrack);
 		~VPXVideoTrack();
 
-		bool endOfTrack() const;
-		uint16 getWidth() const { return _width; }
-		uint16 getHeight() const { return _height; }
-		Graphics::PixelFormat getPixelFormat() const { return _pixelFormat; }
-		bool setOutputPixelFormat(const Graphics::PixelFormat &format) {
+		bool endOfTrack() const override;
+		uint16 getWidth() const override { return _width; }
+		uint16 getHeight() const override { return _height; }
+		Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) override {
 			if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
 				return false;
 			_pixelFormat = format;
 			return true;
 		}
 
-		int getCurFrame() const { return _curFrame; }
-		uint32 getNextFrameStartTime() const { return (uint32)(_nextFrameStartTime * 1000); }
-		const Graphics::Surface *decodeNextFrame();
+		int getCurFrame() const override { return _curFrame; }
+		uint32 getNextFrameStartTime() const override { return (uint32)(_nextFrameStartTime * 1000); }
+		const Graphics::Surface *decodeNextFrame() override;
 		bool decodeFrame(byte *frame, long size);
 		void setEndOfVideo() { _endOfVideo = true; }
 
@@ -135,7 +135,7 @@ private:
 		void setEndOfAudio() { _endOfAudio = true; }
 
 	protected:
-		Audio::AudioStream *getAudioStream() const;
+		Audio::AudioStream *getAudioStream() const override;
 
 	private:
 		Audio::QueuingAudioStream *_audStream;

--- a/video/mpegps_decoder.h
+++ b/video/mpegps_decoder.h
@@ -57,16 +57,16 @@ public:
 	MPEGPSDecoder(double decibel = 0.0);
 	virtual ~MPEGPSDecoder();
 
-	bool loadStream(Common::SeekableReadStream *stream);
-	void close();
+	bool loadStream(Common::SeekableReadStream *stream) override;
+	void close() override;
 
 	// Set the number of prebuffered packets in demuxer
 	// Used only by qdEngine
 	void setPrebufferedPackets(int packets);
 
 protected:
-	void readNextPacket();
-	bool useAudioSync() const { return false; }
+	void readNextPacket() override;
+	bool useAudioSync() const override { return false; }
 
 private:
 	class MPEGPSDemuxer {
@@ -131,17 +131,17 @@ private:
 		MPEGVideoTrack(Common::SeekableReadStream *firstPacket);
 		~MPEGVideoTrack();
 
-		bool endOfTrack() const { return _endOfTrack; }
-		uint16 getWidth() const;
-		uint16 getHeight() const;
-		Graphics::PixelFormat getPixelFormat() const;
-		bool setOutputPixelFormat(const Graphics::PixelFormat &format);
-		int getCurFrame() const { return _curFrame; }
-		uint32 getNextFrameStartTime() const { return _nextFrameStartTime.msecs(); }
-		const Graphics::Surface *decodeNextFrame();
+		bool endOfTrack() const override { return _endOfTrack; }
+		uint16 getWidth() const override;
+		uint16 getHeight() const override;
+		Graphics::PixelFormat getPixelFormat() const override;
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) override;
+		int getCurFrame() const override { return _curFrame; }
+		uint32 getNextFrameStartTime() const override { return _nextFrameStartTime.msecs(); }
+		const Graphics::Surface *decodeNextFrame() override;
 
-		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts);
-		StreamType getStreamType() const { return kStreamTypeVideo; }
+		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts) override;
+		StreamType getStreamType() const override { return kStreamTypeVideo; }
 
 		void setEndOfTrack() { _endOfTrack = true; }
 
@@ -170,11 +170,11 @@ private:
 		MPEGAudioTrack(Common::SeekableReadStream &firstPacket, Audio::Mixer::SoundType soundType);
 		~MPEGAudioTrack();
 
-		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts);
-		StreamType getStreamType() const { return kStreamTypeAudio; }
+		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts) override;
+		StreamType getStreamType() const override { return kStreamTypeAudio; }
 
 	protected:
-		Audio::AudioStream *getAudioStream() const;
+		Audio::AudioStream *getAudioStream() const override;
 
 	private:
 		Audio::PacketizedAudioStream *_audStream;
@@ -187,11 +187,11 @@ private:
 		AC3AudioTrack(Common::SeekableReadStream &firstPacket, double decibel, Audio::Mixer::SoundType soundType);
 		~AC3AudioTrack();
 
-		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts);
-		StreamType getStreamType() const { return kStreamTypeAudio; }
+		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts) override;
+		StreamType getStreamType() const override { return kStreamTypeAudio; }
 
 	protected:
-		Audio::AudioStream *getAudioStream() const;
+		Audio::AudioStream *getAudioStream() const override;
 
 	private:
 		Audio::PacketizedAudioStream *_audStream;
@@ -203,11 +203,11 @@ private:
 		PS2AudioTrack(Common::SeekableReadStream *firstPacket, Audio::Mixer::SoundType soundType);
 		~PS2AudioTrack();
 
-		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts);
-		StreamType getStreamType() const { return kStreamTypeAudio; }
+		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts) override;
+		StreamType getStreamType() const override { return kStreamTypeAudio; }
 
 	protected:
-		Audio::AudioStream *getAudioStream() const;
+		Audio::AudioStream *getAudioStream() const override;
 
 	private:
 		Audio::PacketizedAudioStream *_audStream;

--- a/video/mve_decoder.h
+++ b/video/mve_decoder.h
@@ -102,22 +102,22 @@ class MveDecoder : public VideoDecoder {
 	public:
 		MveVideoTrack(MveDecoder *decoder);
 
-		bool endOfTrack() const;
+		bool endOfTrack() const override;
 
-		uint16 getWidth() const;
-		uint16 getHeight() const;
+		uint16 getWidth() const override;
+		uint16 getHeight() const override;
 
-		Graphics::PixelFormat getPixelFormat() const;
+		Graphics::PixelFormat getPixelFormat() const override;
 
-		int getCurFrame() const;
+		int getCurFrame() const override;
 		// int getFrameCount() const;
 
-		const Graphics::Surface *decodeNextFrame();
-		const byte *getPalette() const;
-		bool hasDirtyPalette() const;
+		const Graphics::Surface *decodeNextFrame() override;
+		const byte *getPalette() const override;
+		bool hasDirtyPalette() const override;
 
 	protected:
-		Common::Rational getFrameRate() const;
+		Common::Rational getFrameRate() const override;
 	};
 
 	class MveAudioTrack : public AudioTrack {
@@ -125,7 +125,7 @@ class MveDecoder : public VideoDecoder {
 	public:
 		MveAudioTrack(MveDecoder *decoder);
 
-		Audio::AudioStream *getAudioStream() const;
+		Audio::AudioStream *getAudioStream() const override;
 	};
 
 	class MveSkipStream {
@@ -156,7 +156,7 @@ public:
 	MveDecoder();
 	virtual ~MveDecoder();
 
-	bool loadStream(Common::SeekableReadStream *stream);
+	bool loadStream(Common::SeekableReadStream *stream) override;
 	void setAudioTrack(int track);
 	void applyPalette(PaletteManager *paletteManager);
 
@@ -165,7 +165,7 @@ public:
 	// void copyDirtyRectsToBuffer(uint8 *dst, uint pitch);
 
 	Common::Rational getFrameRate() { return _frameRate; }
-	void readNextPacket();
+	void readNextPacket() override;
 };
 
 } // End of namespace Video

--- a/video/paco_decoder.h
+++ b/video/paco_decoder.h
@@ -52,13 +52,13 @@ public:
 	virtual ~PacoDecoder();
 	void close() override;
 
-	virtual bool loadStream(Common::SeekableReadStream *stream) override;
+	bool loadStream(Common::SeekableReadStream *stream) override;
 
 	const Common::List<Common::Rect> *getDirtyRects() const;
 	void clearDirtyRects();
 	void copyDirtyRectsToBuffer(uint8 *dst, uint pitch);
 	const byte *getPalette();
-	virtual void readNextPacket() override;
+	void readNextPacket() override;
 
 
 protected:
@@ -69,14 +69,14 @@ protected:
 		~PacoVideoTrack();
 
 		bool endOfTrack() const override;
-		virtual bool isRewindable() const override { return false; }
+		bool isRewindable() const override { return false; }
 
 		uint16 getWidth() const override;
 		uint16 getHeight() const override;
 		Graphics::PixelFormat getPixelFormat() const override;
 		int getCurFrame() const override { return _curFrame; }
 		int getFrameCount() const override { return _frameCount; }
-		virtual const Graphics::Surface *decodeNextFrame() override;
+		const Graphics::Surface *decodeNextFrame() override;
 		virtual void handleFrame(Common::SeekableReadStream *fileStream, uint32 chunkSize, int curFrame);
 		virtual void handleEOC() { _curFrame += 1; };
 		void handlePalette(Common::SeekableReadStream *fileStream);
@@ -109,7 +109,7 @@ protected:
 		bool needsAudio() const;
 
 	protected:
-		Audio::AudioStream *getAudioStream() const { return _packetStream; }
+		Audio::AudioStream *getAudioStream() const override { return _packetStream; }
 
 	private:
 		Audio::StatelessPacketizedAudioStream *_packetStream;

--- a/video/psx_decoder.h
+++ b/video/psx_decoder.h
@@ -65,7 +65,7 @@ public:
 	};
 
 	PSXStreamDecoder(CDSpeed speed, uint32 frameCount = 0);
-	virtual ~PSXStreamDecoder() override;
+	~PSXStreamDecoder() override;
 
 	bool loadStream(Common::SeekableReadStream *stream) override;
 	void close() override;

--- a/video/qt_decoder.h
+++ b/video/qt_decoder.h
@@ -68,13 +68,13 @@ public:
 	QuickTimeDecoder();
 	virtual ~QuickTimeDecoder();
 
-	bool loadFile(const Common::Path &filename);
-	bool loadStream(Common::SeekableReadStream *stream);
-	void close();
-	uint16 getWidth() const { return _width; }
-	uint16 getHeight() const { return _height; }
-	const Graphics::Surface *decodeNextFrame();
-	Audio::Timestamp getDuration() const { return Audio::Timestamp(0, _duration, _timeScale); }
+	bool loadFile(const Common::Path &filename) override;
+	bool loadStream(Common::SeekableReadStream *stream) override;
+	void close() override;
+	uint16 getWidth() const override { return _width; }
+	uint16 getHeight() const override { return _height; }
+	const Graphics::Surface *decodeNextFrame() override;
+	Audio::Timestamp getDuration() const override { return Audio::Timestamp(0, _duration, _timeScale); }
 
 	void enableEditListBoundsCheckQuirk(bool enable) { _enableEditListBoundsCheckQuirk = enable; }
 	Common::String getAliasPath();
@@ -159,7 +159,7 @@ public:
 	void goToNode(uint32 nodeID);
 
 protected:
-	Common::QuickTimeParser::SampleDesc *readSampleDesc(Common::QuickTimeParser::Track *track, uint32 format, uint32 descSize);
+	Common::QuickTimeParser::SampleDesc *readSampleDesc(Common::QuickTimeParser::Track *track, uint32 format, uint32 descSize) override;
 	Common::QuickTimeParser::SampleDesc *readPanoSampleDesc(Common::QuickTimeParser::Track *track, uint32 format, uint32 descSize);
 
 private:
@@ -277,7 +277,7 @@ private:
 		void updateBuffer();
 
 	protected:
-		Audio::SeekableAudioStream *getSeekableAudioStream() const;
+		Audio::SeekableAudioStream *getSeekableAudioStream() const override;
 
 	private:
 		QuickTimeDecoder *_decoder;
@@ -331,27 +331,27 @@ private:
 		VideoTrackHandler(QuickTimeDecoder *decoder, Common::QuickTimeParser::Track *parent);
 		~VideoTrackHandler();
 
-		bool endOfTrack() const;
-		bool isSeekable() const { return true; }
-		bool seek(const Audio::Timestamp &time);
-		Audio::Timestamp getDuration() const;
+		bool endOfTrack() const override;
+		bool isSeekable() const override { return true; }
+		bool seek(const Audio::Timestamp &time) override;
+		Audio::Timestamp getDuration() const override;
 
-		uint16 getWidth() const;
-		uint16 getHeight() const;
-		Graphics::PixelFormat getPixelFormat() const;
-		bool setOutputPixelFormat(const Graphics::PixelFormat &format);
-		int getCurFrame() const { return _curFrame; }
+		uint16 getWidth() const override;
+		uint16 getHeight() const override;
+		Graphics::PixelFormat getPixelFormat() const override;
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) override;
+		int getCurFrame() const override { return _curFrame; }
 		void setCurFrame(int32 curFrame) { _curFrame = curFrame; }
-		int getFrameCount() const;
-		uint32 getNextFrameStartTime() const; // milliseconds
-		const Graphics::Surface *decodeNextFrame();
-		Audio::Timestamp getFrameTime(uint frame) const;
-		const byte *getPalette() const;
-		bool hasDirtyPalette() const { return _dirtyPalette; }
-		bool setReverse(bool reverse);
-		bool isReversed() const { return _reversed; }
-		bool canDither() const;
-		void setDither(const byte *palette);
+		int getFrameCount() const override;
+		uint32 getNextFrameStartTime() const override; // milliseconds
+		const Graphics::Surface *decodeNextFrame() override;
+		Audio::Timestamp getFrameTime(uint frame) const override;
+		const byte *getPalette() const override;
+		bool hasDirtyPalette() const override { return _dirtyPalette; }
+		bool setReverse(bool reverse) override;
+		bool isReversed() const override { return _reversed; }
+		bool canDither() const override;
+		void setDither(const byte *palette) override;
 
 		Common::Rational getScaledWidth() const;
 		Common::Rational getScaledHeight() const;
@@ -389,13 +389,13 @@ private:
 		PanoTrackHandler(QuickTimeDecoder *decoder, Common::QuickTimeParser::Track *parent);
 		~PanoTrackHandler();
 
-		bool endOfTrack() const { return false; }
-		uint16 getWidth() const;
-		uint16 getHeight() const;
-		int getCurFrame() const { return 1; }
-		uint32 getNextFrameStartTime() const { return 0; }
-		Graphics::PixelFormat getPixelFormat() const;
-		const Graphics::Surface *decodeNextFrame();
+		bool endOfTrack() const override { return false; }
+		uint16 getWidth() const override;
+		uint16 getHeight() const override;
+		int getCurFrame() const override { return 1; }
+		uint32 getNextFrameStartTime() const override { return 0; }
+		Graphics::PixelFormat getPixelFormat() const override;
+		const Graphics::Surface *decodeNextFrame() override;
 
 		Common::Rational getScaledWidth() const;
 		Common::Rational getScaledHeight() const;

--- a/video/smk_decoder.h
+++ b/video/smk_decoder.h
@@ -79,19 +79,19 @@ public:
 	SmackerDecoder();
 	virtual ~SmackerDecoder();
 
-	virtual bool loadStream(Common::SeekableReadStream *stream);
-	void close();
+	bool loadStream(Common::SeekableReadStream *stream) override;
+	void close() override;
 	const Graphics::Surface *forceSeekToFrame(uint frame);
-	bool rewind();
+	bool rewind() override;
 
 	Common::Rational getFrameRate() const;
 
 	virtual const Common::Rect *getNextDirtyRect();
 
 protected:
-	void readNextPacket();
-	bool supportsAudioTrackSwitching() const { return true; }
-	AudioTrack *getAudioTrack(int index);
+	void readNextPacket() override;
+	bool supportsAudioTrackSwitching() const override { return true; }
+	AudioTrack *getAudioTrack(int index) override;
 
 	virtual void handleAudioTrack(byte track, uint32 chunkSize, uint32 unpackedSize);
 
@@ -102,24 +102,24 @@ protected:
 		SmackerVideoTrack(uint32 width, uint32 height, uint32 frameCount, const Common::Rational &frameRate, uint32 flags, uint32 version);
 		~SmackerVideoTrack();
 
-		bool isRewindable() const { return true; }
-		bool rewind() { _curFrame = -1; return true; }
+		bool isRewindable() const override { return true; }
+		bool rewind() override { _curFrame = -1; return true; }
 
-		uint16 getWidth() const;
-		uint16 getHeight() const;
-		Graphics::PixelFormat getPixelFormat() const;
-		int getCurFrame() const { return _curFrame; }
-		int getFrameCount() const { return _frameCount; }
-		const Graphics::Surface *decodeNextFrame() { return _surface; }
-		const byte *getPalette() const { _dirtyPalette = false; return _palette.data(); }
-		bool hasDirtyPalette() const { return _dirtyPalette; }
+		uint16 getWidth() const override;
+		uint16 getHeight() const override;
+		Graphics::PixelFormat getPixelFormat() const override;
+		int getCurFrame() const override { return _curFrame; }
+		int getFrameCount() const override { return _frameCount; }
+		const Graphics::Surface *decodeNextFrame() override { return _surface; }
+		const byte *getPalette() const override { _dirtyPalette = false; return _palette.data(); }
+		bool hasDirtyPalette() const override { return _dirtyPalette; }
 
 		void readTrees(SmackerBitStream &bs, uint32 mMapSize, uint32 mClrSize, uint32 fullSize, uint32 typeSize);
 		void increaseCurFrame() { _curFrame++; }
 		void decodeFrame(SmackerBitStream &bs);
 		void unpackPalette(Common::SeekableReadStream *stream);
 
-		Common::Rational getFrameRate() const { return _frameRate; }
+		Common::Rational getFrameRate() const override { return _frameRate; }
 
 		const Common::Rect *getNextDirtyRect();
 
@@ -189,14 +189,14 @@ private:
 		SmackerAudioTrack(const AudioInfo &audioInfo, Audio::Mixer::SoundType soundType);
 		~SmackerAudioTrack();
 
-		bool isRewindable() const { return true; }
-		bool rewind();
+		bool isRewindable() const override { return true; }
+		bool rewind() override;
 
 		void queueCompressedBuffer(byte *buffer, uint32 bufferSize, uint32 unpackedSize);
 		void queuePCM(byte *buffer, uint32 bufferSize);
 
 	protected:
-		Audio::AudioStream *getAudioStream() const;
+		Audio::AudioStream *getAudioStream() const override;
 
 	private:
 		Audio::QueuingAudioStream *_audioStream;
@@ -204,12 +204,12 @@ private:
 	};
 
 	class SmackerEmptyTrack : public Track {
-		VideoDecoder::Track::TrackType getTrackType() const { return VideoDecoder::Track::kTrackTypeNone; }
+		VideoDecoder::Track::TrackType getTrackType() const override { return VideoDecoder::Track::kTrackTypeNone; }
 
-		bool endOfTrack() const { return true; }
+		bool endOfTrack() const override { return true; }
 
-		bool isSeekable() const { return true; }
-		bool seek(const Audio::Timestamp &time) { return true; }
+		bool isSeekable() const override { return true; }
+		bool seek(const Audio::Timestamp &time) override { return true; }
 	};
 
 protected:

--- a/video/theora_decoder.h
+++ b/video/theora_decoder.h
@@ -71,14 +71,14 @@ public:
 	 * Load a video file
 	 * @param stream  the stream to load
 	 */
-	bool loadStream(Common::SeekableReadStream *stream);
-	void close();
+	bool loadStream(Common::SeekableReadStream *stream) override;
+	void close() override;
 
 	/** Frames per second of the loaded video. */
 	Common::Rational getFrameRate() const;
 
 protected:
-	void readNextPacket();
+	void readNextPacket() override;
 
 private:
 	class TheoraVideoTrack : public VideoTrack {
@@ -86,21 +86,21 @@ private:
 		TheoraVideoTrack(th_info &theoraInfo, th_setup_info *theoraSetup);
 		~TheoraVideoTrack();
 
-		bool endOfTrack() const { return _endOfVideo; }
-		uint16 getWidth() const { return _width; }
-		uint16 getHeight() const { return _height; }
-		Graphics::PixelFormat getPixelFormat() const { return _pixelFormat; }
-		bool setOutputPixelFormat(const Graphics::PixelFormat &format) {
+		bool endOfTrack() const override { return _endOfVideo; }
+		uint16 getWidth() const override { return _width; }
+		uint16 getHeight() const override { return _height; }
+		Graphics::PixelFormat getPixelFormat() const override { return _pixelFormat; }
+		bool setOutputPixelFormat(const Graphics::PixelFormat &format) override {
 			if (format.bytesPerPixel != 2 && format.bytesPerPixel != 4)
 				return false;
 			_pixelFormat = format;
 			return true;
 		}
 
-		int getCurFrame() const { return _curFrame; }
+		int getCurFrame() const override { return _curFrame; }
 		const Common::Rational &getFrameRate() const { return _frameRate; }
-		uint32 getNextFrameStartTime() const { return (uint32)(_nextFrameStartTime * 1000); }
-		const Graphics::Surface *decodeNextFrame() { return _displaySurface; }
+		uint32 getNextFrameStartTime() const override { return (uint32)(_nextFrameStartTime * 1000); }
+		const Graphics::Surface *decodeNextFrame() override { return _displaySurface; }
 
 		bool decodePacket(ogg_packet &oggPacket);
 		void setEndOfVideo() { _endOfVideo = true; }
@@ -139,7 +139,7 @@ private:
 		void setEndOfAudio() { _endOfAudio = true; }
 
 	protected:
-		Audio::AudioStream *getAudioStream() const;
+		Audio::AudioStream *getAudioStream() const override;
 
 	private:
 		// single audio fragment audio buffering

--- a/video/video_decoder.h
+++ b/video/video_decoder.h
@@ -597,8 +597,8 @@ protected:
 		VideoTrack() {}
 		virtual ~VideoTrack() {}
 
-		TrackType getTrackType() const  { return kTrackTypeVideo; }
-		virtual bool endOfTrack() const;
+		TrackType getTrackType() const override { return kTrackTypeVideo; }
+		bool endOfTrack() const override;
 
 		/**
 		 * Get the width of this track
@@ -715,9 +715,9 @@ protected:
 		FixedRateVideoTrack() {}
 		virtual ~FixedRateVideoTrack() {}
 
-		uint32 getNextFrameStartTime() const;
-		virtual Audio::Timestamp getDuration() const;
-		Audio::Timestamp getFrameTime(uint frame) const;
+		uint32 getNextFrameStartTime() const override;
+		Audio::Timestamp getDuration() const override;
+		Audio::Timestamp getFrameTime(uint frame) const override;
 
 		/**
 		 * Get the frame that should be displaying at the given time. This is
@@ -740,9 +740,9 @@ protected:
 		AudioTrack(Audio::Mixer::SoundType soundType);
 		virtual ~AudioTrack() {}
 
-		TrackType getTrackType() const { return kTrackTypeAudio; }
+		TrackType getTrackType() const override { return kTrackTypeAudio; }
 
-		virtual bool endOfTrack() const;
+		bool endOfTrack() const override;
 
 		/**
 		 * Start playing this track
@@ -814,7 +814,7 @@ protected:
 		void setMute(bool mute);
 
 	protected:
-		void pauseIntern(bool shouldPause);
+		void pauseIntern(bool shouldPause) override;
 
 		/**
 		 * Get the AudioStream that is the representation of this AudioTrack
@@ -839,11 +839,11 @@ protected:
 		RewindableAudioTrack(Audio::Mixer::SoundType soundType) : AudioTrack(soundType) {}
 		virtual ~RewindableAudioTrack() {}
 
-		bool isRewindable() const { return true; }
-		bool rewind();
+		bool isRewindable() const override { return true; }
+		bool rewind() override;
 
 	protected:
-		Audio::AudioStream *getAudioStream() const;
+		Audio::AudioStream *getAudioStream() const override;
 
 		/**
 		 * Get the RewindableAudioStream pointer to be used by this class
@@ -861,13 +861,13 @@ protected:
 		SeekableAudioTrack(Audio::Mixer::SoundType soundType) : AudioTrack(soundType) {}
 		virtual ~SeekableAudioTrack() {}
 
-		bool isSeekable() const { return true; }
-		bool seek(const Audio::Timestamp &time);
+		bool isSeekable() const override { return true; }
+		bool seek(const Audio::Timestamp &time) override;
 
-		Audio::Timestamp getDuration() const;
+		Audio::Timestamp getDuration() const override;
 
 	protected:
-		Audio::AudioStream *getAudioStream() const;
+		Audio::AudioStream *getAudioStream() const override;
 
 		/**
 		 * Get the SeekableAudioStream pointer to be used by this class
@@ -895,7 +895,7 @@ protected:
 
 	protected:
 		Audio::SeekableAudioStream *_stream;
-		Audio::SeekableAudioStream *getSeekableAudioStream() const { return _stream; }
+		Audio::SeekableAudioStream *getSeekableAudioStream() const override { return _stream; }
 	};
 
 	/**


### PR DESCRIPTION
This adds the override keyword and removes the virtual one everywhere it's possible in the common codebase.
Engines are not touched by this PR.

The missing override keywords were found using GCC and the `-Wsuggest-override` warning.

I checked that building with and without this PR doesn't change the resulting disassembly.
