### PR TITLE
COMMON: Add is_assignable, is_constructible and support move-only SWAPs

### DIFF
--- a/common/type_traits.h
+++ b/common/type_traits.h
@@ -116,6 +116,54 @@ struct conditional<false, T, F> {
 template<bool b, class T, class F>
 using conditional_t = typename conditional<b, T, F>::type;
 
+// additional helper necessary only for GCC 4.7.4
+template<class...>
+struct void_t_helper { using type = void; };
+
+template<class... Ts>
+using void_t = typename void_t_helper<Ts...>::type;
+
+template<typename T>
+inline T &&declval(); // not implemented as it may not be called anyways
+
+template<class, class T, class... Args>
+struct is_constructible_helper {
+	static constexpr const bool v = false;
+};
+
+template<class T, class... Args>
+struct is_constructible_helper<void_t<decltype(T(declval<Args>()...))>, T, Args...> {
+	static constexpr const bool v = true;
+};
+
+template<class T, class... Args>
+using is_constructible = is_constructible_helper<void_t<>, T, Args...>;
+
+template<class T>
+using is_move_constructible = is_constructible<T, remove_cv_t<T> &&>;
+
+template<class T>
+using is_copy_constructible = is_constructible<T, const remove_cv_t<T> &>;
+
+template<class, class T, class U>
+struct is_assignable_helper {
+	static constexpr const bool v = false;
+};
+
+template<class T, class U>
+struct is_assignable_helper<void_t<decltype(declval<remove_cv_t<T>>() = declval<remove_cv_t<U>>())>, T, U> {
+	static constexpr const bool v = true;
+};
+
+template<class T, class U>
+using is_assignable = is_assignable_helper<void_t<>, T, U>;
+
+template<class T>
+using is_move_assignable = is_assignable<T, remove_cv_t<T> &&>;
+
+template<class T>
+using is_copy_assignable = is_assignable<T, const remove_cv_t<T> &>;
+
 } // End of namespace Common
 
 #endif

--- a/common/util.h
+++ b/common/util.h
@@ -83,7 +83,7 @@ template<typename T> inline T CLIP(T v, T amin, T amax)
 /**
  * Template method to swap the values of its two parameters.
  */
-template<typename T> inline void SWAP(T &a, T &b) { T tmp = a; a = b; b = tmp; }
+template<typename T> inline void SWAP(T &a, T &b);
 
 /** Function to rotate the 32-bit integer @p x left by @p r bits */
 static inline uint32 ROTATE_LEFT_32(const uint32 x, const uint32 r) {
@@ -439,8 +439,31 @@ namespace DateTime {
 	int64 getTime();
 }
 
+template<typename T, bool useMove = Common::is_move_constructible<T>::v && Common::is_move_assignable<T>::v>
+struct SWAP_helper {};
+
+template<typename T>
+struct SWAP_helper<T, true> {
+	static void swap(T &a, T &b) {
+		T tmp = Common::move(a);
+		a = Common::move(b);
+		b = Common::move(tmp);
+	}
+};
+
+template<typename T>
+struct SWAP_helper<T, false> {
+	static void swap(T &a, T &b) {
+		T tmp = a;
+		a = b;
+		b = tmp;
+	}
+};
+
 /** @} */
 
 } // End of namespace Common
+
+template<typename T> inline void SWAP(T &a, T &b) { Common::SWAP_helper<T>::swap(a, b); }
 
 #endif

--- a/test/common/util.h
+++ b/test/common/util.h
@@ -250,4 +250,91 @@ class UtilTestSuite : public CxxTest::TestSuite {
 			 }
 		}
 	}
+
+	struct SwapTestBoth {
+		int value = 0;
+		SwapTestBoth(int v) : value(v) {}
+	};
+
+	struct SwapTestCopyable {
+		int value = 0;
+		SwapTestCopyable(int v) : value(v) {}
+		SwapTestCopyable(const SwapTestCopyable &o) : value(o.value) {}
+		SwapTestCopyable &operator =(const SwapTestCopyable &o) {
+			value = o.value;
+			return *this;
+		}
+		SwapTestCopyable(SwapTestCopyable &&o) = delete;
+		SwapTestCopyable &operator =(SwapTestCopyable &&o) = delete;
+	};
+	static_assert(Common::is_copy_constructible<SwapTestCopyable>::v, "SwapTestCopyable should be copy constructible");
+	static_assert(Common::is_copy_assignable<SwapTestCopyable>::v, "SwapTestCopyable should be copy assignable");
+	static_assert(!Common::is_move_constructible<SwapTestCopyable>::v, "SwapTestCopyable should not be move constructible");
+	static_assert(!Common::is_move_assignable<SwapTestCopyable>::v, "SwapTestCopyable should not be move assignable");
+
+	struct SwapTestMovable {
+		int value = 0;
+		SwapTestMovable(int v) : value(v) {}
+		SwapTestMovable(SwapTestMovable &&o) : value(o.value) {
+			o.value = -1;
+		}
+		SwapTestMovable &operator =(SwapTestMovable &&o) {
+			value = o.value;
+			o.value = -1;
+			return *this;
+		}
+		SwapTestMovable(const SwapTestMovable &o) = delete;
+		SwapTestMovable &operator =(const SwapTestMovable &o) = delete;
+	};
+	static_assert(!Common::is_copy_constructible<SwapTestMovable>::v, "SwapTestMovable should not be copy constructible");
+	static_assert(!Common::is_copy_assignable<SwapTestMovable>::v, "SwapTestMovable should not be copy assignable");
+	static_assert(Common::is_move_constructible<SwapTestMovable>::v, "SwapTestMovable should be move constructible");
+	static_assert(Common::is_move_assignable<SwapTestMovable>::v, "SwapTestMovable should be move assignable");
+
+	struct SwapTestMoveConstructible {
+		int value = 0;
+		SwapTestMoveConstructible(int v) : value(v) {}
+		SwapTestMoveConstructible(SwapTestMoveConstructible &&o) : value(o.value) {
+			o.value = -1;
+		}
+		// this is breaking rule-of-five but SWAP should be able to handle it anyways using copy
+		SwapTestMoveConstructible &operator =(SwapTestMoveConstructible &&o) = delete;
+
+		SwapTestMoveConstructible(const SwapTestMoveConstructible &o) : value(o.value) {}
+		SwapTestMoveConstructible &operator =(const SwapTestMoveConstructible &o) {
+			value = o.value;
+			return *this;
+		}
+	};
+	static_assert(Common::is_copy_constructible<SwapTestMoveConstructible>::v, "SwapTestMoveConstructible should be copy constructible");
+	static_assert(Common::is_copy_assignable<SwapTestMoveConstructible>::v, "SwapTestMoveConstructible should be copy assignable");
+	static_assert(Common::is_move_constructible<SwapTestMoveConstructible>::v, "SwapTestMoveConstructible should be move constructible");
+	static_assert(!Common::is_move_assignable<SwapTestMoveConstructible>::v, "SwapTestMoveConstructible should not be move assignable");
+
+	void test_swap() {
+		{
+			SwapTestBoth a(1), b(2);
+			SWAP(a, b);
+			TS_ASSERT_EQUALS(a.value, 2);
+			TS_ASSERT_EQUALS(b.value, 1);
+		}
+		{
+			SwapTestCopyable a(1), b(2);
+			SWAP(a, b);
+			TS_ASSERT_EQUALS(a.value, 2);
+			TS_ASSERT_EQUALS(b.value, 1);
+		}
+		{
+			SwapTestMovable a(1), b(2);
+			SWAP(a, b);
+			TS_ASSERT_EQUALS(a.value, 2);
+			TS_ASSERT_EQUALS(b.value, 1);
+		}
+		{
+			SwapTestMoveConstructible a(1), b(2);
+			SWAP(a, b);
+			TS_ASSERT_EQUALS(a.value, 2);
+			TS_ASSERT_EQUALS(b.value, 1);
+		}
+	}
 };

--- a/test/graphics/hotspot_info.h
+++ b/test/graphics/hotspot_info.h
@@ -25,10 +25,10 @@
 class HotspotInfoTestSuite : public CxxTest::TestSuite {
 public:
 	void test_constructor_with_values() {
-		Graphics::HotspotInfo info(Common::Point(10, 20), "Test");
+		Graphics::HotspotInfo info(Common::Point(10, 20), Common::U32String("Test"));
 		TS_ASSERT_EQUALS(info.position.x, 10);
 		TS_ASSERT_EQUALS(info.position.y, 20);
-		TS_ASSERT_EQUALS(info.name, "Test");
+		TS_ASSERT_EQUALS(info.name, Common::U32String("Test"));
 	}
 
 	void test_default_constructor() {
@@ -39,29 +39,29 @@ public:
 	}
 
 	void test_empty_name() {
-		Graphics::HotspotInfo info(Common::Point(100, 200), "");
+		Graphics::HotspotInfo info(Common::Point(100, 200), Common::U32String(""));
 		TS_ASSERT_EQUALS(info.position.x, 100);
 		TS_ASSERT_EQUALS(info.position.y, 200);
 		TS_ASSERT(info.name.empty());
 	}
 
 	void test_negative_coordinates() {
-		Graphics::HotspotInfo info(Common::Point(-5, -10), "Negative");
+		Graphics::HotspotInfo info(Common::Point(-5, -10), Common::U32String("Negative"));
 		TS_ASSERT_EQUALS(info.position.x, -5);
 		TS_ASSERT_EQUALS(info.position.y, -10);
-		TS_ASSERT_EQUALS(info.name, "Negative");
+		TS_ASSERT_EQUALS(info.name, Common::U32String("Negative"));
 	}
 
 	void test_default_type() {
-		Graphics::HotspotInfo info(Common::Point(0, 0), "");
+		Graphics::HotspotInfo info(Common::Point(0, 0), Common::U32String(""));
 		TS_ASSERT_EQUALS(info.type, Graphics::kHotspotDefault);
 	}
 
 	void test_explicit_type() {
-		Graphics::HotspotInfo npc(Common::Point(10, 20), "Guard", Graphics::kHotspotNPC);
+		Graphics::HotspotInfo npc(Common::Point(10, 20), Common::U32String("Guard"), Graphics::kHotspotNPC);
 		TS_ASSERT_EQUALS(npc.type, Graphics::kHotspotNPC);
 
-		Graphics::HotspotInfo obj(Common::Point(30, 40), "Door", Graphics::kHotspotExit);
+		Graphics::HotspotInfo obj(Common::Point(30, 40), Common::U32String("Door"), Graphics::kHotspotExit);
 		TS_ASSERT_EQUALS(obj.type, Graphics::kHotspotExit);
 	}
 };


### PR DESCRIPTION
`SWAP` does currently not support move-only types and is used in `Common::sort`, so the following code is broken:
```c++
Array<DisposablePtr<int>> array;
sort(array.begin(), array.end(), SortMyPointers);
```

To select the correct specialization I also needed `is_move_constructible` and `is_move_assignable` type traits so I added those and related as well.

At least the old Github Actions CI is green and the static asserts work in [godbolt](https://godbolt.org/z/E9fbfxPzj) using GCC 4.7.4 (for RiscOS)