### PR TITLE
CGE2: Restore missing tailor text

### DIFF
--- a/engines/cge2/text.cpp
+++ b/engines/cge2/text.cpp
@@ -121,6 +121,11 @@ void Text::load() {
 }
 
 char *Text::getText(int ref) {
+	// Text 21:24 is missing from the game data, but its text 
+	// would be duplicative of 21:23. So, use that. See bug #14645.
+	if (ref == ((21 << 8) | 24))
+		ref = (21 << 8) | 23;
+
 	int i;
 	for (i = 0; (i < _size) && (_cache[i]._ref != ref); i++)
 		;


### PR DESCRIPTION
After the concert, talking to the tailor requests text reference `21:24`, which is missing from both the English and Polish game data. 

The workaround according to the bug reporter was to manually add the missing entry:

```
21:24=When will this break end?
21:24=Kiedy skonczy sie ta przerwa?
```

But multiple characters produce the same standard response (with different speech sfx), and the surrounding entries in the English `CGE.SAY` file are:

```
;21:21=Kiedy skonczy sie ta przerwa?
;21:22=Kiedy skonczy sie ta przerwa?
;21:23=Kiedy skonczy sie ta przerwa?
;21:25=No kiedy skonczy sie ta przerwa?
;21:29=No kiedy skonczy sie ta przerwa?
21:21=When will this break end?
21:22=When will this break end?
21:23=When will this break end?
21:25=When will this break end?
21:29=When will this break end?
```

Because `21:24` would duplicate the existing `21:23` line (and others) - hearing the speech sfx confirms it - this change simply maps requests for `21:24` to `21:23`.

The fix stays in the engine while the text still comes from the game data, so we don't need to also rig the CGE extraction utility from `scummvm-tools` to fabricate a `21:24` entry, somehow, for translators. If they did manually added one, the result will still work (same text).

This fixes bug [#14645](https://bugs.scummvm.org/ticket/14645). I didn't test this thoroughly, but I'll monitor the next daily build and fix any issue. Hopefully it'll stop looking like this:

<img width="887" height="637" alt="image" src="https://github.com/user-attachments/assets/5e1969ce-1773-44dd-b899-6eb8d63ccabf" />