### PR TITLE
COMMON: Add move-assign operator to DisposablePtr

### DIFF
--- a/common/ptr.h
+++ b/common/ptr.h
@@ -670,6 +670,14 @@ public:
 		if (_dispose) DL()(_pointer);
 	}
 
+	DisposablePtr<T, DL> &operator=(DisposablePtr<T, DL> &&o) {
+		reset(o._pointer, o._dispose);
+		_shared = move(o._shared);
+		o._pointer = nullptr;
+		o._dispose = DisposeAfterUse::NO;
+		return *this;
+	}
+
 	ReferenceType operator*() const { return *_pointer; }
 	PointerType operator->() const { return _pointer; }
 

--- a/test/common/ptr.h
+++ b/test/common/ptr.h
@@ -166,6 +166,46 @@ class PtrTestSuite : public CxxTest::TestSuite {
 		TS_ASSERT(a.expired());
 		TS_ASSERT(!a.lock());
 	}
+
+	struct IsDeletedClass {
+		bool isDeleted = false;
+		void operator ()(IsDeletedClass *ptr) {
+			TS_ASSERT(!ptr->isDeleted);
+			ptr->isDeleted = true;
+		}
+	};
+
+	void test_disposable_move_assign() {
+		IsDeletedClass obj1, obj2, obj3, obj4;
+		Common::DisposablePtr<IsDeletedClass, IsDeletedClass> p1(&obj1, DisposeAfterUse::YES);
+
+		// move-assign from YES to YES ptr
+		{
+			Common::DisposablePtr<IsDeletedClass, IsDeletedClass> p2(&obj2, DisposeAfterUse::YES);
+			p1 = Common::move(p2);
+			TS_ASSERT(obj1.isDeleted);
+		}
+		TS_ASSERT(!obj2.isDeleted); // p2 did not delete its old object
+
+		// move-assign from NO to YES ptr
+		{
+			Common::DisposablePtr<IsDeletedClass, IsDeletedClass> p3(&obj3, DisposeAfterUse::NO);
+			p1 = Common::move(p3);
+			TS_ASSERT(obj2.isDeleted);
+		}
+		p1.reset();
+		TS_ASSERT(!obj3.isDeleted); // NO dispose flag was correctly propagated
+
+		// move-assign from YES to NO ptr
+		{
+			Common::DisposablePtr<IsDeletedClass, IsDeletedClass> p4(&obj4, DisposeAfterUse::YES);
+			p1 = Common::move(p4);
+			TS_ASSERT(!obj3.isDeleted); // this was still NO
+			TS_ASSERT(!obj4.isDeleted);
+		}
+		p1.reset();
+		TS_ASSERT(obj4.isDeleted); // YES dispose flag was correctly propagated
+	}
 };
 
 int PtrTestSuite::InstanceCountingClass::count = 0;


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->

`DisposablePtr` already had a move constructor but not a move-assign operator. This breaks usages like the following:

```c++
Array<DisposablePtr<int>> arr;
arr.remove_at(3);
```
