### PR TITLE
DIRECTOR: Fix trail-sprite erasure and 0x0 digital-video sizing

### DIFF
--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -304,7 +304,8 @@ bool Channel::isDirty(Sprite *nextSprite) {
 		isDirtyFlag |= _sprite->_castId != nextSprite->_castId ||
 			_sprite->_ink != nextSprite->_ink || _sprite->_backColor != nextSprite->_backColor ||
 			_sprite->_foreColor != nextSprite->_foreColor ||
-			_sprite->_blendAmount != nextSprite->_blendAmount || _sprite->_thickness != nextSprite->_thickness;
+			_sprite->_blendAmount != nextSprite->_blendAmount ||
+			(_sprite->_thickness & kTThickness) != (nextSprite->_thickness & kTThickness);
 		if (!_sprite->_moveable)
 			isDirtyFlag |= _sprite->getPosition() != nextSprite->getPosition();
 		if (isStretched() && !hasTextCastMember(_sprite))

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -630,6 +630,14 @@ void Sprite::setCast(CastMemberID memberID, bool replaceDims) {
 			case kCastShape:
 			case kCastText:
 				break;
+			case kCastDigitalVideo:
+				// A video the score sizes to 0x0 is intentionally invisible (a
+				// hidden timing/audio clock); keep it, don't force native size.
+				if (_width > 0 && _height > 0) {
+					_width = dims.width();
+					_height = dims.height();
+				}
+				break;
 			case kCastBitmap:
 			default:
 				_width = dims.width();


### PR DESCRIPTION
Fix trail sprites erased by tween-flag dirtying

The channel dirty check compared the raw _thickness byte, so toggling only the tween bit (kTTweened) marked the channel dirty and triggered a stage erase that wiped un-owned trail residue. Masks to kTThickness so the tween flag alone no longer dirties the channel.

Keep 0x0 digital-video sprites invisible

setSpriteCasts() resets a non-stretched score sprite to its cast's dimensions; for a digital video this forced an intentionally 0x0 (invisible) sprite to the native movie size, drawing it where the score meant nothing. Skips the resize when the video sprite is 0x0.
