### PR TITLE
DISTS: Add Russian translation to desktop file

### DIFF
--- a/dists/org.scummvm.scummvm.desktop
+++ b/dists/org.scummvm.scummvm.desktop
@@ -7,6 +7,7 @@ Comment[he]=פרשן למספר משחקי הרפתקאות
 Comment[de]=Interpreter für zahlreiche Abenteuerspiele und RPGs
 Comment[es]=Intérprete para varias aventuras gráficas
 Comment[ca]=Intèrpret per diverses aventures gràfiques
+Comment[ru]=Интерпретатор множества приключенческих и ролевых игр
 Exec=scummvm
 Icon=org.scummvm.scummvm
 Terminal=false


### PR DESCRIPTION
The launcher entry `dists/org.scummvm.scummvm.desktop` currently carries `Comment` translations for six languages only (ca, de, es, he, pl, sv). The entry has no `GenericName`, so desktop environments fall back to `Comment` for the subtitle shown under "ScummVM" in the application menu — which for every other locale means the English string.

This adds `Comment[ru]`, reusing verbatim the summary the Russian team already maintains in `po/ru_RU.po`:

```
#. I18N: One line summary as shown in *nix distributions
#: dists/org.scummvm.scummvm.metainfo.xml.cpp:32
msgid "Interpreter for numerous adventure games and role-playing games"
msgstr "Интерпретатор множества приключенческих и ролевых игр"
```

so the menu subtitle now matches what `org.scummvm.scummvm.metainfo.xml` already shows in software centres. No new string is introduced and no translator review is needed.

Verified on Arch Linux with KDE Plasma 6.7 and `LANG=ru_RU.UTF-8`: before the change KDE's service cache held the English `Comment`, after it the Russian one. `desktop-file-validate` passes.

Side note, in case it is useful: `dists/org.scummvm.scummvm.desktop` is not listed in `po/POTFILES`, unlike `dists/org.scummvm.scummvm.metainfo.xml.cpp`. The metainfo summary is therefore generated for 20 languages by `devtools/generate-metainfo.py`, while the desktop entry is still maintained by hand and covers 6. Fifteen languages already have an approved translation of this exact sentence that the launcher entry does not use. I will follow up with a separate PR wiring the desktop entry into the same pipeline.