### PR TITLE
DIRECTOR: Preserve the member type when duplicating buttons

### DIFF
--- a/engines/director/castmember/text.cpp
+++ b/engines/director/castmember/text.cpp
@@ -160,7 +160,7 @@ TextCastMember::TextCastMember(Cast *cast, uint16 castId, Common::SeekableReadSt
 
 TextCastMember::TextCastMember(Cast *cast, uint16 castId, TextCastMember &source)
 	: CastMember(cast, castId) {
-	_type = kCastText;
+	_type = source._type;	// kCastText or kCastButton
 	// force a load so we can copy the cast resource information
 	source.load();
 	_loaded = true;


### PR DESCRIPTION
The copy constructor forced kCastText, so a duplicated button came back as a plain text member (and its on-disk type no longer matched).

Fixes duplicated buttons reloading as text members