### PR TITLE
DIRECTOR: Add another optgraph.dll return value

### DIFF
--- a/engines/director/lingo/xtras/g/glu32.cpp
+++ b/engines/director/lingo/xtras/g/glu32.cpp
@@ -167,6 +167,10 @@ void GLU32Xtra::m_GLUCall(int nargs) {
 			g_lingo->push(Datum((int)16988788)); // TODO: Check with the game
 			return;
 		}
+		if (gameId == "maus2") {
+			g_lingo->push(Datum((int)16455855));
+			return;
+		}
 		if (gameId == "komissar1") {
 			g_lingo->push(Datum(Common::String("37211457"))); // TODO: Check with the game
 			return;


### PR DESCRIPTION
The game "Die CD-ROM mit der Maus 2" will boot now into a "your game isn't running from the CD-Drive it was installed from" error screen, instead of exiting immediately.