### PR TITLE
CHEWY: Fix left mouse clicks being ignored after a lingering Return key

### DIFF
--- a/engines/chewy/main.cpp
+++ b/engines/chewy/main.cpp
@@ -801,6 +801,7 @@ void mouseAction() {
 				g_events->_kbInfo._scanCode = Common::KEYCODE_ESCAPE;
 			}
 		} else if (_G(minfo).button == 1 || g_events->_kbInfo._keyCode == Common::KEYCODE_RETURN) {
+			g_events->_kbInfo._keyCode = '\0';
 			if (!_G(flags).mainMouseFlag) {
 				if (_G(menu_display) == MENU_DISPLAY)
 					g_events->_kbInfo._scanCode = Common::KEYCODE_RETURN;


### PR DESCRIPTION
In mouseAction(), consume the key in the Return/left-click branch, mirroring the Escape branch above it.

mouseAction() treats a pending Return key as a left click, but unlike the Escape branch it never consumed the key code. Since the engine latches _kbInfo._keyCode until some code explicitly clears it, a stale Return kept the "button still held" flag (mainMouseFlag) set forever, so every subsequent left click was discarded. Only a right click or a key handled by one of the few paths that reset the key code (e.g. F5) would recover.

This was easiest to trigger by confirming the GMM save dialog (Ctrl+F5) with Enter: the key-up leaked into the engine after the overlay closed and lingered there.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
