### PR TITLE
NANCY: move instead of copy surface

### DIFF
--- a/engines/nancy/action/puzzle/drivingpuzzle.cpp
+++ b/engines/nancy/action/puzzle/drivingpuzzle.cpp
@@ -324,7 +324,7 @@ int DrivingPuzzle::overlayImageIndex(const Common::String &name) {
 	}
 	surf.setTransparentColor(_drawSurface.getTransparentColor());
 
-	_overlayImages.push_back(surf);
+	_overlayImages.push_back(Common::move(surf));
 	_overlayImageNames.push_back(name);
 	return (int)_overlayImages.size() - 1;
 }


### PR DESCRIPTION
Move surface into array instead of copying to silence the `ManagedSurface` copy ctor deprecation warning.