### PR TITLE
AGDS: Default _fastMode to false so the 25 FPS cap actually applies

### DIFF
--- a/engines/agds/agds.cpp
+++ b/engines/agds/agds.cpp
@@ -71,7 +71,7 @@ AGDSEngine::AGDSEngine(OSystem *system, const ADGameDescription *gameDesc) : Eng
 																			 _ambientSoundId(-1),
 																			 _curtainTimer(-1),
 																			 _curtainScreen(0),
-																			 _fastMode(true),
+																			 _fastMode(false),
 																			 _hintMode(false) {
 }
 


### PR DESCRIPTION
Keeps animations in sync with the narration