### PR TITLE
TWP: Expose subtitle options

### DIFF
--- a/engines/twp/twp.h
+++ b/engines/twp/twp.h
@@ -114,7 +114,8 @@ public:
 		return (f == kSupportsLoadingDuringRuntime) ||
 			   (f == kSupportsSavingDuringRuntime) ||
 			   (f == kSupportsReturnToLauncher) ||
-			   (f == kSupportsChangingOptionsDuringRuntime);
+			   (f == kSupportsChangingOptionsDuringRuntime) ||
+			   (f == kSupportsSubtitleOptions);
 	}
 
 	void updateSettingVars();


### PR DESCRIPTION
## Summary

Advertise subtitle option support for the Thimbleweed Park engine.

## Problem

The TWP engine already uses ScummVM's standard `subtitles` and `speech_mute` configuration values, but it does not report `kSupportsSubtitleOptions`.

As a result, the common ScummVM game options dialog does not show the speech and subtitle mode controls for Thimbleweed Park. Users currently need to edit `scummvm.ini` manually to enable subtitles.

## Change

Add `kSupportsSubtitleOptions` to `TwpEngine::hasFeature()`.

This makes the standard ScummVM audio options available for Thimbleweed Park without introducing a separate engine-specific setting.

## Testing

Tested with Thimbleweed Park GOG 1.0.958.

Before the change, the speech/subtitle mode controls were not displayed in the game options dialog.

After the change, the controls are displayed and selecting speech with subtitles correctly enables subtitles during gameplay.
