### PR TITLE
CGE2: Fix missing dialogue text for bar crook

### DIFF
--- a/engines/cge2/vga13h.cpp
+++ b/engines/cge2/vga13h.cpp
@@ -562,7 +562,16 @@ void Sprite::step(int nr) {
 			seq = _ext->_seq + _seqPtr;
 			if (seq) {
 				if (seq->_dz == 127 && seq->_dx != 0) {
-					_vm->_commandHandlerTurbo->addCommand(kCmdSound, -1, 256 * seq->_dy + seq->_dx, this);
+					const int ref = 256 * seq->_dy + seq->_dx;
+
+					// 23MAGIK emits text 23:02 as a sound event embedded in an
+					// animation sequence row. Route it through kCmdSay so its text
+					// is shown. See bug #14678.
+					if (Common::String(_file).equalsIgnoreCase("23MAGIK") &&
+							ref == ((23 << 8) | 2))
+						_vm->_commandHandlerTurbo->addCommand(kCmdSay, -1, ref, this);
+					else
+						_vm->_commandHandlerTurbo->addCommand(kCmdSound, -1, ref, this);
 				} else {
 					p._x += seq->_dx;
 					p._y += seq->_dy;


### PR DESCRIPTION
When the bar crook speaks in the milk bar, his voice plays but the corresponding text is not displayed.

The line is triggered by this entry in `23MAGIK.SPR`:

```
5   -1    2  23  127    8  gada!
```

This resolves to reference `23:02`, used by both `23FX02.WAV` and the matching `CGE.SAY` text.

The event currently goes through `kCmdSound`, so the audio plays but the text is skipped. This fix sends only this specific `23MAGIK` event through `kCmdSay`, so the audio still plays and the matching text is displayed.

Other sequence sounds are unchanged.

Fixes bug [#14678](https://bugs.scummvm.org/ticket/14678).
