### PR TITLE
CHEWY: Add 3x missing talking animations in room 12

### DIFF
--- a/engines/chewy/defines.h
+++ b/engines/chewy/defines.h
@@ -271,6 +271,7 @@ enum SetupScreenMode {
 #define NI_STAND_R 40
 #define NI_TALK_R 41
 #define NI_BACK 42
+#define CH_BORK_TALK 68
 
 #define ROOM_0_3 3
 

--- a/engines/chewy/rooms/room12.cpp
+++ b/engines/chewy/rooms/room12.cpp
@@ -217,7 +217,7 @@ int16 Room12::use_terminal() {
 				_G(gameState).R12ChewyBork = true;
 				_G(gameState).R12RaumOk = true;
 				autoMove(4, P_CHEWY);
-				start_spz(68, 255, false, P_CHEWY);
+				start_spz(CH_BORK_TALK, 255, false, P_CHEWY);
 				startAadWait(113);
 
 			} else if (_G(gameState).R12TalismanOk && !_G(gameState).R12RaumOk) {
@@ -275,6 +275,7 @@ int16 Room12::useTransformerTube() {
 			_G(atds)->set_ats_str(117, TXT_MARK_LOOK, 0, ATS_DATA);
 		} else {
 			autoMove(7, P_CHEWY);
+			start_spz(CH_TALK3, 255, ANI_FRONT, P_CHEWY);
 			startAadWait(29);
 		}
 	}

--- a/engines/chewy/rooms/room13.cpp
+++ b/engines/chewy/rooms/room13.cpp
@@ -129,7 +129,7 @@ void Room13::talk_bork() {
 		_G(flags).NoScroll = true;
 		auto_scroll(41, 0);
 
-		start_spz(68, 255, false, P_CHEWY);
+		start_spz(CH_BORK_TALK, 255, false, P_CHEWY);
 		startAadWait(248);
 		flic_cut(FCUT_013);
 		load_chewy_taf(CHEWY_NORMAL);

--- a/engines/chewy/t_event.cpp
+++ b/engines/chewy/t_event.cpp
@@ -1283,6 +1283,8 @@ void atdsStringStart(int16 diaNr, int16 strNr, int16 personNr, int16 mode) {
 	case 30000:
 	case 25:
 	case 34:
+	case 111:  // R12: use_linke_rohr()
+	case 114:  // R12: Chewy-as-Bork with terminal
 	case 252:
 	case 253:
 	case 259:
@@ -1324,7 +1326,7 @@ void atdsStringStart(int16 diaNr, int16 strNr, int16 personNr, int16 mode) {
 				break;
 
 			case CHEWY_BORK:
-				aniNr = 68;
+				aniNr = CH_BORK_TALK;
 				break;
 
 			case CHEWY_PUMPKIN:
@@ -1718,7 +1720,7 @@ void atdsStringStart(int16 diaNr, int16 strNr, int16 personNr, int16 mode) {
 					break;
 
 				case CHEWY_BORK:
-					aniNr = 68;
+					aniNr = CH_BORK_TALK;
 					break;
 
 				case CHEWY_PUMPKIN:


### PR DESCRIPTION
This fixes three animations when Chewy is talking that were missing in room 12.

Triggers:
* in Chewy form: When both tubes are empty, use transformer tube (on the right)
* in Chewy form: With talisman in the transformer tube, use terminal
* in Bork form: Use terminal

One save for each trigger: [saves-room12.zip](https://github.com/user-attachments/files/29985164/saves-room12.zip)

Also defines CH_BORK_TALK to hold animation magic number 68 (akin to CH_TALK3, CH_PUMP_TALK, etc.).

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
