### PR TITLE
DIRECTOR: LINGO: Register budapi32 filename for the BuddyAPI Xtra

### DIFF
--- a/engines/director/lingo/xtras/b/budapi.cpp
+++ b/engines/director/lingo/xtras/b/budapi.cpp
@@ -192,6 +192,7 @@ namespace Director {
 const char *BudAPIXtra::xlibName = "BudAPI";
 const XlibFileDesc BudAPIXtra::fileNames[] = {
 	{ "budapi",   nullptr },
+	{ "budapi32", nullptr },
 	{ nullptr,        nullptr },
 };
 


### PR DESCRIPTION
Games shipping the 32-bit budapi32.dll open the xlib under that name, which did not resolve to the implemented BudAPI Xtra.

Verified with Bioscopia (D8) and Physicus (D7), which open both names
