### PR TITLE
DEVTOOLS: Extract MacVenture Steam disk images from the game .exe

### DIFF
--- a/devtools/dumper-companion.py
+++ b/devtools/dumper-companion.py
@@ -18,6 +18,7 @@
 from __future__ import annotations
 
 import argparse
+import hashlib
 import logging
 import os
 import re
@@ -34,7 +35,7 @@ from enum import Enum
 from io import BytesIO, IOBase, StringIO
 from pathlib import Path
 from struct import pack, unpack
-from typing import Any
+from typing import Any, Optional
 from pathlib import Path
 
 import machfs  # type: ignore
@@ -400,6 +401,27 @@ def check_extension(args: argparse.Namespace) -> Extension:
     return Extension.none
 
 
+MACVENTURE_STEAM_EXES = {
+    #  md5                               name          offset   size
+    "2b5e47b77d28d7201d3e7f8681ca9a9f": ("Deja Vu",    1413600, 819200),
+    "c606908f6906adcd1cfb8c575d6b8cf7": ("Deja Vu II", 1418112, 819200),
+    "129ad491400722b76eb3259440e9ad95": ("Shadowgate", 1474800, 839680),
+    "cae6c5101ffd7fa20e249fa7a972f958": ("Uninvited",  1449384, 819200),
+}
+
+
+def read_macventure_steam_exe(path: Path) -> Optional[bytes]:
+    if path.suffix.lower() != ".exe":
+        return None
+    data = path.read_bytes()
+    entry = MACVENTURE_STEAM_EXES.get(hashlib.md5(data).hexdigest())
+    if entry is None:
+        return None
+    name, offset, size = entry
+    print(f"{path.name} from {name} is detected, extracting embedded HFS image")
+    return data[offset : offset + size]
+
+
 def check_fs(iso: str) -> FileSystem:
     disk_formats = []
     f = open(iso, "rb")
@@ -506,6 +528,13 @@ def extract_iso(args: argparse.Namespace) -> None:
         if not isinstance(numeric_level, int):
             raise ValueError("Invalid log level: %s" % loglevel)
         logging.basicConfig(format="%(levelname)s: %(message)s", level=numeric_level)
+
+        exe_image = read_macventure_steam_exe(args.src)
+        if exe_image is not None:
+            vol = machfs.Volume()
+            vol.read(exe_image)
+            extract_partition(args, vol)
+            return
 
         if not args.fs:
             args.fs = check_fs(args.src)


### PR DESCRIPTION
Recognise the four Steam MacVenture executables by MD5 and copy the embedded HFS disk image directly, so dumper-companion can be pointed at the .exe instead of requiring an external PE-resource tool.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
