### PR TITLE
AD: Skip detection for engines with no matching filenames (take two)

### DIFF
--- a/common/macresman.cpp
+++ b/common/macresman.cpp
@@ -1176,6 +1176,38 @@ Path MacResManager::disassembleAppleDoubleName(const Path &name, bool *isAppleDo
 	return ret;
 }
 
+Path MacResManager::disassembleName(const Path &name, bool *isMacDecoratedName) {
+	String fileName = name.baseName();
+
+	// Remove the AppleDouble "._" prefix, if present
+	bool stripped = fileName.hasPrefix("._");
+	if (stripped)
+		fileName.erase(0, 2);
+
+	// Remove the extension used for raw resource forks and AppleDouble
+	// (".rsrc") or MacBinary (".bin") files, if present
+	uint extLen = 0;
+
+	if (fileName.hasSuffixIgnoreCase(".rsrc"))
+		extLen = 5;
+	else if (fileName.hasSuffixIgnoreCase(".bin"))
+		extLen = 4;
+
+	if (extLen) {
+		fileName.erase(fileName.size() - extLen);
+		stripped = true;
+	}
+
+	if (isMacDecoratedName) {
+		*isMacDecoratedName = stripped;
+	}
+
+	if (!stripped)
+		return name;
+
+	return name.getParent().appendComponent(fileName);
+}
+
 void MacResManager::dumpRaw() {
 	byte *data = nullptr;
 	uint dataSize = 0;

--- a/common/macresman.cpp
+++ b/common/macresman.cpp
@@ -1170,6 +1170,9 @@ Path MacResManager::disassembleAppleDoubleName(const Path &name, bool *isAppleDo
 	if (name.isSeparatorTerminated()) {
 		ret.appendInPlace("/");
 	}
+	if (isAppleDouble) {
+		*isAppleDouble = true;
+	}
 	return ret;
 }
 

--- a/common/macresman.h
+++ b/common/macresman.h
@@ -202,6 +202,17 @@ public:
 	static void listFiles(Array<Path> &files, const Path &pattern);
 
 	/**
+	 * Compute the base name for use with open() from a possibly decorated
+	 * on-disk file name, stripping the AppleDouble "._" prefix and the
+	 * ".rsrc"/".bin" extensions. Purely name-based, contents are not checked.
+	 *
+	 * @param name The file name as present on disk
+	 * @param isMacDecoratedName Set to true if any decoration was stripped
+	 * @return The potential base name (equal to name if none applies)
+	 */
+	static Path disassembleName(const Path &name, bool *isMacDecoratedName = nullptr);
+
+	/**
 	 * Close the Mac data/resource fork pair.
 	 */
 	void close();

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -262,11 +262,25 @@ DetectedGames AdvancedMetaEngineDetectionBase::detectGames(const Common::FSList 
 	// the _directoryGlobsMap
 	preprocessDescriptions();
 
-	// Compose a hashmap of all files in fslist.
-	composeFileHashMap(allFiles, fslist, (_maxScanDepth == 0 ? 1 : _maxScanDepth));
+	// Compose a hashmap of all files in fslist. Engines which do not descend
+	// into subdirectories and match plain file names compose an identical one,
+	// so it is composed once per detection run and shared between them.
+	FileMap *files = &allFiles;
+
+	if (_globsMap.empty() && !(_flags & kADFlagMatchFullPaths)) {
+		files = ADCacheMan.getFileMap();
+
+		if (!files) {
+			files = &ADCacheMan.createFileMap();
+
+			composeFileHashMap(*files, fslist, 1);
+		}
+	} else {
+		composeFileHashMap(*files, fslist, (_maxScanDepth == 0 ? 1 : _maxScanDepth));
+	}
 
 	// Run the detector on this
-	ADDetectedGames matches = detectGame(fslist.begin()->getParent(), allFiles, Common::UNK_LANG, Common::kPlatformUnknown, "", skipADFlags, skipIncomplete);
+	ADDetectedGames matches = detectGame(fslist.begin()->getParent(), *files, Common::UNK_LANG, Common::kPlatformUnknown, "", skipADFlags, skipIncomplete);
 
 	cleanupPirated(matches);
 
@@ -289,7 +303,7 @@ DetectedGames AdvancedMetaEngineDetectionBase::detectGames(const Common::FSList 
 	if (!foundKnownGames) {
 		// Use fallback detector if there were no matches by other means
 		ADDetectedGameExtraInfo *extraInfo = nullptr;
-		ADDetectedGame fallbackDetectionResult = fallbackDetect(allFiles, fslist, &extraInfo);
+		ADDetectedGame fallbackDetectionResult = fallbackDetect(*files, fslist, &extraInfo);
 
 		if (fallbackDetectionResult.desc) {
 			DetectedGame fallbackDetectedGame = toDetectedGame(fallbackDetectionResult, extraInfo);

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -253,8 +253,6 @@ bool AdvancedMetaEngineDetectionBase::cleanupPirated(ADDetectedGames &matched) c
 }
 
 DetectedGames AdvancedMetaEngineDetectionBase::detectGames(const Common::FSList &fslist, uint32 skipADFlags, bool skipIncomplete) {
-	FileMap allFiles;
-
 	if (fslist.empty())
 		return DetectedGames();
 
@@ -262,21 +260,29 @@ DetectedGames AdvancedMetaEngineDetectionBase::detectGames(const Common::FSList 
 	// the _directoryGlobsMap
 	preprocessDescriptions();
 
-	// Compose a hashmap of all files in fslist. Engines which do not descend
-	// into subdirectories and match plain file names compose an identical one,
-	// so it is composed once per detection run and shared between them.
-	FileMap *files = &allFiles;
+	// Compose a hashmap of all files in fslist. Every engine composes the very
+	// same one for the game directory itself, so it is composed once per
+	// detection run and shared between them; engines descending into
+	// subdirectories take a copy and add those on top of it.
+	FileMap *files = ADCacheMan.getFileMap();
 
-	if (_globsMap.empty() && !(_flags & kADFlagMatchFullPaths)) {
-		files = ADCacheMan.getFileMap();
+	if (!files) {
+		files = &ADCacheMan.createFileMap();
 
-		if (!files) {
-			files = &ADCacheMan.createFileMap();
+		composeFileHashMap(*files, fslist, 1);
+	}
 
-			composeFileHashMap(*files, fslist, 1);
-		}
-	} else {
-		composeFileHashMap(*files, fslist, (_maxScanDepth == 0 ? 1 : _maxScanDepth));
+	// Copy of the shared map, extended by this engine's subdirectories
+	FileMap subdirFiles;
+
+	if (!_globsMap.empty()) {
+		// The subdirectories must not be added to the shared map, otherwise
+		// every other engine would see the subdirectories of this one.
+		subdirFiles = *files;
+
+		composeFileHashMap(subdirFiles, fslist, (_maxScanDepth == 0 ? 1 : _maxScanDepth), Common::Path(), true);
+
+		files = &subdirFiles;
 	}
 
 	// Run the detector on this
@@ -462,7 +468,7 @@ Common::Error AdvancedMetaEngineDetectionBase::identifyGame(DetectedGame &game, 
 	return Common::kNoError;
 }
 
-void AdvancedMetaEngineDetectionBase::composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth, const Common::Path &parentName) const {
+void AdvancedMetaEngineDetectionBase::composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth, const Common::Path &parentName, bool subdirsOnly) const {
 	if (depth <= 0)
 		return;
 
@@ -470,6 +476,9 @@ void AdvancedMetaEngineDetectionBase::composeFileHashMap(FileMap &allFiles, cons
 		return;
 
 	for (const auto &file : fslist) {
+		if (subdirsOnly && !file.isDirectory())
+			continue;
+
 		Common::String efname = Common::punycode_encodefilename(file.getName());
 		Common::Path tstr = (_flags & kADFlagMatchFullPaths) ? parentName.appendComponent(efname) : Common::Path(efname, Common::Path::kNoSeparator);
 

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -755,6 +755,20 @@ ADDetectedGames AdvancedMetaEngineDetectionBase::detectGame(const Common::FSNode
 
 	preprocessDescriptions();
 
+	// Early rejection: if none of the file names referenced by this engine's
+	// detection entries exist in the game folder, there is no chance of a match.
+	bool anyFileFound = false;
+	for (auto it = allFiles.begin(); it != allFiles.end(); ++it) {
+		if (_fileNamesMap.contains(it->_key)) {
+			anyFileFound = true;
+			break;
+		}
+	}
+	if (!anyFileFound) {
+		debugC(3, kDebugGlobalDetection, "Skipping engine '%s': no matching file names in directory", getName());
+		return matched;
+	}
+
 	// Check which files are included in some ADGameDescription *and* whether
 	// they are present. Compute MD5s and file sizes for the available files.
 	for (descPtr = _gameDescriptors; ((const ADGameDescription *)descPtr)->gameId != nullptr; descPtr += _descItemSize) {
@@ -1040,6 +1054,27 @@ void AdvancedMetaEngineDetectionBase::preprocessDescriptions() {
 	// Now scan all detection entries
 	for (const byte *descPtr = _gameDescriptors; ((const ADGameDescription *)descPtr)->gameId != nullptr; descPtr += _descItemSize) {
 		const ADGameDescription *g = (const ADGameDescription *)descPtr;
+
+		// Collect all unique file names for early rejection
+		for (const ADGameFileDescription *fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {
+			Common::String fname = fileDesc->fileName;
+
+			// For archive entries, extract the archive name
+			if (gameFileToMD5Props(fileDesc, g->flags) & kMD5Archive) {
+				Common::StringTokenizer tok(fname, ":");
+				tok.nextToken(); // skip archive type
+				fname = tok.nextToken(); // archive name
+			}
+
+			// For paths with directory components, extract the leaf filename
+			// unless kADFlagMatchFullPaths is set
+			if (!(_flags & kADFlagMatchFullPaths) && fname.contains('/')) {
+				fname = Common::Path(fname).baseName();
+			}
+
+			_fileNamesMap.setVal(Common::Path(fname, fname.contains('/')
+				? '/' : Common::Path::kNoSeparator), true);
+		}
 
 		// Scan for potential directory globs
 		for (const ADGameFileDescription *fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -763,6 +763,13 @@ ADDetectedGames AdvancedMetaEngineDetectionBase::detectGame(const Common::FSNode
 			anyFileFound = true;
 			break;
 		}
+
+		bool isMacDecoratedName = false;
+		Common::Path undecorated = Common::MacResManager::disassembleName(it->_key, &isMacDecoratedName);
+		if (isMacDecoratedName && _fileNamesMap.contains(undecorated)) {
+			anyFileFound = true;
+			break;
+		}
 	}
 	if (!anyFileFound) {
 		debugC(3, kDebugGlobalDetection, "Skipping engine '%s': no matching file names in directory", getName());

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -732,6 +732,20 @@ ADDetectedGames AdvancedMetaEngineDetectionBase::detectGame(const Common::FSNode
 
 	preprocessDescriptions();
 
+	// Early rejection: if none of the file names referenced by this engine's
+	// detection entries exist in the game folder, there is no chance of a match.
+	bool anyFileFound = false;
+	for (auto it = allFiles.begin(); it != allFiles.end(); ++it) {
+		if (_fileNamesMap.contains(it->_key)) {
+			anyFileFound = true;
+			break;
+		}
+	}
+	if (!anyFileFound) {
+		debugC(3, kDebugGlobalDetection, "Skipping engine '%s': no matching file names in directory", getName());
+		return matched;
+	}
+
 	// Check which files are included in some ADGameDescription *and* whether
 	// they are present. Compute MD5s and file sizes for the available files.
 	for (descPtr = _gameDescriptors; ((const ADGameDescription *)descPtr)->gameId != nullptr; descPtr += _descItemSize) {
@@ -1017,6 +1031,27 @@ void AdvancedMetaEngineDetectionBase::preprocessDescriptions() {
 	// Now scan all detection entries
 	for (const byte *descPtr = _gameDescriptors; ((const ADGameDescription *)descPtr)->gameId != nullptr; descPtr += _descItemSize) {
 		const ADGameDescription *g = (const ADGameDescription *)descPtr;
+
+		// Collect all unique file names for early rejection
+		for (const ADGameFileDescription *fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {
+			Common::String fname = fileDesc->fileName;
+
+			// For archive entries, extract the archive name
+			if (gameFileToMD5Props(fileDesc, g->flags) & kMD5Archive) {
+				Common::StringTokenizer tok(fname, ":");
+				tok.nextToken(); // skip archive type
+				fname = tok.nextToken(); // archive name
+			}
+
+			// For paths with directory components, extract the leaf filename
+			// unless kADFlagMatchFullPaths is set
+			if (!(_flags & kADFlagMatchFullPaths) && fname.contains('/')) {
+				fname = Common::Path(fname).baseName();
+			}
+
+			_fileNamesMap.setVal(Common::Path(fname, fname.contains('/')
+				? '/' : Common::Path::kNoSeparator), true);
+		}
 
 		// Scan for potential directory globs
 		for (const ADGameFileDescription *fileDesc = g->filesDescriptions; fileDesc->fileName; fileDesc++) {

--- a/engines/advancedDetector.cpp
+++ b/engines/advancedDetector.cpp
@@ -740,6 +740,13 @@ ADDetectedGames AdvancedMetaEngineDetectionBase::detectGame(const Common::FSNode
 			anyFileFound = true;
 			break;
 		}
+
+		bool isMacDecoratedName = false;
+		Common::Path undecorated = Common::MacResManager::disassembleName(it->_key, &isMacDecoratedName);
+		if (isMacDecoratedName && _fileNamesMap.contains(undecorated)) {
+			anyFileFound = true;
+			break;
+		}
 	}
 	if (!anyFileFound) {
 		debugC(3, kDebugGlobalDetection, "Skipping engine '%s': no matching file names in directory", getName());

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -554,6 +554,7 @@ private:
 private:
 	Common::HashMap<Common::String, bool, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _grayListMap;
 	Common::HashMap<Common::String, bool, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _globsMap;
+	Common::HashMap<Common::Path, bool, Common::Path::IgnoreCase_Hash, Common::Path::IgnoreCase_EqualTo> _fileNamesMap;
 	bool _hashMapsInited;
 
 protected:

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -594,7 +594,7 @@ protected:
 	 *
 	 * Removes trailing dots and ignores case in the process.
 	 */
-	void composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth, const Common::Path &parentName = Common::Path()) const;
+	void composeFileHashMap(FileMap &allFiles, const Common::FSList &fslist, int depth, const Common::Path &parentName = Common::Path(), bool subdirsOnly = false) const;
 
 	/** Get the properties (size and MD5) of this file. */
 	bool getFileProperties(const FileMap &allFiles, MD5Properties md5prop, const Common::Path &fname, FileProperties &fileProps) const;

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -555,6 +555,7 @@ private:
 private:
 	Common::HashMap<Common::String, bool, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _grayListMap;
 	Common::HashMap<Common::String, bool, Common::IgnoreCase_Hash, Common::IgnoreCase_EqualTo> _globsMap;
+	Common::HashMap<Common::Path, bool, Common::Path::IgnoreCase_Hash, Common::Path::IgnoreCase_EqualTo> _fileNamesMap;
 	bool _hashMapsInited;
 
 protected:

--- a/engines/advancedDetector.h
+++ b/engines/advancedDetector.h
@@ -26,6 +26,7 @@
 #include "engines/engine.h"
 
 #include "common/hash-str.h"
+#include "common/ptr.h"
 
 #include "common/gui_options.h" // Keep it here, so detection tables can refer to them
 
@@ -785,6 +786,16 @@ public:
 		return archiveHashMap.getValOrDefault(node.getPath(), nullptr);
 	}
 
+	AdvancedMetaEngineBase::FileMap *getFileMap() const {
+		return fileMap.get();
+	}
+
+	AdvancedMetaEngineBase::FileMap &createFileMap() {
+		fileMap.reset(new AdvancedMetaEngineBase::FileMap());
+
+		return *fileMap;
+	}
+
 	AdvancedDetectorCacheManager() {
 		clear();
 	}
@@ -799,6 +810,7 @@ public:
 	void clear() {
 		md5HashMap.clear(true);
 		sizeHashMap.clear(true);
+		fileMap.reset();
 		clearArchives();
 	}
 
@@ -811,6 +823,7 @@ private:
 	FileHashMap md5HashMap;
 	SizeHashMap sizeHashMap;
 	ArchiveHashMap archiveHashMap;
+	Common::ScopedPtr<AdvancedMetaEngineBase::FileMap> fileMap;
 };
 
 /** Convenience shortcut for accessing the MD5CacheManager. */

--- a/test/common/macresman.h
+++ b/test/common/macresman.h
@@ -1,0 +1,44 @@
+#include <cxxtest/TestSuite.h>
+#include "common/macresman.h"
+
+/**
+ * Test suite for the file name handling in common/macresman.h
+ */
+class MacResManagerTestSuite : public CxxTest::TestSuite {
+	public:
+
+	void checkName(const Common::Path &name, const Common::Path &expected, bool expectedDecorated) {
+		bool decorated = false;
+		Common::Path result = Common::MacResManager::disassembleName(name, &decorated);
+
+		TS_ASSERT_EQUALS(result, expected);
+		TS_ASSERT_EQUALS(decorated, expectedDecorated);
+	}
+
+	void test_disassembleName() {
+		// Plain names pass through untouched
+		checkName("JMP PP Resources", "JMP PP Resources", false);
+		checkName("data.dat", "data.dat", false);
+
+		// MacBinary ".bin" extension, case-insensitive (bug #17026)
+		checkName("JMP PP Resources.bin", "JMP PP Resources", true);
+		checkName("Foo.BIN", "Foo", true);
+
+		// Raw resource fork / AppleDouble ".rsrc" extension
+		checkName("JMP PP Resources.rsrc", "JMP PP Resources", true);
+
+		// AppleDouble "._" prefix
+		checkName("._JMP PP Resources", "JMP PP Resources", true);
+
+		// Decorations on the last component of a longer path
+		checkName("Data/._Movie", "Data/Movie", true);
+		checkName("Data/Movie.bin", "Data/Movie", true);
+
+		// Both prefix and extension are stripped
+		checkName("._Foo.rsrc", "Foo", true);
+
+		// Substrings that are not decorations are kept
+		checkName("binfile", "binfile", false);
+		checkName("x._y", "x._y", false);
+	}
+};


### PR DESCRIPTION
This is my attempt to do https://github.com/scummvm/scummvm/pull/7756 the right way.

- I kept my original commit to see what has been changed
- I added a test for the case mentioned in  https://bugs.scummvm.org/ticket/17026 (full disclosure: I let Claude write it)
- I also found one forgotten piece of code to be activated (`isAppleDouble`)
