### PR TITLE
FOOL: Create MacWindowManager dynamically instead of statically

### DIFF
--- a/engines/fool/fool.cpp
+++ b/engines/fool/fool.cpp
@@ -43,6 +43,7 @@ FoolEngine::FoolEngine(OSystem *syst, const FOOLGameDescription *gameDesc) : Eng
 }
 
 FoolEngine::~FoolEngine() {
+	delete _wm;
 }
 
 uint32 FoolEngine::getFeatures() const {
@@ -54,10 +55,11 @@ Common::String FoolEngine::getGameId() const {
 }
 
 Common::Error FoolEngine::run() {
+	_wm = new Graphics::MacWindowManager();
 	initGraphics(SCREEN_WIDTH, SCREEN_HEIGHT);
 
 	_screen.create(SCREEN_WIDTH, SCREEN_HEIGHT, Graphics::PixelFormat::createFormatCLUT8());
-	_wm.setScreen(&_screen);
+	_wm->setScreen(&_screen);
 
 	Common::String versionStr(_gameDescription->desc.extra);
 	FoolVersion version = kFool20;

--- a/engines/fool/fool.h
+++ b/engines/fool/fool.h
@@ -62,7 +62,7 @@ protected:
 
 public:
 	Graphics::ManagedSurface _screen;
-	Graphics::MacWindowManager _wm;
+	Graphics::MacWindowManager *_wm = nullptr;
 
 	FoolEngine(OSystem *syst, const FOOLGameDescription *gameDesc);
 	~FoolEngine() override;

--- a/engines/fool/fool_game.cpp
+++ b/engines/fool/fool_game.cpp
@@ -119,7 +119,7 @@ Common::String getFileNameFromModal(bool save, const Common::String &suggested, 
 }
 
 void FoolGame::run() {
-	_toolbox = new Toolbox(&g_engine->_wm);
+	_toolbox = new Toolbox(g_engine->_wm);
 	_zbasic = new ZBasic(_toolbox);
 
 	_toolbox->_setFileModalCallback(getFileNameFromModal);
@@ -2733,12 +2733,12 @@ void FoolGame::sub_129_068() {
 	// 129:00de: JSR - "PEEKLONG"
 	// 129:00e2: SUBI.L - 0x72,D0
 	// 129:00e8: JSR - "PEEKWORD"
-	_windowWidth = g_engine->_wm._screenDims.width();  // window width?
+	_windowWidth = g_engine->_wm->_screenDims.width();  // window width?
 	// 129:00f0: MOVE.L - 0x904,D0
 	// 129:00f6: JSR - "PEEKLONG"
 	// 129:00fa: SUBI.L - 0x74,D0
 	// 129:0100: JSR - "PEEKWORD"
-	_windowHeight = g_engine->_wm._screenDims.height(); // window height?
+	_windowHeight = g_engine->_wm->_screenDims.height(); // window height?
 	var_i16_56 = (_windowWidth - SCREEN_WIDTH)/2;
 	var_i16_58 = (_windowHeight - SCREEN_HEIGHT)/2;
 	// 129:0138

--- a/engines/fool/fool_prologue.cpp
+++ b/engines/fool/fool_prologue.cpp
@@ -41,7 +41,7 @@ namespace Fool {
 // v3.0 - newer ZBasic, changed a few graphics assets, removed custom menu font and sounds for compatibility
 
 void FoolPrologue::run(bool finale, const BitMap &prevWindow) {
-	_toolbox = new Toolbox(&g_engine->_wm);
+	_toolbox = new Toolbox(g_engine->_wm);
 	_zbasic = new ZBasic(_toolbox);
 
 	Common::MacFinderInfo finfo;
@@ -532,8 +532,8 @@ void FoolPrologue::setupWindow() {
 	// 0x000a: JSR - "PEEKLONG"   # current A5
 	// 0x000e: SUBI.L - 0x72,D0
 	// 0x0014: JSR - "PEEKWORD" # quickdraw globals,
-	_windowWidth = g_engine->_wm._screenDims.width();  // window width?
-	_windowHeight = g_engine->_wm._screenDims.height(); // window height?
+	_windowWidth = g_engine->_wm->_screenDims.width();  // window width?
+	_windowHeight = g_engine->_wm->_screenDims.height(); // window height?
 
 	// 129:0034
 	// set left and top offsets based on a drawable area of 512x342

--- a/engines/fool/zbasic.cpp
+++ b/engines/fool/zbasic.cpp
@@ -43,7 +43,7 @@ void menuCommandsCallback(int action, Common::String &text, void *data) {
 ZBasic::ZBasic(Graphics::MacToolbox::Toolbox *toolbox) : _toolbox(toolbox) {
 	_memPool = new Common::MemoryPool(sizeof(int));
 
-	_window = g_engine->_wm.addWindow(false, false, false);
+	_window = g_engine->_wm->addWindow(false, false, false);
 	_window->disableBorder();
 	_window->resize(SCREEN_WIDTH, SCREEN_HEIGHT);
 	_toolbox->_defaultWindow = _window;
@@ -51,10 +51,10 @@ ZBasic::ZBasic(Graphics::MacToolbox::Toolbox *toolbox) : _toolbox(toolbox) {
 	_toolbox->_defaultBits->copyFrom(*_window->getWindowSurface());
 	_window->setSurface(_toolbox->_defaultBits.get(), DisposeAfterUse::NO);
 
-	g_engine->_wm.setBackgroundWindow(_window);
-	if (!g_engine->_wm.getMenu()) {
+	g_engine->_wm->setBackgroundWindow(_window);
+	if (!g_engine->_wm->getMenu()) {
 		// no menu defined, create one for the first time
-		_menu = g_engine->_wm.addMenu();
+		_menu = g_engine->_wm->addMenu();
 		_menu->setCommandsCallback(menuCommandsCallback, nullptr);
 
 		_toolbox->_defaultMenu = _menu;
@@ -63,7 +63,7 @@ ZBasic::ZBasic(Graphics::MacToolbox::Toolbox *toolbox) : _toolbox(toolbox) {
 		_menu->setSurface(_toolbox->_defaultMenuBits.get(), DisposeAfterUse::NO);
 	} else {
 		// menu already exists
-		_menu = g_engine->_wm.getMenu();
+		_menu = g_engine->_wm->getMenu();
 		_toolbox->_defaultMenu = _menu;
 		// we don't get the surface for directly manipulating the menu, but so far we don't need it
 	}
@@ -74,7 +74,7 @@ ZBasic::ZBasic(Graphics::MacToolbox::Toolbox *toolbox) : _toolbox(toolbox) {
 }
 
 ZBasic::~ZBasic() {
-	g_engine->_wm.removeWindow(_window);
+	g_engine->_wm->removeWindow(_window);
 	_window = nullptr;
 	_toolbox->_defaultWindow = nullptr;
 


### PR DESCRIPTION
I noticed that in my setup, where I keep classicmacfonts.dat and macgui.dat in my extra path, The Fool's Errand wouldn't find these files because the MacWindowManager was created before the extra path was handled. This led to at least two rendering glitches:

- Disabled characters that extended below the baseline (e.g. the "py" in "Canopy") were cut off.
- Shortcut commands used the "^" glyph instead of the command key glyph.

I hope the solution is as simple as just creating the window manager dynamically instead.