### PR TITLE
CHEWY: Fix Chewy and Howard sprite placement on train

### DIFF
--- a/engines/chewy/rooms/room40.cpp
+++ b/engines/chewy/rooms/room40.cpp
@@ -186,12 +186,10 @@ void Room40::move_train(int16 mode) {
 		// Train sprite
 		_G(det)->setStaticPos(11, ax, 62, false, false);
 
-		// Chewy and Howard sprite
-		// The original offsets were ax and 62, which for some reason
-		// aren't shown correctly here (perhaps bad correction coords).
-		// Thus, adjust the coordinates here.
+		// Chewy and Howard sprite. Positioned like the train, with the
+		// sprite's own correction offset (26, 18) added.
 		if (mode && _G(gameState).ChewyAni == CHEWY_PUMPKIN)
-			_G(det)->setStaticPos(12, ax + 27, 161, false, true);
+			_G(det)->setStaticPos(12, ax, 62, false, true);
 
 		if (!delay) {
 			lx += SPEED;


### PR DESCRIPTION
I could reproduce comment 2 on https://bugs.scummvm.org/ticket/13637#comment:2 with savegame [chewy-de.085.zip](https://github.com/user-attachments/files/30427312/chewy-de.085.zip) (walk into train station to trigger animation).

On master Chewy and Howard were placed too low on the screen and a bit too far to the right:

<img width="2111" height="1340" alt="Screenshot 2026-07-27 at 19 08 59" src="https://github.com/user-attachments/assets/e7749248-d795-4d8c-91f8-d1e1866a10aa" />

To fix this, this PR reverts a manual placement correction introduced in commit 7686999. I can only imagine that, at the time, maybe there was some engine bug affecting sprite placements making the manual correction necessary. Alternatively, could there be data differences? I could only test with the German CD release version.

With this patch and my copy of the game, Chewy and Howard travel correctly in the train window:

<img width="2111" height="1340" alt="Screenshot 2026-07-27 at 19 10 04" src="https://github.com/user-attachments/assets/f35f9c23-ed9f-4734-9e92-3d161f5bc229" />
