### PR TITLE
BURIED: Update cursor icon after navigation.

### DIFF
--- a/engines/buried/scene_view.cpp
+++ b/engines/buried/scene_view.cpp
@@ -30,6 +30,7 @@
 #include "buried/graphics.h"
 #include "buried/inventory_window.h"
 #include "buried/livetext.h"
+#include "buried/message.h"
 #include "buried/navarrow.h"
 #include "buried/resources.h"
 #include "buried/scene_view.h"
@@ -672,6 +673,9 @@ bool SceneViewWindow::moveToDestination(const DestinationScene &destinationData)
 	// Hardcoded demo ambient
 	if (_vm->isDemo() && newSceneStaticData.location.environment != oldLocation.environment)
 		startDemoAmbientSound();
+
+	// Ensure cursor icon matches interaction points at the destination node.
+	resetCursor();
 
 	return true;
 }
@@ -2500,8 +2504,9 @@ bool SceneViewWindow::changeSpriteStatus(bool status) {
 }
 
 bool SceneViewWindow::resetCursor() {
-	_vm->_gfx->setCursor((Cursor)_curCursor);
-	return true;
+	// Ensure the pointer icon is appropriate for the current scene by simulating
+	// a mouse move to its existing position.
+	return onSetCursor(kMessageTypeMouseMove);
 }
 
 bool SceneViewWindow::displayLiveText(const Common::String &text, bool notifyUser) {


### PR DESCRIPTION
Players can interact with the game world by moving the cursor over 
interactive objects. In the image below, you can see the cursor
changes to a magnifying glass. Clicking allows the player to 
zoom in on the action figure.

<img width="1802" height="1186" alt="Screenshot 2026-08-02 at 2 30 17 PM" src="https://github.com/user-attachments/assets/63ca1e98-b384-429d-b5e6-f4410bf6a2d0" />

If the player turns or navigates to a different node, the cursor
should update to match the interactions (or lack thereof) 
at the new node. However, a bug in the game keeps the stale
cursor icon from the previous node until the user moves the mouse.
In the example above, after navigating left or right, there would be 
nothing to zoom-in on. However, the magnifying glass icon would 
remain until the player moved the mouse.

This PR resets the cursor icon after every navigation, ensuring the
icon is appropriate for the navigation destination. 

This bug is a QoL issue when using a controller or KB+M to navigate.
The issue doesn't surface if you manually click the navigation arrows
on the bottom-right of the screen since you have to move the mouse
back to the viewport to see whether anything is interactive. The issue
appears much more frequently when the cursor remains over the 
viewport but a keyboard's arrow keys or a controller's D-pad
are used to navigate. 