### PR TITLE
CHEWY: Fix non-responsive states in room 07

### DIFF
--- a/engines/chewy/rooms/room07.cpp
+++ b/engines/chewy/rooms/room07.cpp
@@ -80,7 +80,7 @@ void Room7::bell() {
 	if ((!_G(gameState).R7BellCount) ||
 		(_G(gameState).R7BellCount >= 2 && _G(gameState).R7RopeLeft && !_G(gameState).R7RopeOk)) {
 		_G(gameState)._personHide[P_CHEWY] = true;
-		start_aad(5, 0);
+		start_aad(5, 0, true);
 		startAniBlock(3, ABLOCK25);
 
 		_G(det)->showStaticSpr(7);
@@ -127,7 +127,7 @@ void Room7::bell() {
 
 	} else if (!_G(gameState).R7RopeOk) {
 		_G(gameState)._personHide[P_CHEWY] = true;
-		start_aad(7, 0);
+		start_aad(7, 0, true);
 		startAniBlock(3, ABLOCK25);
 		_G(det)->showStaticSpr(7);
 		_G(det)->load_taf_seq(192, 74, nullptr);


### PR DESCRIPTION
This is equivalent to the fix in PR #7655 for room 05. 

After hitting the bell (for the first time, then again when hitting for a third time) the game ended up in a state non-responsive to mouse clicks.

[saves-room07.zip](https://github.com/user-attachments/files/29931399/saves-room07.zip) to reproduce

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the followi

ng template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->



