### PR TITLE
DIRECTOR: Release auto-puppet latches when the score reasserts a sprite

### DIFF
--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -504,6 +504,9 @@ void Score::updateCurrentFrame() {
 		// This copies in the frame data and updates _curFrameNumber.
 		loadFrame(nextFrameNumberToLoad, true);
 
+		for (uint ch = 0; ch < _channels.size(); ch++)
+			_channels[ch]->_sprite->releaseAutoPuppet(_currentFrame->_sprites[ch]->_copyBackMask);
+
 		// Finally, update the channels and buffer any dirty rectangles.
 		// This will ignore any channel data that is overridden with the puppet flag.
 		updateSprites(kRenderModeNormal, true);

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -458,6 +458,24 @@ bool Sprite::getAutoPuppet(AutoPuppetProperty property) {
 	return (_autoPuppet & (1 << property)) != 0;
 }
 
+// Predicates mirror the auto-puppet checks in replaceFrom().
+void Sprite::releaseAutoPuppet(uint32 copyBackMask) {
+	static const struct { AutoPuppetProperty property; uint32 mask; } releases[] = {
+		{ kAPInk,       kSCBInk },
+		{ kAPForeColor, kSCBForeColor },
+		{ kAPBackColor, kSCBBackColor },
+		{ kAPCast,      kSCBCastId },
+		{ kAPLoc,       kSCBStartPoint },
+		{ kAPHeight,    kSCBCastId | kSCBHeight },
+		{ kAPWidth,     kSCBCastId | kSCBWidth },
+		{ kAPMoveable,  kSCBMoveable }
+	};
+
+	for (auto &release : releases)
+		if (copyBackMask & release.mask)
+			setAutoPuppet(release.property, false);
+}
+
 void Sprite::setWidth(int w) {
 	_width = MAX<int>(w, 0);
 

--- a/engines/director/sprite.h
+++ b/engines/director/sprite.h
@@ -129,6 +129,7 @@ public:
 	uint32 getBackColor();
 	void setAutoPuppet(AutoPuppetProperty property, bool value);
 	bool getAutoPuppet(AutoPuppetProperty property);
+	void releaseAutoPuppet(uint32 copyBackMask);
 
 	inline int getWidth() { return _width; }
 	void setWidth(int w);


### PR DESCRIPTION
Release each latch where the score's own delta record carries the matching property, using the same predicates as Sprite::replaceFrom().

Fixes the previous scene's sprites staying drawn over the new one in Physicus (XGame/xSLand.dxr)