### PR TITLE
CHAMBER: resolve global constructor in global array

### DIFF
--- a/engines/chamber/chamber.cpp
+++ b/engines/chamber/chamber.cpp
@@ -55,6 +55,10 @@ ChamberEngine::ChamberEngine(OSystem *syst, const ADGameDescription *desc)
 	g_vm = this;
 	_gameDescription = desc;
 
+	// Late init of global array entry to avoid having a global constructor
+	assert(script_vars[4] == nullptr);
+	script_vars[4] = zones_data;
+
 	const Common::FSNode gameDataDir(ConfMan.getPath("path"));
 
 	// Don't forget to register your random source

--- a/engines/chamber/chamber.cpp
+++ b/engines/chamber/chamber.cpp
@@ -55,9 +55,7 @@ ChamberEngine::ChamberEngine(OSystem *syst, const ADGameDescription *desc)
 	g_vm = this;
 	_gameDescription = desc;
 
-	// Late init of global array entry to avoid having a global constructor
-	assert(script_vars[4] == nullptr);
-	script_vars[4] = zones_data;
+	initScriptVars();
 
 	const Common::FSNode gameDataDir(ConfMan.getPath("path"));
 

--- a/engines/chamber/script.cpp
+++ b/engines/chamber/script.cpp
@@ -65,7 +65,7 @@ void *script_vars[kScrPools_MAX] = {
 	&script_word_vars,
 	&script_byte_vars,
 	inventory_items,
-	zones_data,
+	nullptr, /* To be set to zones_data at runtime in ChamberEngine ctor */
 	pers_list,
 	inventory_items,
 	inventory_items + kItemZapstik1 - 1,

--- a/engines/chamber/script.cpp
+++ b/engines/chamber/script.cpp
@@ -60,19 +60,24 @@ byte *script_ptr, *script_end_ptr;
 byte *script_stack[5 * 2];
 byte **script_stack_ptr = script_stack;
 
-void *script_vars[kScrPools_MAX] = {
-	&script_word_vars,
-	&script_word_vars,
-	&script_byte_vars,
-	inventory_items,
-	nullptr, /* To be set to zones_data at runtime in ChamberEngine ctor */
-	pers_list,
-	inventory_items,
-	inventory_items + kItemZapstik1 - 1,
-	pers_list
-};
+void *script_vars[kScrPools_MAX] = {};
 
 extern void askDisk2(void);
+
+
+void initScriptVars() {
+	// Late init of global array entries to avoid having a global constructor
+
+	script_vars[0] = &script_word_vars;
+	script_vars[1] = &script_word_vars;
+	script_vars[2] = &script_byte_vars;
+	script_vars[3] = inventory_items;
+	script_vars[4] = zones_data;
+	script_vars[5] = pers_list;
+	script_vars[6] = inventory_items;
+	script_vars[7] = inventory_items + kItemZapstik1 - 1;
+	script_vars[8] = pers_list;
+}
 
 /*
 Get next random byte value

--- a/engines/chamber/script.h
+++ b/engines/chamber/script.h
@@ -240,6 +240,8 @@ uint16 runCommandKeepSp(void);
 
 uint16 Swap16(uint16 x);
 
+void initScriptVars();
+
 } // End of namespace Chamber
 
 #endif


### PR DESCRIPTION
Clang thinks that using an `extern` pointer in a global array causes it to require a global constructor. Thus initialization of that array entry is deferred to runtime.