### PR TITLE
CHEWY: Add missing talking animations in rooms 29 and 37

### DIFF
--- a/engines/chewy/t_event.cpp
+++ b/engines/chewy/t_event.cpp
@@ -1284,6 +1284,7 @@ void atdsStringStart(int16 diaNr, int16 strNr, int16 personNr, int16 mode) {
 	case 30000:
 	case 25:
 	case 34:
+	case 62:   // R29: use_pumpe()
 	case 111:  // R12: use_linke_rohr()
 	case 114:  // R12: Chewy-as-Bork with terminal
 	case 252:
@@ -1578,6 +1579,7 @@ void atdsStringStart(int16 diaNr, int16 strNr, int16 personNr, int16 mode) {
 		}
 		break;
 
+	case 145:  // R37: talkWithRooster()
 	case 176:
 	case 177:
 	case 178:


### PR DESCRIPTION
To reproduce with [chewy-d save 52 and 58.zip](https://github.com/user-attachments/files/30310145/chewy-d.save.52.and.58.zip)

* (room 29) load save 52 and use the pump
* (room 37) load save 58 and talk to the rooster

(Chewy wouldn't be animated when talking)


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
