### PR TITLE
DIRECTOR: Read Afterburner-compressed chunks big-endian by default

### DIFF
--- a/engines/director/archive.cpp
+++ b/engines/director/archive.cpp
@@ -1135,7 +1135,7 @@ Common::SeekableReadStreamEndian *RIFXArchive::getResource(uint32 tag, uint16 id
 		} else {
 			_stream->seek(_ilsBodyOffset + res.offset);
 			uint32 actualUncompLength = res.uncompSize;
-			Common::SeekableReadStreamEndian *stream = readZlibData(*_stream, res.size, &actualUncompLength, _isBigEndian);
+			Common::SeekableReadStreamEndian *stream = readZlibData(*_stream, res.size, &actualUncompLength, bigEndian);
 			if (!stream) {
 				error("RIFXArchive::getResource(): Could not uncompress '%s' %d", tag2str(tag), id);
 			}


### PR DESCRIPTION
The zlib branch of RIFXArchive::getResource() passed the archive endianness instead of the computed default, so compressed chunks in little-endian Shockwave movies parsed byte-swapped, unlike the same chunks stored uncompressed or in the ILS.

Fixes 'Stxt init: unhandled offset' fatal loading Option.dcr in bioscopia