### PR TITLE
MACVENTURE: Initialize titlePadding in borderOffsets

### DIFF
--- a/engines/macventure/windows.cpp
+++ b/engines/macventure/windows.cpp
@@ -88,6 +88,7 @@ Graphics::BorderOffsets borderOffsets(MVWindowType type) {
 	offsets.resizeButtonHeight = 0;
 	offsets.upperScrollHeight = 0;
 	offsets.lowerScrollHeight = 0;
+	offsets.titlePadding = 0;
 
 	switch (type) {
 	case MacVenture::kDocument:


### PR DESCRIPTION
The titlePadding field of Graphics::BorderOffsets is left uninitialized in borderOffsets(), which sets every other field explicitly. The garbage value propagated into the console window's title width calculatio , overflowing the destination width and producing an invalid Common::Rect, aborting on the isValidRect() assertion during GUI init. Initialize it to 0 like the other offsets.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
