### PR TITLE
SCI32: Fix right-to-left alignment of scrolled text lines

### DIFF
--- a/engines/sci/graphics/text32.cpp
+++ b/engines/sci/graphics/text32.cpp
@@ -863,9 +863,10 @@ void GfxText32::scrollLine(const Common::String &lineText, int numLines, uint8 c
 	_text = lineText;
 	int16 textWidth = getTextWidth(0, lineText.size());
 
+	const TextAlign farEdge = !g_sci->isLanguageRTL() ? kTextAlignRight : kTextAlignLeft;
 	if (_alignment == kTextAlignCenter) {
 		_drawPosition.x += (_textRect.width() - textWidth) / 2;
-	} else if (_alignment == kTextAlignRight) {
+	} else if (_alignment == farEdge) {
 		_drawPosition.x += _textRect.width() - textWidth;
 	}
 


### PR DESCRIPTION
`drawTextBox()` mirrors the horizontal alignments for right-to-left languages, so that `kTextAlignLeft` pushes a line to the far edge of the text rect. `scrollLine()` was missing that, leaving scrolled lines at the left edge while every other line was drawn at the right.

Noticed in the Hebrew fan translation of SQ6, where the message window is aligned correctly until it scrolls.

Assisted-by: Claude:claude-opus-5


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
