### PR TITLE
DIRECTOR: Reverse ink on colour bitmaps behaves like BackgndTrans

### DIFF
--- a/engines/director/graphics.cpp
+++ b/engines/director/graphics.cpp
@@ -453,7 +453,11 @@ void InkPrimitives<T>::drawPoint(int x, int y, uint32 src, void *data) {
 			// Originally designed for 1-bit mode so that
 			// black pixels would appear white on a black
 			// background.
-			*dst ^= src;
+			if (p->oneBitImage || p->ms || p->applyColor) {
+				*dst ^= src;
+			} else {
+				*dst = (src == p->backColor) ? *dst : src;
+			}
 		} else {
 			// In 32-bit mode, this is the opposite??
 			*dst ^= ~(src);


### PR DESCRIPTION
Reverse ink was implemented as a raw palette-index XOR (*dst ^= src), which is only meaningful for 1-bit images. On >= 8-bit colour bitmaps XOR-ing palette indices is meaningless and produces garbage.

In Loewenzahn 1 (loewe1) the Bauwagen "RegenbogenKartoffel" film loop uses Reverse ink to recolour the potato-king wall picture; it rendered as colourful noise.