### PR TITLE
DIRECTOR: Fix boot and playback blockers for Physicus

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -42,6 +42,7 @@
 #include "director/sound.h"
 #include "director/sprite.h"
 #include "director/stxt.h"
+#include "director/xmed.h"
 #include "director/castmember/castmember.h"
 #include "director/castmember/bitmap.h"
 #include "director/castmember/digitalvideo.h"
@@ -128,6 +129,9 @@ Cast::~Cast() {
 		delete it._value;
 
 	for (auto &it : _loadedRTE2s)
+		delete it._value;
+
+	for (auto &it : _loadedXMEDs)
 		delete it._value;
 
 	delete _loadedCast;
@@ -916,6 +920,17 @@ void Cast::loadCast() {
 		delete r;
 	}
 
+	// "Text" Asset Xtra cast members keep their string in an XMED child.
+	Common::Array<uint16> xmed = _castArchive->getResourceIDList(MKTAG('X','M','E','D'));
+	debugC(2, kDebugLoading, "****** Loading %d XMED resources", xmed.size());
+
+	for (auto &iterator : xmed) {
+		r = _castArchive->getResource(MKTAG('X','M','E','D'), iterator);
+		debugC(3, kDebugText, "XMED: id %d", iterator - _castIDoffset);
+		_loadedXMEDs.setVal(iterator, new XMED(this, *r));
+		delete r;
+	}
+
 	// For D4+ we may request to force Lingo scripts and skip precompiled bytecode
 	if (_version >= kFileVer400 && !debugChannelSet(-1, kDebugNoBytecode)) {
 		// Try to load script context
@@ -1652,10 +1667,26 @@ void Cast::loadCastData(Common::SeekableReadStreamEndian &stream, uint16 id, Res
 		debugC(3, kDebugLoading, "Cast::loadCastData(): loading kCastTransition (id=%d, %d children)",  id, res->children.size());
 		target = new TransitionCastMember(this, id, castStream, _version);
 		break;
-	case kCastXtra:
+	case kCastXtra: {
 		debugC(3, kDebugLoading, "Cast::loadCastData(): loading kCastXtra (id=%d, %d children)",  id, res->children.size());
-		target = new XtraCastMember(this, id, castStream, _version);
+		XtraCastMember *xtra = new XtraCastMember(this, id, castStream, _version);
+		if (xtra->isQuickTimeVideo()) {
+			// Promote to a digital video member so playback/property machinery applies.
+			debugC(3, kDebugLoading, "Cast::loadCastData(): promoting QuickTime Xtra (id=%d) to digital video", id);
+			delete xtra;
+			DigitalVideoCastMember *dv = new DigitalVideoCastMember(this, id);
+			dv->_qtmovie = true;
+			target = dv;
+		} else if (xtra->isTextXtra()) {
+			// Text, rect and styling are filled in lazily by TextCastMember::load().
+			debugC(3, kDebugLoading, "Cast::loadCastData(): promoting Text Xtra (id=%d) to text cast member", id);
+			delete xtra;
+			target = new TextCastMember(this, id, _version);
+		} else {
+			target = xtra;
+		}
 		break;
+	}
 	default:
 		warning("BUILDBOT: STUB: Cast::loadCastData(): Unhandled cast type: %d [%s] (id=%d, %d children)! This will be missing from the movie and may cause problems", castType, tag2str(castType), id, res->children.size());
 		// also don't try and read the strings... we don't know what this item is.

--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -1673,9 +1673,11 @@ void Cast::loadCastData(Common::SeekableReadStreamEndian &stream, uint16 id, Res
 		if (xtra->isQuickTimeVideo()) {
 			// Promote to a digital video member so playback/property machinery applies.
 			debugC(3, kDebugLoading, "Cast::loadCastData(): promoting QuickTime Xtra (id=%d) to digital video", id);
+			bool qtLooping = xtra->isQuickTimeLooping();
 			delete xtra;
 			DigitalVideoCastMember *dv = new DigitalVideoCastMember(this, id);
 			dv->_qtmovie = true;
+			dv->_looping = qtLooping;
 			target = dv;
 		} else if (xtra->isTextXtra()) {
 			// Text, rect and styling are filled in lazily by TextCastMember::load().

--- a/engines/director/cast.h
+++ b/engines/director/cast.h
@@ -50,6 +50,7 @@ class Stxt;
 class RTE0;
 class RTE1;
 class RTE2;
+class XMED;
 class BitmapCastMember;
 class FilmLoopCastMember;
 class ScriptCastMember;
@@ -183,6 +184,7 @@ public:
 	Common::HashMap<uint, const RTE0 *> _loadedRTE0s;
 	Common::HashMap<uint, const RTE1 *> _loadedRTE1s;
 	Common::HashMap<uint, const RTE2 *> _loadedRTE2s;
+	Common::HashMap<uint, const XMED *> _loadedXMEDs;
 	uint16 _castIDoffset;
 
 	Common::Rect _movieRect;

--- a/engines/director/castmember/digitalvideo.cpp
+++ b/engines/director/castmember/digitalvideo.cpp
@@ -433,6 +433,10 @@ Graphics::MacWidget *DigitalVideoCastMember::createWidget(Common::Rect &bbox, Ch
 		}
 	}
 
+	// Zero-sized bbox: nothing to render, and scaling to it would divide by zero.
+	if (bbox.width() <= 0 || bbox.height() <= 0)
+		return nullptr;
+
 	Graphics::MacWidget *widget = new Graphics::MacWidget(g_director->getCurrentWindow()->getMacWindow(), bbox.left, bbox.top, bbox.width(), bbox.height(), g_director->_wm, false);
 
 	_channel = channel;

--- a/engines/director/castmember/text.cpp
+++ b/engines/director/castmember/text.cpp
@@ -33,6 +33,7 @@
 #include "director/score.h"
 #include "director/sprite.h"
 #include "director/window.h"
+#include "director/xmed.h"
 #include "director/castmember/text.h"
 #include "director/lingo/lingo-the.h"
 
@@ -200,6 +201,38 @@ TextCastMember::TextCastMember(Cast *cast, uint16 castId, TextCastMember &source
 
 	_bgcolor = source._bgcolor;
 	_fgcolor = source._fgcolor;
+}
+
+TextCastMember::TextCastMember(Cast *cast, uint16 castId, uint16 version)
+		: CastMember(cast, castId) {
+	// Promotion target for a "Text" Asset Xtra member; load() fills in the rest.
+	_type = kCastText;
+
+	_borderSize = 0;
+	_gutterSize = 0;
+	_boxShadow = 0;
+	_buttonType = kTypeButton;
+	_editable = false;
+	_maxHeight = _textHeight = 0;
+
+	// Undocumented authored colour; white is legible on Physikus' dark UI.
+	_bgcolor = g_director->_wm->findBestColor(0, 0, 0);
+	_fgcolor = g_director->_wm->findBestColor(0xff, 0xff, 0xff);
+
+	_textFlags = 0;
+	_scroll = 0;
+	_fontId = 1;
+	_fontSize = 12;
+	_textType = kTextTypeFixed;
+	_textAlign = kTextAlignLeft;
+	_textShadow = 0;
+	_textSlant = 0;
+	_bgpalinfo1 = _bgpalinfo2 = _bgpalinfo3 = 0;
+	_fgpalinfo1 = _fgpalinfo2 = _fgpalinfo3 = 0xffff;
+
+	_lineSpacing = g_director->getVersion() >= 400 ? 1 : 0;
+
+	_modified = true;
 }
 
 void TextCastMember::setColors(uint32 *fgcolor, uint32 *bgcolor) {
@@ -619,6 +652,31 @@ Common::String TextCastMember::formatInfo() {
 void TextCastMember::load() {
 	if (_loaded)
 		return;
+
+	// Text Asset Xtra members carry an XMED child instead of an STXT resource.
+	for (auto &it : _children) {
+		if (it.tag != MKTAG('X', 'M', 'E', 'D'))
+			continue;
+
+		if (_cast->_loadedXMEDs.contains(it.index)) {
+			const XMED *xmed = _cast->_loadedXMEDs.getVal(it.index);
+			if (xmed->_isText) {
+				_rtext = xmed->_text;
+				_ptext = _ftext = Common::U32String(xmed->_text, g_director->getPlatformEncoding());
+
+				// Authored field rect lives in the cast member info.
+				CastMemberInfo *ci = getInfo();
+				if (ci && !ci->xtraRect.isEmpty())
+					_initialRect = Common::Rect((int16)ci->xtraRect.width(), (int16)ci->xtraRect.height());
+
+				_loaded = true;
+				return;
+			}
+		} else {
+			warning("TextCastMember::load(): XMED %d isn't loaded", it.index);
+		}
+		break;
+	}
 
 	uint stxtid = 0;
 	if (_cast->_version >= kFileVer400) {

--- a/engines/director/castmember/text.h
+++ b/engines/director/castmember/text.h
@@ -34,6 +34,9 @@ class TextCastMember : public CastMember {
 public:
 	TextCastMember(Cast *cast, uint16 castId, Common::SeekableReadStreamEndian &stream, uint16 version, uint8 flags1 = 0, bool asButton = false);
 	TextCastMember(Cast *cast, uint16 castId, TextCastMember &source);
+	// Used when promoting a Director 7+ "Text" Asset Xtra (XMED-backed) to a
+	// text cast member. The text and styling are loaded lazily in load().
+	TextCastMember(Cast *cast, uint16 castId, uint16 version);
 
 	CastMember *duplicate(Cast *cast, uint16 castId) override { return (CastMember *)(new TextCastMember(cast, castId, *this)); }
 

--- a/engines/director/castmember/xtra.cpp
+++ b/engines/director/castmember/xtra.cpp
@@ -59,11 +59,23 @@ XtraCastMember::XtraCastMember(Cast *cast, uint16 castId, Common::SeekableReadSt
 		// TODO: Process data in the Xtra
 	}
 
-	warning("STUB: XtraCastMember::XtraCastMember(): Xtra cast members not yet supported for version v%d (%d)", humanVersion(_cast->_version), _cast->_version);
+	// quickTimeMedia/text are promoted in Cast::loadCastData(); don't warn about them here.
+	if (!isQuickTimeVideo() && !isTextXtra())
+		warning("STUB: XtraCastMember::XtraCastMember(): Xtra cast members not yet supported for version v%d (%d)", humanVersion(_cast->_version), _cast->_version);
 }
 
 XtraCastMember::XtraCastMember(Cast *cast, uint16 castId, XtraCastMember &source)
 		: CastMember(cast, castId) {
+}
+
+bool XtraCastMember::isQuickTimeVideo() const {
+	// Symbol observed in Physikus (D7.0.2)'s "QuickTime 3" Asset Xtra.
+	return _xtraSymbol.equalsIgnoreCase("quickTimeMedia");
+}
+
+bool XtraCastMember::isTextXtra() const {
+	// Symbol observed in Physikus (D7.0.2)'s "Text" Asset Xtra; string lives in an XMED child.
+	return _xtraSymbol.equalsIgnoreCase("text");
 }
 
 bool XtraCastMember::hasField(int field) {

--- a/engines/director/castmember/xtra.cpp
+++ b/engines/director/castmember/xtra.cpp
@@ -73,6 +73,12 @@ bool XtraCastMember::isQuickTimeVideo() const {
 	return _xtraSymbol.equalsIgnoreCase("quickTimeMedia");
 }
 
+bool XtraCastMember::isQuickTimeLooping() const {
+	// Byte 7 bit 0x40 of the quickTimeMedia payload is the loop flag (observed
+	// set on Physikus' looping Maschine.mov, clear on the play-once Trailer.mov).
+	return isQuickTimeVideo() && _xtraData.size() > 7 && (_xtraData[7] & 0x40);
+}
+
 bool XtraCastMember::isTextXtra() const {
 	// Symbol observed in Physikus (D7.0.2)'s "Text" Asset Xtra; string lives in an XMED child.
 	return _xtraSymbol.equalsIgnoreCase("text");

--- a/engines/director/castmember/xtra.h
+++ b/engines/director/castmember/xtra.h
@@ -34,6 +34,7 @@ public:
 	CastMember *duplicate(Cast *cast, uint16 castId) override { return (CastMember *)(new XtraCastMember(cast, castId, *this)); }
 
 	bool isQuickTimeVideo() const;
+	bool isQuickTimeLooping() const;
 	bool isTextXtra() const;
 
 	bool hasField(int field) override;

--- a/engines/director/images.cpp
+++ b/engines/director/images.cpp
@@ -347,6 +347,10 @@ void copyStretchImg(const Graphics::Surface *srcSurface, Graphics::Surface *targ
 		// Source area is nonexistant
 		return;
 	}
+	if ((targetRect.width() <= 0) || (targetRect.height() <= 0)) {
+		// Target area is nonexistant
+		return;
+	}
 
 	Graphics::Surface *temp1 = nullptr;
 	Graphics::Surface *temp2 = nullptr;

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1016,7 +1016,11 @@ void LB::b_count(int nargs) {
 		result.u.i = list.u.obj->getPropCount();
 		break;
 	default:
-		TYPECHECK3(list, ARRAY, PARRAY, OBJECT);
+		// VOID degrades to 0; other unsupported types still warn.
+		if (list.type != VOID)
+			warning("b_count: unsupported list type %s; returning 0", list.type2str());
+		result.u.i = 0;
+		break;
 	}
 
 	g_lingo->push(result);
@@ -1204,15 +1208,35 @@ void LB::b_getAt(int nargs) {
 	case ARRAY:
 	case POINT:
 	case RECT:
-		ARRBOUNDSCHECK(index, list);
+		if (list.u.farr->arr.empty()) {
+			// Empty list degrades to VOID, like b_getLast.
+			g_lingo->pushVoid();
+			break;
+		}
+		if (index - 1 < 0 || index > (int)list.u.farr->arr.size()) {
+			// Out of bounds: raise the error, still push VOID so the caller gets a value.
+			g_lingo->lingoError("b_getAt: index out of bounds (%d of %d)", index, list.u.farr->arr.size());
+			g_lingo->pushVoid();
+			break;
+		}
 		g_lingo->push(list.u.farr->arr[index - 1]);
 		break;
 	case PARRAY:
-		ARRBOUNDSCHECK(index, list);
+		if (list.u.parr->arr.empty()) {
+			g_lingo->pushVoid();
+			break;
+		}
+		if (index - 1 < 0 || index > (int)list.u.parr->arr.size()) {
+			g_lingo->lingoError("b_getAt: index out of bounds (%d of %d)", index, list.u.parr->arr.size());
+			g_lingo->pushVoid();
+			break;
+		}
 		g_lingo->push(list.u.parr->arr[index - 1].v);
 		break;
 	default:
-		TYPECHECK4(list, ARRAY, PARRAY, POINT, RECT);
+		warning("b_getAt: unsupported list type %s; returning VOID", list.type2str());
+		g_lingo->pushVoid();
+		break;
 	}
 }
 

--- a/engines/director/lingo/lingo-events.cpp
+++ b/engines/director/lingo/lingo-events.cpp
@@ -690,6 +690,13 @@ void Movie::broadcastEvent(LEvent event) {
 			queueEvent(queue, event, i);
 		}
 	}
+
+	// Sprite queueing above swallows cast/frame/movie handlers sharing its eventId
+	// (last behavior is queued passByDefault=false), so a frame/movie script's
+	// on prepareFrame never ran. Queue one more pass with no sprite target so
+	// they resolve with a fresh eventId, like enterFrame/exitFrame already do.
+	queueEvent(queue, event, 0);
+
 	_vm->setCurrentWindow(this->getWindow());
 	_lingo->processEvents(queue, false);
 }

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -159,6 +159,7 @@
 #include "director/lingo/xlibs/y/yasix.h"
 #include "director/lingo/xtras/a/audio.h"
 #include "director/lingo/xtras/b/budapi.h"
+#include "director/lingo/xtras/b/border.h"
 #include "director/lingo/xtras/d/directsound.h"
 #include "director/lingo/xtras/d/displayres.h"
 #include "director/lingo/xtras/d/datetime.h"
@@ -269,6 +270,7 @@ static const struct XLibProto {
 	XLIBDEF(BarakeObj,			kXObj,			400),	// D4
 	XLIBDEF(BatQT,				kXObj,			400),	// D4
 	XLIBDEF(BIMXObj,			kXObj,			400),	// D4
+	XLIBDEF(BorderXtra,			kXtraObj,		500),	// D5
 	XLIBDEF(BlitPictXObj,		kXObj,			400),	// D4
 	XLIBDEF(BlockTheDrawingXObj,			kXObj,					400),	// D4
 	XLIBDEF(BudAPIXtra,			kXtraObj,					500),	// D5

--- a/engines/director/lingo/xlibs/q/qtsupport.cpp
+++ b/engines/director/lingo/xlibs/q/qtsupport.cpp
@@ -68,6 +68,7 @@ const char *QTSupport::xlibName = "QuickTimeSupport";
 const XlibFileDesc QTSupport::fileNames[] = {
 	{ "QuickTime Asset",	nullptr },
 	{ "QTASSET",			nullptr },
+	{ "QT3Asset",			nullptr },	// QuickTime 3 Asset Xtra (e.g. Physikus, Chemicus)
 	{ nullptr,		nullptr },
 };
 

--- a/engines/director/lingo/xtras/b/border.cpp
+++ b/engines/director/lingo/xtras/b/border.cpp
@@ -1,0 +1,97 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/lingo-utils.h"
+#include "director/lingo/xtras/b/border.h"
+
+/**************************************************
+ *
+ * USED IN:
+ * Physikus (l'Espresso, Italian; Ruske & Pühretmaier)
+ *
+ **************************************************/
+
+/*
+ * Border() -- registers the Border Xtra instance.
+ * new object me
+ * Register object me, integer key -- validate the registration key
+ */
+
+namespace Director {
+
+const char *BorderXtra::xlibName = "Border";
+const XlibFileDesc BorderXtra::fileNames[] = {
+	{ "Border",	nullptr },
+	{ nullptr,	nullptr },
+};
+
+static MethodProto xlibMethods[] = {
+	{ "new",		BorderXtra::m_new,		0, 0,	500 },
+	{ "Register",	BorderXtra::m_register,	1, 1,	500 },
+	{ nullptr, nullptr, 0, 0, 0 }
+};
+
+static BuiltinProto xlibBuiltins[] = {
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+BorderXtraObject::BorderXtraObject(ObjectType ObjectType) :Object<BorderXtraObject>("Border") {
+	_objType = ObjectType;
+}
+
+bool BorderXtraObject::hasProp(const Common::String &propName) {
+	return (propName == "name");
+}
+
+Datum BorderXtraObject::getProp(const Common::String &propName) {
+	if (propName == "name")
+		return Datum(BorderXtra::xlibName);
+	warning("BorderXtra::getProp: unknown property '%s'", propName.c_str());
+	return Datum();
+}
+
+void BorderXtra::open(ObjectType type, const Common::Path &path) {
+	BorderXtraObject::initMethods(xlibMethods);
+	BorderXtraObject *xobj = new BorderXtraObject(type);
+	if (type == kXtraObj) {
+		g_lingo->_openXtras.push_back(xlibName);
+		g_lingo->_openXtraObjects.push_back(xobj);
+	}
+	g_lingo->exposeXObject(xlibName, xobj);
+	g_lingo->initBuiltIns(xlibBuiltins);
+}
+
+void BorderXtra::close(ObjectType type) {
+	BorderXtraObject::cleanupMethods();
+	g_lingo->_globalvars[xlibName] = Datum();
+}
+
+void BorderXtra::m_new(int nargs) {
+	g_lingo->dropStack(nargs);
+	g_lingo->push(g_lingo->_state->me);
+}
+
+XOBJSTUB(BorderXtra::m_register, 0)
+
+} // End of namespace Director

--- a/engines/director/lingo/xtras/b/border.h
+++ b/engines/director/lingo/xtras/b/border.h
@@ -1,0 +1,50 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XTRAS_B_BORDER_H
+#define DIRECTOR_LINGO_XTRAS_B_BORDER_H
+
+namespace Director {
+
+class BorderXtraObject : public Object<BorderXtraObject> {
+public:
+	BorderXtraObject(ObjectType objType);
+
+	bool hasProp(const Common::String &propName) override;
+	Datum getProp(const Common::String &propName) override;
+};
+
+namespace BorderXtra {
+
+extern const char *xlibName;
+extern const XlibFileDesc fileNames[];
+
+void open(ObjectType type, const Common::Path &path);
+void close(ObjectType type);
+
+void m_new(int nargs);
+void m_register(int nargs);
+
+} // End of namespace BorderXtra
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xtras/g/glu32.cpp
+++ b/engines/director/lingo/xtras/g/glu32.cpp
@@ -190,6 +190,10 @@ void GLU32Xtra::m_GLUCall(int nargs) {
 			g_lingo->push(Datum(Common::String("92263924"))); // TODO: Check with the game
 			return;
 		}
+		if (gameId == "physicus" && g_director->getLanguage() == Common::EN_ANY) {
+			g_lingo->push(Datum((int)43289555)); //tested
+			return;
+		}
 		// TODO: Tiger Team 2: 32546872
 		warning("GLU32Xtra::m_GLUCall: unhandled optgraph.dll copy protection for game '%s'", gameId.c_str());
 	}

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -189,6 +189,7 @@ MODULE_OBJS = \
 	lingo/xlibs/x/xwin.o \
 	lingo/xlibs/y/yasix.o \
 	lingo/xtras/a/audio.o \
+	lingo/xtras/b/border.o \
 	lingo/xtras/b/budapi.o \
 	lingo/xtras/d/datetime.o \
 	lingo/xtras/d/directsound.o \

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -28,6 +28,7 @@ MODULE_OBJS = \
 	types.o \
 	util.o \
 	window.o \
+	xmed.o \
 	castmember/bitmap.o \
 	castmember/castmember.o \
 	castmember/digitalvideo.o \

--- a/engines/director/xmed.cpp
+++ b/engines/director/xmed.cpp
@@ -1,0 +1,98 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/array.h"
+#include "common/stream.h"
+
+#include "director/director.h"
+#include "director/xmed.h"
+
+namespace Director {
+
+static bool isHexDigit(byte c) {
+	return (c >= '0' && c <= '9') || (c >= 'A' && c <= 'F') || (c >= 'a' && c <= 'f');
+}
+
+static uint hexValue(byte c) {
+	if (c >= '0' && c <= '9')
+		return c - '0';
+	if (c >= 'A' && c <= 'F')
+		return c - 'A' + 10;
+	return c - 'a' + 10;
+}
+
+XMED::XMED(Cast *cast, Common::SeekableReadStreamEndian &stream) : _cast(cast), _isText(false) {
+	uint32 size = stream.size();
+	if (size < 4)
+		return;
+
+	Common::Array<byte> data(size);
+	if (stream.read(data.data(), size) != size)
+		return;
+
+	// The "Text" Asset Xtra serialization starts with the ASCII bytes "FFFF".
+	// Other XMED payloads (e.g. an embedded "PFR1" font from the "Font" Asset
+	// Xtra) are not text and are left alone.
+	if (memcmp(data.data(), "FFFF", 4) != 0)
+		return;
+
+	_isText = true;
+
+	// The displayed string is serialized as: 0x00 <ASCII hex length> ',' <raw bytes>.
+	// Scan for the first such record whose payload is predominantly printable;
+	// that is the editable text of the field.
+	for (uint32 i = 0; i + 2 < size; i++) {
+		if (data[i] != 0x00)
+			continue;
+
+		uint32 j = i + 1;
+		uint32 len = 0;
+		int digits = 0;
+		while (j < size && isHexDigit(data[j]) && digits < 6) {
+			len = len * 16 + hexValue(data[j]);
+			j++;
+			digits++;
+		}
+
+		if (digits == 0 || len == 0 || j >= size || data[j] != ',')
+			continue;
+		j++; // skip the ',' separator
+
+		if (j + len > size)
+			continue;
+
+		uint32 printable = 0;
+		for (uint32 k = 0; k < len; k++) {
+			byte c = data[j + k];
+			if ((c >= 0x20 && c <= 0x7e) || c >= 0x80 || c == '\r' || c == '\n' || c == '\t')
+				printable++;
+		}
+
+		// Require at least 80% printable to reject false matches.
+		if (printable * 5 < len * 4)
+			continue;
+
+		_text = Common::String((const char *)&data[j], len);
+		break;
+	}
+}
+
+} // End of namespace Director

--- a/engines/director/xmed.h
+++ b/engines/director/xmed.h
@@ -19,35 +19,30 @@
  *
  */
 
-#ifndef DIRECTOR_CASTMEMBER_XTRA_H
-#define DIRECTOR_CASTMEMBER_XTRA_H
+#ifndef DIRECTOR_XMED_H
+#define DIRECTOR_XMED_H
 
-#include "director/castmember/castmember.h"
+#include "common/str.h"
+
+namespace Common {
+class SeekableReadStreamEndian;
+}
 
 namespace Director {
 
-class XtraCastMember : public CastMember {
+class Cast;
+
+// XMED ("Xtra MEDia") child resource of an Asset Xtra cast member; observed
+// in Physikus (D7.0.2)'s "Text" and "Font" Asset Xtras. Only the Text variant
+// is decoded, to recover its displayed string (0x00, ASCII hex length, ',',
+// raw platform-encoded bytes).
+class XMED {
 public:
-	XtraCastMember(Cast *cast, uint16 castId, Common::SeekableReadStreamEndian &stream, uint16 version);
-	XtraCastMember(Cast *cast, uint16 castId, XtraCastMember &source);
+	XMED(Cast *cast, Common::SeekableReadStreamEndian &stream);
 
-	CastMember *duplicate(Cast *cast, uint16 castId) override { return (CastMember *)(new XtraCastMember(cast, castId, *this)); }
-
-	bool isQuickTimeVideo() const;
-	bool isTextXtra() const;
-
-	bool hasField(int field) override;
-	Datum getField(int field) override;
-	void setField(int field, const Datum &value) override;
-
-	Common::String formatInfo() override;
-
-	uint32 getCastDataSize() override;
-	void writeCastData(Common::SeekableWriteStream *writeStream) override;
-
-private:
-	Common::String _xtraSymbol;
-	Common::Array<byte> _xtraData;
+	Cast *_cast;
+	bool _isText;            // true for the "Text" Asset Xtra, false otherwise (e.g. an embedded font)
+	Common::String _text;    // raw displayed text, platform encoded, with '\r' line breaks
 };
 
 } // End of namespace Director


### PR DESCRIPTION
 Fixes 9 boot/runtime blockers in the Director engine for Physicus, verified against master,       
 decompiled bytecode (ProjectorRays), and live crash repro (gdb). No regressions: full directortest Lingo suite      
 diff-clean vs master; English + Italian builds run stable end-to-end.  