### PR TITLE
NANCY: Add French font characters

### DIFF
--- a/engines/nancy/font.cpp
+++ b/engines/nancy/font.cpp
@@ -95,9 +95,15 @@ void Font::read(Common::SeekableReadStream &stream) {
 			_aWithCircumflexOffset			= stream.readUint16LE();
 			_iWithCircumflexOffset			= stream.readUint16LE();
 			_uWithGraveOffset 				= stream.readUint16LE();
-			_uppercaseAWithDiaeresisOffset	= stream.readUint16LE();
+			if (g_nancy->getGameLanguage() == Common::FR_FRA)
+				_uppercaseCWithCedillaOffset = stream.readUint16LE();
+			else
+				_uppercaseAWithDiaeresisOffset = stream.readUint16LE();
 			_aWithDiaeresisOffset			= stream.readUint16LE();
-			_uppercaseOWithDiaeresisOffset	= stream.readUint16LE();
+			if (g_nancy->getGameLanguage() == Common::FR_FRA)
+				_uWithCircumflexOffset		= stream.readUint16LE();
+			else
+				_uppercaseOWithDiaeresisOffset = stream.readUint16LE();
 			_oWithDiaeresisOffset			= stream.readUint16LE();
 			_uppercaseUWithDiaeresisOffset	= stream.readUint16LE();
 			_uWithDiaeresisOffset			= stream.readUint16LE();
@@ -117,8 +123,13 @@ void Font::read(Common::SeekableReadStream &stream) {
 
 		if (g_nancy->getGameType() >= kGameTypeNancy10) {
 			// Nancy10 added even more characters to its fonts
-			_uppercaseAWithDotOffset        = stream.readUint16LE();
-			_aWithDotOffset                 = stream.readUint16LE();
+			if (g_nancy->getGameLanguage() == Common::FR_FRA) {
+				_oeLigatureOffset			= stream.readUint16LE();
+				_iWithDiaeresisOffset		= stream.readUint16LE();
+			} else {
+				_uppercaseAWithDotOffset	= stream.readUint16LE();
+				_aWithDotOffset				= stream.readUint16LE();
+			}
 			_underscoreOffset               = stream.readUint16LE();
 			_hashOffset                     = stream.readUint16LE();
 			_dollarOffset                   = stream.readUint16LE();
@@ -359,9 +370,19 @@ Common::Rect Font::getCharacterSourceRect(char chr) const {
 					offset = -1;
 				}
 				break;
+			case '\xc7':
+				offset = _uppercaseCWithCedillaOffset;
+				break;
+			case '\xfb':
+				offset = _uWithCircumflexOffset;
+				break;
+			case '\xef':
+				offset = _iWithDiaeresisOffset;
+				break;
 			// TODO: _uppercaseAWithDotOffset
 			// TODO: _aWithDotOffset
 			// TODO: _euroOffset
+			// TODO: _oeLigatureOffset
 			default:
 				offset = -1;
 				break;

--- a/engines/nancy/font.cpp
+++ b/engines/nancy/font.cpp
@@ -84,39 +84,39 @@ void Font::read(Common::SeekableReadStream &stream) {
 	} else {
 		if (g_nancy->getGameType() >= kGameTypeNancy6) {
 			// Nancy6 added more characters to its fonts
-			_aWithGraveOffset 				= stream.readUint16LE();
-			_cWithCedillaOffset				= stream.readUint16LE();
-			_eWithGraveOffset 				= stream.readUint16LE();
-			_eWithAcuteOffset 				= stream.readUint16LE();
-			_eWithCircumflexOffset			= stream.readUint16LE();
-			_eWithDiaeresisOffset			= stream.readUint16LE();
-			_oWithCircumflexOffset			= stream.readUint16LE();
-			_uppercaseAWithGraveOffset		= stream.readUint16LE();
-			_aWithCircumflexOffset			= stream.readUint16LE();
-			_iWithCircumflexOffset			= stream.readUint16LE();
-			_uWithGraveOffset 				= stream.readUint16LE();
+			_aWithGraveOffset 					= stream.readUint16LE();
+			_cWithCedillaOffset					= stream.readUint16LE();
+			_eWithGraveOffset 					= stream.readUint16LE();
+			_eWithAcuteOffset 					= stream.readUint16LE();
+			_eWithCircumflexOffset				= stream.readUint16LE();
+			_eWithDiaeresisOffset				= stream.readUint16LE();
+			_oWithCircumflexOffset				= stream.readUint16LE();
+			_uppercaseAWithGraveOffset			= stream.readUint16LE();
+			_aWithCircumflexOffset				= stream.readUint16LE();
+			_iWithCircumflexOffset				= stream.readUint16LE();
+			_uWithGraveOffset 					= stream.readUint16LE();
 			if (g_nancy->getGameLanguage() == Common::FR_FRA)
-				_uppercaseCWithCedillaOffset = stream.readUint16LE();
+				_uppercaseCWithCedillaOffset	= stream.readUint16LE();
 			else
-				_uppercaseAWithDiaeresisOffset = stream.readUint16LE();
-			_aWithDiaeresisOffset			= stream.readUint16LE();
+				_uppercaseAWithDiaeresisOffset	= stream.readUint16LE();
+			_aWithDiaeresisOffset				= stream.readUint16LE();
 			if (g_nancy->getGameLanguage() == Common::FR_FRA)
-				_uWithCircumflexOffset		= stream.readUint16LE();
+				_uWithCircumflexOffset			= stream.readUint16LE();
 			else
-				_uppercaseOWithDiaeresisOffset = stream.readUint16LE();
-			_oWithDiaeresisOffset			= stream.readUint16LE();
-			_uppercaseUWithDiaeresisOffset	= stream.readUint16LE();
-			_uWithDiaeresisOffset			= stream.readUint16LE();
-			_invertedExclamationMarkOffset	= stream.readUint16LE();
-			_invertedQuestionMarkOffset		= stream.readUint16LE();
-			_uppercaseNWithTildeOffset		= stream.readUint16LE();
-			_nWithTildeOffset				= stream.readUint16LE();
-			_uppercaseEWithAcuteOffset		= stream.readUint16LE();
-			_aWithAcuteOffset				= stream.readUint16LE();
-			_iWithAcuteOffset				= stream.readUint16LE();
-			_oWithAcuteOffset				= stream.readUint16LE();
-			_uWithAcuteOffset				= stream.readUint16LE();
-			_eszettOffset					= stream.readUint16LE();
+				_uppercaseOWithDiaeresisOffset 	= stream.readUint16LE();
+			_oWithDiaeresisOffset				= stream.readUint16LE();
+			_uppercaseUWithDiaeresisOffset		= stream.readUint16LE();
+			_uWithDiaeresisOffset				= stream.readUint16LE();
+			_invertedExclamationMarkOffset		= stream.readUint16LE();
+			_invertedQuestionMarkOffset			= stream.readUint16LE();
+			_uppercaseNWithTildeOffset			= stream.readUint16LE();
+			_nWithTildeOffset					= stream.readUint16LE();
+			_uppercaseEWithAcuteOffset			= stream.readUint16LE();
+			_aWithAcuteOffset					= stream.readUint16LE();
+			_iWithAcuteOffset					= stream.readUint16LE();
+			_oWithAcuteOffset					= stream.readUint16LE();
+			_uWithAcuteOffset					= stream.readUint16LE();
+			_eszettOffset						= stream.readUint16LE();
 
 			numCharacters = 105;
 		}
@@ -130,14 +130,14 @@ void Font::read(Common::SeekableReadStream &stream) {
 				_uppercaseAWithDotOffset	= stream.readUint16LE();
 				_aWithDotOffset				= stream.readUint16LE();
 			}
-			_underscoreOffset               = stream.readUint16LE();
-			_hashOffset                     = stream.readUint16LE();
-			_dollarOffset                   = stream.readUint16LE();
-			_lessThanOffset                 = stream.readUint16LE();
-			_greaterThanOffset              = stream.readUint16LE();
-			_leftCurlyBracketOffset         = stream.readUint16LE();
-			_rightCurlyBracketOffset        = stream.readUint16LE();
-			_euroOffset                     = stream.readUint16LE();
+			_underscoreOffset				= stream.readUint16LE();
+			_hashOffset						= stream.readUint16LE();
+			_dollarOffset					= stream.readUint16LE();
+			_lessThanOffset					= stream.readUint16LE();
+			_greaterThanOffset				= stream.readUint16LE();
+			_leftCurlyBracketOffset			= stream.readUint16LE();
+			_rightCurlyBracketOffset		= stream.readUint16LE();
+			_euroOffset						= stream.readUint16LE();
 
 			numCharacters = 115;
 		}

--- a/engines/nancy/font.h
+++ b/engines/nancy/font.h
@@ -140,6 +140,12 @@ private:
 	int16 _rightCurlyBracketOffset          = -1;
 	int16 _euroOffset                       = -1;
 
+	// Specific offsets in French variant of nancy12
+	int16 _uppercaseCWithCedillaOffset		= -1;
+	int16 _uWithCircumflexOffset			= -1;
+	int16 _oeLigatureOffset					= -1;
+	int16 _iWithDiaeresisOffset				= -1;
+
 	Common::Array<Common::Rect> _characterRects;
 
 	Graphics::ManagedSurface _image;

--- a/engines/nancy/font.h
+++ b/engines/nancy/font.h
@@ -74,25 +74,25 @@ private:
 	uint16 _spaceWidth = 0;
 
 	// Specific offsets into the _characterRects array
-	uint16 _uppercaseOffset			= 0;
-	uint16 _lowercaseOffset			= 0;
-	uint16 _digitOffset				= 0;
-	uint16 _periodOffset			= 0;
-	uint16 _commaOffset				= 0;
-	uint16 _equalitySignOffset		= 0;
-	uint16 _colonOffset				= 0;
-	uint16 _dashOffset				= 0;
-	uint16 _questionMarkOffset		= 0;
-	uint16 _exclamationMarkOffset	= 0;
-	uint16 _percentOffset			= 0;
-	uint16 _ampersandOffset			= 0;
-	uint16 _asteriskOffset			= 0;
-	uint16 _leftBracketOffset		= 0;
-	uint16 _rightBracketOffset		= 0;
-	uint16 _plusOffset				= 0;
-	uint16 _apostropheOffset		= 0;
-	uint16 _semicolonOffset			= 0;
-	uint16 _slashOffset				= 0;
+	uint16 _uppercaseOffset					= 0;
+	uint16 _lowercaseOffset					= 0;
+	uint16 _digitOffset						= 0;
+	uint16 _periodOffset					= 0;
+	uint16 _commaOffset						= 0;
+	uint16 _equalitySignOffset				= 0;
+	uint16 _colonOffset						= 0;
+	uint16 _dashOffset						= 0;
+	uint16 _questionMarkOffset				= 0;
+	uint16 _exclamationMarkOffset			= 0;
+	uint16 _percentOffset					= 0;
+	uint16 _ampersandOffset					= 0;
+	uint16 _asteriskOffset					= 0;
+	uint16 _leftBracketOffset				= 0;
+	uint16 _rightBracketOffset				= 0;
+	uint16 _plusOffset						= 0;
+	uint16 _apostropheOffset				= 0;
+	uint16 _semicolonOffset					= 0;
+	uint16 _slashOffset						= 0;
 
 	// Specific offsets for Cyrillic characters. Introduced in nancy5, only used in Russian variants
 	// The original data references the letters one by one, out of order. We only keep the two offsets below
@@ -129,16 +129,16 @@ private:
 	int16 _eszettOffset						= -1;
 
 	// Even more specific offsets for extended ASCII characters. Introduced in nancy10
-	int16 _uppercaseAWithDotOffset          = -1;
-	int16 _aWithDotOffset                   = -1;
-	int16 _underscoreOffset                 = -1;
-	int16 _hashOffset                       = -1;
-	int16 _dollarOffset                     = -1;
-	int16 _lessThanOffset                   = -1;
-	int16 _greaterThanOffset                = -1;
-	int16 _leftCurlyBracketOffset           = -1;
-	int16 _rightCurlyBracketOffset          = -1;
-	int16 _euroOffset                       = -1;
+	int16 _uppercaseAWithDotOffset			= -1;
+	int16 _aWithDotOffset					= -1;
+	int16 _underscoreOffset					= -1;
+	int16 _hashOffset						= -1;
+	int16 _dollarOffset						= -1;
+	int16 _lessThanOffset					= -1;
+	int16 _greaterThanOffset				= -1;
+	int16 _leftCurlyBracketOffset			= -1;
+	int16 _rightCurlyBracketOffset			= -1;
+	int16 _euroOffset						= -1;
 
 	// Specific offsets in French variant of nancy12
 	int16 _uppercaseCWithCedillaOffset		= -1;


### PR DESCRIPTION
for French variant of nancy12; these take the place of unused characters.

New chars 'Ç', 'û', and 'ï' (and should be 'œ' too but I don't know its `chr` value).

Example atlases, en and fr:
<img width="120" height="418" alt="FONT13-atlas-en" src="https://github.com/user-attachments/assets/5280ba8f-ba6e-4642-b0b5-26c64b0d82d2" /> <img width="120" height="418" alt="FONT13-atlas-fr" src="https://github.com/user-attachments/assets/c18d903d-1dec-4f3a-9fd2-a6c0829ef73c" />

