### PR TITLE
SDL: Preserve events outside ImGui input capture

### DIFF
--- a/backends/events/sdl/sdl2-events.cpp
+++ b/backends/events/sdl/sdl2-events.cpp
@@ -695,7 +695,10 @@ bool SdlEventSource::pollEvent(Common::Event &event) {
 		if (ImGui_ImplSDL2_Ready()) {
 			ImGui_ImplSDL2_ProcessEvent(&ev);
 			ImGuiIO &io = ImGui::GetIO();
-			if (io.WantTextInput || io.WantCaptureMouse)
+			bool mouseEvent = ev.type == SDL_MOUSEMOTION || ev.type == SDL_MOUSEBUTTONDOWN ||
+				ev.type == SDL_MOUSEBUTTONUP || ev.type == SDL_MOUSEWHEEL;
+			bool textEvent = ev.type == SDL_TEXTINPUT;
+			if ((mouseEvent && io.WantCaptureMouse) || (textEvent && io.WantTextInput))
 				continue;
 		}
 #endif
@@ -779,7 +782,16 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 			}
 		}
 
-		switch (ev.window.event) {
+	switch (ev.window.event) {
+	case SDL_WINDOWEVENT_CLOSE:
+		if (_graphicsManager) {
+			uint32 windowID = SDL_GetWindowID(_graphicsManager->getWindow()->getSDLWindow());
+			if (windowID != ev.window.windowID)
+				return false;
+		}
+
+		event.type = Common::EVENT_QUIT;
+		return true;
 
 		case SDL_WINDOWEVENT_EXPOSED:
 			if (_graphicsManager) {

--- a/backends/events/sdl/sdl3-events.cpp
+++ b/backends/events/sdl/sdl3-events.cpp
@@ -678,7 +678,10 @@ bool SdlEventSource::pollEvent(Common::Event &event) {
 #if defined(USE_IMGUI)
 		ImGui_ImplSDL3_ProcessEvent(&ev);
 		ImGuiIO &io = ImGui::GetIO();
-		if (io.WantTextInput || io.WantCaptureMouse)
+		bool mouseEvent = ev.type == SDL_EVENT_MOUSE_MOTION || ev.type == SDL_EVENT_MOUSE_BUTTON_DOWN ||
+			ev.type == SDL_EVENT_MOUSE_BUTTON_UP || ev.type == SDL_EVENT_MOUSE_WHEEL;
+		bool textEvent = ev.type == SDL_EVENT_TEXT_INPUT;
+		if ((mouseEvent && io.WantCaptureMouse) || (textEvent && io.WantTextInput))
 			continue;
 #endif
 		if (dispatchSDLEvent(ev, event))
@@ -747,6 +750,16 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 
 		return _queuedFakeKeyUp;
 		}
+
+	case SDL_EVENT_WINDOW_CLOSE_REQUESTED:
+		if (_graphicsManager) {
+			uint32 windowID = SDL_GetWindowID(_graphicsManager->getWindow()->getSDLWindow());
+			if (windowID != ev.window.windowID)
+				return false;
+		}
+
+		event.type = Common::EVENT_QUIT;
+		return true;
 
 		case SDL_EVENT_WINDOW_EXPOSED:
 			if (_graphicsManager) {


### PR DESCRIPTION
As discussed on Discord, this is a fix for when the SDL backends will eat up non-mouse and non-text events (including SDL_QUIT), in the attempt of handling ImGui `WantCaptureMouse` and `WantTextInput`.