### PR TITLE
CHAMBER: Honor the selected CGA/EGA variant when both are in one folder

### DIFF
--- a/engines/chamber/detection.cpp
+++ b/engines/chamber/detection.cpp
@@ -71,6 +71,9 @@ static const ADGameDescription gameDescriptions[] = {
 class ChamberMetaEngineDetection : public AdvancedMetaEngineDetection<ADGameDescription> {
 public:
 	ChamberMetaEngineDetection() : AdvancedMetaEngineDetection(Chamber::gameDescriptions, Chamber::ChamberGames) {
+		// Use kADFlagUseExtraAsHint to distinguish between the CGA and EGA versions
+		// when both are present in the same directory (e.g. the Steam release)
+		_flags = kADFlagUseExtraAsHint;
 	}
 
 	const char *getName() const override {


### PR DESCRIPTION
The Steam release ships the CGA and EGA data files in the same directory, so both DOS/US detection entries match. On launch, the game description was re-detected using only gameid/language/platform, which are identical for both entries, so the first match (CGA) was always picked regardless of which entry the user selected in the launcher. Use kADFlagUseExtraAsHint (as Lure does for its EGA/VGA case) so the launcher stores extra=EGA and launch-time detection filters on it.

Fixes bug #17004.

Note: Games added to the launcher before this fix need to be removed and re-added, so that the launcher stores the selected variant (<code>extra=EGA</code>) in the config.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
