### PR TITLE
DIRECTOR: Fix Opera Fatal intro crash and frozen video sequence

### DIFF
--- a/engines/director/castmember/digitalvideo.cpp
+++ b/engines/director/castmember/digitalvideo.cpp
@@ -561,8 +561,13 @@ uint DigitalVideoCastMember::getMovieTotalTime() {
 }
 
 void DigitalVideoCastMember::seekMovie(int stamp) {
-	if (!_video)
+	if (!_channel)
 		return;
+
+	if (!_video || !_video->isVideoLoaded()) {
+		if (!loadVideoFromCast())
+			return;
+	}
 
 	_channel->_startTime = stamp;
 
@@ -578,8 +583,13 @@ void DigitalVideoCastMember::seekMovie(int stamp) {
 }
 
 void DigitalVideoCastMember::setStopTime(int stamp) {
-	if (!_video)
+	if (!_channel)
 		return;
+
+	if (!_video || !_video->isVideoLoaded()) {
+		if (!loadVideoFromCast())
+			return;
+	}
 
 	_channel->_stopTime = stamp;
 
@@ -589,8 +599,13 @@ void DigitalVideoCastMember::setStopTime(int stamp) {
 }
 
 void DigitalVideoCastMember::setMovieRate(double rate) {
-	if (!_video)
+	if (!_channel)
 		return;
+
+	if (!_video || !_video->isVideoLoaded()) {
+		if (!loadVideoFromCast())
+			return;
+	}
 
 	_channel->_movieRate = rate;
 

--- a/engines/director/castmember/digitalvideo.cpp
+++ b/engines/director/castmember/digitalvideo.cpp
@@ -478,9 +478,13 @@ Graphics::MacWidget *DigitalVideoCastMember::createWidget(Common::Rect &bbox, Ch
 		}
 	}
 
-	// Zero-sized bbox: nothing to render, and scaling to it would divide by zero.
-	if (bbox.width() <= 0 || bbox.height() <= 0)
+	// Zero-sized bbox: nothing to render. Still pump the decoder so an
+	// invisible video used only as a timing/audio clock keeps advancing.
+	if (bbox.width() <= 0 || bbox.height() <= 0) {
+		if (_channel && _channel->_movieRate != 0.0 && _video->needsUpdate())
+			_video->decodeNextFrame();
 		return nullptr;
+	}
 
 	Graphics::MacWidget *widget = new Graphics::MacWidget(g_director->getCurrentWindow()->getMacWindow(), bbox.left, bbox.top, bbox.width(), bbox.height(), g_director->_wm, false);
 

--- a/engines/director/lingo/lingo-the.cpp
+++ b/engines/director/lingo/lingo-the.cpp
@@ -2028,16 +2028,18 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 		break;
 	case kTheMovieRate:
 		channel->_movieRate = d.asFloat();
-		if (sprite->_cast && sprite->_cast->_type == kCastDigitalVideo)
+		if (sprite->_cast && sprite->_cast->_type == kCastDigitalVideo) {
+			((DigitalVideoCastMember *)sprite->_cast)->setChannel(channel);
 			((DigitalVideoCastMember *)sprite->_cast)->setMovieRate(channel->_movieRate);
-		else
+		} else
 			warning("Setting movieTime for non-digital video");
 		break;
 	case kTheMovieTime:
 		channel->_movieTime = d.asInt();
-		if (sprite->_cast->_type == kCastDigitalVideo)
+		if (sprite->_cast && sprite->_cast->_type == kCastDigitalVideo) {
+			((DigitalVideoCastMember *)sprite->_cast)->setChannel(channel);
 			((DigitalVideoCastMember *)sprite->_cast)->seekMovie(channel->_movieTime);
-		else
+		} else
 			warning("Setting movieTime for non-digital video");
 		break;
 	case kThePattern:
@@ -2072,16 +2074,18 @@ void Lingo::setTheSprite(Datum &id1, int field, Datum &d) {
 		break;
 	case kTheStartTime:
 		channel->_startTime = d.asInt();
-		if (sprite->_cast->_type == kCastDigitalVideo)
+		if (sprite->_cast && sprite->_cast->_type == kCastDigitalVideo) {
+			((DigitalVideoCastMember *)sprite->_cast)->setChannel(channel);
 			((DigitalVideoCastMember *)sprite->_cast)->seekMovie(channel->_startTime);
-		else
+		} else
 			warning("Setting startTime for non-digital video");
 		break;
 	case kTheStopTime:
 		channel->_stopTime = d.asInt();
-		if (sprite->_cast->_type == kCastDigitalVideo)
+		if (sprite->_cast && sprite->_cast->_type == kCastDigitalVideo) {
+			((DigitalVideoCastMember *)sprite->_cast)->setChannel(channel);
 			((DigitalVideoCastMember *)sprite->_cast)->setStopTime(channel->_stopTime);
-		else
+		} else
 			warning("Setting stopTime for non-digital video");
 		break;
 	case kTheStretch:


### PR DESCRIPTION
Opera Fatal (operafatal, Windows/Italian) crashed on startup, and after                              
   the crash was fixed the intro froze on its first scene.                                              
                                                                                                        
   Two commits:                                                                                         
                                                                                                        
   1. Bind digital-video channel before applying sprite properties                                      
      setTheSprite() applied `the movieRate`/`movieTime`/`stopTime` to the                              
      intro's digital-video cast member before its channel was bound, so the                            
      setters dereferenced a null channel and decoder. Crash gone (5/5 runs).                           
                                                                                                        
   2. Decode off-screen digital videos used as timing clocks                                            
      opera\intro\intro drives the whole intro from `the movieTime` of an                               
      off-stage QuickTime movie (CON0822.MOV, sprite 40, 0x0 bbox) that                                 
      advances scenes on idle. createWidget() returned before decoding on a                             
      zero-sized bbox, so the started decoder was never pumped and its                                  
      audio-mastered clock stalled after the initial buffer, freezing the                               
      intro. Pumping the decoder for playing zero-bbox videos lets the clock                            
      advance; the intro now plays through (frame 27 -> 59 -> game) and the                             
      incremental decode also feeds the audio.