### PR TITLE
DIRECTOR: Fix Physicus/Physikus boot blockers (Xtra stubs, CD detection, SIGFPE guards)

### DIFF
--- a/engines/director/castmember/digitalvideo.cpp
+++ b/engines/director/castmember/digitalvideo.cpp
@@ -433,6 +433,10 @@ Graphics::MacWidget *DigitalVideoCastMember::createWidget(Common::Rect &bbox, Ch
 		}
 	}
 
+	// Zero-sized bbox: nothing to render, and scaling to it would divide by zero.
+	if (bbox.width() <= 0 || bbox.height() <= 0)
+		return nullptr;
+
 	Graphics::MacWidget *widget = new Graphics::MacWidget(g_director->getCurrentWindow()->getMacWindow(), bbox.left, bbox.top, bbox.width(), bbox.height(), g_director->_wm, false);
 
 	_channel = channel;

--- a/engines/director/images.cpp
+++ b/engines/director/images.cpp
@@ -347,6 +347,10 @@ void copyStretchImg(const Graphics::Surface *srcSurface, Graphics::Surface *targ
 		// Source area is nonexistant
 		return;
 	}
+	if ((targetRect.width() <= 0) || (targetRect.height() <= 0)) {
+		// Target area is nonexistant
+		return;
+	}
 
 	Graphics::Surface *temp1 = nullptr;
 	Graphics::Surface *temp2 = nullptr;

--- a/engines/director/lingo/lingo-object.cpp
+++ b/engines/director/lingo/lingo-object.cpp
@@ -158,6 +158,7 @@
 #include "director/lingo/xlibs/x/xwin.h"
 #include "director/lingo/xlibs/y/yasix.h"
 #include "director/lingo/xtras/a/audio.h"
+#include "director/lingo/xtras/b/border.h"
 #include "director/lingo/xtras/b/budapi.h"
 #include "director/lingo/xtras/d/directsound.h"
 #include "director/lingo/xtras/d/displayres.h"
@@ -271,6 +272,7 @@ static const struct XLibProto {
 	XLIBDEF(BIMXObj,			kXObj,			400),	// D4
 	XLIBDEF(BlitPictXObj,		kXObj,			400),	// D4
 	XLIBDEF(BlockTheDrawingXObj,			kXObj,					400),	// D4
+	XLIBDEF(BorderXtra,			kXtraObj,		500),	// D5
 	XLIBDEF(BudAPIXtra,			kXtraObj,					500),	// D5
 	XLIBDEF(CDROMXObj,			kXObj,			200),	// D2
 	XLIBDEF(CloseBleedWindowXCMD,kXObj,			300),	// D3

--- a/engines/director/lingo/xlibs/q/qtsupport.cpp
+++ b/engines/director/lingo/xlibs/q/qtsupport.cpp
@@ -25,6 +25,7 @@
  * The Legend of Lotus Spring
  * Löwenzahn 2&3
  * Oscar the Balloonist Drops into the Countryside
+ * Physicus / Physikus (l'Espresso, Italian; Ruske & Pühretmaier)
  *
  *************************************/
 
@@ -68,6 +69,7 @@ const char *QTSupport::xlibName = "QuickTimeSupport";
 const XlibFileDesc QTSupport::fileNames[] = {
 	{ "QuickTime Asset",	nullptr },
 	{ "QTASSET",			nullptr },
+	{ "QT3Asset",			nullptr },	// QuickTime 3 Asset Xtra
 	{ nullptr,		nullptr },
 };
 

--- a/engines/director/lingo/xtras/b/border.cpp
+++ b/engines/director/lingo/xtras/b/border.cpp
@@ -1,0 +1,97 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "director/director.h"
+#include "director/lingo/lingo.h"
+#include "director/lingo/lingo-object.h"
+#include "director/lingo/lingo-utils.h"
+#include "director/lingo/xtras/b/border.h"
+
+/**************************************************
+ *
+ * USED IN:
+ * Physikus (l'Espresso, Italian; Ruske & Pühretmaier)
+ *
+ **************************************************/
+
+/*
+ * Border() -- registers the Border Xtra instance.
+ * new object me
+ * Register object me, integer key -- validate the registration key
+ */
+
+namespace Director {
+
+const char *BorderXtra::xlibName = "Border";
+const XlibFileDesc BorderXtra::fileNames[] = {
+	{ "Border",	nullptr },
+	{ nullptr,	nullptr },
+};
+
+static MethodProto xlibMethods[] = {
+	{ "new",		BorderXtra::m_new,		0, 0,	500 },
+	{ "Register",	BorderXtra::m_register,	1, 1,	500 },
+	{ nullptr, nullptr, 0, 0, 0 }
+};
+
+static BuiltinProto xlibBuiltins[] = {
+	{ nullptr, nullptr, 0, 0, 0, VOIDSYM }
+};
+
+BorderXtraObject::BorderXtraObject(ObjectType ObjectType) :Object<BorderXtraObject>("Border") {
+	_objType = ObjectType;
+}
+
+bool BorderXtraObject::hasProp(const Common::String &propName) {
+	return (propName == "name");
+}
+
+Datum BorderXtraObject::getProp(const Common::String &propName) {
+	if (propName == "name")
+		return Datum(BorderXtra::xlibName);
+	warning("BorderXtra::getProp: unknown property '%s'", propName.c_str());
+	return Datum();
+}
+
+void BorderXtra::open(ObjectType type, const Common::Path &path) {
+	BorderXtraObject::initMethods(xlibMethods);
+	BorderXtraObject *xobj = new BorderXtraObject(type);
+	if (type == kXtraObj) {
+		g_lingo->_openXtras.push_back(xlibName);
+		g_lingo->_openXtraObjects.push_back(xobj);
+	}
+	g_lingo->exposeXObject(xlibName, xobj);
+	g_lingo->initBuiltIns(xlibBuiltins);
+}
+
+void BorderXtra::close(ObjectType type) {
+	BorderXtraObject::cleanupMethods();
+	g_lingo->_globalvars[xlibName] = Datum();
+}
+
+void BorderXtra::m_new(int nargs) {
+	g_lingo->dropStack(nargs);
+	g_lingo->push(g_lingo->_state->me);
+}
+
+XOBJSTUB(BorderXtra::m_register, 0)
+
+} // End of namespace Director

--- a/engines/director/lingo/xtras/b/border.h
+++ b/engines/director/lingo/xtras/b/border.h
@@ -1,0 +1,50 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef DIRECTOR_LINGO_XTRAS_B_BORDER_H
+#define DIRECTOR_LINGO_XTRAS_B_BORDER_H
+
+namespace Director {
+
+class BorderXtraObject : public Object<BorderXtraObject> {
+public:
+	BorderXtraObject(ObjectType objType);
+
+	bool hasProp(const Common::String &propName) override;
+	Datum getProp(const Common::String &propName) override;
+};
+
+namespace BorderXtra {
+
+extern const char *xlibName;
+extern const XlibFileDesc fileNames[];
+
+void open(ObjectType type, const Common::Path &path);
+void close(ObjectType type);
+
+void m_new(int nargs);
+void m_register(int nargs);
+
+} // End of namespace BorderXtra
+
+} // End of namespace Director
+
+#endif

--- a/engines/director/lingo/xtras/b/budapi.cpp
+++ b/engines/director/lingo/xtras/b/budapi.cpp
@@ -22,6 +22,7 @@
 #include "common/system.h"
 
 #include "director/director.h"
+#include "director/util.h"
 #include "director/lingo/lingo.h"
 #include "director/lingo/lingo-object.h"
 #include "director/lingo/lingo-utils.h"
@@ -34,6 +35,7 @@
  * Loewenzahn 2 / 3 / 4 / 5 / 6 / 7 / 8 / Adventskalender / Spielebox
  * TKKG 6 / 7 / 8 / 9 / 11 / 13 / 14
  * Oscar the Balloonist Flies into the Mountains
+ * Physicus / Physikus (l'Espresso, Italian; Ruske & Pühretmaier)
  *
  **************************************************/
 
@@ -374,7 +376,26 @@ void BudAPIXtra::m_new(int nargs) {
 XOBJSTUB(BudAPIXtra::m_baVersion, 0)
 XOBJSTUB(BudAPIXtra::m_baSysFolder, 0)
 XOBJSTUB(BudAPIXtra::m_baCpuInfo, 0)
-XOBJSTUB(BudAPIXtra::m_baDiskInfo, 0)
+void BudAPIXtra::m_baDiskInfo(int nargs) {
+	Common::String infoType = g_lingo->pop().asString();
+	Common::String disk = g_lingo->pop().asString();
+
+	if (!infoType.equalsIgnoreCase("type")) {
+		warning("STUB: BudAPIXtra::m_baDiskInfo: unsupported InfoType '%s'", infoType.c_str());
+		g_lingo->push(Datum());
+		return;
+	}
+
+	if (disk.hasSuffix(":"))
+		disk.deleteLastChar();
+
+	if (disk.equalsIgnoreCase("e"))
+		g_lingo->push(Datum(Common::String("CD-Rom")));
+	else if (disk.equalsIgnoreCase("c"))
+		g_lingo->push(Datum(Common::String("Hard")));
+	else
+		g_lingo->push(Datum(Common::String("")));
+}
 XOBJSTUB(BudAPIXtra::m_baMemoryInfo, 0)
 XOBJSTUB(BudAPIXtra::m_baFindApp, 0)
 XOBJSTUB(BudAPIXtra::m_baReadIni, 0)
@@ -436,7 +457,10 @@ XOBJSTUB(BudAPIXtra::m_baPrinterInfo, 0)
 XOBJSTUB(BudAPIXtra::m_baSetPrinter, 0)
 XOBJSTUB(BudAPIXtra::m_baRefreshDesktop, 0)
 XOBJSTUB(BudAPIXtra::m_baFileAge, 0)
-XOBJSTUB(BudAPIXtra::m_baFileExists, 0)
+void BudAPIXtra::m_baFileExists(int nargs) {
+	Common::String name = g_lingo->pop().asString();
+	g_lingo->push(Datum(findPath(name, true, true, false).empty() ? 0 : 1));
+}
 XOBJSTUB(BudAPIXtra::m_baFolderExists, 0)
 XOBJSTUB(BudAPIXtra::m_baCreateFolder, 0)
 XOBJSTUB(BudAPIXtra::m_baDeleteFolder, 0)

--- a/engines/director/lingo/xtras/g/glu32.cpp
+++ b/engines/director/lingo/xtras/g/glu32.cpp
@@ -190,6 +190,10 @@ void GLU32Xtra::m_GLUCall(int nargs) {
 			g_lingo->push(Datum(Common::String("92263924"))); // TODO: Check with the game
 			return;
 		}
+		if (gameId == "physicus" && g_director->getLanguage() == Common::EN_ANY) {
+			g_lingo->push(Datum((int)43289555)); //tested
+			return;
+		}
 		// TODO: Tiger Team 2: 32546872
 		warning("GLU32Xtra::m_GLUCall: unhandled optgraph.dll copy protection for game '%s'", gameId.c_str());
 	}

--- a/engines/director/module.mk
+++ b/engines/director/module.mk
@@ -189,6 +189,7 @@ MODULE_OBJS = \
 	lingo/xlibs/x/xwin.o \
 	lingo/xlibs/y/yasix.o \
 	lingo/xtras/a/audio.o \
+	lingo/xtras/b/border.o \
 	lingo/xtras/b/budapi.o \
 	lingo/xtras/d/datetime.o \
 	lingo/xtras/d/directsound.o \


### PR DESCRIPTION
   Six independent fixes uncovered while getting Physicus/Physikus (English + Italian) to boot and run. 
                                                                                                        
   - Add Border Xtra stub                                                                               
   - Map QT3Asset Xtra to QuickTimeSupport                                                              
   - Don't create a digital-video widget for an empty sprite bbox                                       
   - Guard copyStretchImg against an empty target rect                                                  
   - Add physicus optgraph.dll copy-protection magic (English)                                          
   - Implement BudAPI baDiskInfo type detection and baFileExists