### PR TITLE
CHEWY: Add missing animation for Chewy in room 11 (Bork-Bork dialog)

### DIFF
--- a/engines/chewy/t_event.cpp
+++ b/engines/chewy/t_event.cpp
@@ -1217,7 +1217,8 @@ void endDialogCloseup(int16 diaNr, int16 blkNr, int16 strEndNr) {
 		_G(flags).AutoAniPlay = false;
 		break;
 
-	case 5:
+	case 5:  // R11_BORK_DIA
+		aadWait(-1);
 		autoMove(6, P_CHEWY);
 		break;
 
@@ -1388,7 +1389,13 @@ void atdsStringStart(int16 diaNr, int16 strNr, int16 personNr, int16 mode) {
 
 	case R11_BORK_DIA:
 		oldFormat = true;
-		if (personNr == 1) {
+		if (personNr == P_CHEWY) {
+			if (mode == AAD_STR_START) {
+				start_spz(CH_BORK_TALK, 255, ANI_FRONT, P_CHEWY);
+			} else {
+				stop_spz();
+			}
+		} else if (personNr == 1) {
 			if (mode == AAD_STR_START) {
 				_G(talk_start_ani) = 9;
 				_G(talk_hide_static) = 8;


### PR DESCRIPTION
To reproduce load [chewy-de.035.zip](https://github.com/user-attachments/files/30307025/chewy-de.035.zip) in room 11, where Chewy has Bork shape, and talk to the stationary Bork "Lt. Debug". Chewy would not have a talking animation then. Also adds a fix to finish talking before walking after the dialog.

<!---
Thank you for contributing to ScummVM. Please read the 
following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
