### PR TITLE
DIRECTOR: Don't mark bitmaps runtime-changed at load time

### DIFF
--- a/engines/director/castmember/bitmap.cpp
+++ b/engines/director/castmember/bitmap.cpp
@@ -827,7 +827,11 @@ void BitmapCastMember::load() {
 
 	// dumpFile("LoadedBitmap", _castId, MKTAG('B', 'I', 'T', 'D'), (byte *)img->getSurface()->getPixels(), img->getSurface()->h * img->getSurface()->w);
 
+	// setPicture() marks us dirty so the renderer refreshes, but loading
+	// itself is not a runtime change: restore the change-tracking state
+	bool wasChanged = _isChanged;
 	setPicture(*img, true);
+	_isChanged = wasChanged;
 
 	if (ConfMan.getBool("dump_scripts")) {
 


### PR DESCRIPTION
BitmapCastMember::load() routes the decoded image through setPicture(), which flags the member as changed so the renderer refreshes. That flag is also the save preflight's persist-dirty signal, so every loaded bitmap looked runtime-modified and movies whose version has no bitmap writer (D6+) refused to save.

Preserve the change-tracking state across the load: a freshly loaded member matches its on-disk data by definition.

Fixes TKKG4 refusing to save on its first save attempt