### PR TITLE
CHEWY: Ignore next KEYUP when resuming from overlay

### DIFF
--- a/engines/chewy/chewy.cpp
+++ b/engines/chewy/chewy.cpp
@@ -79,6 +79,18 @@ void ChewyEngine::initialize() {
 	syncSoundSettings();
 }
 
+void ChewyEngine::pauseEngineIntern(bool pause) {
+	Engine::pauseEngineIntern(pause);
+
+	if (!pause) {
+		// When a key was pressed to dismiss the ScummVM overlay,
+		// the key-down event may have been consumed outside the engine.
+		// In this case we should not respond to the next (leaked)
+		// key-up event unless it is preceded by another key-down.
+		g_events->ignoreNextKeyUp();
+	}
+}
+
 Common::Error ChewyEngine::run() {
 	// Initialize backend
 	//initGraphics(640, 480);

--- a/engines/chewy/chewy.h
+++ b/engines/chewy/chewy.h
@@ -66,6 +66,7 @@ protected:
 	void initialize();
 	void shutdown() {}
 
+	void pauseEngineIntern(bool pause) override;
 public:
 	const ChewyGameDescription *_gameDescription;
 	Common::RandomSource _rnd;

--- a/engines/chewy/events.cpp
+++ b/engines/chewy/events.cpp
@@ -85,8 +85,6 @@ static void returnInventoryCursorToSlot() {
 }
 
 void EventsManager::handleMouseEvent(const Common::Event &event) {
-	_pendingEvents.push(event);
-
 	_mousePos = event.mouse;
 	bool isWheelEnabled = !_G(menu_display) && !_G(flags).InventMenu &&
 		g_engine->canSaveAutosaveCurrently() &&
@@ -144,8 +142,6 @@ void EventsManager::handleMouseEvent(const Common::Event &event) {
 }
 
 void EventsManager::handleKbdEvent(const Common::Event &event) {
-	_pendingKeyEvents.push(event);
-
 	switch (event.type) {
 	case Common::EVENT_KEYDOWN:
 		// Fresh keyboard input (not leaked from overlay)
@@ -181,8 +177,6 @@ void EventsManager::delay(size_t time) {
 
 void EventsManager::clearEvents() {
 	processEvents();
-	_pendingEvents.clear();
-	_pendingKeyEvents.clear();
 
 	_kbInfo._scanCode = Common::KEYCODE_INVALID;
 	_kbInfo._keyCode = '\0';

--- a/engines/chewy/events.cpp
+++ b/engines/chewy/events.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#include "common/debug.h"
 #include "common/system.h"
 #include "chewy/cursor.h"
 #include "chewy/events.h"
@@ -72,7 +73,7 @@ void EventsManager::updateScreen() {
 void EventsManager::handleEvent(const Common::Event &event) {
 	if (event.type >= Common::EVENT_MOUSEMOVE && event.type <= Common::EVENT_MBUTTONUP)
 		handleMouseEvent(event);
-	else if (event.type == Common::EVENT_KEYUP)
+	else if (event.type == Common::EVENT_KEYDOWN || event.type == Common::EVENT_KEYUP)
 		handleKbdEvent(event);
 }
 
@@ -145,11 +146,26 @@ void EventsManager::handleMouseEvent(const Common::Event &event) {
 void EventsManager::handleKbdEvent(const Common::Event &event) {
 	_pendingKeyEvents.push(event);
 
-	if (event.type == Common::EVENT_KEYUP) {
+	switch (event.type) {
+	case Common::EVENT_KEYDOWN:
+		// Fresh keyboard input (not leaked from overlay)
+		_ignoreKeyUp = false;
+		return;
+
+	case Common::EVENT_KEYUP:
+		if (_ignoreKeyUp) {
+			// This key-up has no matching key-down within the running engine.
+			debug(1, "dropping leaked key up after resume: keycode=%d ascii=%d", event.kbd.keycode, event.kbd.ascii);
+			return;
+		}
 		_kbInfo._keyCode = event.kbd.ascii;
 		_kbInfo._scanCode = event.kbd.keycode;
 		if (event.kbd.flags & Common::KBD_ALT)
 			_kbInfo._scanCode |= ALT;
+		return;
+
+	default:
+		return;
 	}
 }
 

--- a/engines/chewy/events.h
+++ b/engines/chewy/events.h
@@ -56,6 +56,7 @@ private:
 	Common::Queue<Common::Event> _pendingEvents;
 	Common::Queue<Common::Event> _pendingKeyEvents;
 	int16 _hotkey = Common::KEYCODE_INVALID;
+	bool _ignoreKeyUp = false;
 
 	/**
 	 * Checks for timers' expiration
@@ -150,6 +151,12 @@ public:
 
 	void setHotKey(Common::KeyCode key) { _hotkey = key; }
 	int16 getSwitchCode();
+
+	/**
+	 * Activate a filter that drops key-up events until the next
+	 * key-down.
+	 */
+	void ignoreNextKeyUp() { _ignoreKeyUp = true; }
 };
 
 extern EventsManager *g_events;

--- a/engines/chewy/events.h
+++ b/engines/chewy/events.h
@@ -23,7 +23,6 @@
 #define CHEWY_EVENTS_H
 
 #include "common/events.h"
-#include "common/queue.h"
 #include "graphics/screen.h"
 
 namespace Chewy {
@@ -53,8 +52,6 @@ private:
 	void handleKbdEvent(const Common::Event &event);
 
 	TimerList _timers;
-	Common::Queue<Common::Event> _pendingEvents;
-	Common::Queue<Common::Event> _pendingKeyEvents;
 	int16 _hotkey = Common::KEYCODE_INVALID;
 	bool _ignoreKeyUp = false;
 
@@ -105,39 +102,6 @@ public:
 	 * and polling events
 	 */
 	void update();
-
-	/**
-	 * Returns true if any unprocessed keyboard events are pending
-	 */
-	bool keyEventPending() {
-		processEvents();
-		return !_pendingKeyEvents.empty();
-	}
-
-	/**
-	 * Returns true if any unprocessed event other than key events
-	 * are pending
-	 */
-	bool eventPending() {
-		processEvents();
-		return !_pendingEvents.empty();
-	}
-
-	/**
-	 * Returns the next pending unprocessed keyboard event
-	 */
-	Common::Event getPendingKeyEvent() {
-		processEvents();
-		return _pendingKeyEvents.empty() ? Common::Event() : _pendingKeyEvents.pop();
-	}
-
-	/**
-	 * Returns the next event, if any
-	 */
-	Common::Event getPendingEvent() {
-		processEvents();
-		return _pendingEvents.empty() ? Common::Event() : _pendingEvents.pop();
-	}
 
 	/**
 	 * Sets the mouse position


### PR DESCRIPTION
This is a follow up to #7656. When I used the GMM to save the game and confirmed the save game title with Return, a corresponding `EVENT_KEYUP` could leak to the game. This had the same effect as a phantom left click somewhere on the screen (Chewy would start to walk there). 

The workaround implemented by this PR is to keep track of `EVENT_KEYDOWN`, and only act on `EVENT_KEYUP` if a corresponding key-down has been registered before.

In a separate commit this removes the queues `_pendingEvents` and `_pendingKeyEvents` and related code. The queues were only written to (and cleared eventually), but their contents were never consumed.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
