### PR TITLE
GRAPHICS: Add kTTFRenderModeNormalWithGridFitting

### DIFF
--- a/graphics/fonts/ttf.cpp
+++ b/graphics/fonts/ttf.cpp
@@ -332,6 +332,11 @@ bool TTFFont::load(Common::SeekableReadStream *ttfFile, DisposeAfterUse::Flag di
 		_renderMode = FT_RENDER_MODE_MONO;
 		break;
 
+	case kTTFRenderModeNormalWithGridFitting:
+		_loadFlags = FT_LOAD_TARGET_MONO;
+		_renderMode = FT_RENDER_MODE_NORMAL;
+		break;
+
 	default:
 		break;
 	}

--- a/graphics/fonts/ttf.h
+++ b/graphics/fonts/ttf.h
@@ -57,7 +57,13 @@ enum TTFRenderMode {
 	 * Render fully monochrome. This makes glyph pixels either be fully opaque
 	 * or fully transparent.
 	 */
-	kTTFRenderModeMonochrome
+	kTTFRenderModeMonochrome,
+
+	/**
+	 * Standard render mode, but uses strong grid-fitting.
+	 * Equivalent of FreeType2's FT_RENDER_MODE_NORMAL with FT_LOAD_TARGET_MONO
+	 */
+	kTTFRenderModeNormalWithGridFitting
 };
 
 /**


### PR DESCRIPTION
This PR adds a new render mode for TTF which combines `FT_RENDER_MODE_NORMAL` with `FT_LOAD_TARGET_MONO`. 

Trying to replicate an original text look I found that using both `kTTFRenderModeNormal` as well as `kTTFRenderModeLight` would shift the rendered glyphs a half-pixel to the right causing blurry text and differing kerning compared to `kTTFRenderModeMonochrome`. In the game this would be very noticeable even with the largest font size used. Also alternatives like various dilation or max filters would not lead to the same rendering as the original.

However I found that using this combination of freetype flags would snap the glyphs to the pixel grid and achieve not only similar but pretty much *perfect* results in my engine:
<img width="1083" height="261" alt="image" src="https://github.com/user-attachments/assets/b9943a2f-b87e-402f-853a-86f6e1f36ec4" />
<sub>The game always draws the string a couple times without AA in black and then again with AA, so the kerning has to match for my usecase. <br/>"Original" is a screenshot from the original game, the others are outputs of ScummVM</sub>

I also considered adding a second `TTFRenderMode` (or new `TTFLoadMode`) parameter to let other engine developers choose even more freely but this would be a more invasive change. Let me know if this is preferred over this smaller change.

-----

As for combining different hinting modes for loading/rendering the FreeType2 documentation says "You can use a hinting algorithm that doesn't correspond to the same rendering mode.". For this specific combination it says "The result is probably unpleasant if the glyph is rendered in non-monochrome modes.", but the "probably" does not apply for my case.