### PR TITLE
CHEWY: Fix #16948 (non-responsive state in room 05)

### DIFF
--- a/engines/chewy/r_event.cpp
+++ b/engines/chewy/r_event.cpp
@@ -1158,7 +1158,7 @@ void sib_event_inv(int16 sib_nr) {
 			_G(gameState).R5Terminal = true;
 			cur_2_inventory();
 			delInventory(RED_CARD_INV);
-			start_aad(103, -1);
+			start_aad(103, -1, true);
 			_G(det)->startDetail(6, 255, ANI_FRONT);
 			_G(atds)->set_all_ats_str(27, 1, ATS_DATA);
 			_G(atds)->set_all_ats_str(30, 1, ATS_DATA);


### PR DESCRIPTION
This fixes https://bugs.scummvm.org/ticket/16948 .

The weird non-responsive state (game wouldn't react to mouse clicks) doesn't occur anymore since `continueWhenSpeechEnds` is enabled for the automatic dialog after inserting the keycard.

Apparently, the strange non-responsive state, that I could enter for example by hitting F3 (look), was caused because `EventsManager::_kbInfo._keyCode` was still set to the F3 keycode and nothing cleared it. This would override mouse clicks in `EventsManager::getSwitchCode()`. But since `continueWhenSpeechEnds` prevents getting into this state for room 05 at least, I haven't looked further into this complication.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
