### PR TITLE
DIRECTOR: LINGO: Add the soundDevice entity (D7)

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -376,7 +376,6 @@ static const BuiltinProto builtins[] = {
    pathName				//	D5
    preloadMode			//				D8
    selectiomn			//	D5
-   soundDevice			//			D7
    version				//	D5
 
    Movie properties:

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -166,6 +166,7 @@ TheEntity entities[] = {					//	hasId  ver.	isFunction
 	{ kTheSerialNumber,		"serialNumber",		false, 500, false },//				D5 p, documnted in D7
 	{ kTheShiftDown,		"shiftDown",		false, 200, true },	// D2 f
 	{ kTheSoundEnabled,		"soundEnabled",		false, 200, false },// D2 p
+	{ kTheSoundDevice,		"soundDevice",		false, 700, false },//					D7 p
 	{ kTheSoundEntity,		"sound",			true,  300, false },// 		D3 p
 	{ kTheSoundKeepDevice,	"soundKeepDevice",	false, 600, false },//					D6 p, documented in D7
 	{ kTheSoundLevel,		"soundLevel",		false, 200, false },// D2 p
@@ -1093,6 +1094,9 @@ Datum Lingo::getTheEntity(int entity, Datum &id, int field) {
 			}
 		}
 		break;
+	case kTheSoundDevice:
+		d = _soundDevice;
+		break;
 	case kTheSoundKeepDevice:
 		// System property; for Windows only, prevents the sound driver from unloading
 		// and reloading each time a sound needs to play. The default value is TRUE.
@@ -1450,6 +1454,10 @@ void Lingo::setTheEntity(int entity, Datum &id, int field, Datum &d) {
 				break;
 			}
 		}
+		break;
+	case kTheSoundDevice:
+		// Ignored: ScummVM has one fixed output with no switchable backend,
+		// as in Director when the requested device is unavailable.
 		break;
 	case kTheSoundKeepDevice:
 		// We do not need to unload the sound driver, so just ignore this.

--- a/engines/director/lingo/lingo-the.h
+++ b/engines/director/lingo/lingo-the.h
@@ -148,6 +148,7 @@ enum TheEntityType {
 	kTheSelStart,
 	kTheSerialNumber,
 	kTheShiftDown,
+	kTheSoundDevice,
 	kTheSoundEntity,
 	kTheSoundEnabled,
 	kTheSoundKeepDevice,

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -207,6 +207,7 @@ Lingo::Lingo(DirectorEngine *vm) : _vm(vm) {
 	_trace = false;
 	_traceLoad = 0;
 	_updateMovieEnabled = false;
+	_soundDevice = "DirectSound";
 
 	// events
 	_passEvent = false;

--- a/engines/director/lingo/lingo.h
+++ b/engines/director/lingo/lingo.h
@@ -496,6 +496,7 @@ public:
 	int _traceLoad; // internal Director verbosity level
 	bool _updateMovieEnabled;
 	bool _romanLingo;
+	Common::String _soundDevice;
 
 	Datum getTheEntity(int entity, Datum &id, int field);
 	void setTheEntity(int entity, Datum &id, int field, Datum &d);


### PR DESCRIPTION
Fixes 'LC::cb_theassign2 Can't assign theEntity: (soundDevice)' at every movie start in physicus (StartHandler does
'the soundDevice = "QT3Mix"')