### PR TITLE
ASYLUM: Possible fix for incorrect walk sounds

### DIFF
--- a/engines/asylum/resources/actor.cpp
+++ b/engines/asylum/resources/actor.cpp
@@ -63,13 +63,10 @@ Actor::Actor(AsylumEngine *engine, ActorIndex index) : _vm(engine), _index(index
  	_field_60 = 0;
  	_actionIdx3 = 0;
  	// TODO field_68 till field_617
- 	_walkingSound1 = 0;
- 	_walkingSound2 = 0;
- 	_walkingSound3 = 0;
- 	_walkingSound4 = 0;
+	memset(_walkingSounds, 0, sizeof(_walkingSounds));
  	_field_64C = 0;
  	_field_650 = 0;
- 	memset(_graphicResourceIds, 0 , sizeof(_graphicResourceIds));
+	memset(_graphicResourceIds, 0, sizeof(_graphicResourceIds));
  	memset(&_name, 0, sizeof(_name));
  	memset(&_distancesEO, 0, sizeof(_distancesEO));
  	memset(&_distancesNS, 0, sizeof(_distancesNS));
@@ -149,10 +146,10 @@ void Actor::load(Common::SeekableReadStream *stream) {
 	stream->skip(0x5B0);
 
 	inventory.load(stream);
-	_walkingSound1 = stream->readSint32LE();
-	_walkingSound2 = stream->readSint32LE();
-	_walkingSound3 = stream->readSint32LE();
-	_walkingSound4 = stream->readSint32LE();
+
+	for (int32 i = 0; i < ARRAYSIZE(_walkingSounds); i++)
+		_walkingSounds[i] = (ResourceId)stream->readSint32LE();
+
 	_field_64C     = stream->readUint32LE();
 	_field_650     = stream->readUint32LE();
 
@@ -242,10 +239,9 @@ void Actor::saveLoadWithSerializer(Common::Serializer &s) {
 
 	inventory.saveLoadWithSerializer(s);
 
-	s.syncAsSint32LE(_walkingSound1);
-	s.syncAsSint32LE(_walkingSound2);
-	s.syncAsSint32LE(_walkingSound3);
-	s.syncAsSint32LE(_walkingSound4);
+	for (int i = 0; i < ARRAYSIZE(_walkingSounds); i++)
+		s.syncAsSint32LE(_walkingSounds[i]);
+
 	s.syncAsUint32LE(_field_64C);
 	s.syncAsUint32LE(_field_650);
 
@@ -1724,8 +1720,7 @@ void Actor::move(ActorDirection actorDir, uint32 dist) {
 
 		_frameIndex = (_frameIndex + 1) % _frameCount;
 
-		if (_walkingSound1 != kResourceNone) {
-
+		if (_walkingSounds[0] != kResourceNone) {
 			// Compute volume
 			int32 vol = (int32)sqrt((double)-Config.sfxVolume);
 			if (_index != getSharedData()->getPlayerIndex())
@@ -1738,16 +1733,16 @@ void Actor::move(ActorDirection actorDir, uint32 dist) {
 			if (_field_944 != 1 && _field_944 != 4) {
 				// Compute resource Id
 				ResourceId resourceId = kResourceNone;
-				if (getWorld()->actions[_actionIdx3]->soundResourceIdFrame != kResourceNone && strcmp((char *)&_name, "Crow") && strcmp((char *)&_name, "Big Crow")) {
+				if (getWorld()->actions[_actionIdx3]->walkingSounds[0] != kResourceNone && strcmp((char *)&_name, "Crow") && strcmp((char *)&_name, "Big Crow")) {
 					if (_frameIndex == _field_64C)
-						resourceId = (ResourceId)(getWorld()->actions[_actionIdx3]->soundResourceIdFrame + (int)rnd(2));
+						resourceId = (ResourceId)(getWorld()->actions[_actionIdx3]->walkingSounds[0 + (int)rnd(2)]);
 					else if (_frameIndex == _field_650)
-						resourceId = (ResourceId)(getWorld()->actions[_actionIdx3]->soundResourceId + (int)rnd(2));
+						resourceId = (ResourceId)(getWorld()->actions[_actionIdx3]->walkingSounds[2 + (int)rnd(2)]);
 				} else {
 					if (_frameIndex == _field_64C)
-						resourceId = (ResourceId)(_walkingSound1 + (int)rnd(2));
+						resourceId = (ResourceId)(_walkingSounds[0 + (int)rnd(2)]);
 					else if (_frameIndex == _field_650)
-						resourceId = (ResourceId)(_walkingSound3 + (int)rnd(2));
+						resourceId = (ResourceId)(_walkingSounds[2 + (int)rnd(2)]);
 				}
 
 				// Play sound
@@ -1760,7 +1755,7 @@ void Actor::move(ActorDirection actorDir, uint32 dist) {
 		if (getWorld()->chapter == kChapter2) {
 			incPosition(actorDir, (int16)dist, &_point1);
 
-			if (_walkingSound1 == kResourceNone)
+			if (_walkingSounds[0] == kResourceNone)
 				break;
 
 			// Compute volume
@@ -1774,16 +1769,16 @@ void Actor::move(ActorDirection actorDir, uint32 dist) {
 
 			// Compute resource Id
 			ResourceId resourceId = kResourceNone;
-			if (getWorld()->actions[_actionIdx3]->soundResourceIdFrame != kResourceNone && strcmp((char *)&_name, "Crow") && strcmp((char *)&_name, "Big Crow")) {
+			if (getWorld()->actions[_actionIdx3]->walkingSounds[0] != kResourceNone && strcmp((char *)&_name, "Crow") && strcmp((char *)&_name, "Big Crow")) {
 				if (_frameIndex == _field_64C)
-					resourceId = (ResourceId)(getWorld()->actions[_actionIdx3]->soundResourceIdFrame + (int)rnd(2));
+					resourceId = (ResourceId)(getWorld()->actions[_actionIdx3]->walkingSounds[0 + (int)rnd(2)]);
 				else if (_frameIndex == _field_650)
-					resourceId = (ResourceId)(getWorld()->actions[_actionIdx3]->soundResourceId + (int)rnd(2));
+					resourceId = (ResourceId)(getWorld()->actions[_actionIdx3]->walkingSounds[2 + (int)rnd(2)]);
 			} else {
 				if (_frameIndex == _field_64C)
-					resourceId = (ResourceId)(_walkingSound1 + (int)rnd(2));
+					resourceId = (ResourceId)(_walkingSounds[0 + (int)rnd(2)]);
 				else if (_frameIndex == _field_650)
-					resourceId = (ResourceId)(_walkingSound3 + (int)rnd(2));
+					resourceId = (ResourceId)(_walkingSounds[2 + (int)rnd(2)]);
 			}
 
 			// Play sound

--- a/engines/asylum/resources/actor.h
+++ b/engines/asylum/resources/actor.h
@@ -367,10 +367,7 @@ private:
 	int32  _field_60;
 	int32  _actionIdx3;
 	// TODO field_68 till field_617
-	ResourceId _walkingSound1;
-	ResourceId _walkingSound2;
-	ResourceId _walkingSound3;
-	ResourceId _walkingSound4;
+	ResourceId _walkingSounds[4];
 	uint32  _field_64C;
 	uint32  _field_650;
 	ResourceId  _graphicResourceIds[55];

--- a/engines/asylum/resources/script.cpp
+++ b/engines/asylum/resources/script.cpp
@@ -61,10 +61,10 @@ void ActionArea::load(Common::SeekableReadStream *stream) {
 
 	field_7C             = stream->readSint32LE();
 	polygonIndex         = stream->readUint32LE();
-	soundResourceIdFrame = (ResourceId)stream->readSint32LE();
-	field_88             = stream->readSint32LE();
-	soundResourceId      = (ResourceId)stream->readSint32LE();
-	field_90             = stream->readSint32LE();
+
+	for (int32 i = 0; i < ARRAYSIZE(walkingSounds); i++)
+		walkingSounds[i] = (ResourceId)stream->readSint32LE();
+
 	paletteResourceId    = (ResourceId)stream->readSint32LE();
 
 	for (int32 i = 0; i < 5; i++)
@@ -90,10 +90,10 @@ void ActionArea::saveLoadWithSerializer(Common::Serializer &s) {
 
 	s.syncAsSint32LE(field_7C);
 	s.syncAsUint32LE(polygonIndex);
-	s.syncAsSint32LE(soundResourceIdFrame);
-	s.syncAsSint32LE(field_88);
-	s.syncAsSint32LE(soundResourceId);
-	s.syncAsSint32LE(field_90);
+
+	for (int32 i = 0; i < 4; i++)
+		s.syncAsSint32LE(walkingSounds[i]);
+
 	s.syncAsSint32LE(paletteResourceId);
 
 	for (int32 i = 0; i < 5; i++)

--- a/engines/asylum/resources/script.h
+++ b/engines/asylum/resources/script.h
@@ -69,10 +69,7 @@ struct ActionArea : public Common::Serializable {
 	int32 flagNums[10];
 	int32 field_7C;
 	uint32 polygonIndex;
-	ResourceId soundResourceIdFrame;
-	int32 field_88;
-	ResourceId soundResourceId;
-	int32 field_90;
+	ResourceId walkingSounds[4];
 	ResourceId paletteResourceId;
 	int32 paths[5];
 	int32 volume;
@@ -91,10 +88,7 @@ struct ActionArea : public Common::Serializable {
 		memset(&flagNums, 0, sizeof(flagNums));
 		field_7C = 0;
 		polygonIndex = 0;
-		soundResourceIdFrame = kResourceNone;
-		field_88 = 0;
-		soundResourceId = kResourceNone;
-		field_90 = 0;
+		memset(&walkingSounds, 0, sizeof(walkingSounds));
 		paletteResourceId = kResourceNone;
 		memset(&paths, 0, sizeof(paths));
 		volume = 0;
@@ -107,9 +101,9 @@ struct ActionArea : public Common::Serializable {
 
 		output += Common::String::format("Action %d: %s\n", id, name);
 		output += Common::String::format("           flags=%d      scriptIndex=%d      scriptIndex2=%d   type=%d\n", flags, scriptIndex, scriptIndex2, actionType);
-		output += Common::String::format("           sound=%d      polygon=%d          palette=%d        volume=%d\n", soundResourceId, polygonIndex, paletteResourceId, volume);
+		output += Common::String::format("           sound=%d      polygon=%d          palette=%d        volume=%d\n", walkingSounds[2], polygonIndex, paletteResourceId, volume);
 		output += Common::String::format("           field01=%d    field02=%d          field40=%d        field44=%d\n", field01, field02, field_40, field_44);
-		output += Common::String::format("           field7C=%d    field84=%d          field88=%d        field90=%d\n", field_7C, soundResourceIdFrame, field_88, field_90);
+		output += Common::String::format("           field7C=%d    field84=%d          field88=%d        field90=%d\n", field_7C, walkingSounds[0], walkingSounds[1], walkingSounds[3]);
 
 		return output;
 	}


### PR DESCRIPTION
TL;DR - The Asylum engine uses the following pattern for walking sounds:

`resourceId = (ResourceId)(walkingSoundN + (int)(rnd(2));`

Meaning that it assumes that related walking sounds have adjacent resource IDs. This pull request is based on the assumption that this is wrong, and that what it's supposed to do is:

`resourceId = (ResourceId)walkingSounds[N + (int)(rnd(2))];`

Longer explanation:

I noticed an annoying audio glitch in the second chapter of Sanitarium: When walking across grass, there would be random sounds that sounded more like walking over gravel instead.

There are four walk sounds for the actor, named `_walkingSound1` through `_walkingSound4`. I assume these are the default walking sounds. Parts of the map can override this with four fields of their own, though they are confusingly named `soundResourceIdFrame`, `field_88`, `soundResourceId`, and `field_90`.

There are sounds for both left and right foot, I guess - they are tied to exact frames of the walk animation, it seems? - and it picks either the first or the third of the walk sounds. Then it randomly adds 1 to those resource Ids. The other two sounds remain unused, which seems strange to me. I assume the resource IDs were stored in arrays, and that the 1 should be randomly added to the array _index_, not the value itself.

I want to stress again that this is a _complete and utter guess on my part_ that I have not verified against... well, anything other than that the behavior seems right to me. I'm attaching my savegame to make it easier to reproduce, though if that doesn't work you can easily get to chapter two in a matter of minutes.

[asylum-saves.zip](https://github.com/user-attachments/files/29974286/asylum-saves.zip)
