### PR TITLE
AGS: Add detection, support for Gobliiins 5 v1.0.5

### DIFF
--- a/engines/ags/detection_tables.h
+++ b/engines/ags/detection_tables.h
@@ -5067,6 +5067,8 @@ const AGSGameDescription GAME_DESCRIPTIONS[] = {
 	GAME_ENTRY_STEAM("gobliiins5-1", "Gobliiins5-Part1.ags", "41513db1bd8870e43426b9e94bb26ad1", 171800709),
 	// Gobliiins Collection release 2026-05-27
 	GAME_ENTRY_PLATFORM("gobliiins5", "Gobliiins5.ags", "58c44c065cbdbddf83e9535ef17ed51f", 281472880, "Switch"),
+	// Gobliiins Collection release 2026-0?-?? v1.0.5 update
+	GAME_ENTRY_PLATFORM("gobliiins5", "Gobliiins5.ags", "8796d0826649a3e6920d799cf7f472bb", 281555704, "Switch"),
 
 
 	// Itch.io v? release 2026-02-10

--- a/engines/ags/plugins/ags_console_sys_plugin/ags_console_sys_plugin.cpp
+++ b/engines/ags/plugins/ags_console_sys_plugin/ags_console_sys_plugin.cpp
@@ -47,6 +47,7 @@ void AGSConsoleSysPlugin::AGS_EngineStartup(IAGSEngine *engine) {
 	SCRIPT_METHOD(AGSConsoleSysPlugin::SetTextureFilteringType^1, AGSConsoleSysPlugin::SetTextureFilteringType);
 
 	SCRIPT_METHOD(Game_RAG::EnableCheats^0, AGSConsoleSysPlugin::EnableCheats);
+	SCRIPT_METHOD(Game_RAG::IsAnyJoyconMouseInContact^0, AGSConsoleSysPlugin::IsAnyJoyconMouseInContact);
 }
 
 void AGSConsoleSysPlugin::GetSystemInputDeviceType(ScriptMethodParams &params) {
@@ -137,9 +138,14 @@ void AGSConsoleSysPlugin::SetTextureFilteringType(ScriptMethodParams &params) {
 }
 
 void AGSConsoleSysPlugin::EnableCheats(ScriptMethodParams &params) {
+	warning("AGSConsoleSysPlugin::EnableCheats STUB: returning false");
 	params._result = false;
 }
 
+void AGSConsoleSysPlugin::IsAnyJoyconMouseInContact(ScriptMethodParams &params) {
+	// warning("AGSConsoleSysPlugin::IsAnyJoyconMouseInContact STUB: returning false");
+	params._result = true;
+}
 
 } // namespace AGSConsoleSysPlugin
 } // namespace Plugins

--- a/engines/ags/plugins/ags_console_sys_plugin/ags_console_sys_plugin.h
+++ b/engines/ags/plugins/ags_console_sys_plugin/ags_console_sys_plugin.h
@@ -43,6 +43,7 @@ private:
 	void SetPixelPerfect(ScriptMethodParams &params);
 	void SetTextureFilteringType(ScriptMethodParams &params);
 	void EnableCheats(ScriptMethodParams &params);
+	void IsAnyJoyconMouseInContact(ScriptMethodParams &params);
 
 public:
 	AGSConsoleSysPlugin() : PluginBase() {}


### PR DESCRIPTION
I have no idea what `IsAnyJoyconMouseInContact` implies, but enabling it shows the Menu button that allows you to quit the game.