### PR TITLE
LIBRETRO: Pace audio generation against wall time, not frame count

### DIFF
--- a/backends/platform/libretro/src/libretro-core.cpp
+++ b/backends/platform/libretro/src/libretro-core.cpp
@@ -38,6 +38,10 @@
 #include <libgen.h>
 #endif
 
+/* cpu_features_get_time_usec(): monotonic microsecond clock used to pace audio
+ * generation against real wall time (see audio_run). */
+#include <features/features_cpu.h>
+
 /**
  * Include base/internal_version.h to allow access to SCUMMVM_VERSION.
  * @see retro_get_system_info()
@@ -97,6 +101,9 @@ static float frame_rate = 0;
 static uint16 sample_rate = 0;
 static float audio_samples_per_frame   = 0.0f; // length in samples per frame
 static float audio_samples_accumulator = 0.0f;
+// Wall-clock timestamp (usec) of the previous audio_run, or 0 to (re)seed from
+// the nominal per-frame count on the next call. See audio_run for the rationale.
+static retro_time_t audio_last_time_usec = 0;
 
 static int16 *audio_sample_buffer = NULL; // pointer to output buffer
 
@@ -191,6 +198,7 @@ static void log_scummvm_exit_code(void) {
 
 static void audio_buffer_init(uint16 sample_rate, uint16 frame_rate) {
 	audio_samples_accumulator = 0.0f;
+	audio_last_time_usec      = 0; // reseed pacing after a rate change
 	audio_samples_per_frame   = (float)sample_rate / (float)frame_rate;
 	uint32 audio_sample_buffer_size  = ((uint32)retro_setting_get_audio_samples_buffer_size()) * 2 * sizeof(int16);
 	audio_sample_buffer       = audio_sample_buffer ? (int16 *)realloc(audio_sample_buffer, audio_sample_buffer_size) : (int16 *)malloc(audio_sample_buffer_size);
@@ -206,12 +214,46 @@ static void audio_run(void) {
 	uint32 samples_to_read;
 	uint32 samples_produced;
 
-	/* Audio_samples_per_frame is decimal;
-	 * get integer component */
-	samples_to_read = (uint32)audio_samples_per_frame;
+	/* Pace audio generation against real elapsed wall time rather than emitting a
+	 * fixed sample_rate/frame_rate batch per call.
+	 *
+	 * audio_run() runs once per retro_run(). The frontend is free to call
+	 * retro_run() at a rate that differs from frame_rate: on lower-end devices a
+	 * heavy scene can drop it below frame_rate, and some frontends run it above.
+	 * A fixed per-frame batch ties the produced sample rate to the *achieved*
+	 * frame rate, so a frontend running at 55 fps only feeds 55/60 of the audio
+	 * its output device consumes and its buffer underruns (audible gaps), while a
+	 * frontend running fast overproduces. Deriving the batch from the elapsed time
+	 * keeps average production at exactly sample_rate regardless of the retro_run
+	 * cadence: samples/sec = calls/sec * sample_rate * sec/call = sample_rate.
+	 * Video stays frame-locked; only audio is decoupled. */
+	float samples_target;
+	retro_time_t now_usec = cpu_features_get_time_usec();
+	if (audio_last_time_usec == 0) {
+		/* First call after (re)init or a rate change: no interval to measure. */
+		samples_target = audio_samples_per_frame;
+	} else {
+		retro_time_t elapsed_usec = now_usec - audio_last_time_usec;
+		/* Bound the catch-up. A load pause, a save-state or a debugger stop can
+		 * leave a huge gap; without a cap that would dump a multi-second batch and
+		 * overflow both audio_sample_buffer and the frontend. Two frames absorbs
+		 * normal frame-time jitter and always fits: audio_sample_buffer is sized to
+		 * next_pow2(2 * samples-per-frame) (see retro_setting_get_audio_samples_buffer_size),
+		 * i.e. >= this two-frame maximum by construction. */
+		const retro_time_t max_usec = (retro_time_t)(2000000.0f / frame_rate);
+		if (elapsed_usec > max_usec)
+			elapsed_usec = max_usec;
+		else if (elapsed_usec < 0)
+			elapsed_usec = 0;
+		samples_target = (float)sample_rate * (float)elapsed_usec / 1000000.0f;
+	}
+	audio_last_time_usec = now_usec;
+
+	/* Samples_target is decimal; get integer component */
+	samples_to_read = (uint32)samples_target;
 
 	/* Account for fractional component */
-	audio_samples_accumulator += audio_samples_per_frame - (float)samples_to_read;
+	audio_samples_accumulator += samples_target - (float)samples_to_read;
 
 	if (audio_samples_accumulator >= 1.0f) {
 		samples_to_read++;


### PR DESCRIPTION
## Problem

`audio_run()` emits a fixed `sample_rate / frame_rate` samples per call (e.g. 800
at 48000/60). Since it runs once per `retro_run()`, the produced sample rate is
tied to the **achieved** call rate rather than real time:

- A frontend that cannot sustain `frame_rate` (a heavy scene on a lower-end
  device — e.g. Android during an animated intro) calls `retro_run()` fewer than
  `frame_rate` times per second, so the core produces fewer than `sample_rate`
  samples per second while the audio device keeps consuming `sample_rate`. The
  output buffer underruns and the audio breaks up. The video already degrades
  gracefully (frame-locked), but the audio does not — it starves 1:1 with any
  frame-rate shortfall.
- A frontend running faster than `frame_rate` over-produces and the surplus is
  dropped.

Measured on a mid-range Android phone (Loom, opening scene), and reproduced on
desktop by throttling the frontend to ~50 fps: at 50 fps the core produced
~39 000 samples/s against 48 000 consumed (~9 000/s deficit, continuous
underruns).

## Fix

Derive the per-call batch from the real elapsed wall time since the previous
`audio_run()` (`cpu_features_get_time_usec()`), instead of a fixed per-frame
count. Average production is then `sample_rate` regardless of the `retro_run()`
cadence:

```
samples/sec = calls/sec * (sample_rate * sec/call) = sample_rate
```

Video stays frame-locked; only audio is decoupled. The catch-up is capped at two
frames so a load pause / save-state / debugger stop cannot dump a multi-second
batch. The buffer already holds this: it is sized to `next_pow2(2 ×
samples-per-frame)` (see `retro_setting_get_audio_samples_buffer_size`), i.e. ≥
the two-frame maximum by construction. The fractional-sample accumulator is
preserved.

## Behavior / risk

- **Common case unchanged.** A frontend locked to `frame_rate` (RetroArch at
  vsync) sees ~16.67 ms elapsed each call → 800 samples → identical to before.
- **Slow frontend:** now maintains `sample_rate` output instead of underrunning.
- **Fast frontend (e.g. 144 Hz uncapped):** now produces the correct
  `sample_rate` instead of over-producing and having samples dropped.
- **Fast-forward:** elapsed per call is tiny, so little audio is produced — i.e.
  fast-forward is effectively silent. Most frontends mute FF audio anyway; this
  matches that expectation rather than flooding the batcher.
- Pure arithmetic: no added sleep or blocking. Measured core-phase time is
  unchanged (8.66 ms vs 8.64 ms p50 before/after on the same scene).

Happy to gate this behind a core option if preferred, but it is strictly more
correct as the default and the common (vsync-locked) path is unaffected.

## Test

Same source built twice (with/without the change), driven by a frontend
throttled to a fixed sub-`frame_rate` rate, audio input vs output rate measured:

| build | fps | audio produced | audio consumed | underruns / 12 s |
|-------|-----|----------------|----------------|------------------|
| stock | 49.4 | 39 070 /s | 47 980 /s | 99 |
| fixed | 50.8 | 48 017 /s | 48 039 /s | 0 |

At 60 fps both are identical (no regression); the game plays normally with music.
