### PR TITLE
AWE: Fix sfx music crash on OpenBSD (or through TSan)

### DIFF
--- a/audio/rate.cpp
+++ b/audio/rate.cpp
@@ -541,6 +541,8 @@ int RateConverter_Impl<inStereo, outStereo, reverseStereo>::convert(AudioStream 
 }
 
 RateConverter *makeRateConverter(st_rate_t inRate, st_rate_t outRate, bool inStereo, bool outStereo, bool reverseStereo) {
+	assert(inRate != 0 && outRate != 0);
+
 	if (inStereo) {
 		if (outStereo) {
 			if (reverseStereo)

--- a/engines/awe/sfx_player.cpp
+++ b/engines/awe/sfx_player.cpp
@@ -52,11 +52,13 @@ SfxPlayer::SfxPlayer(Resource *res)
 }
 
 void SfxPlayer::setEventsDelay(uint16 delay) {
+	Common::StackLock lock(_mutex);
 	debugC(kDebugSound, "SfxPlayer::setEventsDelay(%d)", delay);
 	_delay = delay;
 }
 
 void SfxPlayer::loadSfxModule(uint16 resNum, uint16 delay, uint8 pos) {
+	Common::StackLock lock(_mutex);
 	debugC(kDebugSound, "SfxPlayer::loadSfxModule(0x%X, %d, %d)", resNum, delay, pos);
 	MemEntry *me = &_res->_memList[resNum];
 	if (me->status == Resource::STATUS_LOADED && me->type == Resource::RT_MUSIC) {
@@ -100,6 +102,7 @@ void SfxPlayer::prepareInstruments(const uint8 *p) {
 }
 
 void SfxPlayer::play(int rate) {
+	Common::StackLock lock(_mutex);
 	_playing = true;
 	_rate = rate;
 	_samplesLeft = 0;
@@ -174,17 +177,20 @@ void SfxPlayer::mixSamples(int16 *buf, int len) {
 }
 
 void SfxPlayer::readSamples(int16 *buf, int len) {
+	Common::StackLock lock(_mutex);
 	if (_delay != 0) {
 		mixSamples(buf, len / 2);
 	}
 }
 
 void SfxPlayer::start() {
+	Common::StackLock lock(_mutex);
 	debugC(kDebugSound, "SfxPlayer::start()");
 	_sfxMod.curPos = 0;
 }
 
 void SfxPlayer::stop() {
+	Common::StackLock lock(_mutex);
 	debugC(kDebugSound, "SfxPlayer::stop()");
 	_playing = false;
 }

--- a/engines/awe/sfx_player.h
+++ b/engines/awe/sfx_player.h
@@ -23,6 +23,7 @@
 #define AWE_SFX_PLAYER_H
 
 #include "awe/intern.h"
+#include "common/mutex.h"
 
 namespace Awe {
 
@@ -82,6 +83,8 @@ struct SfxPlayer {
 	int _rate = 0;
 	int _samplesLeft = 0;
 	SfxChannel _channels[NUM_CHANNELS];
+
+	Common::Mutex _mutex;
 
 	SfxPlayer(Resource *res);
 

--- a/engines/awe/sound.cpp
+++ b/engines/awe/sound.cpp
@@ -38,8 +38,8 @@ void Sound::playMusic(const char *path, int loops) {
 }
 
 void Sound::playSfxMusic(int num) {
-	_mixer->playStream(Audio::Mixer::kMusicSoundType, &_musicHandle, _sfxStream, -1, 255, 0, DisposeAfterUse::YES, true);
 	_sfx->play(_mixer->getOutputRate());
+	_mixer->playStream(Audio::Mixer::kMusicSoundType, &_musicHandle, _sfxStream, -1, 255, 0, DisposeAfterUse::YES, true);
 }
 
 void Sound::playAifcMusic(const char *path, uint32 offset) {


### PR DESCRIPTION
## Problem

Starting _Another World_ on OpenBSD would crash when the game starts, with a fatal `pthread_mutex_destroy on mutex with waiters!` error. I think this is due to OpenBSD's pthread implementation being (purposefully) [unforgiving](https://lobste.rs/s/dpfish/openbsd_gives_hint_on_forgetting_unlock).

Fortunately, it's easy to reproduce the issue on other systems: just build and run the engine with `--enable-tsan`.

## PR contents

* This seems to be a simple matter of reversing the order of the `mixer->playStream()` and `_sfx->play()` calls, in `Sound::playSfxMusic()`. First commit does this. (related, previous commit: 7372d035692b0206eb2cee78337684cf5644835e)
* Second commit adds an `assert()` to `makeRateConverter()`, in development builds. This helps catching improper caller usage like this, at an earlier stage. 
* Third commit is what Claude Pro Opus 4.8 suggests, after investigating what ThreadSanitizer reported. **This one I can't comment on, much, so I'd rather have someone review it.** (I've labelled it with `Assisted-by: Claude...`).