### PR TITLE
SCI: Fix RTL text box clipping

### DIFF
--- a/engines/sci/graphics/text16.cpp
+++ b/engines/sci/graphics/text16.cpp
@@ -647,7 +647,7 @@ void GfxText16::Box(const char *text, uint16 languageSplitter, bool show, const 
 		}
 
 
-		if (g_sci->isLanguageRTL())
+		if (g_sci->isLanguageRTL() && offset > 0)
 			// In the game fonts, characters have spacing on the left, and no spacing on the right,
 			// therefore, when we start drawing from the right, they "start from the border"
 			// e.g., in SQ3 Hebrew user's input prompt.


### PR DESCRIPTION
Avoid applying the RTL left-padding compensation when the first line is already drawn at offset 0. This prevents Hebrew text from shifting past the box edge and losing the leftmost pixel column.

This fixes https://github.com/adventurebrew/HebrewAdventure/issues/14


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
