### PR TITLE
CHEWY: Fix station employee animation when Howard is around, room 42

### DIFF
--- a/engines/chewy/rooms/room42.cpp
+++ b/engines/chewy/rooms/room42.cpp
@@ -41,18 +41,17 @@ void Room42::entry() {
 		_G(SetUpScreenFunc) = setup_func;
 
 		if (!_G(flags).LoadGame) {
-			_G(det)->stopDetail(0);
-			_G(timer_nr)[0] = _G(room)->set_timer(8, 5);
-			_G(det)->set_static_ani(8, -1);
 			_G(gameState).R42StationEmployeeAway = true;
-			_G(det)->stopSound(0);
-
-			_G(SetUpScreenFunc) = setup_func;
 
 			setPersonPos(80, 43, P_HOWARD, P_LEFT);
 			_G(atds)->set_all_ats_str(263, 1, ATS_DATA);
 			_G(atds)->set_all_ats_str(264, 1, ATS_DATA);
 		}
+
+		_G(det)->stopDetail(0);
+		_G(det)->stopSound(0);
+		_G(timer_nr)[0] = _G(room)->set_timer(8, 5);
+		_G(det)->set_static_ani(8, -1);
 
 		if (_G(obj)->checkInventory(HOTEL_INV) && _G(obj)->checkInventory(TICKET_INV) && !_G(gameState).R42LetterOk)
 			startAadWait(302);


### PR DESCRIPTION
This was broken when loading a savegame: The station employee would run his sleeping animation, and this animation would overlap with his talking animation during dialog.

<img width="418" height="590" alt="Screenshot 2026-07-23 at 19 28 41" src="https://github.com/user-attachments/assets/96b89333-33c7-421f-ae44-280f4e835417" />

To fix this ensure detail animation setup happens both when entering the room or when loading a game.
 
Reproducer: Load [chewy-de.071.zip](https://github.com/user-attachments/files/30410707/chewy-de.071.zip) and talk to the station employee. Compare behavior to when you first exit and re-enter the room.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
