### PR TITLE
SCI32: Fix right-to-left text with inline style control codes

### DIFF
--- a/engines/sci/graphics/text32.cpp
+++ b/engines/sci/graphics/text32.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#include "common/array.h"
 #include "common/util.h"
 #include "common/stack.h"
 #include "common/unicode-bidi.h"
@@ -428,15 +429,10 @@ void GfxText32::drawText(const uint index, uint length) {
 	// implementation in SSCI, but is accurate. Primarily the changes revolve
 	// around eliminating some extra temporaries and fixing the logic to match.
 
-	Common::String textString;
-	const char *text;
-	if (!g_sci->isLanguageRTL()) {
-		text = _text.c_str() + index;
-	} else {
-		const char *textOrig = _text.c_str() + index;
-		Common::String textLogical = Common::String(textOrig, (uint32)length);
-		textString = Common::convertBiDiString(textLogical, g_sci->getLanguage(), Common::BiDiParagraph::BIDI_PAR_RTL);
-		text = textString.c_str();
+	const char *text = _text.c_str() + index;
+	if (g_sci->isLanguageRTL()) {
+		drawTextRTL(text, length);
+		return;
 	}
 
 	while (length-- > 0) {
@@ -463,6 +459,70 @@ void GfxText32::drawText(const uint index, uint length) {
 			drawChar(currentChar);
 		}
 	}
+}
+
+// The styles that the inline control codes give to a character
+struct TextStyle {
+	GuiResourceId fontId;
+	uint8 foreColor;
+};
+
+void GfxText32::drawTextRTL(const char *text, uint length) {
+	Common::String textLogical;
+	// The style each printable character is drawn in
+	Common::Array<TextStyle> styles;
+
+	TextStyle currentStyle;
+	currentStyle.fontId = _fontId;
+	currentStyle.foreColor = _foreColor;
+	// Alignment positions the line as a whole, so only its final value is used
+	TextAlign alignment = _alignment;
+
+	while (length-- > 0) {
+		const char currentChar = *text++;
+
+		if (currentChar == '|') {
+			char controlChar;
+			uint16 value;
+			// Leaves the loop rather than the function, so that the characters
+			// collected so far are still drawn below
+			if (!readStyleControl(text, length, controlChar, value)) {
+				break;
+			}
+
+			if (controlChar == 'a') {
+				alignment = (TextAlign)value;
+			} else if (controlChar == 'c') {
+				currentStyle.foreColor = value;
+			} else if (controlChar == 'f') {
+				currentStyle.fontId = value;
+			}
+		} else {
+			textLogical += currentChar;
+			styles.push_back(currentStyle);
+		}
+	}
+
+	// The only right-to-left language in SCI is Hebrew, see isLanguageRTL
+	assert(g_sci->getLanguage() == Common::HE_ISR);
+	const Common::CodePage codePage = Common::kWindows1255;
+	const Common::UnicodeBiDiText bidi(textLogical.decode(codePage), Common::BIDI_PAR_RTL);
+	const Common::String textVisual = bidi.visual.encode(codePage);
+
+	// Reordering separates the characters from the controls that styled them,
+	// so each one is drawn in the style its logical position gave it
+	for (uint i = 0; i < textVisual.size(); ++i) {
+		const TextStyle &style = styles[bidi.getLogicalPosition(i)];
+		setFont(style.fontId);
+		_foreColor = style.foreColor;
+		drawChar((byte)textVisual[i]);
+	}
+
+	// Leave behind the styles that were in effect at the logical end of the
+	// line, because that is where the next line carries on from
+	setFont(currentStyle.fontId);
+	_foreColor = currentStyle.foreColor;
+	_alignment = alignment;
 }
 
 void GfxText32::invertRect(const reg_t bitmapId, int16 bitmapStride, const Common::Rect &rect, const uint8 foreColor, const uint8 backColor, const bool doScaling) {

--- a/engines/sci/graphics/text32.cpp
+++ b/engines/sci/graphics/text32.cpp
@@ -378,6 +378,49 @@ void GfxText32::drawTextBox(const Common::String &text) {
 	drawTextBox();
 }
 
+// This internal function gets called as soon as a '|' is found in a text. It
+// will read the encountered code and its value, and forward the text past the
+// whole control code.
+// Returns false when the control code runs off the end of the text, in which
+// case the caller stops reading it.
+static bool readStyleControl(const char *&text, uint &length, char &controlChar, uint16 &value) {
+	controlChar = *text++;
+	--length;
+
+	if (length == 0) {
+		return false;
+	}
+
+	value = 0;
+	if (controlChar == 'a' || controlChar == 'c' || controlChar == 'f') {
+		while (length > 0) {
+			const char valueChar = *text;
+			if (valueChar < '0' || valueChar > '9') {
+				break;
+			}
+
+			++text;
+			--length;
+			value = 10 * value + (valueChar - '0');
+		}
+
+		if (length == 0) {
+			return false;
+		}
+	}
+
+	while (length > 0 && *text != '|') {
+		++text;
+		--length;
+	}
+	if (length > 0) {
+		++text;
+		--length;
+	}
+
+	return true;
+}
+
 void GfxText32::drawText(const uint index, uint length) {
 	assert(index + length <= _text.size());
 
@@ -403,47 +446,18 @@ void GfxText32::drawText(const uint index, uint length) {
 		}
 
 		if (currentChar == '|') {
-			const char controlChar = *text++;
-			--length;
-
-			if (length == 0) {
+			char controlChar;
+			uint16 value;
+			if (!readStyleControl(text, length, controlChar, value)) {
 				return;
 			}
 
-			if (controlChar == 'a' || controlChar == 'c' || controlChar == 'f') {
-				uint16 value = 0;
-
-				while (length > 0) {
-					const char valueChar = *text;
-					if (valueChar < '0' || valueChar > '9') {
-						break;
-					}
-
-					++text;
-					--length;
-					value = 10 * value + (valueChar - '0');
-				}
-
-				if (length == 0) {
-					return;
-				}
-
-				if (controlChar == 'a') {
-					_alignment = (TextAlign)value;
-				} else if (controlChar == 'c') {
-					_foreColor = value;
-				} else if (controlChar == 'f') {
-					setFont(value);
-				}
-			}
-
-			while (length > 0 && *text != '|') {
-				++text;
-				--length;
-			}
-			if (length > 0) {
-				++text;
-				--length;
+			if (controlChar == 'a') {
+				_alignment = (TextAlign)value;
+			} else if (controlChar == 'c') {
+				_foreColor = value;
+			} else if (controlChar == 'f') {
+				setFont(value);
 			}
 		} else {
 			drawChar(currentChar);

--- a/engines/sci/graphics/text32.h
+++ b/engines/sci/graphics/text32.h
@@ -122,6 +122,13 @@ private:
 	void drawText(const uint index, uint length);
 
 	/**
+	 * Draws text in a right-to-left language. Only the printable characters
+	 * take part in the bidirectional reordering; each is then drawn in the
+	 * style that its logical position gave it.
+	 */
+	void drawTextRTL(const char *text, uint length);
+
+	/**
 	 * Gets the length of the longest run of text available within the currently
 	 * loaded text, starting from the given `charIndex` and running for up to
 	 * `maxWidth` pixels. Returns the number of characters that can be written,


### PR DESCRIPTION
Two commits: the first moves `drawText()`'s control-code parsing into `readStyleControl()` with no functional change, so the right-to-left path can share it. The second commit is the fix.

SCI32 text interleaves printable characters with pipe-delimited style codes such as `|f70|`. The right-to-left path passed the whole line, codes included, to `Common::convertBiDiString()`, which reorders them along with the text; the draw loop then read the displaced codes as ordinary characters and painted them as glyphs. In the Hebrew fan translation of SQ6 this produced `font.70 glyph 102 drawn out of bounds` — glyph 102 being the 'f' of the control code itself.

`drawTextRTL()` separates the printable characters from the codes, resolves the codes into the font and colour each character is drawn in, and after reordering draws every character in the style its logical position selected.

Tested in SQ6 Hebrew and in SQ6 English.

Assisted-by: Claude:claude-opus-5
