### PR TITLE
NANCY: Fix SecondaryMovie overread

### DIFF
--- a/engines/nancy/action/secondarymovie.cpp
+++ b/engines/nancy/action/secondarymovie.cpp
@@ -757,8 +757,24 @@ void PlaySecondaryMovie::execute() {
 				srcRect = Common::Rect(_fullFrame.w, _fullFrame.h);
 			}
 
+			Common::Rect destRect = _videoDescs[descID].destRect;
+
+			// The videoDesc's size might be larger than the decoded video (for example, nancy10's
+			// COR_AceFidgetEars_ANIM, and nancy12's PAR_ArcadeAnimationB); clamp here to avoid
+			// reading out-of-bounds during draw. (Adjust destRect too: avoid stretching)
+			const int16 decodedWidth = (int16)_decoder.getWidth();
+			if (srcRect.width() > decodedWidth) {
+				srcRect.setWidth(decodedWidth);
+				destRect.setWidth(decodedWidth);
+			}
+			const int16 decodedHeight = (int16)_decoder.getHeight();
+			if (srcRect.height() > decodedHeight) {
+				srcRect.setHeight(decodedHeight);
+				destRect.setHeight(decodedHeight);
+			}
+
 			_drawSurface.create(_fullFrame, srcRect);
-			moveTo(_videoDescs[descID].destRect);
+			moveTo(destRect);
 
 			_needsRedraw = true;
 


### PR DESCRIPTION
The SecondaryVideoDescription's width and/or height sometimes doesn't match the decoded video. (The original games draw some garbage pixels on rare occasions.)

Fix [#17016](https://bugs.scummvm.org/ticket/17016)

~~(I do some subtraction to adjust destRect because I'm afraid to assume destRect's width and height must match srcRect's)~~

Some garbage pixels in the original games:
<img width="207" height="129" alt="image" src="https://github.com/user-attachments/assets/d363a2e7-4246-4887-b569-5998948e52fc" /> <img width="112" height="126" alt="Screenshot_20260725_012026" src="https://github.com/user-attachments/assets/f2dc1342-53f6-4afa-8f6b-2ef038792414" />




<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
