### PR TITLE
AGDS: Add support for the Steam release of Black Mirror

### DIFF
--- a/engines/agds/agds.cpp
+++ b/engines/agds/agds.cpp
@@ -1453,6 +1453,8 @@ int AGDSEngine::version() const {
 		return 0;
 	if (v2())
 		return 2;
+	if (_gameDescription->flags & AGDS_STEAM)
+		return 3;
 	return 1;
 }
 

--- a/engines/agds/detection.h
+++ b/engines/agds/detection.h
@@ -26,6 +26,7 @@ namespace AGDS {
 
 enum AGDSGameFlag {
 	AGDS_V2 = (1 << 0),
+	AGDS_STEAM = (1 << 1),
 };
 
 } // End of namespace AGDS

--- a/engines/agds/detection_tables.h
+++ b/engines/agds/detection_tables.h
@@ -73,6 +73,15 @@ static const ADGameDescription gameDescriptions[] = {
 	 Common::kPlatformWindows,
 	 ADGF_DROPPLATFORM,
 	 GUIO1(GUIO_NONE)},
+	{"black-mirror",
+	 "Steam",
+	 AD_ENTRY2s(
+		 "gfx1.grp", "2ede03d9a50e0bfedd0d7656c47d2de4", 913209074,
+		 "data.adb", "cffd38b88a245765987f9ff5cce3c5c9", 2184448),
+	 Common::UNK_LANG,
+	 Common::kPlatformWindows,
+	 ADGF_DROPPLATFORM | AGDS_STEAM | ADGF_UNSTABLE,
+	 GUIO1(GUIO_NONE)},
 
 	// NiBiRu
 	{

--- a/engines/agds/object.cpp
+++ b/engines/agds/object.cpp
@@ -92,7 +92,7 @@ void Object::readStringTable(unsigned resOffset, uint16 resCount) {
 	if (_stringTableLoaded)
 		return;
 
-	resOffset += 5 /*instruction*/ + (_version >= 2 ? 0x13 : 0x11) /*another header*/;
+	resOffset += 5 /*instruction*/ + (_version == 2 ? 0x13 : 0x11) /*another header*/;
 	if (resOffset >= _code.size())
 		error("invalid resource table offset %u/%u", resOffset, _code.size());
 

--- a/engines/agds/process.cpp
+++ b/engines/agds/process.cpp
@@ -413,6 +413,9 @@ uint16 Process::nextOpcode() {
 		}
 		return op - 7995;
 
+	case 3:
+		return op + 1;
+
 	default:
 		return op;
 	}
@@ -513,6 +516,8 @@ Common::String Process::disassemble(const ObjectPtr &object, int version) {
 			}
 		} else if (version == 0) {
 			op += 5;
+		} else if (version == 3) {
+			op += 1;
 		}
 
 		source += Common::String::format("%04x: %02x: ", ip - 1, op);


### PR DESCRIPTION
The Steam release of Black Mirror (appid 292930) ships with data files whose script bytecode uses a slightly different opcode encoding than the retail CD release: each opcode is offset by one, so the raw byte for the "enter" opcode is 0x04 (instead of 0x05 in retail, 0x00 in the demo).

Add a new AGDS_STEAM flag, a corresponding version 3 in AGDSEngine returning op + 1 from nextOpcode(), and a matching branch in the disassembler. The version 2 (NiBiRu) header layout check in Object::readStringTable is narrowed from >= 2 to == 2 so that the new version 3 (Steam) falls back to the retail 0x11 header size.

Detection entry added with data.adb md5
cffd38b88a245765987f9ff5cce3c5c9 (2184448 bytes) and gfx1.grp md5 2ede03d9a50e0bfedd0d7656c47d2de4 (913209074 bytes). Marked ADGF_UNSTABLE and UNK_LANG since the Steam release is multi-language.

Assisted-by: Claude:claude-opus-4.7
