### PR TITLE
MM: XEEN: Play pharoh1b.voc only once in the intro

### DIFF
--- a/engines/mm/xeen/worldofxeen/darkside_cutscenes.cpp
+++ b/engines/mm/xeen/worldofxeen/darkside_cutscenes.cpp
@@ -321,8 +321,10 @@ bool DarkSideCutscenes::showDarkSideIntro1() {
 		pyramid.draw(0, idx, Common::Point(132, 62));
 		_subtitles.show();
 
-		if (!sound.isSoundPlaying() && !phar2)
+		if (!sound.isSoundPlaying() && !phar2) {
 			sound.playVoice("pharoh1b.voc");
+			phar2 = true;
+		}
 
 		WAIT_SUBTITLES(4);
 	}


### PR DESCRIPTION
The phar2 guard was never set, so the second Pharaoh voice line was replayed "The royal pyramid is under siege" whenever the sample finished before the animation loop did. Every other voice block in this cutscene sets its guard; this one was missed. Noticeable with the French voices, whose timing probably differs from the English ones.