### PR TITLE
CHEWY: Add missing Chewy animation in room 40 when train passes

### DIFF
--- a/engines/chewy/t_event.cpp
+++ b/engines/chewy/t_event.cpp
@@ -1291,6 +1291,8 @@ void atdsStringStart(int16 diaNr, int16 strNr, int16 personNr, int16 mode) {
 	case 62:   // R29: use_pumpe()
 	case 111:  // R12: use_linke_rohr()
 	case 114:  // R12: Chewy-as-Bork with terminal
+	case 206:  // R40: move_train(), before the train passes
+	case 207:  // R40: move_train(), after the train passes
 	case 252:
 	case 253:
 	case 259:


### PR DESCRIPTION
(after mailing the stamped letter)

To reproduce, load [chewy-de.072.zip](https://github.com/user-attachments/files/30423079/chewy-de.072.zip) and exit room. Chewy wasn't animated when saying his lines before and after the train passes.



<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
