### PR TITLE
CHEWY: Add dialog animation for Howard in room 41

### DIFF
--- a/engines/chewy/t_event.cpp
+++ b/engines/chewy/t_event.cpp
@@ -1584,6 +1584,24 @@ void atdsStringStart(int16 diaNr, int16 strNr, int16 personNr, int16 mode) {
 			}
 			}
 			break;
+		case P_3:         // Howard in dialog with Chewy, Holly, and Molly
+			if (mode == AAD_STR_START) {
+				switch (_G(gameState).mi[P_HOWARD]) {
+				case 2:
+					start_spz(50, 255, ANI_FRONT, P_HOWARD);
+					break;
+				case 3:
+					start_spz(57, 255, ANI_FRONT, P_HOWARD);
+					break;
+				default:
+					start_spz(HO_TALK_L, 255, ANI_FRONT, P_HOWARD);
+					break;
+				}
+			} else {
+				stop_spz();
+			}
+			break;
+
 		default:
 			break;
 		}


### PR DESCRIPTION
In 4-person dialogs in this room, Howard wasn't animated. 

This is fixed by adding a case for `P_3` (= 3), crafted similar to other dialogs with Howard, which now applies to him. Without this we would just drop into the default case = no animation.

The constant `P_HOWARD` (= 1) actually corresponds to Holly in this dialog, so the case handling is a little confusing.

To reproduce with [chewy-de saves 69 and 70.zip](https://github.com/user-attachments/files/30312951/chewy-de.saves.69.and.70.zip):
* load save 69 and talk to Holly
* load save 70 and use stamped letter with Molly

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
