### PR TITLE
MACVENTURE: Deja Vu playtesting fixes

### DIFF
--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -967,15 +967,19 @@ void Gui::drawDraggedObjects() {
 			ImageAsset *asset = _assets[_draggedObjects[i].id];
 
 			// In case of overflow from the right/top
-			uint w = asset->getWidth() + MIN((int16)0, _draggedObjects[i].pos.x);
-			uint h = asset->getHeight() + MIN((int16)0, _draggedObjects[i].pos.y);
+			int w = asset->getWidth() + MIN((int16)0, _draggedObjects[i].pos.x);
+			int h = asset->getHeight() + MIN((int16)0, _draggedObjects[i].pos.y);
 
 			// In case of overflow from the bottom/left
 			if (_draggedObjects[i].pos.x > 0 && _draggedObjects[i].pos.x + w > kScreenWidth) {
-				w = kScreenWidth - _draggedObjects[i].pos.x;
+				w = MAX(0, kScreenWidth - _draggedObjects[i].pos.x);
 			}
 			if (_draggedObjects[i].pos.y > 0 && _draggedObjects[i].pos.y + h > kScreenHeight) {
-				h = kScreenHeight - _draggedObjects[i].pos.y;
+				h = MAX(0, kScreenHeight - _draggedObjects[i].pos.y);
+			}
+
+			if (w <= 0 || h <= 0) {
+				continue;
 			}
 
 			Common::Point target = _draggedObjects[i].pos;

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -529,10 +529,11 @@ WindowReference Gui::createInventoryWindow(ObjID objRef) {
 	loadBorders(newWindow, newData.type);
 	newWindow->resizeInner(newData.bounds.width(), newData.bounds.height() - bbs.bottomScrollbarHeight);
 	newWindow->move(newData.bounds.left - bbs.leftOffset, newData.bounds.top - bbs.topOffset);
-	newWindow->setCallback(inventoryWindowCallback, new InventoryCallbackStruct{this, newData.refcon});
+	InventoryCallbackStruct *callbackData = new InventoryCallbackStruct{this, newData.refcon};
+	newWindow->setCallback(inventoryWindowCallback, callbackData);
 	//newWindow->setCloseable(true);
 
-	_inventoryWindows.push_back(InventoryWindowData{newWindow, newData.refcon});
+	_inventoryWindows.push_back(InventoryWindowData{newWindow, newData.refcon, callbackData});
 
 	debugC(1, kMVDebugGUI, "Create new inventory window. Reference: %d", newData.refcon);
 	return newData.refcon;
@@ -1442,6 +1443,8 @@ Common::Point Gui::localizeTravelledDistance(Common::Point point, WindowReferenc
 void Gui::removeInventoryWindow(WindowReference ref) {
 	for (auto &invWinData: _inventoryWindows) {
 		if (invWinData.ref == ref) {
+			invWinData.win->setCallback(nullptr, nullptr);
+			delete invWinData.callbackData;
 			_inventoryWindows.erase(&invWinData);
 			break;
 		}
@@ -1552,12 +1555,8 @@ bool diplomaWindowCallback(Graphics::WindowClick click, Common::Event &event, vo
 
 bool inventoryWindowCallback(Graphics::WindowClick click, Common::Event &event, void *data) {
 	InventoryCallbackStruct *g = (InventoryCallbackStruct *)data;
-	bool res = g->gui->processInventoryEvents(g->ref, click, event);
 
-	if (event.type == Common::EVENT_LBUTTONUP && click == Graphics::kBorderCloseButton)
-		delete g;
-
-	return res;
+	return g->gui->processInventoryEvents(g->ref, click, event);
 }
 
 void menuCommandsCallback(int action, Common::String &text, void *data) {

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -490,11 +490,21 @@ WindowReference Gui::createInventoryWindow(ObjID objRef) {
 	WindowData newData;
 	GlobalSettings settings = _engine->getGlobalSettings();
 	if (!_objToInvRef.contains(objRef)) {
-		_objToInvRef[objRef] = (WindowReference)(_inventoryWindows.size() + kInventoryStart); // This is a HACK
-		newData.refcon = _objToInvRef[objRef];
-	} else {
-		newData.refcon = _objToInvRef[objRef];
+		WindowReference newRef = kInventoryStart;
+		bool taken = true;
+		while (taken) {
+			taken = false;
+			for (auto &invWindowData : _inventoryWindows) {
+				if (invWindowData.ref == newRef) {
+					taken = true;
+					newRef = (WindowReference)(newRef + 1);
+					break;
+				}
+			}
+		}
+		_objToInvRef[objRef] = newRef;
 	}
+	newData.refcon = _objToInvRef[objRef];
 
 	if (_windowData->back().refcon < 0x80) { // There is already another inventory window
 		newData.bounds = _windowData->back().bounds; // Inventory windows are always last
@@ -1231,11 +1241,11 @@ WindowData &Gui::findWindowData(WindowReference reference) {
 	assert(_windowData);
 
 	Common::List<WindowData>::iterator iter = _windowData->begin();
-	while (iter->refcon != reference && iter != _windowData->end()) {
+	while (iter != _windowData->end() && iter->refcon != reference) {
 		iter++;
 	}
 
-	if (iter->refcon == reference)
+	if (iter != _windowData->end())
 		return *iter;
 
 	error("GUI: Could not locate the desired window data");
@@ -1295,8 +1305,8 @@ WindowReference Gui::findObjWindow(ObjID objID) {
 		}
 	}
 
-	for (uint i = kInventoryStart; i < _inventoryWindows.size() + kInventoryStart; i++) {
-		const WindowData &data = getWindowData((WindowReference)i);
+	for (auto &invWindowData : _inventoryWindows) {
+		const WindowData &data = getWindowData(invWindowData.ref);
 		if (data.objRef == objID) {
 			return data.refcon;
 		}
@@ -1441,6 +1451,14 @@ void Gui::removeInventoryWindow(WindowReference ref) {
 	for (it = _windowData->begin(); it != _windowData->end(); it++) {
 		if (it->refcon == ref) {
 			_windowData->erase(it);
+			break;
+		}
+	}
+
+	Common::HashMap<ObjID, WindowReference>::iterator objIt;
+	for (objIt = _objToInvRef.begin(); objIt != _objToInvRef.end(); ++objIt) {
+		if (objIt->_value == ref) {
+			_objToInvRef.erase(objIt);
 			break;
 		}
 	}

--- a/engines/macventure/gui.h
+++ b/engines/macventure/gui.h
@@ -58,6 +58,7 @@ class ConsoleText;
 class CommandButton;
 class ImageAsset;
 class Dialog;
+struct InventoryCallbackStruct;
 
 BorderBounds borderBounds(MVWindowType type);
 Graphics::BorderOffsets borderOffsets(MVWindowType type);
@@ -209,6 +210,7 @@ private: // Attributes
 	struct InventoryWindowData {
 		Graphics::MacWindow *win;
 		WindowReference ref;
+		InventoryCallbackStruct *callbackData;
 	};
 	Common::Array<InventoryWindowData> _inventoryWindows;
 	Common::HashMap<ObjID, WindowReference> _objToInvRef;

--- a/engines/macventure/script.cpp
+++ b/engines/macventure/script.cpp
@@ -1147,7 +1147,8 @@ void ScriptEngine::opd8WIN(EngineState *state, EngineFrame *frame) {
 
 void ScriptEngine::opd9SLEEP(EngineState *state, EngineFrame *frame) {
 	int16 ticks = state->pop();
-	g_system->delayMillis((ticks / 60) * 1000);
+	if (ticks > 0)
+		g_system->delayMillis((ticks * 1000) / 60);
 	_engine->preparedToRun();
 }
 
@@ -1174,7 +1175,8 @@ void ScriptEngine::opdeUPSC(EngineState *state, EngineFrame *frame) {
 
 void ScriptEngine::opdfFMAI(EngineState *state, EngineFrame *frame) {
 	int16 ticks = state->pop();
-	g_system->delayMillis((ticks / 60) * 1000);
+	if (ticks > 0)
+		g_system->delayMillis((ticks * 1000) / 60);
 	_engine->revert();
 }
 


### PR DESCRIPTION
Script sleep opcodes truncate sub-second delays. The tick to millisecond conversion drops the fractional part, so short scripted delays become no delay at all and animations run too fast.

Inventory window references are assumed to be consecutive. They are handed out as the current window count and looked up by iterating that same count, so closing a window that is not the last one makes findObjWindow() ask for a reference that no longer exists, aborting with "Could not locate the desired window data".

Use-after-free in the inventory window callback. The callback deletes its own data on the close box click, but MacWindow invokes the callback several times per event and the window is only destroyed at the next removeMarked(), so it keeps dispatching through a dangling pointer. Random segfaults, depending on what the allocator reuses.

Zero sized / wrapped surface when dragging objects off the screen. Dragging an object to the screen edge produces a zero sized surface, whose base pointer is null, tripping an assertion in copyRectToScreen(); dragging it past the edge wraps the unsigned clamping into a huge allocation.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
