### PR TITLE
MADS: NEBULAR: Better support DOS demo startup

### DIFF
--- a/engines/mads/core/inter.cpp
+++ b/engines/mads/core/inter.cpp
@@ -485,7 +485,7 @@ static void inter_show_word(int class_, int id) {
 		} else {
 			inter_set_colors(LEFT_SELECT);
 		}
-		font_write(font_misc, &scr_inter, temp_buf, x, y, 0);
+		font_write(font_misc ? font_misc : font_inter, &scr_inter, temp_buf, x, y, 0);
 		goto done;
 		break;
 

--- a/engines/mads/core/kernel.cpp
+++ b/engines/mads/core/kernel.cpp
@@ -383,23 +383,27 @@ int kernel_game_startup(int game_video_mode, int load_flag,
 
 	// Load the main interface fonts
 	if (load_flag & KERNEL_STARTUP_FONT) {
+		const bool isRexDemo = g_engine->getGameID() == GType_RexNebular && g_engine->isDemo();
+
 		font_main = font_load("*FONTMAIN.FF");
 		font_inter = font_load("*FONTINTR.FF");
 		font_conv = font_load("*FONTCONV.FF");
-		font_misc = font_load("*FONTMISC.FF");
+		font_misc = isRexDemo ? nullptr : font_load("*FONTMISC.FF");
 
 		font_menu = font_tele = nullptr;
 
 		if (g_engine->getGameID() == GType_RexNebular) {
-			font_tele = font_load("*FONTTELE.FF");
+			if (!isRexDemo)
+				font_tele = font_load("*FONTTELE.FF");
 			box_param.font = font_inter;
 		} else {
 			font_menu = font_load("*FONTMENU.FF");
 		}
 
-		if ((font_main == NULL) || (font_inter == NULL) || (font_conv == NULL) || (font_misc == NULL) ||
+		if ((font_main == NULL) || (font_inter == NULL) || (font_conv == NULL) ||
+			(!isRexDemo && font_misc == NULL) ||
 			(g_engine->getGameID() != GType_RexNebular && font_menu == NULL) ||
-			(g_engine->getGameID() == GType_RexNebular && font_tele == NULL)) {
+			(g_engine->getGameID() == GType_RexNebular && !isRexDemo && font_tele == NULL)) {
 #ifndef disable_error_check
 			error_code = ERROR_KERNEL_NO_FONTS;
 #endif

--- a/engines/mads/core/loader.cpp
+++ b/engines/mads/core/loader.cpp
@@ -20,6 +20,8 @@
  */
 
 #include "common/textconsole.h"
+#include "common/compression/dcl.h"
+#include "common/memstream.h"
 #include "mads/core/loader.h"
 #include "mads/core/general.h"
 #include "mads/core/pack.h"
@@ -232,9 +234,15 @@ long loader_read(void *target, long record_size, long record_count, LoadHandle h
 			if (decompress_buffer != NULL) {
 				if (!fileio_fread_f(decompress_buffer, compressed_size, 1, handle->handle)) goto done;
 
-				result = pack_data(packing_flag, total_size,
-					FROM_MEMORY, decompress_buffer,
-					TO_MEMORY, target);
+				if (pack_strategy == PACK_DCL) {
+					Common::MemoryReadStream stream(decompress_buffer, compressed_size);
+					result = Common::decompressDCL(&stream, (byte *)target,
+						compressed_size, total_size) ? total_size : 0;
+				} else {
+					result = pack_data(packing_flag, total_size,
+						FROM_MEMORY, decompress_buffer,
+						TO_MEMORY, target);
+				}
 				already_unpacked = true;
 			}
 		}

--- a/engines/mads/core/pack.cpp
+++ b/engines/mads/core/pack.cpp
@@ -114,13 +114,19 @@ bool PackList::load(Common::SeekableReadStream *src) {
 	num_records = src->readUint16LE();
 
 	// Confirm that the ID is correct
-	if (strncmp(id_string, PACK_ID_STRING, PACK_ID_CHECK) != 0)
+	const bool isVersion1 = strncmp(id_string, PACK_ID_STRING_V1, PACK_ID_CHECK) == 0;
+	if (!isVersion1 && strncmp(id_string, PACK_ID_STRING, PACK_ID_CHECK) != 0)
 		return false;
 
 	// Read in the index. Note that only num_records worth of entries are
 	// valid, but space is left in the file for the maximum amount of entries
-	for (int i = 0; i < PACK_MAX_LIST_LENGTH; ++i)
+	for (int i = 0; i < PACK_MAX_LIST_LENGTH; ++i) {
 		strategy[i].load(src);
+		// MADSPACK 1.0 used value 1 for PKWARE compression. Version 2.0
+		// assigned that value to the newer pFAB compressor.
+		if (isVersion1 && strategy[i].type == PACK_PFAB)
+			strategy[i].type = PACK_DCL;
+	}
 
 	return true;
 }

--- a/engines/mads/core/pack.h
+++ b/engines/mads/core/pack.h
@@ -28,6 +28,7 @@
 namespace MADS {
 
 #define PACK_ID_STRING                "MADSPACK 2.0\032"
+#define PACK_ID_STRING_V1             "MADSPACK 1.0\032"
 #define PACK_ID_LENGTH                14
 #define PACK_ID_CHECK                 12
 
@@ -44,6 +45,7 @@ namespace MADS {
 #define PACK_NONE                     0       /* No compression */
 #define PACK_PFAB                     1       /* Dave's Stuff   */
 #define PACK_ZIP                      2       /* Zipped         */
+#define PACK_DCL                      3       /* PKWARE DCL     */
 
 #define PACK_IMPLODE_SIZE             35256   /* pkzip implode buffer */
 #define PACK_EXPLODE_SIZE             12574   /* pkzip explode buffer */

--- a/engines/mads/nebular/main.cpp
+++ b/engines/mads/nebular/main.cpp
@@ -241,7 +241,7 @@ static void game_main(int argc, const char **argv) {
 	mads_mode = env_verify();
 
 	new_section = 1;
-	new_room = 101;
+	new_room = g_engine->isDemo() ? 102 : 101;
 	player.x = 160;
 	player.y = 78;
 
@@ -313,6 +313,8 @@ void nebular_main() {
 
 	if (ConfMan.getBool("start_game") || ConfMan.hasKey("save_slot"))
 		selected_item = 0;
+	else if (g_engine->isDemo())
+		selected_item = 9;
 	else if (ConfMan.getBool("start_intro"))
 		selected_item = 3;
 	else
@@ -372,6 +374,13 @@ void nebular_main() {
 			// Quotes
 			TextView::textview_main("quotes");
 			selected_item = -1;
+			break;
+
+		case 9:
+			// The DOS demo batch file plays this ANIMVIEW playlist before
+			// starting its three-room playable section.
+			AnimView::animview_main("@demodisk");
+			selected_item = 0;
 			break;
 
 		case WIN_QUICK_DEATH + 16:


### PR DESCRIPTION
This PR adds support for starting and running the DOS demo of *Rex Nebular and the Cosmic Gender Bender*. It detects MADSPACK 1.0 resources correctly, follows the demo's original DOS startup sequence, and handles its reduced font set by falling back to the available interface font where needed.

The changes are limited to the demo path, so full-game startup and resource handling remain unchanged. The DOS demo has been tested and now starts and runs. Three hurdles that prevented that are removed.