### PR TITLE
DIRECTOR: LINGO: Map D5+ objcall bytecodes to cb_call

### DIFF
--- a/engines/director/lingo/lingo-bytecode.cpp
+++ b/engines/director/lingo/lingo-bytecode.cpp
@@ -106,6 +106,7 @@ static const LingoV4Bytecode lingoV4[] = {
 	{ 0x64, LC::c_stackpeek, 	"b" },
 	{ 0x65, LC::c_stackdrop, 	"b" },
 	{ 0x66, LC::cb_v4theentitynamepush, "bN" },
+	{ 0x67, LC::cb_call,		"bN" }, // D5+ objcall
 
 	{ 0x81, LC::c_intpush,		"W" },
 	{ 0x82, LC::c_argcnoretpush,"w" },
@@ -141,6 +142,7 @@ static const LingoV4Bytecode lingoV4[] = {
 	{ 0xa4, LC::c_stackpeek, 	"w" },
 	{ 0xa5, LC::c_stackdrop, 	"w" },
 	{ 0xa6, LC::cb_v4theentitynamepush, "wN" },
+	{ 0xa7, LC::cb_call,		"wN" }, // D5+ objcall
 	{ 0, nullptr, nullptr }
 };
 


### PR DESCRIPTION
Opcodes 0x67/0xa7 (kOpObjCall in ProjectorRays) had no table entry, so obj.method() calls compiled to cb_unk stubs that pushed nothing and corrupted the stack. LC::call() already dispatches method calls with the object as first argument, same as ExtCall.

Fixes early self-exit in Bioscopia (D8), whose list accesses (getAt/setAt) and BuddyAPI calls compile to opcode 0xa7
