### PR TITLE
LIBRETRO: Guard NULL g_system when changing gui_h_res / aspect

### DIFF
--- a/backends/platform/libretro/src/libretro-core.cpp
+++ b/backends/platform/libretro/src/libretro-core.cpp
@@ -512,7 +512,7 @@ static void update_variables(void) {
 	var.value = NULL;
 	if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value) {
 		uint16 new_gui_height = (int)atoi(var.value);
-		av_status |= new_gui_height != gui_height && LIBRETRO_G_SYSTEM->inLauncher() ? AV_STATUS_UPDATE_GUI : 0;
+		av_status |= new_gui_height != gui_height && LIBRETRO_G_SYSTEM && LIBRETRO_G_SYSTEM->inLauncher() ? AV_STATUS_UPDATE_GUI : 0;
 		gui_height = new_gui_height;
 	}
 
@@ -526,7 +526,7 @@ static void update_variables(void) {
 			den = 9;
 		}
 		uint16 new_gui_width = gui_height * num / den + (gui_height * num % den != 0);
-		av_status |= (new_gui_width != gui_width) && LIBRETRO_G_SYSTEM->inLauncher() ? AV_STATUS_UPDATE_GUI : 0;
+		av_status |= (new_gui_width != gui_width) && LIBRETRO_G_SYSTEM && LIBRETRO_G_SYSTEM->inLauncher() ? AV_STATUS_UPDATE_GUI : 0;
 		gui_width = new_gui_width;
 	}
 #endif


### PR DESCRIPTION
## Problem

Setting `scummvm_gui_h_res` (or `scummvm_gui_aspect_ratio`) to any value other
than its current default makes the core **SIGSEGV during `retro_init`**, before
any game loads. With the default value it never crashes — which is why the crash
looks resolution-value-specific.

## Root cause

`update_variables()` is called from `retro_init()`, but `g_system`
(`LIBRETRO_G_SYSTEM`) is only assigned at the *end* of `retro_init()`. The
`USE_HIGHRES` block dereferences it immediately:

```c
uint16 new_gui_height = (int)atoi(var.value);
av_status |= new_gui_height != gui_height && LIBRETRO_G_SYSTEM->inLauncher() ? AV_STATUS_UPDATE_GUI : 0;
```

On the first `update_variables()` call `g_system` is still `NULL`, so
`LIBRETRO_G_SYSTEM->inLauncher()` is a null dereference. It is hidden by
short-circuit evaluation: when the stored value equals the current default,
`new_gui_height != gui_height` is false and `inLauncher()` is never reached.
Change the value and the `&&` reaches the null deref → crash. Same pattern on
the `scummvm_gui_aspect_ratio` branch a few lines down.

This is frontend-independent: RetroArch calls `retro_set_environment` (serving
the saved `.opt` value) before `retro_init` just like every other frontend, and
reproduces the crash with the same option saved via its Quick Menu. Related:
libretro/scummvm#93.

## Fix

Guard the dereference:

```c
av_status |= new_gui_height != gui_height && LIBRETRO_G_SYSTEM && LIBRETRO_G_SYSTEM->inLauncher() ? AV_STATUS_UPDATE_GUI : 0;
```

(same on the aspect-ratio branch). During `retro_init` `g_system` is `NULL`, so
the `AV_STATUS_UPDATE_GUI` flag is simply not raised — which is correct: there is
no live GUI to reconfigure yet, and `gui_height` / `gui_width` are still recorded
unconditionally on the following line, so the requested launcher resolution takes
effect as normal. Once `g_system` exists the behaviour is unchanged.

## Scope / behaviour

- `scummvm_gui_h_res` only sizes the **ScummVM Launcher / overlay** surface
  (`initSize` overrides to the gui resolution *only* when no game domain is
  active); in-game the surface stays at the game's native size. So this fix stops
  the crash and lets the launcher honour a lower resolution — it does not change
  in-game rendering. No functional change for the default value.
- Two-line change, no new state, no perf impact.
