### PR TITLE
GRAPHICS: MACGUI: Fix invalid rectangle when drawing tall scrolled text

### DIFF
--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -922,8 +922,14 @@ void MacText::removeLastLine() {
 }
 
 void MacText::drawStep(ManagedSurface *g, ManagedSurface *src, ManagedSurface *border, int x, int y, int w, int h, int xoff, int yoff, uint32 tcolor, uint32 btcolor) {
-	if (x + w < src->w || y + h < src->h)
-		g->fillRect(Common::Rect(x + xoff, y + yoff, x + w + xoff, y + h + yoff), tcolor);
+	// The fill covers the destination area the blits below write to, so it has
+	// to be expressed in destination coordinates and clipped to the surface:
+	// Common::Rect is 16 bit and asserts in its constructor, before any clipping
+	int fillRight = MIN<int>(xoff + w, g->w);
+	int fillBottom = MIN<int>(yoff + h, g->h);
+
+	if ((x + w < src->w || y + h < src->h) && xoff < fillRight && yoff < fillBottom)
+		g->fillRect(Common::Rect(xoff, yoff, fillRight, fillBottom), tcolor);
 
 	// blit shadow surface first
 	if (_canvas._textShadow)
@@ -1042,7 +1048,7 @@ bool MacText::draw(bool forceRedraw) {
 	if (!(_contentIsDirty || forceRedraw))
 		return true;
 
-	draw(_composeSurface, 0, _scrollPos, _canvas._surface->w, _scrollPos + _canvas._surface->h, offset.x, offset.y);
+	draw(_composeSurface, 0, _scrollPos, _canvas._surface->w, _canvas._surface->h, offset.x, offset.y);
 
 	for (int bb = 0; bb < _shadow; bb++) {
 		_composeSurface->hLine(_shadow, _composeSurface->h - _shadow + bb, _composeSurface->w, 0);


### PR DESCRIPTION
The change in drawStep() does alter behaviour in one real case: for scrolled text the old rectangle lands outside the destination surface, so the fill effectively never happens, while it now clears the visible area before the blit — which looks like the original intent, but I have no Director games at hand to check the heaviest MacText user.

Also, MacTextCanvas::reallocSurface() grows _surface and _shadowSurface when the text gets taller, but never _charBoxMask / _glyphMask, so the masks drift out of sync with the canvas. That is what makes the fill condition true on the mask pass in my crash. I leave it alone, but it looks like a bug of its own.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

ATTENTION TO AI USERS:

EVERY WORD of your code, comments, commit log messages, PR description, must be re-read by a human and checked for sanity, correctness and common sense. At any sight of AI slop, including lengthy LLM-oriented explanations, your PR will be closed.

On top of that, we created AI-specific guidelines https://github.com/scummvm/scummvm/blob/master/AI-GUIDELINES.md

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not, please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

We require linear history, so no merge commits are allowed.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
