### PR TITLE
DIRECTOR: Fix buffer overflow writing 8bpp bitmaps with padded pitch

### DIFF
--- a/engines/director/castmember/bitmap.cpp
+++ b/engines/director/castmember/bitmap.cpp
@@ -1193,23 +1193,10 @@ uint32 BitmapCastMember::writeBITDResource(Common::SeekableWriteStream *writeStr
 	}
 
 	// No compression for now
-	// pixels.size() == bytes needed
 	Graphics::Surface pixels;
 	Graphics::PixelFormat format;
-
-	if (_bitsPerPixel >> 3) {
-		format.bytesPerPixel = _bitsPerPixel >> 3;
-		pixels.create(_picture->_surface.w, _picture->_surface.h, format);
-	} else {
-		format.bytesPerPixel = 1;
-		pixels.create(_pitch, _picture->_surface.h, format);
-	}
-
-	offset = 0;
-
-	if (_bitsPerPixel == 8 && _picture->_surface.w < (int)(_pitch * _picture->_surface.h / _picture->_surface.h)) {
-		offset = (_pitch - _picture->_surface.w) % 2;
-	}
+	format.bytesPerPixel = 1;
+	pixels.create(_pitch, _picture->_surface.h, format);
 
 	debugC(5, kDebugSaving, "BitmapCastMember::writeBITDResource: Saving 'BITD' Resource: bitsPerPixel: %d, castId: %d", _bitsPerPixel, _castId);
 	for (int y = 0; y < _picture->_surface.h; y++) {
@@ -1241,7 +1228,7 @@ uint32 BitmapCastMember::writeBITDResource(Common::SeekableWriteStream *writeStr
 				break;
 
 			case 8:
-				*(ptr + (y * offset)) = *((byte *)_picture->_surface.getBasePtr(x, y));
+				*ptr = *((byte *)_picture->_surface.getBasePtr(x, y));
 				ptr++; x++;
 				break;
 
@@ -1273,6 +1260,7 @@ uint32 BitmapCastMember::writeBITDResource(Common::SeekableWriteStream *writeStr
 	if (debugChannelSet(7, kDebugSaving)) {
 		dumpFile("BitmapData", _castId, MKTAG('B', 'I', 'T', 'D'), (byte *)pixels.getPixels(), _picture->_surface.h * _pitch);
 	}
+	pixels.free();
 	return 0;
 }
 


### PR DESCRIPTION
writeBITDResource() allocated w bytes per row but wrote _pitch bytes, and the 8bpp case shifted each row's writes by y * padding, walking off the buffer. Allocate _pitch bytes per row and write rows in place.

Fixes heap-buffer-overflow saving the initial movie in operafatal