### PR TITLE
DIRECTOR: Fix film loop D4 and D5+ behavior

### DIFF
--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -908,6 +908,16 @@ bool Score::renderTransition(uint16 frameId, RenderMode mode) {
 }
 
 void Score::incrementFilmLoops() {
+	// Film loops do not advance while the movie is paused
+	if (_window->_playbackPaused)
+		return;
+
+	// In D4, film loops also freeze while the playhead loops in a single
+	// frame, e.g. via go the frame. D5 and later animate in that case
+	if (_vm->getVersion() < 500 && _curFrameNumber == _filmLoopsLastFrame)
+		return;
+	_filmLoopsLastFrame = _curFrameNumber;
+
 	for (auto &it : _channels) {
 		if (it->_sprite->_cast && (it->_sprite->_cast->_type == kCastFilmLoop || it->_sprite->_cast->_type == kCastMovie)) {
 			FilmLoopCastMember *fl = ((FilmLoopCastMember *)it->_sprite->_cast);

--- a/engines/director/score.h
+++ b/engines/director/score.h
@@ -249,6 +249,9 @@ private:
 	int _currentLabel;
 	DirectorSound *_soundManager;
 
+	// score frame number at the last film loop advance
+	uint32 _filmLoopsLastFrame = 0;
+
 	int _previousBuildBotBuild = -1;
 	bool _firstRun = true;
 };


### PR DESCRIPTION
Film loops advanced every render tick regardless of playback state. Now they freeze while the movie is paused (all versions), and in D4 while the playhead loops in a single frame (e.g. go the frame); D5 and later animate in that case.
