### PR TITLE
CHEWY: Add missing talking animation in room 11 with terminal

### DIFF
--- a/engines/chewy/t_event.cpp
+++ b/engines/chewy/t_event.cpp
@@ -1238,6 +1238,7 @@ void endDialogCloseup(int16 diaNr, int16 blkNr, int16 strEndNr) {
 #define R14_HERMIT_DIA 10000
 #define R8_NIMOYANER1_DIA 10001
 #define R8_NIMOYANER2_DIA 10002
+#define R11_TERMINAL_DIA 10003
 #define R12_BORK_DIA 10004
 #define R11_BORK_DIA 10005
 #define R8_NIMOYANER3_DIA 10006
@@ -1371,6 +1372,7 @@ void atdsStringStart(int16 diaNr, int16 strNr, int16 personNr, int16 mode) {
 	case R14_HERMIT_DIA:
 	case R8_NIMOYANER1_DIA:
 	case R8_NIMOYANER2_DIA:
+	case R11_TERMINAL_DIA:
 		if (personNr <= P_CHEWY) {
 			if (mode == AAD_STR_START) {
 				start_spz(CH_TALK3, 255, ANI_FRONT, P_CHEWY);


### PR DESCRIPTION
In room 11, there's a dialog with a computer terminal. Without this patch Chewy doesn't move his lips when talking. Original DOS implementation also shows the animation: https://www.youtube.com/watch?v=GC0QF_Ib34U&t=760s

The patch is very straightforward. I'm a bit curious why this case was dropped before, though... There's #defines for values from 10000 to 10020, just 10003 was missing.

To reproduce (with a German game copy, at least) load the save [chewy-de.030.zip](https://github.com/user-attachments/files/29980749/chewy-de.030.zip) and use "Flacher Bork" from the inventory with "Scanner". Choose any line from the multiple choice dialog once prompted.

(Note that there's still some weirdness with spoken dialog lines not progressing automatically. I'll prepare a separate PR for that once I've done more testing.)