### PR TITLE
Cryo eden dos

### DIFF
--- a/engines/cryo/cryo.cpp
+++ b/engines/cryo/cryo.cpp
@@ -30,6 +30,9 @@
 #include "engines/util.h"
 
 #include "cryo/cryo.h"
+#include "engines/advancedDetector.h"
+
+#include "cryo/detection.h"
 #include "cryo/eden.h"
 
 namespace Cryo {
@@ -71,6 +74,10 @@ Common::Error CryoEngine::run() {
 	_game->run();
 
 	return Common::kNoError;
+}
+
+bool CryoEngine::isMovieReel() const {
+	return (_gameDescription->flags & GF_MOVIE_REEL) != 0;
 }
 
 bool CryoEngine::hasFeature(EngineFeature f) const {

--- a/engines/cryo/cryo.h
+++ b/engines/cryo/cryo.h
@@ -75,13 +75,15 @@ public:
 
 	bool _showHotspots;
 
-	void pollEvents();
+	// Pump events after waiting delayMs. Callers with something to do sooner,
+	// like feeding a playing movie, pass a shorter wait
+	void pollEvents(uint32 delayMs = 10);
 
 	void hideMouse();
 	void showMouse();
 	void getMousePosition(int16 *x, int16 *y);
 	void setMousePosition(int16 x, int16 y);
-	bool isMouseButtonDown();
+	bool isMouseButtonDown(uint32 delayMs = 10);
 
 private:
 	int _mouseButton;

--- a/engines/cryo/cryo.h
+++ b/engines/cryo/cryo.h
@@ -63,6 +63,8 @@ public:
 	const char *getGameId() const;
 	Common::Platform getPlatform() const;
 	bool isDemo() const;
+	/** True for a release that is only a reel of movies, with no game data. */
+	bool isMovieReel() const;
 
 	// We need random numbers
 	Common::RandomSource *_rnd;

--- a/engines/cryo/cryolib.cpp
+++ b/engines/cryo/cryolib.cpp
@@ -263,8 +263,8 @@ void CLBlitter_FillScreenView(unsigned int fill) {
 
 ///// events wrapper
 
-void CryoEngine::pollEvents() {
-	g_system->delayMillis(10);
+void CryoEngine::pollEvents(uint32 delayMs) {
+	g_system->delayMillis(delayMs);
 
 	Common::Event event;
 	while (g_system->getEventManager()->pollEvent(event)) {
@@ -309,8 +309,8 @@ void CryoEngine::setMousePosition(int16 x, int16 y) {
 	g_system->warpMouse(x, y);
 }
 
-bool CryoEngine::isMouseButtonDown() {
-	pollEvents();
+bool CryoEngine::isMouseButtonDown(uint32 delayMs) {
+	pollEvents(delayMs);
 	return _mouseButton != 0;
 }
 

--- a/engines/cryo/debugger.cpp
+++ b/engines/cryo/debugger.cpp
@@ -28,6 +28,7 @@ Debugger::Debugger(CryoEngine *vm) : GUI::Debugger(), _vm(vm) {
 	registerCmd("showHotspots", WRAP_METHOD(Debugger, Cmd_ShowHotspots));
 	registerCmd("fullInventory", WRAP_METHOD(Debugger, Cmd_FullInventory));
 	registerCmd("phase", WRAP_METHOD(Debugger, Cmd_Phase));
+	registerCmd("playVideo", WRAP_METHOD(Debugger, Cmd_PlayVideo));
 }
 
 /**
@@ -79,5 +80,19 @@ bool Debugger::Cmd_Phase(int argc, const char **argv) {
 	            globals->_phaseNum, globals->_roomNum, globals->_roomNum);
 
 	return true;
+}
+
+/**
+ * Play a movie by number, the same way the game itself would.
+ */
+bool Debugger::Cmd_PlayVideo(int argc, const char **argv) {
+	if (argc != 2) {
+		debugPrintf("Usage: %s <num>\n", argv[0]);
+		return true;
+	}
+
+	_vm->_game->debugPlayVideo((int16)strtol(argv[1], nullptr, 0));
+
+	return false;
 }
 } // End of namespace Cryo

--- a/engines/cryo/debugger.cpp
+++ b/engines/cryo/debugger.cpp
@@ -27,6 +27,7 @@ namespace Cryo {
 Debugger::Debugger(CryoEngine *vm) : GUI::Debugger(), _vm(vm) {
 	registerCmd("showHotspots", WRAP_METHOD(Debugger, Cmd_ShowHotspots));
 	registerCmd("fullInventory", WRAP_METHOD(Debugger, Cmd_FullInventory));
+	registerCmd("phase", WRAP_METHOD(Debugger, Cmd_Phase));
 }
 
 /**
@@ -58,5 +59,25 @@ bool Debugger::Cmd_FullInventory(int argc, const char **argv) {
 	_vm->_game->showObjects();
 
 	return false;
+}
+
+/**
+ * Show or set the story phase. Dialog lines are gated on it, so a character
+ * with nothing to say is usually a phase that has not been reached yet.
+ */
+bool Debugger::Cmd_Phase(int argc, const char **argv) {
+	global_t *globals = _vm->_game->_globals;
+
+	if (argc == 2)
+		globals->_phaseNum = (int16)strtol(argv[1], nullptr, 0);
+	else if (argc != 1) {
+		debugPrintf("Usage: %s [phase]\n", argv[0]);
+		return true;
+	}
+
+	debugPrintf("phase %d (0x%X), room %d (0x%X)\n", globals->_phaseNum,
+	            globals->_phaseNum, globals->_roomNum, globals->_roomNum);
+
+	return true;
 }
 } // End of namespace Cryo

--- a/engines/cryo/debugger.h
+++ b/engines/cryo/debugger.h
@@ -41,6 +41,7 @@ protected:
 	bool Cmd_ShowHotspots(int argc, const char **argv);
 	bool Cmd_FullInventory(int argc, const char **argv);
 	bool Cmd_Phase(int argc, const char **argv);
+	bool Cmd_PlayVideo(int argc, const char **argv);
 };
 
 } // End of namespace Cryo

--- a/engines/cryo/debugger.h
+++ b/engines/cryo/debugger.h
@@ -40,6 +40,7 @@ public:
 protected:
 	bool Cmd_ShowHotspots(int argc, const char **argv);
 	bool Cmd_FullInventory(int argc, const char **argv);
+	bool Cmd_Phase(int argc, const char **argv);
 };
 
 } // End of namespace Cryo

--- a/engines/cryo/defs.h
+++ b/engines/cryo/defs.h
@@ -404,8 +404,12 @@ struct Follower {      // Characters on Mirror screen
 	int16       ex;
 	int16       ey;
 	int16       _spriteBank;
-	int16       ff_C;
-	int16       ff_E;
+	/**
+	 * The corner of the background to magnify when this character is being
+	 * spoken to, so that one background can stand behind several of them.
+	 */
+	int16       _zoomX;
+	int16       _zoomY;
 };
 
 struct Icon {

--- a/engines/cryo/defs.h
+++ b/engines/cryo/defs.h
@@ -33,6 +33,11 @@ namespace Cryo {
 
 #define FONT_HEIGHT 9
 
+// _gameLipsync holds the animation table followed by the lipsync data area
+#define LIPSYNC_ANIM_TABLE_SIZE 7260
+#define LIPSYNC_DATA_SIZE 1024
+#define LIPSYNC_BUFFER_SIZE (LIPSYNC_ANIM_TABLE_SIZE + LIPSYNC_DATA_SIZE)
+
 /*
 Glossary
   room      - a single game world's screen. referenced by 16-bit number 0xAALL, where AA - area# and LL - location#

--- a/engines/cryo/defs.h
+++ b/engines/cryo/defs.h
@@ -32,6 +32,8 @@ namespace Cryo {
 ///////////////// Game defs
 
 #define FONT_HEIGHT 9
+// The subtitle view is 60 rows tall, so at most 6 lines fit in it
+#define MAX_SUBTITLE_LINES 6
 
 // _gameLipsync holds the animation table followed by the lipsync data area
 #define LIPSYNC_ANIM_TABLE_SIZE 7260

--- a/engines/cryo/detection.cpp
+++ b/engines/cryo/detection.cpp
@@ -37,7 +37,7 @@ static const ADGameDescription gameDescriptions[] = {
 	// Probably not worth it
 	{
 		"losteden",
-		nullptr,
+		"Non-Interactive Demo",
 		AD_ENTRY1s("EDEN6.HSQ", "00b43c44cf2ac50b1a45dfad5fa5360d", 17093),
 		Common::EN_ANY,
 		Common::kPlatformDOS,
@@ -48,7 +48,7 @@ static const ADGameDescription gameDescriptions[] = {
 	// Lost Eden PC interactive demo version
 	{
 		"losteden",
-		nullptr,
+		"Interactive Demo",
 		AD_ENTRY1s("EDEN.DAT", nullptr, 205473728),
 		Common::EN_ANY,
 		Common::kPlatformDOS,
@@ -56,11 +56,11 @@ static const ADGameDescription gameDescriptions[] = {
 		GUIO1(GUIO_NOMIDI)
 	},
 
-	// Lost Eden PC version
+	// Lost Eden PC version, as sold by GOG
 	{
 		"losteden",
-		nullptr,
-		AD_ENTRY1s("EDEN.DAT", nullptr, 449853776),
+		"GOG release",
+		AD_ENTRY1s("EDEN.DAT", "020b3ad90320721e682445814b2581d3", 449853776),
 		Common::EN_ANY,
 		Common::kPlatformDOS,
 		ADGF_UNSTABLE,

--- a/engines/cryo/detection.cpp
+++ b/engines/cryo/detection.cpp
@@ -43,14 +43,14 @@ namespace Cryo {
 static const ADGameDescription gameDescriptions[] = {
 
 	// Lost Eden PC non-interactive demo version
-	// Probably not worth it
+	// No game data, only loose movies: the reel is all there is to run
 	{
 		"losteden",
 		"Non-Interactive Demo",
 		AD_ENTRY1s("EDEN6.HSQ", "00b43c44cf2ac50b1a45dfad5fa5360d", 17093),
 		Common::EN_ANY,
 		Common::kPlatformDOS,
-		ADGF_DEMO | ADGF_UNSTABLE,
+		ADGF_DEMO | ADGF_UNSTABLE | GF_MOVIE_REEL,
 		GUIO1(GUIO_NOMIDI)
 	},
 

--- a/engines/cryo/detection.cpp
+++ b/engines/cryo/detection.cpp
@@ -23,10 +23,19 @@
 
 #include "engines/advancedDetector.h"
 
+#include "cryo/detection.h"
 
 static const PlainGameDescriptor cryoGames[] = {
 	{"losteden", "Lost Eden"},
 	{nullptr, nullptr}
+};
+
+static const DebugChannelDef debugFlagList[] = {
+	{Cryo::kDebugResource, "resource", "What is read out of the game's own files"},
+	{Cryo::kDebugGraphics, "graphics", "Rooms, sprites and the pictures behind them"},
+	{Cryo::kDebugScript, "script", "Conditions, dialogs and the turns the game takes"},
+	{Cryo::kDebugMovie, "movie", "Movies and the subtitles which caption them"},
+	DEBUG_CHANNEL_END
 };
 
 namespace Cryo {
@@ -146,6 +155,10 @@ public:
 
 	const char *getOriginalCopyright() const override {
 		return "Cryo Engine (C) Cryo Interactive";
+	}
+
+	const DebugChannelDef *getDebugChannels() const override {
+		return debugFlagList;
 	}
 };
 

--- a/engines/cryo/detection.h
+++ b/engines/cryo/detection.h
@@ -33,6 +33,11 @@ enum CryoDebugChannels {
 	kDebugMovie			///< Movies and the subtitles which caption them
 };
 
+enum CryoGameFlags {
+	/** A release with no game data, only loose movies and a list to walk */
+	GF_MOVIE_REEL = (1 << 0)
+};
+
 } // End of namespace Cryo
 
 #endif

--- a/engines/cryo/detection.h
+++ b/engines/cryo/detection.h
@@ -1,0 +1,38 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CRYO_DETECTION_H
+#define CRYO_DETECTION_H
+
+#include "common/debug.h"
+
+namespace Cryo {
+
+enum CryoDebugChannels {
+	kDebugResource = 1,	///< What is read out of the game's own files
+	kDebugGraphics,		///< Rooms, sprites and the pictures behind them
+	kDebugScript,		///< Conditions, dialogs and the turns the game takes
+	kDebugMovie			///< Movies and the subtitles which caption them
+};
+
+} // End of namespace Cryo
+
+#endif

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -4408,12 +4408,15 @@ void EdenGame::FRDevents() {
 	if (_globals->_displayFlags & DisplayFlags::dfFrescoes) {
 		if (_frescoTalk)
 			_graphics->restoreUnderSubtitles();
-		if (_currCursor == 9 && !_torchCursor) {
+		// The torch is cursor 9 on the Macintosh but 15 on DOS, where 15 is also
+		// where the flute's icon sits in the main bank
+		const int16 torchCursor = (_vm->getPlatform() == Common::kPlatformMacintosh) ? 9 : 15;
+		if (_currCursor == torchCursor && !_torchCursor) {
 			_graphics->rundcurs();
 			_torchCursor = true;
 			_graphics->setGlowX(-1);
 		}
-		if (_currCursor != 9 && _torchCursor) {
+		if (_currCursor != torchCursor && _torchCursor) {
 			_graphics->unglow();
 			_torchCursor = false;
 			_cursorSaved = false;
@@ -7727,7 +7730,7 @@ void EdenGame::displayMappingLine(int16 r3, int16 r4, byte *target, byte *textur
 }
 
 // PC cursor
-CubeCursor _cursorsPC[9] = {
+CubeCursor _cursorsPC[10] = {
 		{ { 0, 0, 0, 0, 0, 0 }, 3, 2 },
 		{ { 1, 1, 0, 1, 1, 0 }, 2, -2 },
 		{ { 2, 2, 2, 2, 2, 2 }, 1, 2 },
@@ -7737,7 +7740,10 @@ CubeCursor _cursorsPC[9] = {
 		{ { 6, 6, 6, 6, 6, 6 }, 1, 2 },
 		{ { 7, 7, 7, 7, 7, 7 }, 1, -2 },
 //		{ { 0, 8, 0, 0, 8, 8 }, 2, 2 },
-		{ { 0, 8, 0, 0, 8, 8 }, 2, 2 }
+		{ { 0, 8, 0, 0, 8, 8 }, 2, 2 },
+		// The face drDrawFlag20 asks for, which the table stopped short of. Its
+		// texture is pale stone, and it turns at the rate cursor 0 does
+		{ { 9, 9, 9, 9, 9, 9 }, 3, 2 }
 };
 
 XYZ _cubePC[6][3] = {
@@ -8012,6 +8018,7 @@ void EdenGame::initCubePC() {
 }
 
 void EdenGame::selectPCMap(int16 num) {
+	num = CLIP<int16>(num, 0, ARRAYSIZE(_cursorsPC) - 1);
 	if (num != _cursCurPCMap) {
 		_pcCursor = &_cursorsPC[num];
 		unsigned char *bank = _mainBankBuf + READ_LE_UINT16(_mainBankBuf);

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -40,6 +40,7 @@
 #include "cryo/eden.h"
 #include "cryo/sound.h"
 #include "cryo/eden_graphics.h"
+#include "cryo/detection.h"
 
 namespace Cryo {
 
@@ -552,7 +553,7 @@ void EdenGame::deplaval(uint16 roomNum) {
 void EdenGame::move(Direction dir) {
 	Room *room = _globals->_roomPtr;
 	int16 roomNum = _globals->_roomNum;
-	debug("move: from room %4X", roomNum);
+	debugC(1, kDebugScript, "Moving out of room 0x%X", roomNum);
 	char newLoc = 0;
 	_graphics->rundcurs();
 	display();
@@ -923,7 +924,7 @@ void EdenGame::actionLookLake() {
 		_globals->_curAreaFlags |= AreaFlags::afFlag8;
 		room->_id = 3;
 	}
-	debug("sea monster: room = %X, d0 = %X\n", _globals->_roomNum, _globals->_roomImgBank);
+	debugC(1, kDebugScript, "Sea monster in room 0x%X, bank %d", _globals->_roomNum, _globals->_roomImgBank);
 	_graphics->hideBars();
 	_graphics->playHNM(vid);
 	updateRoom(_globals->_roomNum);           //TODO: getting memory trashed here?
@@ -1088,6 +1089,7 @@ void EdenGame::useBank(int16 bank) {
 
 	_bankData = _bankDataBuf;
 	if (_curBankNum != bank) {
+		debugC(2, kDebugGraphics, "Bank %d becomes the one in hand", bank);
 		loadRawFile(bank, _bankDataBuf);
 		verifh(_bankDataBuf);
 		_curBankNum = bank;
@@ -1980,7 +1982,9 @@ void EdenGame::loadCharacter(perso_t *perso) {
 		ptr += READ_LE_UINT16(ptr) - 2;
 		_globals->_persoSpritePtr = baseptr;
 		_globals->_persoSpritePtr2 = baseptr + READ_LE_UINT16(ptr);
-		debug("load perso: b6 len is %d", (int)(_globals->_persoSpritePtr2 - _globals->_persoSpritePtr));
+		debugC(2, kDebugResource, "Character %d loaded, %d bytes of sprite",
+	      _globals->_characterPtr ? (int)(_globals->_characterPtr - _persons) : -1,
+	      (int)(_globals->_persoSpritePtr2 - _globals->_persoSpritePtr));
 	} else {
 		useBank(_globals->_characterImageBank);
 		_characterBankData = _bankData;
@@ -2761,9 +2765,9 @@ void EdenGame::actionDino() {
 	_globals->_roomCharacterPowers = perso->_powers;
 	_globals->_characterPtr = perso;
 	initCharacterPointers(perso);
-	debug("beg dino talk");
+	debugC(1, kDebugScript, "Dinosaur %d begins to talk", _globals->_characterPtr ? (int)(_globals->_characterPtr - _persons) : -1);
 	parle_moi();
-	debug("end dino talk");
+	debugC(1, kDebugScript, "Dinosaur %d has finished talking", _globals->_characterPtr ? (int)(_globals->_characterPtr - _persons) : -1);
 	if (_globals->_areaNum == Areas::arWhiteArch)
 		return;
 	if (_globals->_var60)
@@ -3141,7 +3145,7 @@ void EdenGame::dialautooff() {
 
 void EdenGame::follow() {
 	if (_globals->_roomCharacterType == PersonFlags::pfType12) {
-		debug("follow: hiding person %d", (int)(_globals->_roomCharacterPtr - _persons));
+		debugC(1, kDebugScript, "Hiding character %d, who is following", (int)(_globals->_roomCharacterPtr - _persons));
 		_globals->_roomCharacterPtr->_flags |= PersonFlags::pf80;
 		_globals->_roomCharacterPtr->_roomNum = 0;
 		_globals->_gameFlags |= GameFlags::gfFlag8;
@@ -3915,7 +3919,7 @@ void EdenGame::getdino(Room *room) {
 
 // Original name: getsalle
 Room *EdenGame::getRoom(int16 loc) { //TODO: byte?
-	debug("get room for %X, starting from %d, looking for %X", loc, _globals->_areaPtr->_firstRoomIdx, _globals->_partyOutside);
+	debugC(2, kDebugScript, "Looking for location 0x%X from room %d, party outside 0x%X", loc, _globals->_areaPtr->_firstRoomIdx, _globals->_partyOutside);
 	Room *room = &_gameRooms[_globals->_areaPtr->_firstRoomIdx];
 	loc &= 0xFF;
 	for (;; room++) {
@@ -3926,7 +3930,7 @@ Room *EdenGame::getRoom(int16 loc) { //TODO: byte?
 		if (_globals->_partyOutside == room->_party || room->_party == 0xFFFF)
 			break;
 	}
-	debug("found room: party = %X, bank = %X", room->_party, room->_bank);
+	debugC(2, kDebugScript, "Found room %d: party 0x%X, bank %d, background %d", (int)(room - _gameRooms), room->_party, room->_bank, room->_backgroundBankNum);
 	_globals->_roomImgBank = room->_bank;
 	_globals->_labyrinthRoom = 0;
 	if (_globals->_roomImgBank > 104 && _globals->_roomImgBank <= 112)
@@ -4013,7 +4017,7 @@ void EdenGame::maj2() {
 void EdenGame::updateRoom1(int16 roomNum) {
 	Room *room = getRoom(roomNum & 0xFF);
 	_globals->_roomPtr = room;
-	debug("DrawRoom: room 0x%X, arg = 0x%X", _globals->_roomNum, roomNum);
+	debugC(1, kDebugGraphics, "Updating to room 0x%X, asked for 0x%X", _globals->_roomNum, roomNum);
 	_globals->_curRoomFlags = room->_flags;
 	_globals->_varF1 = room->_flags;
 	animpiece();
@@ -4684,7 +4688,7 @@ void EdenGame::mouse() {
 	                                    _cursorPosY + _cursCenter, _globals->_iconsIndex)))
 		return;
 	_curSpot2 = _currSpot;
-	debug("invoking mouse action %d", _currSpot->_actionId);
+	debugC(1, kDebugScript, "Mouse action %d in room 0x%X", _currSpot->_actionId, _globals->_roomNum);
 	if (mouse_actions[_currSpot->_actionId])
 		(this->*mouse_actions[_currSpot->_actionId])();
 }
@@ -5201,7 +5205,7 @@ void EdenGame::noclicpanel() {
 	}
 	byte num;
 	if (_curSpot2 >= &_gameIcons[119]) {
-		debug("noclic: objid = %p, glob3,2 = %2X %2X", (void *)_curSpot2, _globals->_menuItemIdHi, _globals->_menuItemIdLo);
+		debugC(2, kDebugScript, "Panel: spot %p, menu item %02X %02X", (void *)_curSpot2, _globals->_menuItemIdHi, _globals->_menuItemIdLo);
 		if (_curSpot2->_objectId == (uint16)((_globals->_menuItemIdLo + _globals->_menuItemIdHi) << 8)) //TODO: check me
 			return;
 	} else {
@@ -5223,7 +5227,7 @@ void EdenGame::noclicpanel() {
 skip:
 	;
 	_globals->_menuItemIdHi = (_curSpot2->_objectId & 0xFF00) >> 8;
-	debug("noclic: new glob3,2 = %2X %2X", _globals->_menuItemIdHi, _globals->_menuItemIdLo);
+	debugC(2, kDebugScript, "Panel: menu item now %02X %02X", _globals->_menuItemIdHi, _globals->_menuItemIdLo);
 	displayResult();
 	num &= 0xF0;
 	if (num != 0x30)
@@ -5883,7 +5887,7 @@ void EdenGame::perso_ici(int16 action) {
 
 // Original name: setpersohere
 void EdenGame::setCharacterHere() {
-	debug("setCharacterHere, perso is %d", (int)(_globals->_characterPtr - _persons));
+	debugC(2, kDebugScript, "Character %d is now in room 0x%X", (int)(_globals->_characterPtr - _persons), _globals->_roomNum);
 	_globals->_partyOutside = 0;
 	_globals->_party = 0;
 	_globals->_roomCharacterPtr = nullptr;
@@ -5909,7 +5913,7 @@ void EdenGame::faire_suivre(int16 roomNum) {
 
 // Original name: suis_moi5
 void EdenGame::AddCharacterToParty() {
-	debug("adding person %d to party", (int)(_globals->_characterPtr - _persons));
+	debugC(1, kDebugScript, "Character %d joins the party", (int)(_globals->_characterPtr - _persons));
 	_globals->_characterPtr->_flags |= PersonFlags::pfInParty;
 	_globals->_characterPtr->_roomNum = _globals->_roomNum;
 	_globals->_party |= _globals->_characterPtr->_partyMask;
@@ -5926,7 +5930,7 @@ void EdenGame::addToParty(int16 index) {
 
 // Original name: reste_ici5
 void EdenGame::removeCharacterFromParty() {
-	debug("removing person %d from party", (int)(_globals->_characterPtr - _persons));
+	debugC(1, kDebugScript, "Character %d leaves the party", (int)(_globals->_characterPtr - _persons));
 	_globals->_characterPtr->_flags &= ~PersonFlags::pfInParty;
 	_globals->_partyOutside |= _globals->_characterPtr->_partyMask;
 	_globals->_party &= ~_globals->_characterPtr->_partyMask;
@@ -6007,7 +6011,7 @@ void EdenGame::incPhase() {
 	};
 
 	_globals->_phaseNum++;
-	debug("!!! next phase - %4X , room %4X", _globals->_phaseNum, _globals->_roomNum);
+	debugC(1, kDebugScript, "Phase advances to 0x%X in room 0x%X", _globals->_phaseNum, _globals->_roomNum);
 	_globals->_phaseActionsCount = 0;
 	for (const phase_t *phase = phases; phase->_id != -1; phase++) {
 		if (_globals->_phaseNum == phase->_id) {
@@ -6178,7 +6182,7 @@ void EdenGame::bigphase1() {
 	};
 
 	int16 phase = (_globals->_phaseNum & ~3) + 0x10;   //TODO: check me
-	debug("!!! big phase - %4X", phase);
+	debugC(1, kDebugScript, "Phase set to 0x%X in room 0x%X", phase, _globals->_roomNum);
 	_globals->_phaseActionsCount = 0;
 	_globals->_phaseNum = phase;
 	if (phase > 560)
@@ -6896,7 +6900,7 @@ char EdenGame::testCondition(int16 index) {
 		} while (sp2 != sp);
 	}
 //	if (value)
-	debug("cond %d(-1) returns %s", index, value ? "TRUE" : "false");
+	debugC(3, kDebugScript, "Condition %d is %s", index, value ? "TRUE" : "false");
 //	if (index == 402) debug("(glob_61.b == %X) & (glob_12.w == %X) & (glob_4C.b == %X) & (glob_4E.b == %X)", p_global->eventType, p_global->phaseNum, p_global->worldTyrannSighted, p_global->ff_4E);
 	return value != 0;
 }

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -1821,7 +1821,7 @@ void EdenGame::animCharacter() {
 	}
 	if (_animateTalking) {
 		if (!_animationTable) {
-			_animationTable = _gameLipsync + 7262;    //TODO: fix me
+			_animationTable = _gameLipsync + LIPSYNC_ANIM_TABLE_SIZE + 2;
 			if (!_backgroundSaved) {
 				_graphics->saveMouthBackground();
 				_backgroundSaved = true;
@@ -4087,7 +4087,7 @@ void EdenGame::allocateBuffers() {
 	ALLOC(_mainBankBuf, 0x9400, byte);
 	ALLOC(_glowBuffer, 0x2800, byte);
 	ALLOC(_gameFont, 0x900, byte);
-	ALLOC(_gameLipsync, 0x205C, byte);
+	ALLOC(_gameLipsync, LIPSYNC_BUFFER_SIZE, byte);
 	ALLOC(_musicBuf, kMaxMusicSize, byte);
 #undef ALLOC
 }
@@ -4837,7 +4837,10 @@ void EdenGame::persovox() {
 	volumeLeft = _globals->_prefVoiceVol[0];
 	volumeRight = _globals->_prefVoiceVol[1];
 	_voiceChannel->setVolume(volumeLeft, volumeRight);
-	_voiceChannel->queueBuffer(_voiceSamplesBuffer, _voiceSamplesSize, true);
+	// A release which doesn't carry this line leaves nothing to play, but the
+	// line is still on screen to be read and clicked away
+	if (_voiceSamplesSize > 0)
+		_voiceChannel->queueBuffer(_voiceSamplesBuffer, _voiceSamplesSize, true);
 	_personTalking = true;
 	_musicFadeFlag = 0;
 	_lastAnimTicks = _vm->_timerTicks;

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -1967,8 +1967,9 @@ void EdenGame::loadCharacter(perso_t *perso) {
 		return;
 
 	if (perso->_spriteBank != _globals->_characterImageBank) {
-		_graphics->setCurCharRect(&_characterRects[perso->_id]); //TODO: array of int16?
-		dword_30728 = _characterArray[perso->_id];
+		// Both tables only cover the speaking characters, ids 0 to 18
+		_graphics->setCurCharRect(&_characterRects[MIN<int>(perso->_id, ARRAYSIZE(_characterRects) - 1)]);
+		dword_30728 = _characterArray[MIN<int>(perso->_id, ARRAYSIZE(_characterArray) - 1)];
 		ef_perso();
 		_globals->_characterImageBank = perso->_spriteBank;
 		useBank(_globals->_characterImageBank);
@@ -2253,8 +2254,11 @@ void EdenGame::getDataSync() {
 // Original name: ReadNombreFrames
 int16 EdenGame::readFrameNumber() {
 	int16 num = 0;
-	_animationTable = _gameLipsync + 7260 + 2;    //TODO: fix me
-	while (*_animationTable++ != 0xFF)
+	// Stop one byte short of the end: animCharacter() indexes the table with
+	// frame numbers up to and including the returned count
+	byte *end = _gameLipsync + LIPSYNC_BUFFER_SIZE - 1;
+	_animationTable = _gameLipsync + LIPSYNC_ANIM_TABLE_SIZE + 2;
+	while (_animationTable < end && *_animationTable++ != 0xFF)
 		num++;
 	return num;
 }
@@ -3423,13 +3427,19 @@ bool EdenGame::dial_scan(Dialog *dial) {
 	}
 
 	if (!skipFl) {
-		perso_t *perso;
-		for (perso = _persons; !(perso->_partyMask == mask && perso->_roomNum == _globals->_roomNum); perso++)
-			; //Find matching
+		perso_t *perso = _persons;
+		perso_t *lastPerso = &_persons[ARRAYSIZE(_persons)];
+		while (perso != lastPerso && !(perso->_partyMask == mask && perso->_roomNum == _globals->_roomNum))
+			perso++; //Find matching
 
-		_globals->_characterPtr = perso;
-		initCharacterPointers(perso);
-		no_perso();
+		// Leave the character in place rather than acting on what follows the
+		// array; the line still has to run, it may carry a phase change
+		if (perso != lastPerso) {
+			_globals->_characterPtr = perso;
+			initCharacterPointers(perso);
+			no_perso();
+		} else
+			warning("dial_scan: no person with mask %04X in room %04X", mask, _globals->_roomNum);
 	}
 
 	hidx = _globals->_dialogPtr->_textCondHiMask;
@@ -4950,7 +4960,6 @@ object_t *EdenGame::getObjectPtr(int16 id) {
 
 void EdenGame::countObjects() {
 	int16 index = 0;
-	byte total = 0;
 	for (int i = 0; i < MAX_OBJECTS; i++) {
 		int16 count = _objects[i]._count;
 		if (count == 0)
@@ -4959,13 +4968,10 @@ void EdenGame::countObjects() {
 		if (_objects[i]._flags & ObjectFlags::ofInHands)
 			count--;
 
-		if (count) {
-			total += count;
-			while (count--)
-				_ownObjects[index++] = _objects[i]._id;
-		}
+		while (count-- > 0 && index < ARRAYSIZE(_ownObjects))
+			_ownObjects[index++] = _objects[i]._id;
 	}
-	_globals->_objCount = total;
+	_globals->_objCount = (byte)index;
 }
 
 void EdenGame::showObjects() {
@@ -5956,7 +5962,7 @@ void EdenGame::perso_ici(int16 action) {
 
 // Original name: setpersohere
 void EdenGame::setCharacterHere() {
-	debugC(2, kDebugScript, "Character %d is now in room 0x%X", (int)(_globals->_characterPtr - _persons), _globals->_roomNum);
+	debugC(2, kDebugScript, "Character %d is now in room 0x%X", _globals->_characterPtr ? (int)(_globals->_characterPtr - _persons) : -1, _globals->_roomNum);
 	_globals->_partyOutside = 0;
 	_globals->_party = 0;
 	_globals->_roomCharacterPtr = nullptr;

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -44,6 +44,13 @@
 
 namespace Cryo {
 
+// Panel slots: icons 105-108 list the saves, 109-111 save into them. Sprites
+// 8 to 10 of the panel bank are the slot labels
+static const int16 kFirstLoadIcon = 105;
+static const int16 kFirstSaveIcon = 109;
+static const int16 kNumSaveSlots = 3;
+static const int16 kFirstSlotSprite = 8;
+
 #define Z_RESET -3400
 #define Z_STEP 200
 #define Z_UP 1
@@ -2294,53 +2301,84 @@ void EdenGame::my_bulle() {
 	int16 wordsOnLine = 0;
 	int16 wordWidth = 0;
 	int16 lineWidth = 0;
+	// A phrase can ask for a game variable to be spelled out mid-line
+	char number[8];
+	const char *numberPtr = nullptr;
 	byte c;
-	while ((c = *textPtr++) != 0xFF) {
-		if (c == 0x11 || c == 0x13) {
-			if (_globals->_phaseNum <= 272 || _globals->_phaseNum == 386) {
-				_globals->_eloiHaveNews = c & 0xF;
-				_globals->_var4D = _globals->_worldTyranSighted;
+	for (;;) {
+		if (numberPtr) {
+			c = *numberPtr++;
+			if (!c) {
+				numberPtr = nullptr;
+				continue;
 			}
-		} else if (c >= 0x80 && c < 0x90)
-			SysBeep(1);
-		else if (c >= 0x90 && c < 0xA0) {
-			while (*textPtr++ != 0xFF) {}
-			textPtr--;
-		} else if (c >= 0xA0 && c < 0xC0)
-			_globals->_textToken1 = c & 0xF;
-		else if (c >= 0xC0 && c < 0xD0)
-			_globals->_textToken2 = c & 0xF;
-		else if (c >= 0xD0 && c < 0xE0) {
-			byte c1 = *textPtr++;
-			if (c == 0xD2)
-#ifdef FAKE_DOS_VERSION
-				_globals->_textWidthLimit = c1 + 160;
-#else
-				_globals->_textWidthLimit = c1 + _subtitlesXCenter; // TODO: signed? 160 in pc ver
-#endif
-			else {
-				byte c2 = *textPtr++;
-				switch (_globals->_numGiveObjs) {
-				case 0:
-					_globals->_giveObj1 = c2;
-					break;
-				case 1:
-					_globals->_giveObj2 = c2;
-					break;
-				case 2:
-					_globals->_giveObj3 = c2;
-					break;
-				default:
-					break;
+		} else {
+			c = *textPtr++;
+			if (c == 0xFF)
+				break;
+
+			if (c == 0x11 || c == 0x13) {
+				if (_globals->_phaseNum <= 272 || _globals->_phaseNum == 386) {
+					_globals->_eloiHaveNews = c & 0xF;
+					_globals->_var4D = _globals->_worldTyranSighted;
 				}
-				_globals->_numGiveObjs++;
-				*icons++ = *textPtr++;
-				*icons++ = *textPtr++;
-				*icons++ = c2;
-			}
-		} else if (c >= 0xE0 && c < 0xFF)
-			SysBeep(1);
-		else if (c != '\r') {
+				continue;
+			} else if (c >= 0x80 && c < 0x90) {
+				SysBeep(1);
+				continue;
+			} else if (c == 0x91) {
+				// Spell out the byte variable named by the next byte, which is
+				// how the save and load lines number their slot
+				Common::sprintf_s(number, sizeof(number), "%d", getByteVar(*textPtr++));
+				numberPtr = number;
+				continue;
+			} else if (c >= 0x90 && c < 0xA0) {
+				while (*textPtr++ != 0xFF) {}
+				textPtr--;
+				continue;
+			} else if (c >= 0xA0 && c < 0xC0) {
+				_globals->_textToken1 = c & 0xF;
+				continue;
+			} else if (c >= 0xC0 && c < 0xD0) {
+				_globals->_textToken2 = c & 0xF;
+				continue;
+			} else if (c >= 0xD0 && c < 0xE0) {
+				byte c1 = *textPtr++;
+				if (c == 0xD2)
+#ifdef FAKE_DOS_VERSION
+					_globals->_textWidthLimit = c1 + 160;
+#else
+					_globals->_textWidthLimit = c1 + _subtitlesXCenter; // TODO: signed? 160 in pc ver
+#endif
+				else {
+					byte c2 = *textPtr++;
+					switch (_globals->_numGiveObjs) {
+					case 0:
+						_globals->_giveObj1 = c2;
+						break;
+					case 1:
+						_globals->_giveObj2 = c2;
+						break;
+					case 2:
+						_globals->_giveObj3 = c2;
+						break;
+					default:
+						break;
+					}
+					_globals->_numGiveObjs++;
+					*icons++ = *textPtr++;
+					*icons++ = *textPtr++;
+					*icons++ = c2;
+				}
+				continue;
+			} else if (c >= 0xE0 && c < 0xFF) {
+				SysBeep(1);
+				continue;
+			} else if (c == '\r')
+				continue;
+		}
+
+		{
 			*sentencePtr++ = c;
 			byte width = _gameFont[c];
 #ifdef FAKE_DOS_VERSION
@@ -5209,10 +5247,18 @@ void EdenGame::noclicpanel() {
 		if (_curSpot2->_objectId == (uint16)((_globals->_menuItemIdLo + _globals->_menuItemIdHi) << 8)) //TODO: check me
 			return;
 	} else {
-		int idx = _curSpot2 - &_gameIcons[105];
-		if (idx == 0) {
-			_globals->_menuItemIdLo = 1;
-			num = 1;
+		int idx = _curSpot2 - &_gameIcons[kFirstLoadIcon];
+		if (idx >= 0 && idx < kNumSaveSlots) {
+			// The dialog has a line per area and picks between them on the area
+			// number left here, so give it the saved game's, not the running one's
+			byte areaNum = getSaveAreaNum(idx);
+			if (!areaNum)
+				return;
+			num = idx + 1;
+			if (num == _globals->_var43)
+				return;
+			_globals->_var43 = num;
+			_globals->_menuItemIdLo = areaNum;
 			goto skip;
 		}
 		num = (idx & 0x7F) + 1;
@@ -5220,7 +5266,8 @@ void EdenGame::noclicpanel() {
 			num = 1;
 		if (num == _globals->_var43)
 			return;
-		_globals->_var43 = 0;
+		// The panel's save and load lines name their slot by spelling this out
+		_globals->_var43 = num;
 	}
 	num = _globals->_menuItemIdLo;
 	_globals->_menuItemIdLo = _curSpot2->_objectId & 0xFF;
@@ -5290,17 +5337,17 @@ void EdenGame::testvoice() {
 
 void EdenGame::load() {
 	char name[132];
+	int16 slot = _curSpot2 - &_gameIcons[kFirstLoadIcon];
+	if (slot < 0 || slot >= kNumSaveSlots)
+		return;
+
 	_gameLoaded = false;
 	byte oldMusic = _globals->_currMusicNum;   //TODO: from uint16 to byte?!
 	fademusica0(1);
 	desktopcolors();
 	FlushEvents(-1, 0);
-//	if(OpenDialog(0, 0)) //TODO: write me
-	{
-		// TODO
-		Common::strcpy_s(name, "edsave1.000");
-		loadgame(name);
-	}
+	getSaveStateName(name, sizeof(name), slot);
+	loadgame(name);
 	_vm->hideMouse();
 	CLBlitter_FillScreenView(0xFFFFFFFF);
 	_graphics->fadeToBlack(3);
@@ -5327,6 +5374,10 @@ void EdenGame::load() {
 	drawTopScreen();
 	_globals->_inventoryScrollPos = 0;
 	showObjects();
+	// updateRoom() blacks out the main view and slides the bars back in from
+	// the backup view, so put them there too, as starting a game does
+	saveFriezes();
+	_graphics->setShowBlackBars(true);
 	updateRoom(_globals->_roomNum);
 	if (talk) {
 		_globals->_iconsIndex = 4;
@@ -5362,13 +5413,16 @@ void EdenGame::initafterload() {
 
 void EdenGame::save() {
 	char name[260];
+	int16 slot = _curSpot2 - &_gameIcons[kFirstSaveIcon];
+	if (slot < 0 || slot >= kNumSaveSlots)
+		return;
+
 	fademusica0(1);
 	desktopcolors();
 	FlushEvents(-1, 0);
-	//SaveDialog(byte_37150, byte_37196->ff_A);
-	//TODO
-	Common::strcpy_s(name, "edsave1.000");
+	getSaveStateName(name, sizeof(name), slot);
 	saveGame(name);
+	displaySaveSlots();
 	_vm->hideMouse();
 	CLBlitter_FillScreenView(0xFFFFFFFF);
 	_graphics->fadeToBlack(3);
@@ -5661,6 +5715,7 @@ void EdenGame::clickTapeCursor() {
 void EdenGame::displayPanel() {
 	useBank(65);
 	_graphics->drawSprite(0, 0, 16);
+	displaySaveSlots();
 	_graphics->paneltobuf();
 	displayLanguage();
 	displayCursors();
@@ -6414,6 +6469,45 @@ void EdenGame::phase544() {
 void EdenGame::phase560() {
 	_persons[PER_ELOI]._roomNum = 3073;
 	_gameRooms[127]._exits[1] = 0;
+}
+
+void EdenGame::getSaveStateName(char *dest, int size, int16 slot) {
+	Common::sprintf_s(dest, size, "edsave1.%03d", slot);
+}
+
+// The area number is the first thing syncGlobalValues() writes, and
+// syncGlobalPointers() puts thirteen indices in front of it.
+static const int32 kSaveAreaNumOffset = 13 * 4;
+
+// Which of the twelve areas a saved game was made in, without loading it
+byte EdenGame::getSaveAreaNum(int16 slot) {
+	char name[32];
+	getSaveStateName(name, sizeof(name), slot);
+
+	Common::InSaveFile *fh = g_system->getSavefileManager()->openForLoading(name);
+	if (!fh)
+		return 0;
+
+	byte areaNum = 0;
+	if (fh->seek(kSaveAreaNumOffset, SEEK_SET))
+		areaNum = fh->readByte();
+	delete fh;
+
+	return areaNum;
+}
+
+// Label the existing saves in the panel's load box, which is empty artwork
+void EdenGame::displaySaveSlots() {
+	char name[32];
+	useBank(65);
+	for (int16 slot = 0; slot < kNumSaveSlots; slot++) {
+		getSaveStateName(name, sizeof(name), slot);
+		if (!g_system->getSavefileManager()->exists(name))
+			continue;
+
+		Icon *icon = &_gameIcons[kFirstLoadIcon + slot];
+		_graphics->drawSprite(kFirstSlotSprite + slot, icon->sx, icon->sy);
+	}
 }
 
 void EdenGame::saveGame(char *name) {

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -7007,7 +7007,12 @@ char EdenGame::testCondition(int16 index) {
 				uint16 value2 = fetchValue();
 				value = operation(op, value, value2);
 			} else {
-				assert(sp < stack + 32);
+				// Each pass pushes a value and an operator, and the reduction
+				// below pushes a final value
+				if (sp + 3 > stack + ARRAYSIZE(stack)) {
+					warning("testCondition: condition stack overflow");
+					return false;
+				}
 				*sp++ = value;
 				*sp++ = op;
 				break;
@@ -7164,7 +7169,8 @@ uint8 EdenGame::getByteVar(uint16 offset) {
 		VAR(0x6E, _labyrinthDirections);
 		VAR(0x6F, _labyrinthRoom);
 	default:
-		error("Undefined byte variable access (0x%X)", offset);
+		warning("Undefined byte variable access (0x%X)", offset);
+		break;
 	}
 	return 0;
 }
@@ -7203,7 +7209,8 @@ uint16 EdenGame::getWordVar(uint16 offset) {
 		VAR(0x3E, _morkusSpyVideoNum3); //TODO: pad?
 		VAR(0x40, _morkusSpyVideoNum4); //TODO: pad?
 	default:
-		error("Undefined word variable access (0x%X)", offset);
+		warning("Undefined word variable access (0x%X)", offset);
+		break;
 	}
 	return 0;
 }

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -4275,6 +4275,8 @@ void EdenGame::edmain() {
 			}
 		}
 		_graphics->rundcurs();
+		// A room which keeps its picture in a movie goes on showing it
+		_graphics->stepRoomVideo();
 		musicspy();
 		FRDevents();
 		handleNarrator();

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -4144,6 +4144,27 @@ void EdenGame::debugPlayVideo(int16 num) {
 	_graphics->playHNM(num);
 }
 
+// DEMO.EXE plays a subset of these and HNM.BAT hands the whole set to an
+// external viewer; together they come to this list. DINOLA1, which DEMO.EXE
+// also names, is not on the disc
+static const char *const kMovieReel[] = {
+	"ANCIBUR2.HNM", "CEMETER2.HNM", "CRYO.HNM",     "CRYO2.HNM",
+	"DINOINT1.HNM", "DINOINT2.HNM", "DINOINT3.HNM", "DINOINT4.HNM",
+	"FORETVOL.HNM", "GEOL2.HNM",    "GRANPRAI.HNM", "MARAIVOL.HNM",
+	"PAYSAGE.HNM",  "PTEROCI2.HNM", "PTEROCIT.HNM", "ROI.HNM",
+	"SOHTIL1.HNM",  "SROI2.HNM",    "TYRACHAS.HNM", "VIL2INT5.HNM",
+	"VILOPTER.HNM", "VIRGIN.HNM"
+};
+
+void EdenGame::playMovieReel() {
+	for (int i = 0; i < ARRAYSIZE(kMovieReel) && !_vm->shouldQuit(); i++) {
+		if (!_graphics->playMovieFile(kMovieReel[i])) {
+			// Many are packed with a scheme the decoder does not cover yet
+			debugC(1, kDebugMovie, "Skipped %s of the reel", kMovieReel[i]);
+		}
+	}
+}
+
 void EdenGame::run() {
 	_invIconsCount = (_vm->getPlatform() == Common::kPlatformMacintosh) ? 9 : 11;
 	_roomIconsBase = _invIconsBase + _invIconsCount;
@@ -4157,11 +4178,18 @@ void EdenGame::run() {
 	_graphics->setSavedUnderSubtitles(false);
 
 	allocateBuffers();
-	openbigfile();
-	_graphics->openWindow();
-	loadpermfiles();
 
-	if (!_bufferAllocationErrorFl) {
+	// A reel of movies has no resource file to open and no game to set up
+	bool movieReel = _vm->isMovieReel();
+	if (!movieReel)
+		openbigfile();
+	_graphics->openWindow();
+	if (!movieReel)
+		loadpermfiles();
+
+	if (movieReel) {
+		playMovieReel();
+	} else if (!_bufferAllocationErrorFl) {
 		LostEdenMac_InitPrefs();
 		if (_vm->getPlatform() == Common::kPlatformMacintosh)
 			initCubeMac();

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -6293,7 +6293,7 @@ void EdenGame::bigphase1() {
 		&EdenGame::phase560
 	};
 
-	int16 phase = (_globals->_phaseNum & ~3) + 0x10;   //TODO: check me
+	int16 phase = (_globals->_phaseNum & ~0xF) + 0x10;
 	debugC(1, kDebugScript, "Phase set to 0x%X in room 0x%X", phase, _globals->_roomNum);
 	_globals->_phaseActionsCount = 0;
 	_globals->_phaseNum = phase;

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -151,6 +151,7 @@ EdenGame::EdenGame(CryoEngine *vm) : _vm(vm), kMaxMusicSize(2200000) {
 	_rotationAngleY = _rotationAngleX = _rotationAngleZ = 0;
 	_translationY = _translationX = 0.0;	//TODO: never changed, make consts?
 	_cursorOldTick = 0;
+	_cubeStepDelay = 0;
 
 	_invIconsBase = 19;
 //	invIconsCount = (_vm->getPlatform() == Common::kPlatformMacintosh) ? 9 : 11;
@@ -8036,10 +8037,16 @@ void EdenGame::enginePC() {
 	if (_normalCursor && (_globals->_drawFlags & DrawFlags::drDrawFlag20))
 		curs = 9;
 	selectPCMap(curs);
-	_cursorNewTick = g_system->getMillis();
-	if (_cursorNewTick - _cursorOldTick < 1)
+
+	// This cube counts 72 angles to the turn taken two at a time, so a step
+	// covers ten degrees where the Macintosh one covers two. Let three passes
+	// go by between steps, still drawing so it does not blink out
+	if (++_cubeStepDelay < 4) {
+		renderCube();
 		return;
-	_cursorOldTick = _cursorNewTick;
+	}
+	_cubeStepDelay = 0;
+
 	int step = _pcCursor->_speed;
 	switch (_pcCursor->_kind) {
 	case 0:

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -6472,7 +6472,9 @@ void EdenGame::phase560() {
 }
 
 void EdenGame::getSaveStateName(char *dest, int size, int16 slot) {
-	Common::sprintf_s(dest, size, "edsave1.%03d", slot);
+	// Scoped to the target: the releases number their conditions differently,
+	// so a save read by another release picks its dialog lines by the wrong ones
+	Common::sprintf_s(dest, size, "%s.%03d", ConfMan.getActiveDomainName().c_str(), slot);
 }
 
 // The area number is the first thing syncGlobalValues() writes, and

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -1374,7 +1374,9 @@ void EdenGame::newCitadel(char area, int16 level, Room *room) {
 	while (cita->_id < level)
 		cita++;
 
-	uint16 index = ((room->_flags & 0xC0) >> 6);    //TODO: this is very wrong
+	// The two top flag bits choose a pair of entries, of which areas 4 and 6
+	// take the second, so they come down five places and not six
+	uint16 index = ((room->_flags & 0xC0) >> 5);
 	if (area == 4 || area == 6)
 		index++;
 

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -136,6 +136,7 @@ EdenGame::EdenGame(CryoEngine *vm) : _vm(vm), kMaxMusicSize(2200000) {
 	byte_31D64 = false;
 	_noPalette = false;
 	_gameLoaded = false;
+	_startupSaveSlot = ConfMan.hasKey("save_slot") ? ConfMan.getInt("save_slot") : -1;
 	memset(_tapes, 0, sizeof(_tapes));
 	_confirmMode = 0;
 	_curSliderValuePtr = nullptr;
@@ -4151,6 +4152,13 @@ void EdenGame::run() {
 			_normalCursor = true;
 			_torchCursor = false;
 			_graphics->setCursKeepPos(-1,-1);
+			// Stands in for the intro, and has to be read after initGlobals()
+			// which wipes what it puts in place. Consumed once, so finishing the
+			// game starts the next one from the beginning
+			if (_startupSaveSlot >= 0) {
+				loadGameFromSlot(_startupSaveSlot);
+				_startupSaveSlot = -1;
+			}
 			if (!_gameLoaded)
 				intro();
 			edmain();
@@ -6475,6 +6483,28 @@ void EdenGame::getSaveStateName(char *dest, int size, int16 slot) {
 	// Scoped to the target: the releases number their conditions differently,
 	// so a save read by another release picks its dialog lines by the wrong ones
 	Common::sprintf_s(dest, size, "%s.%03d", ConfMan.getActiveDomainName().c_str(), slot);
+}
+
+/**
+ * Read a saved game in by slot, for --save-slot on the command line. The
+ * panel's load line does a good deal more, but only because it has a game
+ * running to fade out of and back into; here there is none yet, and enterGame()
+ * goes on to start the loaded one.
+ */
+bool EdenGame::loadGameFromSlot(int16 slot) {
+	// Bounded by what is on disc, not by the four slots the panel lists
+	if (slot < 0) {
+		warning("There is no saved game %d", slot);
+		return false;
+	}
+
+	char name[132];
+	getSaveStateName(name, sizeof(name), slot);
+	loadgame(name);
+	if (!_gameLoaded)
+		warning("Could not read saved game %s", name);
+
+	return _gameLoaded;
 }
 
 // The area number is the first thing syncGlobalValues() writes, and

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -3532,7 +3532,10 @@ void EdenGame::chronoEvent() {
 	addTime(5);
 	if (!(_globals->_chronoFlag & 1))
 		return;
-	_globals->_chrono -= 200;
+	if (_globals->_chrono >= 200)
+		_globals->_chrono -= 200;
+	else
+		_globals->_chrono = 0;
 	if (_globals->_chrono == 0)
 		_globals->_chronoFlag |= 2;
 	if (!(_globals->_chronoFlag & 2))
@@ -7177,7 +7180,8 @@ uint8 EdenGame::getByteVar(uint16 offset) {
 
 uint16 EdenGame::getWordVar(uint16 offset) {
 	switch (offset) {
-		VAR(4, _randomNumber);   //TODO: this is randomized in pc ver and used by some conds. always zero on mac
+	case 4:
+		return _vm->_rnd->getRandomNumber(0xFFFF);
 		VAR(6, _gameTime);
 		VAR(8, _gameDays);
 		VAR(0xA, _chrono);

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -126,6 +126,7 @@ EdenGame::EdenGame(CryoEngine *vm) : _vm(vm), kMaxMusicSize(2200000) {
 	_normalCursor = false;
 	_specialTextMode = false;
 	_voiceSamplesSize = 0;
+	_voiceSampleRate = 11025;
 	_animateTalking = false;
 	_personTalking = false;
 	_musicFadeFlag = 0;
@@ -4846,8 +4847,9 @@ void EdenGame::startmusique(byte num) {
 	_musicSamplesPtr = _musicBuf + 32 + 4 + pat_size;
 	int16 freq = READ_LE_UINT16(_musicSamplesPtr - 2);
 
+	// The rate is given as the divisor the DOS driver loaded its timer with
 	delete _musicChannel;
-	_musicChannel = new CSoundChannel(_vm->_mixer, freq == 166 ? 11025 : 22050, false);
+	_musicChannel = new CSoundChannel(_vm->_mixer, 1000000 / (256 - (freq & 0xFF)), false);
 	_musicEnabledFlag = true;
 
 	_musicSequencePos = 0;
@@ -4900,11 +4902,18 @@ void EdenGame::persovox() {
 	} while (_musicChannel->_volumeLeft != volumeLeft || _musicChannel->_volumeRight != volumeRight);
 	volumeLeft = _globals->_prefVoiceVol[0];
 	volumeRight = _globals->_prefVoiceVol[1];
+	debugC(1, kDebugResource, "Voice: phrase %d, %d bytes queued at %d Hz, %d ms",
+	       _globals->_textNum, _voiceSamplesSize, _voiceSampleRate,
+	       _voiceSamplesSize * 1000 / _voiceSampleRate);
 	_voiceChannel->setVolume(volumeLeft, volumeRight);
 	// A release which doesn't carry this line leaves nothing to play, but the
 	// line is still on screen to be read and clicked away
-	if (_voiceSamplesSize > 0)
+	if (_voiceSamplesSize > 0) {
+		// The voices were not all taken at the one rate: most stand at 11111 Hz
+		// but the dinosaurs speak at 10869
+		_voiceChannel->setSampleRate(_voiceSampleRate);
 		_voiceChannel->queueBuffer(_voiceSamplesBuffer, _voiceSamplesSize, true);
+	}
 	_personTalking = true;
 	_musicFadeFlag = 0;
 	_lastAnimTicks = _vm->_timerTicks;
@@ -4943,6 +4952,7 @@ perso_t *EdenGame::personSubtitles() {
 void EdenGame::endCharacterSpeech() {
 	_graphics->restoreUnderSubtitles();
 	if (_personTalking) {
+		debugC(1, kDebugResource, "Voice stopped with %d buffers still queued", _voiceChannel->numQueued());
 		_voiceChannel->stop();
 		_personTalking = false;
 		_musicFadeFlag = 3;

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -2394,27 +2394,32 @@ void EdenGame::my_bulle() {
 			lineWidth += width;
 			int16 overrun = lineWidth - _globals->_textWidthLimit;
 			if (overrun > 0) {
-				_numTextLines++;
-				if (c != ' ') {
-					*linesp++ = wordsOnLine;
-					*linesp++ = wordWidth + _spaceWidth - overrun;
+				if (_numTextLines < MAX_SUBTITLE_LINES) {
+					_numTextLines++;
+					if (c != ' ') {
+						*linesp++ = wordsOnLine;
+						*linesp++ = wordWidth + _spaceWidth - overrun;
+						lineWidth = wordWidth;
+					} else {
+						*linesp++ = wordsOnLine + 1;
+						*linesp++ = _spaceWidth - overrun;
+						lineWidth = 0;
+					}
+				} else if (c != ' ')
 					lineWidth = wordWidth;
-				} else {
-					*linesp++ = wordsOnLine + 1;
-					*linesp++ = _spaceWidth - overrun;   //TODO: checkme
+				else
 					lineWidth = 0;
-				}
 				wordWidth = 0;
 				wordsOnLine = 0;
-			} else {
-				if (c == ' ') {
-					wordsOnLine++;
-					wordWidth = 0;
-				}
+			} else if (c == ' ') {
+				wordsOnLine++;
+				wordWidth = 0;
 			}
 		}
 	}
 	_numTextLines++;
+	if (_numTextLines > MAX_SUBTITLE_LINES)
+		_numTextLines = MAX_SUBTITLE_LINES;
 	*linesp++ = wordsOnLine + 1;
 	*linesp++ = wordWidth;
 	*sentencePtr = c;
@@ -2458,7 +2463,7 @@ void EdenGame::my_pr_bulle() {
 	textout = _graphics->getSubtitlesViewBuf();
 	byte *textPtr = _sentenceBuffer;
 	int16 lines = 1;
-	while (!done) {
+	while (!done && lines <= MAX_SUBTITLE_LINES) {
 		int16 numWords = *coo++;       // num words on line
 		int16 padSize = *coo++;        // amount of extra spacing
 		byte *currOut = textout;

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -2078,6 +2078,9 @@ void EdenGame::displayBackgroundFollower() {
 				bank = 327;
 			useBank(bank + _globals->_roomBackgroundBankNum);
 			_graphics->drawSprite(0, 0, 16, true);
+			// One background stands behind several characters, each against a
+			// corner of its own, blown up to fill the picture
+			_graphics->zoomBackground(follower->_zoomX, follower->_zoomY);
 			break;
 		}
 	}
@@ -6668,8 +6671,8 @@ void EdenGame::syncGame(Common::Serializer s) {
 	s.syncAsSint16LE(_followerList[13].ex);
 	s.syncAsSint16LE(_followerList[13].ey);
 	s.syncAsSint16LE(_followerList[13]._spriteBank);
-	s.syncAsSint16LE(_followerList[13].ff_C);
-	s.syncAsSint16LE(_followerList[13].ff_E);
+	s.syncAsSint16LE(_followerList[13]._zoomX);
+	s.syncAsSint16LE(_followerList[13]._zoomY);
 
 	// _persons
 	for (int i = 0; i < 58; i++) {

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -4140,6 +4140,10 @@ void EdenGame::stopMusic() {
 	_musicChannel->stop();
 }
 
+void EdenGame::debugPlayVideo(int16 num) {
+	_graphics->playHNM(num);
+}
+
 void EdenGame::run() {
 	_invIconsCount = (_vm->getPlatform() == Common::kPlatformMacintosh) ? 9 : 11;
 	_roomIconsBase = _invIconsBase + _invIconsCount;

--- a/engines/cryo/eden.cpp
+++ b/engines/cryo/eden.cpp
@@ -1039,10 +1039,16 @@ void EdenGame::display() {
 		}
 		CLBlitter_CopyView2Screen(_graphics->getMainView());
 	} else {
-		if (_globals->_mirrorEffect)
+		if (_globals->_mirrorEffect) {
+			// The number chooses a transition in the DOS release, of which 6, 16
+			// and 20 are used; this follows the Macintosh release and fades
+			debugC(1, kDebugGraphics, "Transition %d into room 0x%X, which the fade stands in for",
+			       _globals->_mirrorEffect, _globals->_roomNum);
 			_graphics->displayEffect3();
-		else
+		} else {
+			debugC(1, kDebugGraphics, "Transition of the mirror, %d", _globals->_var103);
 			_graphics->displayEffect2();
+		}
 
 		_globals->_var103 = 0;
 		_globals->_mirrorEffect = 0;

--- a/engines/cryo/eden.h
+++ b/engines/cryo/eden.h
@@ -482,6 +482,9 @@ private:
 	void phase528();
 	void phase544();
 	void phase560();
+	void getSaveStateName(char *dest, int size, int16 slot);
+	byte getSaveAreaNum(int16 slot);
+	void displaySaveSlots();
 	void saveGame(char *name);
 	void loadrestart();
 	void loadgame(char *name);

--- a/engines/cryo/eden.h
+++ b/engines/cryo/eden.h
@@ -668,6 +668,9 @@ private:
 
 	bool  _specialTextMode;
 	int   _voiceSamplesSize;   //TODO: perso vox sample data len
+	/** The rate the voice now in the buffer was taken at, which is not the same
+	    for every one of them */
+	int   _voiceSampleRate;
 	int16 _musicRightVol;
 	int16 _musicLeftVol;
 

--- a/engines/cryo/eden.h
+++ b/engines/cryo/eden.h
@@ -51,6 +51,7 @@ public:
 	~EdenGame();
 
 	void run();
+	void playMovieReel();
 	void debugPlayVideo(int16 num);
 	object_t *getObjectPtr(int16 id);
 	void showObjects();

--- a/engines/cryo/eden.h
+++ b/engines/cryo/eden.h
@@ -483,6 +483,7 @@ private:
 	void phase544();
 	void phase560();
 	void getSaveStateName(char *dest, int size, int16 slot);
+	bool loadGameFromSlot(int16 slot);
 	byte getSaveAreaNum(int16 slot);
 	void displaySaveSlots();
 	void saveGame(char *name);
@@ -684,6 +685,8 @@ private:
 
 	bool  _noPalette;
 	bool  _gameLoaded;
+	/** The slot --save-slot named, or -1. Taken up once, in place of the intro. */
+	int16 _startupSaveSlot;
 #define MAX_TAPES 16
 	tape_t _tapes[MAX_TAPES];
 	byte   _confirmMode;

--- a/engines/cryo/eden.h
+++ b/engines/cryo/eden.h
@@ -51,6 +51,7 @@ public:
 	~EdenGame();
 
 	void run();
+	void debugPlayVideo(int16 num);
 	object_t *getObjectPtr(int16 id);
 	void showObjects();
 	void saveFriezes();

--- a/engines/cryo/eden.h
+++ b/engines/cryo/eden.h
@@ -722,6 +722,8 @@ private:
 	byte  _cubeTexture[0x4000];
 	int   _cubeFaces;
 	uint32 _cursorOldTick, _cursorNewTick;
+	// How many turns of the cursor cube have been let go by, see enginePC()
+	int _cubeStepDelay;
 	byte *_codePtr;
 
 	uint8 tab_2CB1E[8][4];

--- a/engines/cryo/eden_graphics.cpp
+++ b/engines/cryo/eden_graphics.cpp
@@ -26,6 +26,8 @@
 #include "cryo/eden_graphics.h"
 #include "cryo/detection.h"
 
+#include "common/file.h"
+
 #include "graphics/blit.h"
 #include "video/hnm_decoder.h"
 
@@ -1309,6 +1311,84 @@ void EdenGraphics::showMovie(int16 num, char arg1) {
 
 	delete _hnmView;
 	delete decoder;
+}
+
+// Play a movie loose on the disc rather than inside the resource file. False
+// when the file isn't there or holds nothing we can decode
+bool EdenGraphics::playMovieFile(const Common::String &fileName) {
+	Common::File *stream = new Common::File();
+	if (!stream->open(Common::Path(fileName))) {
+		delete stream;
+		return false;
+	}
+
+	Video::VideoDecoder *decoder = new Video::HNMDecoder(g_system->getScreenFormat());
+	if (!decoder->loadStream(stream)) {
+		// The older, untagged variant. loadStream() takes the stream over
+		// either way, so the second attempt needs one of its own
+		delete decoder;
+		stream = new Common::File();
+		if (!stream->open(Common::Path(fileName))) {
+			delete stream;
+			return false;
+		}
+		decoder = new HNM1Decoder();
+		if (!decoder->loadStream(stream)) {
+			delete decoder;
+			return false;
+		}
+	}
+
+	decoder->start();
+
+	View *view = new View(decoder->getWidth(), decoder->getHeight());
+	view->setSrcZoomValues(0, 0);
+	view->setDisplayZoomValues(decoder->getWidth() * 2, decoder->getHeight() * 2);
+	view->centerIn(_game->_vm->_screenView);
+
+	// These movies differ in height, so blank the screen or the previous one
+	// shows around the edges of a shorter one
+	CLBlitter_FillScreenView(0);
+
+	color_t palette[256];
+	bool canceled = false;
+	do {
+		bool newFrame = false;
+		if (decoder->needsUpdate()) {
+			const Graphics::Surface *frame = decoder->decodeNextFrame();
+			if (frame) {
+				Graphics::copyBlit(view->_bufferPtr, (const byte *)frame->getPixels(),
+				                   view->_pitch, frame->pitch, frame->w, frame->h, 1);
+			}
+			if (decoder->hasDirtyPalette()) {
+				const byte *framePalette = decoder->getPalette();
+				for (int i = 0; i < 256; i++) {
+					palette[i].r = framePalette[(i * 3) + 0] << 8;
+					palette[i].g = framePalette[(i * 3) + 1] << 8;
+					palette[i].b = framePalette[(i * 3) + 2] << 8;
+				}
+				CLBlitter_Send2ScreenNextCopy(palette, 0, 256);
+			}
+			newFrame = true;
+		}
+
+		if (newFrame)
+			CLBlitter_CopyView2Screen(view);
+
+		// A click moves on to the next movie, as pressing a key did with the
+		// viewer the demo's batch file called
+		if (_game->_vm->isMouseButtonDown(CLIP<uint32>(decoder->getTimeToNextFrame(), 1, 10))) {
+			if (!_game->isMouseHeld()) {
+				_game->setMouseHeld();
+				canceled = true;
+			}
+		} else
+			_game->setMouseNotHeld();
+	} while (!_game->_vm->shouldQuit() && !decoder->endOfVideo() && !canceled);
+
+	delete view;
+	delete decoder;
+	return true;
 }
 
 bool EdenGraphics::getShowBlackBars() {

--- a/engines/cryo/eden_graphics.cpp
+++ b/engines/cryo/eden_graphics.cpp
@@ -54,6 +54,9 @@ EdenGraphics::EdenGraphics(EdenGame *game) : _game(game) {
 	_underBarsView = nullptr;
 	_needToFade = false;
 	_eff2pat = 0;
+	_roomVideo = nullptr;
+	_roomVideoNum = 0;
+	_roomVideoIsHNM1 = false;
 	_tracedSpriteIndex = _tracedSpriteBank = _tracedSpriteX = _tracedSpriteY = -1;
 
 	_savedUnderSubtitles = false;
@@ -72,6 +75,7 @@ EdenGraphics::EdenGraphics(EdenGame *game) : _game(game) {
 }
 
 EdenGraphics::~EdenGraphics() {
+	closeRoomVideo();
 	delete _underBarsView;
 	delete _view2;
 	delete _subtitlesView;
@@ -724,6 +728,136 @@ void EdenGraphics::zoomBackground(int16 srcX, int16 srcY) {
 	delete[] corner;
 }
 
+// The picture sits between the two friezes
+static const int16 kPictureTop = 16;
+static const int16 kPictureHeight = 160;
+
+/**
+ * Play the movie a room takes its picture from, into the room's own view, so
+ * that whatever the room draws afterwards lands on top of the frame it leaves.
+ *
+ * A room flagged rf08 has no bank to be drawn from: the number it carries is a
+ * movie, and afsalle plays it here for every such room, whether it scrolls or
+ * not. The Macintosh release has banks in their place and never comes this way.
+ */
+/** Open the movie a room takes its picture from. False when there is none. */
+bool EdenGraphics::openRoomVideo(int16 num) {
+	const uint16 resNum = num - 1 + 485;
+	Common::SeekableReadStream *stream = _game->loadSubStream(resNum);
+	if (!stream)
+		return false;
+
+	_roomVideoIsHNM1 = false;
+	_roomVideo = new Video::HNMDecoder(g_system->getScreenFormat());
+	if (!_roomVideo->loadStream(stream)) {
+		// The valleys are of the older untagged kind. loadStream() takes the
+		// stream over either way, so the second attempt needs one of its own.
+		delete _roomVideo;
+		stream = _game->loadSubStream(resNum);
+		_roomVideoIsHNM1 = true;
+		_roomVideo = new HNM1Decoder();
+		if (!stream || !_roomVideo->loadStream(stream)) {
+			debugC(1, kDebugMovie, "Room movie %d (resource %d) is in no format we decode", num, resNum);
+			delete _roomVideo;
+			_roomVideo = nullptr;
+			return false;
+		}
+	}
+
+	_roomVideoNum = num;
+	_roomVideo->start();
+	return true;
+}
+
+void EdenGraphics::closeRoomVideo() {
+	delete _roomVideo;
+	_roomVideo = nullptr;
+	_roomVideoNum = 0;
+	_roomVideoIsHNM1 = false;
+}
+
+/**
+ * Show one frame of the movie a room takes its picture from, if one is due.
+ * Called every pass round the game's own loop, so the picture goes on moving
+ * for as long as the room is up, and begins again when it runs out.
+ */
+void EdenGraphics::stepRoomVideo() {
+	if (!_roomVideo)
+		return;
+
+	// Only while the room itself is up: whatever else takes the screen over puts
+	// its own flag in place of the one afsalle set
+	if (!(_game->_globals->_displayFlags & DisplayFlags::dfFlag80))
+		return;
+
+	if (_roomVideo->endOfVideo()) {
+		// The water returns to where it started, so it can simply begin again
+		const int16 num = _roomVideoNum;
+		closeRoomVideo();
+		if (!openRoomVideo(num))
+			return;
+	}
+
+	if (!_roomVideo->needsUpdate())
+		return;
+
+	// Two frames to a picture, the even ones its left half and the odd ones its
+	// right. A room which scrolls is both halves, one which does not is the left
+	const int16 dstX = ((_roomVideo->getCurFrame() + 1) & 1) ? 320 : 0;
+
+	const Graphics::Surface *frame = _roomVideo->decodeNextFrame();
+	if (frame) {
+		const int16 w = MIN<int16>(frame->w, 320);
+		const int16 h = MIN<int16>(frame->h, kPictureHeight);
+		for (int16 y = 0; y < h; y++)
+			memcpy(_mainViewBuf + (kPictureTop + y) * 640 + dstX, frame->getBasePtr(0, y), w);
+	}
+
+	if (_roomVideo->hasDirtyPalette()) {
+		// The room has no bank to take a palette from, so this is its palette.
+		// Only the colours the movie names, though: GAAT.HNM names 1 to 128 and
+		// the rest is what everything else, the cursor included, is drawn in
+		uint16 first = 0, last = 255;
+		if (_roomVideoIsHNM1)
+			((HNM1Decoder *)_roomVideo)->getPaletteRange(first, last);
+
+		const byte *framePalette = _roomVideo->getPalette();
+		for (uint16 i = first; i <= last; i++) {
+			color3_t color;
+			color.r = framePalette[i * 3 + 0] << 8;
+			color.g = framePalette[i * 3 + 1] << 8;
+			color.b = framePalette[i * 3 + 2] << 8;
+			CLPalette_SetRGBColor(_globalPalette, i, &color);
+		}
+		debugC(2, kDebugMovie, "Room movie palette: colours %d..%d are its own", first, last);
+		CLBlitter_Send2ScreenNextCopy(_globalPalette, 0, 256);
+	}
+
+	// The loop this is called from ends in display(), which sends the view over
+	// once the cursor is in it; sending it here left a black square behind
+}
+
+/**
+ * Put up the picture of a room which keeps it in a movie, and leave the movie
+ * open so that it goes on moving. Both halves are drawn at once, so the picture
+ * is whole before the room draws anything over it.
+ */
+void EdenGraphics::playRoomVideo(int16 num) {
+	closeRoomVideo();
+	if (!openRoomVideo(num))
+		return;
+
+	debugC(1, kDebugMovie, "Room movie %d, %d frames of %dx%d",
+	       num, _roomVideo->getFrameCount(), _roomVideo->getWidth(), _roomVideo->getHeight());
+
+	// Both halves, so that nothing of the room before this is left showing
+	for (int i = 0; i < 2 && !_roomVideo->endOfVideo(); i++) {
+		while (!_roomVideo->needsUpdate() && !_game->_vm->shouldQuit())
+			_game->_vm->pollEvents(CLIP<uint32>(_roomVideo->getTimeToNextFrame(), 1, 10));
+		stepRoomVideo();
+	}
+}
+
 // Original name afsalle1
 void EdenGraphics::displaySingleRoom(Room *room) {
 	byte *ptr = (byte *)getElem(_game->getPlaceRawBuf(), room->_id - 1);
@@ -835,6 +969,22 @@ void EdenGraphics::displayRoom() {
 	_game->_globals->_displayFlags = DisplayFlags::dfFlag1;
 	_game->_globals->_roomBaseX = 0;
 	_game->_globals->_roomBackgroundBankNum = room->_backgroundBankNum;
+	// afsalle picks up the room image bank before it looks at the flags, so that
+	// is the bank the picture comes from, not the room's own
+	debugC(1, kDebugGraphics, "Room 0x%X: flags 0x%02X, image bank %d, room bank %d, background %d",
+	       _game->_globals->_roomNum, room->_flags, _game->_globals->_roomImgBank,
+	       room->_bank, room->_backgroundBankNum);
+
+	// A room flagged rf08 carries a movie number rather than a bank, and afsalle
+	// plays it whether the room scrolls or not. The six valleys are animations,
+	// GAAT.HNM holding 32 complete 320x160 frames of Chamaar:
+	//
+	//     Chamaar    17 -> GAAT.HNM     Tamara     43 -> TAMA.HNM
+	//     Uluru      41 -> TUNA.HNM     Cantura    44 -> CONT.HNM
+	//     Koto       42 -> KOTO.HNM     Shandovra  45 -> HAND.HNM
+	//
+	// The Macintosh release cut each into a pair of banks and pointed its room
+	// table at those, so following it here loaded two characters for a valley
 	if (room->_flags & RoomFlags::rf08) {
 		_game->_globals->_displayFlags |= DisplayFlags::dfFlag80;
 		if (room->_flags & RoomFlags::rfPanable) {
@@ -843,20 +993,21 @@ void EdenGraphics::displayRoom() {
 			_game->_globals->_varF4 = 0;
 			rundcurs();
 			_game->saveFriezes();
-			_game->useBank(room->_bank - 1);
-			drawSprite(0, 0, 16, true);
-			_game->useBank(room->_bank);
-			drawSprite(0, 320, 16, true);
-			displaySingleRoom(room);
+		}
+
+		// Whether it scrolls or not, the picture is the movie
+		playRoomVideo(_game->_globals->_roomImgBank);
+
+		displaySingleRoom(room);
+		if (room->_flags & RoomFlags::rfPanable) {
 			_game->_globals->_roomBaseX = 320;
 			if ((room + 1)->_bank != 65535)
 				displaySingleRoom(room + 1);
 		}
-		else
-			displaySingleRoom(room);
 	}
 	else {
-		//TODO: roomImgBank is garbage here!
+		closeRoomVideo();
+		// afsalle reads this number and hands it to the player above
 		debugC(1, kDebugGraphics, "Displaying room 0x%X from bank %d", _game->_globals->_roomNum, _game->_globals->_roomImgBank);
 		_game->useBank(_game->_globals->_roomImgBank);
 		displaySingleRoom(room);

--- a/engines/cryo/eden_graphics.cpp
+++ b/engines/cryo/eden_graphics.cpp
@@ -807,7 +807,8 @@ void EdenGraphics::displayRoom() {
 			drawSprite(0, 320, 16, true);
 			displaySingleRoom(room);
 			_game->_globals->_roomBaseX = 320;
-			displaySingleRoom(room + 1);
+			if ((room + 1)->_bank != 65535)
+				displaySingleRoom(room + 1);
 		}
 		else
 			displaySingleRoom(room);

--- a/engines/cryo/eden_graphics.cpp
+++ b/engines/cryo/eden_graphics.cpp
@@ -693,6 +693,37 @@ void EdenGraphics::displaySubtitles() {
 	}
 }
 
+/**
+ * Blow up a corner of the background just drawn until it fills the picture.
+ * A character is framed against a corner of its own that way, so the one
+ * background stands behind several of them, and it is only the background
+ * which grows: whoever is drawn over it afterwards keeps their own size.
+ */
+void EdenGraphics::zoomBackground(int16 srcX, int16 srcY) {
+	// What fills the picture at twice the size
+	const int16 srcWidth = 320 / 2;
+	const int16 srcHeight = 160 / 2;
+
+	debugC(1, kDebugGraphics, "Blowing up the background from %d,%d (room 0x%X, display flags 0x%02X)",
+	       srcX, srcY, _game->_globals->_roomNum, _game->_globals->_displayFlags);
+
+	srcX = CLIP<int16>(srcX, 0, 320 - srcWidth);
+	srcY = CLIP<int16>(srcY, 0, 160 - srcHeight);
+
+	byte *corner = new byte[srcWidth * srcHeight];
+	for (int16 y = 0; y < srcHeight; y++)
+		memcpy(corner + y * srcWidth, _mainViewBuf + (16 + srcY + y) * 640 + srcX, srcWidth);
+
+	for (int16 y = 0; y < srcHeight * 2; y++) {
+		byte *dst = _mainViewBuf + (16 + y) * 640;
+		const byte *src = corner + (y / 2) * srcWidth;
+		for (int16 x = 0; x < srcWidth * 2; x++)
+			dst[x] = src[x / 2];
+	}
+
+	delete[] corner;
+}
+
 // Original name afsalle1
 void EdenGraphics::displaySingleRoom(Room *room) {
 	byte *ptr = (byte *)getElem(_game->getPlaceRawBuf(), room->_id - 1);

--- a/engines/cryo/eden_graphics.cpp
+++ b/engines/cryo/eden_graphics.cpp
@@ -35,6 +35,9 @@
 
 namespace Cryo {
 
+// Main view rows: 0-15 top bar, 16-175 picture, 176-199 bottom bar
+static const int16 kPictureBottom = 176;
+
 EdenGraphics::EdenGraphics(EdenGame *game) : _game(game) {
 	_glowH = _glowW = _glowY = _glowX = 0;
 	_showVideoSubtitle = false;
@@ -593,6 +596,10 @@ void EdenGraphics::displayImage() {
 		byte mode = *pix++;
 		if (mode != 0xFF && mode != 0xFE)
 			continue;   //TODO: enclosing block?
+		if (y + h > kPictureBottom)
+			h -= (y + h - kPictureBottom);
+		if (h <= 0)
+			continue;
 		if (h1 & 0x80) {
 			// compressed
 			for (; h-- > 0;) {

--- a/engines/cryo/eden_graphics.cpp
+++ b/engines/cryo/eden_graphics.cpp
@@ -952,6 +952,13 @@ void EdenGraphics::displayEffect2() {
 		displayEffect4();
 		return;
 	}
+	// Transition 16 stipples one picture away and the next one in. The DOS
+	// driver orders its dots from a table built as it loads, so these follow
+	// the engine's own order instead
+	if (_game->_globals->_var103 == 16) {
+		effetpix();
+		return;
+	}
 	switch (++_eff2pat) {
 	case 1:
 		colimacon(pattern1);

--- a/engines/cryo/eden_graphics.cpp
+++ b/engines/cryo/eden_graphics.cpp
@@ -1258,6 +1258,7 @@ void EdenGraphics::showMovie(int16 num, char arg1) {
 	}
 
 	do {
+		bool newFrame = false;
 		if (decoder->needsUpdate()) {
 			const Graphics::Surface *frame = decoder->decodeNextFrame();
 			if (frame) {
@@ -1272,30 +1273,38 @@ void EdenGraphics::showMovie(int16 num, char arg1) {
 				}
 				CLBlitter_Send2ScreenNextCopy(palette16, 0, 256);
 			}
+			newFrame = true;
 		}
 		_hnmFrameNum = decoder->getCurFrame();
 
-		if (_game->getSpecialTextMode())
-			handleHNMSubtitles();
-		else
+		// The dialog scan that picks a caption marks the line said and steps the
+		// dialog on, so ask only once a frame has been decoded: this loop runs
+		// many times per frame and each pass ate another line
+		if (_game->getSpecialTextMode()) {
+			if (newFrame)
+				handleHNMSubtitles();
+		} else
 			_game->musicspy();
 
-		CLBlitter_CopyView2Screen(_hnmView);
+		// Only blit when there is a new frame; doing it every iteration pushes
+		// the next frame past its due time and starves the movie's sound
+		if (newFrame)
+			CLBlitter_CopyView2Screen(_hnmView);
 		assert(_game->_vm->_screenView->_pitch == 320);
-		_game->_vm->pollEvents();
 
-		if (arg1) {
-			if (_game->_vm->isMouseButtonDown()) {
-				if (!_game->isMouseHeld()) {
-					_game->setMouseHeld();
-					_videoCanceledFlag = true;
-				}
+		// Wait no longer than the time left until the next frame is due
+		bool mouseDown = _game->_vm->isMouseButtonDown(CLIP<uint32>(decoder->getTimeToNextFrame(), 1, 10));
+
+		// Cancelling used to be tied to the letterbox flag, which left the two
+		// logo movies at the very start of the game impossible to click through
+		if (mouseDown) {
+			if (!_game->isMouseHeld()) {
+				_game->setMouseHeld();
+				_videoCanceledFlag = true;
 			}
-			else
-				_game->setMouseNotHeld();
 		}
-
-		g_system->delayMillis(10);
+		else
+			_game->setMouseNotHeld();
 	} while (!_game->_vm->shouldQuit() && !decoder->endOfVideo() && !_videoCanceledFlag);
 
 	delete _hnmView;
@@ -1362,6 +1371,10 @@ void EdenGraphics::playHNM(int16 num) {
 		_game->_globals->_varF1 = RoomFlags::rf40 | RoomFlags::rf04 | RoomFlags::rf01;
 	if (_game->_globals->_curVideoNum == 149)
 		_game->_globals->_varF1 = RoomFlags::rf40 | RoomFlags::rf04 | RoomFlags::rf01;
+
+	// A left over index keeps matching the movie's caption lines, which then
+	// win over whatever else wants to speak, the panel included
+	_game->_globals->_videoSubtitleIndex = 0;
 }
 
 void EdenGraphics::initGlobals() {

--- a/engines/cryo/eden_graphics.cpp
+++ b/engines/cryo/eden_graphics.cpp
@@ -24,6 +24,7 @@
 #include "cryo/cryolib.h"
 #include "cryo/eden.h"
 #include "cryo/eden_graphics.h"
+#include "cryo/detection.h"
 
 #include "graphics/blit.h"
 #include "video/hnm_decoder.h"
@@ -46,6 +47,7 @@ EdenGraphics::EdenGraphics(EdenGame *game) : _game(game) {
 	_underBarsView = nullptr;
 	_needToFade = false;
 	_eff2pat = 0;
+	_tracedSpriteIndex = _tracedSpriteBank = _tracedSpriteX = _tracedSpriteY = -1;
 
 	_savedUnderSubtitles = false;
 	_underSubtitlesViewBuf = nullptr;
@@ -121,6 +123,17 @@ void EdenGraphics::readPalette(byte *ptr) {
 
 // Original name: noclipax
 void EdenGraphics::drawSprite(int16 index, int16 x, int16 y, bool withBlack, bool onSubtitle) {
+	// Whatever does not change is drawn again every pass round the loop, so
+	// keep to what is new: the same sprite in the same place says nothing twice
+	if (index != _tracedSpriteIndex || x != _tracedSpriteX || y != _tracedSpriteY ||
+	    _game->getCurBankNum() != _tracedSpriteBank) {
+		_tracedSpriteIndex = index;
+		_tracedSpriteBank = _game->getCurBankNum();
+		_tracedSpriteX = x;
+		_tracedSpriteY = y;
+		debugC(4, kDebugGraphics, "Drawing sprite %d of bank %d at %d,%d%s%s", index,
+		       _game->getCurBankNum(), x, y, withBlack ? ", opaque" : "", onSubtitle ? ", on the subtitles" : "");
+	}
 	uint16 width = (!onSubtitle) ? 640 : _subtitlesXWidth;
 	byte *pix = _game->getBankData();
 	byte *buf = (!onSubtitle) ? _mainViewBuf : _subtitlesViewBuf;
@@ -704,7 +717,7 @@ void EdenGraphics::displaySingleRoom(Room *room) {
 						addIcon = true;
 				}
 				else if (b0 >= 100) {
-					debug("add object %d", b0 - 100);
+					debugC(3, kDebugGraphics, "Room 0x%X: object %d lies here", _game->_globals->_roomNum, b0 - 100);
 					if (_game->isObjectHere(b0 - 100)) {
 						addIcon = true;
 						_game->_globals->_varF7 = 1;
@@ -726,7 +739,7 @@ void EdenGraphics::displaySingleRoom(Room *room) {
 					ptr += 2;
 					x += _game->_globals->_roomBaseX;
 					ex += _game->_globals->_roomBaseX;
-					debug("add hotspot at %3d:%3d - %3d:%3d, action = %d", x, y, ex, ey, b0);
+					debugC(3, kDebugGraphics, "Room 0x%X: hotspot %3d:%3d - %3d:%3d, action %d", _game->_globals->_roomNum, x, y, ex, ey, b0);
 
 					if (_game->_vm->_showHotspots) {
 						for (int iii = x; iii < ex; iii++)
@@ -801,7 +814,7 @@ void EdenGraphics::displayRoom() {
 	}
 	else {
 		//TODO: roomImgBank is garbage here!
-		debug("displayRoom: room 0x%X using bank %d", _game->_globals->_roomNum, _game->_globals->_roomImgBank);
+		debugC(1, kDebugGraphics, "Displaying room 0x%X from bank %d", _game->_globals->_roomNum, _game->_globals->_roomImgBank);
 		_game->useBank(_game->_globals->_roomImgBank);
 		displaySingleRoom(room);
 		assert(_game->_vm->_screenView->_pitch == 320);
@@ -1192,7 +1205,7 @@ void EdenGraphics::effetpix() {
 void EdenGraphics::showMovie(int16 num, char arg1) {
 	Common::SeekableReadStream *stream = _game->loadSubStream(num - 1 + 485);
 	if (!stream) {
-		warning("Could not load movie %d", num);
+		warning("Could not load movie %d (resource %d)", num, num - 1 + 485);
 		return;
 	}
 

--- a/engines/cryo/eden_graphics.cpp
+++ b/engines/cryo/eden_graphics.cpp
@@ -29,6 +29,8 @@
 #include "graphics/blit.h"
 #include "video/hnm_decoder.h"
 
+#include "cryo/hnm1decoder.h"
+
 namespace Cryo {
 
 EdenGraphics::EdenGraphics(EdenGame *game) : _game(game) {
@@ -1222,9 +1224,19 @@ void EdenGraphics::showMovie(int16 num, char arg1) {
 
 	Video::VideoDecoder *decoder = new Video::HNMDecoder(g_system->getScreenFormat(), false, palette);
 	if (!decoder->loadStream(stream)) {
-		warning("Could not load movie %d", num);
+		// Some movies use an older, untagged HNM variant that HNMDecoder
+		// doesn't recognize. loadStream() always takes ownership of the
+		// stream, even on failure, so a fresh one is needed for this
+		// second attempt.
 		delete decoder;
-		return;
+		stream = _game->loadSubStream(num - 1 + 485);
+		decoder = new HNM1Decoder();
+		if (!stream || !decoder->loadStream(stream)) {
+			// Some numbers in this range are VOC resources rather than movies
+			debugC(1, kDebugMovie, "Movie %d (resource %d) is in no format we decode", num, num - 1 + 485);
+			delete decoder;
+			return;
+		}
 	}
 
 	if (_game->_globals->_curVideoNum == 92) {

--- a/engines/cryo/eden_graphics.h
+++ b/engines/cryo/eden_graphics.h
@@ -24,6 +24,10 @@
 
 #include "cryo/defs.h" // Room
 
+namespace Video {
+class VideoDecoder;
+}
+
 namespace Cryo {
 
 class EdenGame;
@@ -37,6 +41,9 @@ public:
 	// Original name: noclipax
 	void drawSprite(int16 index, int16 x, int16 y, bool withBlack = false, bool onSubtitle = false);
 	void zoomBackground(int16 srcX, int16 srcY);
+	void playRoomVideo(int16 num);
+	void stepRoomVideo();
+	void closeRoomVideo();
 
 	// Original name: af_subtitle
 	void displaySubtitles();
@@ -157,6 +164,13 @@ public:
 
 private:
 	EdenGame *_game;
+
+	bool openRoomVideo(int16 num);
+
+	/** The movie a room which keeps its picture in one is showing, if any */
+	Video::VideoDecoder *_roomVideo;
+	int16 _roomVideoNum;
+	bool _roomVideoIsHNM1;
 
 	/** The last sprite spoken of, so that redrawing it is not spoken of again */
 	int16 _tracedSpriteIndex;

--- a/engines/cryo/eden_graphics.h
+++ b/engines/cryo/eden_graphics.h
@@ -155,6 +155,12 @@ public:
 private:
 	EdenGame *_game;
 
+	/** The last sprite spoken of, so that redrawing it is not spoken of again */
+	int16 _tracedSpriteIndex;
+	int16 _tracedSpriteBank;
+	int16 _tracedSpriteX;
+	int16 _tracedSpriteY;
+
 	int16 _glowX;
 	int16 _glowY;
 	int16 _glowW;

--- a/engines/cryo/eden_graphics.h
+++ b/engines/cryo/eden_graphics.h
@@ -36,6 +36,7 @@ public:
 
 	// Original name: noclipax
 	void drawSprite(int16 index, int16 x, int16 y, bool withBlack = false, bool onSubtitle = false);
+	void zoomBackground(int16 srcX, int16 srcY);
 
 	// Original name: af_subtitle
 	void displaySubtitles();

--- a/engines/cryo/eden_graphics.h
+++ b/engines/cryo/eden_graphics.h
@@ -78,6 +78,8 @@ public:
 	void setShowBlackBars(bool value);
 
 	bool getShowBlackBars();
+	/** Play a movie straight off the disc, outside the game's resource file. */
+	bool playMovieFile(const Common::String &fileName);
 
 	void paneltobuf();
 

--- a/engines/cryo/hnm1decoder.cpp
+++ b/engines/cryo/hnm1decoder.cpp
@@ -1,0 +1,875 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "cryo/hnm1decoder.h"
+
+#include "audio/decoders/raw.h"
+#include "audio/decoders/voc.h"
+#include "common/endian.h"
+#include "common/memstream.h"
+#include "common/stream.h"
+#include "common/textconsole.h"
+
+namespace Cryo {
+
+// Number of bytes the decompressors may write past the logical end of a frame:
+// a run or a copy is never cut short, so the last one can overshoot a little.
+static const uint32 kDecodeSlack = 512;
+
+// Chunk tags, as the little endian words they are compared against
+static const uint16 kChunkSound   = 0x6473; // "sd"
+static const uint16 kChunkPalette = 0x6C70; // "pl"
+
+/**
+ * The LZ77 variant used by EdenGame::expandHSQ() (resource.cpp), with a 16 bit
+ * little endian, least significant bit first queue. Unlike expandHSQ() this
+ * takes explicit bounds instead of trusting the stream to end in the right
+ * place.
+ */
+static bool decodeHSQ(const byte *src, uint32 srcSize, byte *dst, uint32 dstSize, uint32 dstCapacity) {
+	uint32 pos = 0, out = 0;
+	uint16 queue = 0;
+
+	auto nextBit = [&]() -> int {
+		int bit = queue & 1;
+		queue >>= 1;
+		if (!queue) {
+			if (pos + 2 > srcSize)
+				return -1;
+			queue = READ_LE_UINT16(src + pos);
+			pos += 2;
+			bit = queue & 1;
+			queue = (queue >> 1) | 0x8000;
+		}
+		return bit;
+	};
+
+	while (out < dstSize) {
+		int bit = nextBit();
+		if (bit < 0)
+			return false;
+
+		if (bit) {
+			if (pos >= srcSize || out >= dstCapacity)
+				return false;
+			dst[out++] = src[pos++];
+			continue;
+		}
+
+		uint32 length = 0;
+		int32 offset;
+		bit = nextBit();
+		if (bit < 0)
+			return false;
+
+		if (!bit) {
+			for (int i = 0; i < 2; i++) {
+				bit = nextBit();
+				if (bit < 0)
+					return false;
+				length = (length << 1) | bit;
+			}
+			if (pos >= srcSize)
+				return false;
+			offset = (int32)(0xFF00 | src[pos++]) - 0x10000;
+		} else {
+			if (pos + 2 > srcSize)
+				return false;
+			uint16 tmp = READ_LE_UINT16(src + pos);
+			pos += 2;
+			length = tmp & 7;
+			offset = (int32)((tmp >> 3) | 0xE000) - 0x10000;
+			if (!length) {
+				if (pos >= srcSize)
+					return false;
+				length = src[pos++];
+				if (!length)
+					return true; // End of stream
+			}
+		}
+
+		if ((int32)out + offset < 0)
+			return false;
+		uint32 from = (uint32)((int32)out + offset);
+		for (length += 2; length > 0; length--) {
+			if (out >= dstCapacity)
+				return false;
+			dst[out++] = dst[from++];
+		}
+	}
+
+	return true;
+}
+
+/**
+ * First stage of the 0xAD scheme (FUN_1000_3b6d in the DOS executable): a byte
+ * oriented LZ77. Control bytes below 0x80 are literals, biased by @p bias.
+ * Back references come in pairs which share the extra bits of a single second
+ * byte, so the first of a pair takes two bytes and the second only one.
+ */
+static bool decodeLZ(const byte *src, uint32 srcSize, uint32 &srcUsed, byte *dst,
+                     uint32 dstPos, uint32 dstEnd, uint32 dstCapacity, byte bias) {
+	uint32 pos = 0;
+	byte extras = 0;
+	bool second = false;
+
+	while (dstPos < dstEnd) {
+		if (pos >= srcSize || dstPos >= dstCapacity)
+			return false;
+
+		byte control = src[pos];
+		if (control < 0x80) {
+			// A zero stays zero, anything else picks up the bias
+			dst[dstPos++] = control ? (byte)(control + bias) : 0;
+			pos++;
+			continue;
+		}
+
+		uint32 distance, length;
+		if (!second) {
+			if (pos + 2 > srcSize)
+				return false;
+			extras = src[pos + 1];
+			distance = (byte)((byte)(control << 1) + ((extras >> 4) & 1)) + 1u;
+			length = (extras >> 5) + 2u;
+			pos += 2;
+			second = true;
+		} else {
+			byte low = extras & 0x0F;
+			distance = (byte)((byte)(control << 1) + (low & 1)) + 1u;
+			length = (low >> 1) + 2u;
+			pos++;
+			second = false;
+		}
+
+		if (distance > dstPos)
+			return false;
+		uint32 from = dstPos - distance;
+		for (; length > 0; length--) {
+			if (dstPos >= dstCapacity)
+				return false;
+			dst[dstPos++] = dst[from++];
+		}
+	}
+
+	srcUsed = pos;
+	return true;
+}
+
+/**
+ * The 0xAC scheme (FUN_1000_e850 and the loop at LAB_1000_e79b in the demo's
+ * DEMO.EXE). Two stages again, but where the 0xAD scheme keeps everything the
+ * second stage needs in one bit stream, this one spreads the work over five,
+ * whose offsets sit in a longer chunk header. They are all counted from two
+ * bytes before the chunk:
+ *
+ *   +10, +12  run lengths, a nibble each
+ *   +14       the bit stream driving the second stage
+ *   +16, +18  the control bytes and the extra bits the first stage reads
+ *   +20       how much the first stage leaves for the second
+ *
+ * The picture can come out a handful of pixels short of its last row, which is
+ * how the original behaves too: both stop as soon as the first stage's output
+ * has been read through, wherever in the row that leaves them.
+ */
+static bool decodeAC(const byte *chunk, uint32 size, byte *dst, uint32 dstSize,
+                     uint32 dstCapacity) {
+	if (size < 22 || dstSize > dstCapacity) {
+		return false;
+	}
+
+	uint32 lengthsA = READ_LE_UINT16(chunk + 10);
+	uint32 lengthsB = READ_LE_UINT16(chunk + 12);
+	uint32 bits     = READ_LE_UINT16(chunk + 14);
+	uint32 control  = READ_LE_UINT16(chunk + 16);
+	uint32 extras   = READ_LE_UINT16(chunk + 18);
+	uint32 stage1Size = READ_LE_UINT16(chunk + 20);
+
+	if (lengthsA < 2 || lengthsB < 2 || bits < 2 || control < 2 || extras < 2 ||
+	        !stage1Size || stage1Size > dstSize) {
+		return false;
+	}
+	lengthsA -= 2;
+	lengthsB -= 2;
+	bits -= 2;
+	control -= 2;
+	extras -= 2;
+
+	// First stage: an LZ77 pass into the tail of the buffer, shaped like the
+	// 0xAD one but with the control byte complemented before the distance
+	uint32 out = dstSize - stage1Size;
+	byte pair = 0;
+	bool second = false;
+	while (out < dstSize) {
+		if (control >= size) {
+			return false;
+		}
+		byte code = chunk[control++];
+		if (code < 0x80) {
+			dst[out++] = code;
+			continue;
+		}
+
+		byte inverted = ~code;
+		uint32 distance, length;
+		if (!second) {
+			if (extras >= size) {
+				return false;
+			}
+			pair = chunk[extras++];
+			distance = (byte)((byte)(inverted << 1) + 1 + ((pair >> 4) & 1));
+			length = (pair >> 5) + 2u;
+			second = true;
+		} else {
+			byte low = pair & 0x0F;
+			distance = (byte)((byte)(inverted << 1) + 1 + (low & 1));
+			length = (low >> 1) + 2u;
+			second = false;
+		}
+
+		if (!distance || distance > out) {
+			return false;
+		}
+		uint32 from = out - distance;
+		for (; length > 0 && out < dstSize; length--) {
+			dst[out++] = dst[from++];
+		}
+	}
+
+	// Second stage: expand that into the picture. A zero bit copies a byte
+	// across, the rest are runs of one, whose length comes from a nibble of one
+	// of the two length streams.
+	uint32 src = dstSize - stage1Size;
+	uint32 pos = 0;
+	uint16 queue = 0;
+	bool highNibble = true;
+	bool failed = false;
+
+	// The same queue as the 0xAD scheme uses: most significant bit first, with a
+	// set sentinel appended so that running out reads back as zero.
+	auto nextBit = [&]() -> int {
+		int bit = (queue >> 15) & 1;
+		queue = (uint16)(queue << 1);
+		if (!queue) {
+			if (bits + 2 > size) {
+				failed = true;
+				return 0;
+			}
+			uint16 word = READ_LE_UINT16(chunk + bits);
+			bits += 2;
+			queue = (uint16)((word << 1) | 1);
+			return (word >> 15) & 1;
+		}
+		return bit;
+	};
+
+	while (src < dstSize && !failed) {
+		if (!nextBit()) {
+			if (pos >= dstCapacity) {
+				return false;
+			}
+			dst[pos++] = dst[src++];
+			continue;
+		}
+
+		uint32 length;
+		if (!nextBit()) {
+			// A nibble of the first length stream, taken high half first. The
+			// low half belongs to the byte already stepped over.
+			if (highNibble) {
+				if (lengthsA >= size) {
+					return false;
+				}
+				length = (chunk[lengthsA++] >> 4) + 2u;
+			} else {
+				length = (chunk[lengthsA - 1] & 0x0F) + 2u;
+			}
+			highNibble = !highNibble;
+		} else if (!nextBit()) {
+			length = 2;
+		} else {
+			if (lengthsB >= size) {
+				return false;
+			}
+			length = chunk[lengthsB++] + 0x12u;
+		}
+
+		byte value = dst[src++];
+		for (; length > 0; length--) {
+			if (pos >= dstCapacity) {
+				return false;
+			}
+			dst[pos++] = value;
+		}
+	}
+
+	return !failed;
+}
+
+/**
+ * Second stage of the 0xAD scheme (LAB_1000_39f3 and LAB_1000_3aaf): a run
+ * length pass driven by a bit stream which directly follows the first stage's
+ * data, while the bytes it works on come from the first stage's output.
+ *
+ * @p longRunsFirst picks between the two orderings of the length code the
+ * original uses, selected by bit 7 of the compression flags.
+ */
+static bool decodeRLE(const byte *bits, uint32 bitsSize, byte *dst, uint32 dstCapacity,
+                      uint32 byteSrc, uint32 dstPos, uint32 dstEnd, bool longRunsFirst) {
+	uint32 pos = 0;
+	uint16 queue = 0;
+	uint32 run = 0;
+	bool failed = false;
+
+	// A 16 bit MSB first queue with a set sentinel appended, so it has run out
+	// exactly when it reads back as zero
+	auto nextBit = [&]() -> int {
+		int bit = (queue >> 15) & 1;
+		queue = (uint16)(queue << 1);
+		if (!queue) {
+			if (pos + 2 > bitsSize) {
+				failed = true;
+				return 0;
+			}
+			uint16 word = READ_LE_UINT16(bits + pos);
+			pos += 2;
+			queue = (uint16)((word << 1) | 1);
+			return (word >> 15) & 1;
+		}
+		return bit;
+	};
+
+	auto fill = [&](byte value, uint32 count) {
+		while (count-- > 0) {
+			if (dstPos >= dstCapacity) {
+				failed = true;
+				return;
+			}
+			dst[dstPos++] = value;
+		}
+	};
+
+	// Long runs take their length from the byte stream, and leave a length
+	// behind for the next long run to pick up.
+	auto longRun = [&](byte value) {
+		uint32 count;
+		if (run > 4) {
+			count = run;
+			run = 0;
+		} else if (run == 4) {
+			if (pos >= bitsSize) {
+				failed = true;
+				return;
+			}
+			count = bits[pos++] + 0x14u;
+			run = 0;
+		} else {
+			if (pos >= bitsSize) {
+				failed = true;
+				return;
+			}
+			byte length = bits[pos];
+			if (length >> 4) {
+				count = (length >> 4) + 4u;
+				pos++;
+			} else {
+				if (pos + 2 > bitsSize) {
+					failed = true;
+					return;
+				}
+				count = bits[pos + 1] + 0x14u;
+				pos += 2;
+			}
+			run = (length & 0x0F) + 4u;
+		}
+		fill(value, count);
+	};
+
+	while (dstPos < dstEnd && !failed) {
+		if (!nextBit()) {
+			// Copy one byte straight from the first stage's output
+			if (byteSrc >= dstCapacity || dstPos >= dstCapacity)
+				return false;
+			dst[dstPos++] = dst[byteSrc++];
+			continue;
+		}
+
+		if (byteSrc >= dstCapacity)
+			return false;
+		byte value = dst[byteSrc++];
+
+		if (longRunsFirst) {
+			if (!nextBit())
+				longRun(value);
+			else if (!nextBit())
+				fill(value, 2);
+			else if (!nextBit())
+				fill(value, 3);
+			else
+				fill(value, 4);
+		} else {
+			if (!nextBit())
+				fill(value, 2);
+			else if (!nextBit())
+				fill(value, 3);
+			else if (!nextBit())
+				fill(value, 4);
+			else
+				longRun(value);
+		}
+	}
+
+	return !failed;
+}
+
+/**
+ * Read a palette in the format used both by the container header and by "pl"
+ * chunks: runs of (start, count, RGB triples), terminated by 0xFF,0xFF.
+ * Components are 6 bits wide.
+ */
+static bool readPalette(const byte *data, uint32 size, uint32 &used, Graphics::Palette &palette,
+                        uint16 *first = nullptr, uint16 *last = nullptr) {
+	uint32 pos = 0;
+	for (;;) {
+		if (pos + 2 > size)
+			return false;
+		byte start = data[pos];
+		byte count = data[pos + 1];
+		pos += 2;
+		if (start == 0xFF && count == 0xFF)
+			break;
+		uint16 num = count ? count : 256;
+		if (start + num > 256 || pos + num * 3 > size)
+			return false;
+		for (uint16 i = 0; i < num; i++, pos += 3)
+			palette.set(start + i, data[pos] * 4, data[pos + 1] * 4, data[pos + 2] * 4);
+		// A movie names only the colours it uses. The rest belong to whatever
+		// else is on screen - the cursor and the friezes among them - and are
+		// not the movie's to give away.
+		if (first && start < *first)
+			*first = start;
+		if (last && start + num - 1 > *last)
+			*last = start + num - 1;
+	}
+	used = pos;
+	return true;
+}
+
+/**
+ * Walk the chunk list of a frame record, reporting the image chunk (if any)
+ * and the extent of the sound data.
+ */
+static bool parseRecord(const byte *record, uint32 size, uint32 &imageChunk,
+                        uint32 &soundStart, uint32 &soundSize) {
+	imageChunk = 0;
+	soundStart = 0;
+	soundSize = 0;
+
+	uint32 pos = 2;
+	while (pos + 4 <= size) {
+		uint16 tag = READ_LE_UINT16(record + pos);
+		if (tag != kChunkSound && tag != kChunkPalette) {
+			// A picture needs ten bytes of header at least. Records exist which
+			// carry only sound and then four bytes of padding, and that padding
+			// is not a short picture.
+			if (pos + 10 <= size)
+				imageChunk = pos;
+			return true;
+		}
+
+		uint32 length = READ_LE_UINT16(record + pos + 2);
+		if (length < 4 || pos + length > size)
+			return false;
+		if (tag == kChunkSound) {
+			soundStart = pos + 4;
+			soundSize = length - 4;
+		}
+		pos += length;
+	}
+
+	// A record without an image chunk is legal: it only carries sound
+	return true;
+}
+
+HNM1Decoder::HNM1Decoder() : _stream(nullptr), _videoTrack(nullptr) {
+}
+
+HNM1Decoder::~HNM1Decoder() {
+	close();
+}
+
+bool HNM1Decoder::loadStream(Common::SeekableReadStream *stream) {
+	close();
+	_stream = stream;
+
+	uint32 streamSize = stream->size();
+	if (streamSize < 8)
+		return false;
+
+	uint16 dataOffset = stream->readUint16LE();
+	if (dataOffset < 8 || dataOffset >= streamSize)
+		return false;
+
+	// The palette, the marker byte and the frame offset table all have to fit
+	// exactly into the space before the frame records.
+	byte *header = new byte[dataOffset];
+	stream->seek(0, SEEK_SET);
+	if (stream->read(header, dataOffset) != dataOffset) {
+		delete[] header;
+		return false;
+	}
+
+	Graphics::Palette palette(256);
+	uint32 used = 0;
+	uint16 palFirst = 255, palLast = 0;
+	if (!readPalette(header + 2, dataOffset - 2, used, palette, &palFirst, &palLast)) {
+		delete[] header;
+		return false;
+	}
+
+	uint32 pos = 2 + used;
+	if (pos >= dataOffset) {
+		delete[] header;
+		return false;
+	}
+	// A spare 0xFF sits between the palette and the frame offsets in some
+	// movies and not in others; the demo disc has both kinds. Where it is
+	// missing the offsets start right after the palette's own terminator.
+	if (header[pos] == 0xFF)
+		pos++;
+
+	Common::Array<uint32> frameOffsets;
+	uint32 remaining = streamSize - dataOffset;
+	for (;;) {
+		if (pos + 4 > dataOffset) {
+			delete[] header;
+			return false;
+		}
+		uint32 value = READ_LE_UINT32(header + pos);
+		pos += 4;
+		frameOffsets.push_back(value);
+		if (value == remaining)
+			break;
+		if (value > remaining) {
+			delete[] header;
+			return false;
+		}
+	}
+
+	byte rawPalette[256 * 3];
+	memcpy(rawPalette, palette.data(), sizeof(rawPalette));
+	delete[] header;
+
+	// Everything before the frame records must be accounted for, and there
+	// has to be at least one record (the table always ends with a marker).
+	if (pos != dataOffset || frameOffsets.size() < 2)
+		return false;
+
+	// Walk the records to pick up the sound, work out how tall the movie is,
+	// and make sure this really is a stream we can decode. Sound is stored as
+	// one VOC file sliced across the records.
+	Common::MemoryWriteStreamDynamic soundData(DisposeAfterUse::YES);
+	uint16 height = 0;
+	for (uint frame = 0; frame + 1 < frameOffsets.size(); frame++) {
+		uint32 start = dataOffset + frameOffsets[frame];
+		uint32 size = frameOffsets[frame + 1] - frameOffsets[frame];
+		if (size < 4)
+			return false;
+
+		byte *record = new byte[size];
+		stream->seek(start, SEEK_SET);
+		if (stream->read(record, size) != size) {
+			delete[] record;
+			return false;
+		}
+
+		// A record opens with its own length, and the offsets can reach past it:
+		// one movie on the demo disc has a record trailed by leftovers from
+		// whatever built the file, command line and all. Go by the record.
+		size = MIN(size, (uint32)MAX<uint16>(READ_LE_UINT16(record), 4));
+
+		uint32 imageChunk, soundStart, soundSize;
+		bool usable = parseRecord(record, size, imageChunk, soundStart, soundSize);
+
+		if (usable && imageChunk) {
+			if (imageChunk + 10 > size) {
+				usable = false;
+			} else {
+				byte checksum = 0;
+				for (int i = 0; i < 6; i++)
+					checksum += record[imageChunk + 4 + i];
+				uint16 heightMode = READ_LE_UINT16(record + imageChunk + 2);
+				uint16 chunkHeight = heightMode & 0xFF;
+				byte mode = heightMode >> 8;
+
+				// 0xFE is a complete picture and 0xFF a strip laid over it. A
+				// frame that is neither is left to fail when its turn comes,
+				// which holds the picture rather than losing the whole movie
+				if ((mode == 0xFE || mode == 0xFF) && chunkHeight &&
+				        chunkHeight <= kMaxHeight &&
+				        (checksum == 0xAB || checksum == 0xAC || checksum == 0xAD))
+					// Only a frame we can draw has a say in how tall the movie is
+					height = MAX(height, chunkHeight);
+			}
+		}
+
+		if (usable && soundSize)
+			soundData.write(record + soundStart, soundSize);
+
+		delete[] record;
+
+		if (!usable)
+			return false;
+	}
+
+	if (!height)
+		return false;
+
+	if (soundData.size() > 0) {
+		// soundData frees its own buffer, so the audio stream gets a copy it
+		// can own: the read stream takes it over, and makeVOCStream() takes
+		// over the read stream, including when it rejects the data.
+		byte *sound = (byte *)malloc(soundData.size());
+		if (!sound)
+			return false;
+		memcpy(sound, soundData.getData(), soundData.size());
+		Common::MemoryReadStream *voc = new Common::MemoryReadStream(sound,
+		        soundData.size(), DisposeAfterUse::YES);
+		Audio::SeekableAudioStream *audio = Audio::makeVOCStream(voc, Audio::FLAG_UNSIGNED,
+		                                    DisposeAfterUse::YES);
+		if (audio)
+			addTrack(new HNM1AudioTrack(audio, getSoundType()));
+	}
+
+	_videoTrack = new HNM1VideoTrack(stream, dataOffset, frameOffsets, rawPalette, height, palFirst, palLast);
+	addTrack(_videoTrack);
+	return true;
+}
+
+void HNM1Decoder::getPaletteRange(uint16 &first, uint16 &last) const {
+	first = _videoTrack ? _videoTrack->getPaletteFirst() : 0;
+	last = _videoTrack ? _videoTrack->getPaletteLast() : 0;
+}
+
+void HNM1Decoder::close() {
+	VideoDecoder::close();
+	_videoTrack = nullptr;
+
+	delete _stream;
+	_stream = nullptr;
+}
+
+HNM1Decoder::HNM1VideoTrack::HNM1VideoTrack(Common::SeekableReadStream *stream, uint32 dataOffset,
+        const Common::Array<uint32> &frameOffsets, const byte *palette, uint16 height,
+        uint16 palFirst, uint16 palLast) :
+	_stream(stream), _dataOffset(dataOffset), _frameOffsets(frameOffsets), _curFrame(-1),
+	_height(height), _palette(palette, 256), _dirtyPalette(true), _record(nullptr),
+	_palFirst(palFirst), _palLast(palLast),
+	_recordAlloc(0) {
+
+	_surface.create(kWidth, _height, Graphics::PixelFormat::createFormatCLUT8());
+	_decodeBuffer = new byte[(uint32)kWidth * kMaxHeight + 4 + kDecodeSlack]();
+}
+
+HNM1Decoder::HNM1VideoTrack::~HNM1VideoTrack() {
+	_surface.free();
+	delete[] _record;
+	delete[] _decodeBuffer;
+}
+
+void HNM1Decoder::HNM1VideoTrack::updatePalette(const byte *data, uint32 size) {
+	uint32 used = 0;
+	if (readPalette(data, size, used, _palette, &_palFirst, &_palLast))
+		_dirtyPalette = true;
+}
+
+bool HNM1Decoder::HNM1VideoTrack::decodeImage(const byte *chunk, uint32 size) {
+	if (size < 10)
+		return false;
+
+	// A complete picture is as wide as the frame; a strip says how wide it is in
+	// the low nine bits of its flags
+	uint16 width = READ_LE_UINT16(chunk) & 0x1FF;
+	uint16 heightMode = READ_LE_UINT16(chunk + 2);
+	uint16 height = heightMode & 0xFF;
+	byte mode = heightMode >> 8;
+	const byte *compHeader = chunk + 4;
+	const byte *payload = chunk + 10;
+	uint32 payloadSize = size - 10;
+
+	byte checksum = 0;
+	for (int i = 0; i < 6; i++)
+		checksum += compHeader[i];
+
+	uint32 uncompressed = READ_LE_UINT16(compHeader);
+	uint32 imageSize = (uint32)width * height;
+	if (!width || width > kWidth || !height || height > _height || uncompressed < imageSize)
+		return false;
+
+	// The image can be preceded by a few bytes of padding, which the original
+	// leaves in place and draws from just past.
+	uint32 imageOffset = uncompressed - imageSize;
+	if (imageOffset > 4)
+		return false;
+
+	const uint32 capacity = (uint32)kWidth * kMaxHeight + 4 + kDecodeSlack;
+
+	// The 0xAD scheme can keep the first four bytes of the chunk unpacked at the
+	// head of the buffer, which pushes the picture along by that much
+	uint32 plainBytes = 0;
+
+	if (checksum == 0xAB) {
+		if (!decodeHSQ(payload, payloadSize, _decodeBuffer, uncompressed, capacity))
+			return false;
+	} else if (checksum == 0xAC) {
+		// This one reads streams from all over the chunk, so it gets the lot
+		if (!decodeAC(chunk, size, _decodeBuffer, uncompressed, capacity))
+			return false;
+	} else if (checksum == 0xAD) {
+		uint32 stage1Size = READ_LE_UINT16(compHeader + 2);
+		byte compFlags = compHeader[4];
+
+		uint32 out = 0;
+		const byte *src = payload;
+		uint32 srcSize = payloadSize;
+		if (!(compFlags & 0x04)) {
+			// The first four bytes of the image are stored plainly
+			if (payloadSize < 4)
+				return false;
+			memcpy(_decodeBuffer, payload, 4);
+			out = 4;
+			src += 4;
+			srcSize -= 4;
+			plainBytes = 4;
+		}
+
+		uint32 end = out + uncompressed;
+		if (stage1Size > uncompressed || end > capacity)
+			return false;
+
+		uint32 srcUsed = 0;
+		uint32 scratch = end - stage1Size;
+		if (!decodeLZ(src, srcSize, srcUsed, _decodeBuffer, scratch, end, capacity,
+		              (compFlags & 0x40) ? 0x80 : 0x00))
+			return false;
+		if (!decodeRLE(src + srcUsed, srcSize - srcUsed, _decodeBuffer, capacity, scratch,
+		               out, end, (compFlags & 0x80) != 0))
+			return false;
+	} else {
+		return false;
+	}
+
+	const byte *src = _decodeBuffer + plainBytes + imageOffset;
+
+	if (mode == 0xFF) {
+		// Zeroes are left alone so what is already there shows through. Two
+		// words at the head of the buffer give left and top; a strip without
+		// them goes at the origin, as the frame-wide credit strips do
+		uint16 left = 0;
+		uint16 top = 0;
+		if (plainBytes == 4) {
+			left = READ_LE_UINT16(_decodeBuffer);
+			top = READ_LE_UINT16(_decodeBuffer + 2);
+		}
+		if (left + width > kWidth || top + height > _height)
+			return false;
+		byte *dst = (byte *)_surface.getPixels() + (uint32)top * kWidth + left;
+		for (uint16 row = 0; row < height; row++) {
+			for (uint16 col = 0; col < width; col++) {
+				if (src[col])
+					dst[col] = src[col];
+			}
+			src += width;
+			dst += kWidth;
+		}
+		return true;
+	}
+
+	// A complete picture is laid down as it comes, and rows past its height keep
+	// whatever the last frame put there
+	byte *dst = (byte *)_surface.getPixels();
+	for (uint16 row = 0; row < height; row++) {
+		memcpy(dst, src, width);
+		src += width;
+		dst += kWidth;
+	}
+	return true;
+}
+
+const Graphics::Surface *HNM1Decoder::HNM1VideoTrack::decodeNextFrame() {
+	if (endOfTrack())
+		return nullptr;
+
+	_curFrame++;
+
+	uint32 start = _dataOffset + _frameOffsets[_curFrame];
+	uint32 size = _frameOffsets[_curFrame + 1] - _frameOffsets[_curFrame];
+	if (size < 4)
+		return &_surface;
+
+	if (_recordAlloc < size) {
+		delete[] _record;
+		_record = new byte[size];
+		_recordAlloc = size;
+	}
+	_stream->seek(start, SEEK_SET);
+	if (_stream->read(_record, size) != size)
+		return &_surface;
+
+	// The record's own length wins over the offsets, which can reach past it
+	size = MIN(size, (uint32)MAX<uint16>(READ_LE_UINT16(_record), 4));
+
+	// Palette updates have to be applied before the image is decoded
+	uint32 pos = 2;
+	while (pos + 4 <= size) {
+		uint16 tag = READ_LE_UINT16(_record + pos);
+		if (tag != kChunkSound && tag != kChunkPalette)
+			break;
+		uint32 length = READ_LE_UINT16(_record + pos + 2);
+		if (length < 4 || pos + length > size)
+			return &_surface;
+		if (tag == kChunkPalette)
+			updatePalette(_record + pos + 4, length - 4);
+		pos += length;
+	}
+
+	if (pos + 10 <= size && !decodeImage(_record + pos, size - pos)) {
+		// Not everything in this format is understood; leaving the previous
+		// image alone looks better than showing garbage.
+		debug(5, "HNM1: Could not decode frame %d", _curFrame);
+	}
+
+	return &_surface;
+}
+
+HNM1Decoder::HNM1AudioTrack::HNM1AudioTrack(Audio::SeekableAudioStream *stream,
+        Audio::Mixer::SoundType soundType) : AudioTrack(soundType), _stream(stream) {
+}
+
+HNM1Decoder::HNM1AudioTrack::~HNM1AudioTrack() {
+	delete _stream;
+}
+
+Audio::AudioStream *HNM1Decoder::HNM1AudioTrack::getAudioStream() const {
+	return _stream;
+}
+
+} // End of namespace Cryo

--- a/engines/cryo/hnm1decoder.h
+++ b/engines/cryo/hnm1decoder.h
@@ -1,0 +1,170 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef CRYO_HNM1DECODER_H
+#define CRYO_HNM1DECODER_H
+
+#include "common/array.h"
+#include "graphics/palette.h"
+#include "graphics/surface.h"
+#include "video/video_decoder.h"
+
+namespace Audio {
+class SeekableAudioStream;
+}
+
+namespace Common {
+class SeekableReadStream;
+}
+
+namespace Cryo {
+
+/**
+ * Decoder for the untagged predecessor of Cryo's HNM4 video format. Lost Eden
+ * stores a number of movies in it (the Cryo and Virgin Interactive logos,
+ * several world flyovers, ...) alongside its regular HNM4 ones.
+ *
+ * The container has no magic tag and no superchunk framing:
+ *
+ *   uint16 LE dataOffset   - offset at which the frame records begin
+ *   palette                - start/count/RGB triples, 6 bits per component,
+ *                            terminated by 0xFF,0xFF
+ *   byte 0xFF              - marker
+ *   uint32 LE offsets[N+1] - offset of each of the N frame records, relative
+ *                            to dataOffset. offsets[N] is the number of bytes
+ *                            left in the stream, i.e. an end marker.
+ *
+ * A frame record is a list of chunks:
+ *
+ *   uint16 LE recordSize   - size of the whole record
+ *   then, repeatedly:
+ *     uint16 tag
+ *       "sd", "pl": uint16 LE length (counting the four byte header), data.
+ *                   "sd" holds a slice of one VOC file spanning the whole
+ *                   movie, "pl" a palette update in the format used above.
+ *       anything else: an image chunk, always last in the record:
+ *         uint16 LE flags/width, uint16 LE (mode << 8 | height),
+ *         six byte compression header, compressed data.
+ *
+ * Images decompress to width * height bytes, optionally preceded by up to
+ * four bytes of padding, and are drawn at the top of the frame; rows past
+ * the chunk's height keep what the previous frame left there. Only mode 0xFE,
+ * a complete picture, is handled: mode 0xFF renders into an off screen buffer
+ * instead, so movies using it are rejected rather than shown incorrectly.
+ * One of two compression schemes is used, selected by a checksum over the six
+ * byte compression header:
+ *
+ *   0xAB - the LZ77 variant also used by EdenGame::expandHSQ() (resource.cpp)
+ *   0xAD - two stages: a byte oriented LZ77 pass expands the data into a
+ *          scratch area at the end of the output buffer, then a bit driven
+ *          RLE pass expands that into the image
+ */
+class HNM1Decoder : public Video::VideoDecoder {
+public:
+	HNM1Decoder();
+	~HNM1Decoder() override;
+
+	bool loadStream(Common::SeekableReadStream *stream) override;
+	void close() override;
+
+	/**
+	 * The range of colours the movie names, the rest belonging to whatever else
+	 * is on screen. Both zero when there is no picture to speak of.
+	 */
+	void getPaletteRange(uint16 &first, uint16 &last) const;
+
+private:
+	enum {
+		kWidth = 320,
+		kMaxHeight = 200,
+		// Neither the container nor the chunks encode a frame delay. This is
+		// the rate the movies with sound play back at, and matches the delay
+		// the regular HNM decoder uses for soundless HNM4 clips.
+		kFrameDelayMs = 80
+	};
+
+	class HNM1VideoTrack : public VideoTrack {
+	public:
+		HNM1VideoTrack(Common::SeekableReadStream *stream, uint32 dataOffset,
+		               const Common::Array<uint32> &frameOffsets, const byte *palette,
+		               uint16 height, uint16 palFirst, uint16 palLast);
+		~HNM1VideoTrack() override;
+
+		bool endOfTrack() const override { return _curFrame + 1 >= getFrameCount(); }
+		uint16 getWidth() const override { return kWidth; }
+		uint16 getHeight() const override { return _height; }
+		Graphics::PixelFormat getPixelFormat() const override { return _surface.format; }
+		int getCurFrame() const override { return _curFrame; }
+		int getFrameCount() const override { return _frameOffsets.size() - 1; }
+		uint32 getNextFrameStartTime() const override {
+			return (uint32)(_curFrame + 1) * kFrameDelayMs;
+		}
+		const Graphics::Surface *decodeNextFrame() override;
+		const byte *getPalette() const override { _dirtyPalette = false; return _palette.data(); }
+		bool hasDirtyPalette() const override { return _dirtyPalette; }
+
+		/** Which colours the movie names. The rest are not its to give away. */
+		uint16 getPaletteFirst() const { return _palFirst; }
+		uint16 getPaletteLast() const { return _palLast; }
+
+		uint16 _palFirst;
+		uint16 _palLast;
+
+	private:
+		/** Decode an image chunk into the surface. */
+		bool decodeImage(const byte *chunk, uint32 size);
+		/** Apply a palette update chunk. */
+		void updatePalette(const byte *data, uint32 size);
+
+		Common::SeekableReadStream *_stream; // Not owned
+		uint32 _dataOffset;
+		Common::Array<uint32> _frameOffsets;
+		int _curFrame;
+		uint16 _height;
+
+		Graphics::Surface _surface;
+		Graphics::Palette _palette;
+		mutable bool _dirtyPalette;
+
+		byte *_record;
+		uint32 _recordAlloc;
+		byte *_decodeBuffer;
+	};
+
+	class HNM1AudioTrack : public AudioTrack {
+	public:
+		HNM1AudioTrack(Audio::SeekableAudioStream *stream, Audio::Mixer::SoundType soundType);
+		~HNM1AudioTrack() override;
+
+	protected:
+		Audio::AudioStream *getAudioStream() const override;
+
+	private:
+		Audio::SeekableAudioStream *_stream;
+	};
+
+	Common::SeekableReadStream *_stream;
+	HNM1VideoTrack *_videoTrack;
+};
+
+} // End of namespace Cryo
+
+#endif

--- a/engines/cryo/module.mk
+++ b/engines/cryo/module.mk
@@ -6,6 +6,7 @@ MODULE_OBJS = \
 	debugger.o \
 	eden.o \
 	eden_graphics.o \
+	hnm1decoder.o \
 	metaengine.o \
 	resource.o \
 	sound.o

--- a/engines/cryo/resource.cpp
+++ b/engines/cryo/resource.cpp
@@ -207,16 +207,15 @@ int EdenGame::loadSound(uint16 num) {
 	PakHeaderItem *file = &_bigfileHeader->_files[resNum];
 	int32 size = file->_size;
 	int32 offs = file->_offs;
+	// The demo leaves an empty entry for a line it does not carry
+	if (size <= 0) {
+		warning("Sound %d is not in this release of the game", num);
+		return 0;
+	}
 	debugC(2, kDebugResource, "Loading sound %d as resource %d (%s) at 0x%X, %d bytes", num, resNum, file->_name.c_str(), (uint)offs, size);
-	if (_soundAllocated) {
-		free(_voiceSamplesBuffer);
-		_voiceSamplesBuffer = nullptr;
-		_soundAllocated = false; //TODO: bug??? no alloc
-	}
-	else {
-		_voiceSamplesBuffer = (byte *)malloc(size);
-		_soundAllocated = true;
-	}
+	free(_voiceSamplesBuffer);
+	_voiceSamplesBuffer = (byte *)malloc(size);
+	_soundAllocated = true;
 
 	_bigfile.seek(offs, SEEK_SET);
 	//For PC loaded data is a VOC file, on Mac version this is a raw samples
@@ -235,7 +234,12 @@ int EdenGame::loadSound(uint16 num) {
 		unsigned int chunkLen = FROM_LE_32(val);
 
 		if (chunkType == 5) {
-			_bigfile.read(_gameLipsync + 7260, chunkLen);
+			if (chunkLen > LIPSYNC_DATA_SIZE) {
+				warning("Lipsync chunk too large (%u bytes), truncating to %d", chunkLen, LIPSYNC_DATA_SIZE);
+				_bigfile.read(_gameLipsync + LIPSYNC_ANIM_TABLE_SIZE, LIPSYNC_DATA_SIZE);
+				_bigfile.skip(chunkLen - LIPSYNC_DATA_SIZE);
+			} else
+				_bigfile.read(_gameLipsync + LIPSYNC_ANIM_TABLE_SIZE, chunkLen);
 			chunkType = _bigfile.readByte();
 			_bigfile.read(&val, 3);
 			chunkLen = FROM_LE_32(val);
@@ -471,7 +475,11 @@ bool EdenGame::ReadDataSyncVOC(unsigned int num) {
 		loadpartoffile(resNum, &chunkLen, filePos, 3);
 		filePos += 3;
 		chunkLen = FROM_LE_32(chunkLen);
-		loadpartoffile(resNum, _gameLipsync + 7260, filePos, chunkLen);
+		if (chunkLen > LIPSYNC_DATA_SIZE) {
+			warning("Lipsync chunk too large (%u bytes), truncating to %d", chunkLen, LIPSYNC_DATA_SIZE);
+			chunkLen = LIPSYNC_DATA_SIZE;
+		}
+		loadpartoffile(resNum, _gameLipsync + LIPSYNC_ANIM_TABLE_SIZE, filePos, chunkLen);
 		return true;
 	}
 	return false;
@@ -481,8 +489,8 @@ bool EdenGame::ReadDataSync(uint16 num) {
 	if (_vm->getPlatform() == Common::kPlatformMacintosh) {
 		long pos = READ_LE_UINT32(_gameLipsync + num * 4);
 		if (pos != -1) {
-			long len = 1024;
-			loadpartoffile(1936, _gameLipsync + 7260, pos, len);
+			long len = LIPSYNC_DATA_SIZE;
+			loadpartoffile(1936, _gameLipsync + LIPSYNC_ANIM_TABLE_SIZE, pos, len);
 			return true;
 		}
 	}
@@ -495,6 +503,13 @@ void EdenGame::loadpartoffile(uint16 num, void *buffer, int32 pos, int32 len) {
 	assert(num < _bigfileHeader->_count);
 	PakHeaderItem *file = &_bigfileHeader->_files[num];
 	int32 offs = READ_LE_UINT32(&file->_offs);
+	// Entries the demo does not ship have neither length nor offset, so a read
+	// used to hand back the head of the resource file itself
+	if (file->_size <= 0 || pos + len > file->_size) {
+		warning("Resource %d holds no %d bytes at %d", num, len, pos);
+		memset(buffer, 0, len);
+		return;
+	}
 	debugC(2, kDebugResource, "Loading resource %d (%s) at 0x%X(+0x%X), %d of %d bytes", num, file->_name.c_str(), (uint)offs, pos, len, file->_size);
 	_bigfile.seek(offs + pos, SEEK_SET);
 	_bigfile.read(buffer, len);

--- a/engines/cryo/resource.cpp
+++ b/engines/cryo/resource.cpp
@@ -358,7 +358,8 @@ void EdenGame::loadpermfiles() {
 		convertMacToPC();
 
 		// Skip the icons and rooms of the DOS version
-		f.skip(kNumIcons * 14 + kNumRooms * 11);
+		f.skip(kNumIcons * 18 +		// sizeof(Icon)
+		       kNumRooms * 14);		// sizeof(Room)
 		break;
 	default:
 		error("Unsupported platform");

--- a/engines/cryo/resource.cpp
+++ b/engines/cryo/resource.cpp
@@ -226,31 +226,44 @@ int EdenGame::loadSound(uint16 num) {
 		// 1. Standard VOC header
 		_bigfile.read(_voiceSamplesBuffer, 0x1A);
 
-		// 2. Lipsync?
-		unsigned char chunkType = _bigfile.readByte();
+		// 2. The chunks: a lipsync one where there is one, then the samples in
+		// one sound chunk or, for nineteen of the voices, in several
+		int32 samplesRead = 0;
+		int32 bytesLeft = size - 0x1A;
 
-		uint32 val = 0;
-		_bigfile.read(&val, 3);
-		unsigned int chunkLen = FROM_LE_32(val);
-
-		if (chunkType == 5) {
-			if (chunkLen > LIPSYNC_DATA_SIZE) {
-				warning("Lipsync chunk too large (%u bytes), truncating to %d", chunkLen, LIPSYNC_DATA_SIZE);
-				_bigfile.read(_gameLipsync + LIPSYNC_ANIM_TABLE_SIZE, LIPSYNC_DATA_SIZE);
-				_bigfile.skip(chunkLen - LIPSYNC_DATA_SIZE);
-			} else
-				_bigfile.read(_gameLipsync + LIPSYNC_ANIM_TABLE_SIZE, chunkLen);
-			chunkType = _bigfile.readByte();
+		while (bytesLeft >= 4) {
+			unsigned char chunkType = _bigfile.readByte();
+			uint32 val = 0;
 			_bigfile.read(&val, 3);
-			chunkLen = FROM_LE_32(val);
+			unsigned int chunkLen = FROM_LE_32(val);
+			bytesLeft -= 4;
+
+			// The terminator, and anything the file is too short to hold
+			if (chunkType == 0 || chunkLen > (uint32)bytesLeft)
+				break;
+			bytesLeft -= chunkLen;
+
+			if (chunkType == 5) {
+				if (chunkLen > LIPSYNC_DATA_SIZE) {
+					warning("Lipsync chunk too large (%u bytes), truncating to %d", chunkLen, LIPSYNC_DATA_SIZE);
+					_bigfile.read(_gameLipsync + LIPSYNC_ANIM_TABLE_SIZE, LIPSYNC_DATA_SIZE);
+					_bigfile.skip(chunkLen - LIPSYNC_DATA_SIZE);
+				} else
+					_bigfile.read(_gameLipsync + LIPSYNC_ANIM_TABLE_SIZE, chunkLen);
+			} else if (chunkType == 1 && chunkLen >= 2) {
+				// The rate, as the divisor the DOS driver loaded its timer with,
+				// and the packing
+				byte timeConstant = _bigfile.readByte();
+				_bigfile.readByte();
+				if (!samplesRead)
+					_voiceSampleRate = 1000000 / (256 - timeConstant);
+				_bigfile.read(_voiceSamplesBuffer + samplesRead, chunkLen - 2);
+				samplesRead += chunkLen - 2;
+			} else
+				_bigfile.skip(chunkLen);
 		}
 
-		// 3. Normal sound data
-		if (chunkType == 1) {
-			_bigfile.readUint16LE();
-			size = chunkLen - 2;
-			_bigfile.read(_voiceSamplesBuffer, size);
-		}
+		size = samplesRead;
 	}
 
 	return size;

--- a/engines/cryo/resource.cpp
+++ b/engines/cryo/resource.cpp
@@ -375,8 +375,8 @@ void EdenGame::loadpermfiles() {
 		_followerList[i].ex = f.readSint16LE();
 		_followerList[i].ey = f.readSint16LE();
 		_followerList[i]._spriteBank = f.readSint16LE();
-		_followerList[i].ff_C = f.readSint16LE();
-		_followerList[i].ff_E = f.readSint16LE();
+		_followerList[i]._zoomX = f.readSint16LE();
+		_followerList[i]._zoomY = f.readSint16LE();
 	}
 
 	f.read(_labyrinthPath, kNumLabyrinthPath);

--- a/engines/cryo/resource.cpp
+++ b/engines/cryo/resource.cpp
@@ -21,6 +21,7 @@
 
 #include "cryo/defs.h"
 #include "cryo/cryo.h"
+#include "cryo/detection.h"
 #include "cryo/cryolib.h"
 #include "cryo/eden.h"
 
@@ -53,12 +54,12 @@ void EdenGame::verifh(byte *ptr) {
 	if (sum != 0xAB)
 		return;
 
-	debug("* Begin unpacking resource");
 	head -= 6;
 	uint16 h0 = READ_LE_UINT16(head);
 	// 3 = 2 bytes for the uint16 and 1 byte for an unused char
 	head += 3;
 	uint16 h3 = READ_LE_UINT16(head);
+	debugC(2, kDebugResource, "Unpacking %d bytes into %d", h3, h0);
 	head += 2;
 	byte *data = h0 + head + 26;
 	h3 -= 6;
@@ -113,6 +114,7 @@ void EdenGame::loadRawFile(uint16 num, byte *buffer) {
 	PakHeaderItem *file = &_bigfileHeader->_files[num];
 	int32 size = file->_size;
 	int32 offs = file->_offs;
+	debugC(2, kDebugResource, "Loading resource %d (%s) at 0x%X, %d bytes", num, file->_name.c_str(), (uint)offs, size);
 
 	_bigfile.seek(offs, SEEK_SET);
 	_bigfile.read(buffer, size);
@@ -128,7 +130,7 @@ void EdenGame::loadIconFile(uint16 num, Icon *buffer) {
 	PakHeaderItem *file = &_bigfileHeader->_files[num];
 	int32 size = file->_size;
 	int32 offs = file->_offs;
-	debug("* Loading icon - Resource %d (%s) at 0x%X, %d bytes", num, file->_name.c_str(), offs, size);
+	debugC(2, kDebugResource, "Loading icons %d (%s) at 0x%X, %d bytes", num, file->_name.c_str(), (uint)offs, size);
 	_bigfile.seek(offs, SEEK_SET);
 
 	int count = size / 18;	// sizeof(Icon)
@@ -164,7 +166,7 @@ void EdenGame::loadRoomFile(uint16 num, Room *buffer) {
 	PakHeaderItem *file = &_bigfileHeader->_files[num];
 	int32 size = file->_size;
 	int32 offs = file->_offs;
-	debug("* Loading room - Resource %d (%s) at 0x%X, %d bytes", num, file->_name.c_str(), offs, size);
+	debugC(2, kDebugResource, "Loading rooms %d (%s) at 0x%X, %d bytes", num, file->_name.c_str(), (uint)offs, size);
 	_bigfile.seek(offs, SEEK_SET);
 
 	int count = size / 14;	// sizeof(Room)
@@ -193,7 +195,7 @@ Common::SeekableReadStream *EdenGame::loadSubStream(uint16 resNum) {
 	PakHeaderItem *file = &_bigfileHeader->_files[resNum];
 	int size = file->_size;
 	int offs = file->_offs;
-	debug("* Loading file %s at 0x%X, %d bytes", file->_name.c_str(), (uint)offs, size);
+	debugC(2, kDebugResource, "Loading stream %d (%s) at 0x%X, %d bytes", resNum, file->_name.c_str(), (uint)offs, size);
 	return new Common::SafeSeekableSubReadStream(&_bigfile, offs, offs + size, DisposeAfterUse::NO);
 }
 
@@ -204,7 +206,7 @@ int EdenGame::loadSound(uint16 num) {
 	PakHeaderItem *file = &_bigfileHeader->_files[resNum];
 	int32 size = file->_size;
 	int32 offs = file->_offs;
-	debug("* Loading sound %d (%s) at 0x%X, %d bytes", num, file->_name.c_str(), (uint)offs, size);
+	debugC(2, kDebugResource, "Loading sound %d as resource %d (%s) at 0x%X, %d bytes", num, resNum, file->_name.c_str(), (uint)offs, size);
 	if (_soundAllocated) {
 		free(_voiceSamplesBuffer);
 		_voiceSamplesBuffer = nullptr;
@@ -492,7 +494,7 @@ void EdenGame::loadpartoffile(uint16 num, void *buffer, int32 pos, int32 len) {
 	assert(num < _bigfileHeader->_count);
 	PakHeaderItem *file = &_bigfileHeader->_files[num];
 	int32 offs = READ_LE_UINT32(&file->_offs);
-	debug("* Loading partial resource %d (%s) at 0x%X(+0x%X), %d bytes", num, file->_name.c_str(), offs, pos, len);
+	debugC(2, kDebugResource, "Loading resource %d (%s) at 0x%X(+0x%X), %d of %d bytes", num, file->_name.c_str(), (uint)offs, pos, len, file->_size);
 	_bigfile.seek(offs + pos, SEEK_SET);
 	_bigfile.read(buffer, len);
 }

--- a/engines/cryo/resource.cpp
+++ b/engines/cryo/resource.cpp
@@ -72,7 +72,8 @@ void EdenGame::verifh(byte *ptr) {
 }
 
 void EdenGame::openbigfile() {
-	_bigfile.open("EDEN.DAT");
+	if (!_bigfile.open("EDEN.DAT"))
+		error("Could not open EDEN.DAT");
 
 	char buf[16];
 	int count = _bigfile.readUint16LE();

--- a/engines/cryo/sound.cpp
+++ b/engines/cryo/sound.cpp
@@ -84,6 +84,15 @@ unsigned int CSoundChannel::numQueued() {
 	return _audioStream ? _audioStream->numQueuedStreams() : 0;
 }
 
+void CSoundChannel::setSampleRate(unsigned int sampleRate) {
+	if (sampleRate == _sampleRate)
+		return;
+
+	// The stream carries the rate, so a new one has to stand in its place
+	stop();
+	_sampleRate = sampleRate;
+}
+
 unsigned int CSoundChannel::getVolume() {
 	return (_volumeRight + _volumeLeft) / 2;
 }

--- a/engines/cryo/sound.h
+++ b/engines/cryo/sound.h
@@ -58,6 +58,10 @@ public:
 	// How many buffers in queue (including currently playing one)
 	unsigned int numQueued();
 
+	// Play the samples to come at a new rate, dropping anything still queued
+	// at the old one
+	void setSampleRate(unsigned int sampleRate);
+
 	// Volume control
 	int _volumeLeft, _volumeRight;
 	unsigned int getVolume();

--- a/video/hnm_decoder.cpp
+++ b/video/hnm_decoder.cpp
@@ -40,7 +40,7 @@ HNMDecoder::HNMDecoder(const Graphics::PixelFormat &format, bool loop,
                        byte *initialPalette) : _regularFrameDelayMs(uint32(-1)),
 	_videoTrack(nullptr), _audioTrack(nullptr), _stream(nullptr), _format(format),
 	_loop(loop), _initialPalette(initialPalette), _alignedChunks(false),
-	_dataBuffer(nullptr), _dataBufferAlloc(0) {
+	_audioSamplesPerFrame(0), _endOfStream(false) {
 	if (initialPalette && format.bytesPerPixel >= 2) {
 		error("Invalid pixel format while initial palette is set");
 	}
@@ -174,6 +174,10 @@ bool HNMDecoder::loadStream(Common::SeekableReadStream *stream) {
 		close();
 		return false;
 	}
+	// A frame which carries no sound still takes up its share of the sound
+	// timeline; this is how much of it
+	_audioSamplesPerFrame = audioSampleRate * _regularFrameDelayMs / 1000;
+
 	addTrack(_videoTrack);
 	if (_audioTrack) {
 		addTrack(_audioTrack);
@@ -191,24 +195,32 @@ void HNMDecoder::close() {
 	delete _stream;
 	_stream = nullptr;
 
-	delete[] _dataBuffer;
-	_dataBuffer = nullptr;
-	_dataBufferAlloc = 0;
+	while (!_demuxedFrames.empty()) {
+		delete[] _demuxedFrames.pop()._data;
+	}
+	_endOfStream = false;
 }
 
-void HNMDecoder::readNextPacket() {
-	// We are called to feed a frame
-	// Each chunk is packetized and a packet seems to contain only one frame
+bool HNMDecoder::demuxFrame() {
+	// Reading past the end would hand us whatever readUint32LE() leaves behind
+	// when it comes up short, which then looks like a huge superchunk
+	if (_endOfStream) {
+		return false;
+	}
+
+	// Each superchunk holds one frame: its sound, and the chunks its picture is
+	// built from
 	uint32 superchunkRemaining = _stream->readUint32LE();
-	if (!superchunkRemaining) {
+	if (_stream->eos() || !superchunkRemaining) {
 		if (!_loop) {
-			error("End of file but still requesting data");
-		} else {
-			// Looping: read back from start of file, skip header and read a new super chunk header
-			_videoTrack->restart();
-			_stream->seek(64, SEEK_SET);
-			superchunkRemaining = _stream->readUint32LE();
+			// Nothing left in the file
+			_endOfStream = true;
+			return false;
 		}
+		// Looping: read back from start of file, skip header and read a new super chunk header
+		_videoTrack->restart();
+		_stream->seek(64, SEEK_SET);
+		superchunkRemaining = _stream->readUint32LE();
 	}
 	superchunkRemaining = superchunkRemaining & 0x00ffffff;
 	if (superchunkRemaining < 4) {
@@ -216,55 +228,111 @@ void HNMDecoder::readNextPacket() {
 	}
 	superchunkRemaining -= 4;
 
-	if (_dataBufferAlloc < superchunkRemaining) {
-		delete[] _dataBuffer;
-		_dataBuffer = new byte[superchunkRemaining];
-		_dataBufferAlloc = superchunkRemaining;
-	}
-	if (_stream->read(_dataBuffer, superchunkRemaining) != superchunkRemaining) {
+	DemuxedFrame frame;
+	frame._size = superchunkRemaining;
+	frame._data = new byte[superchunkRemaining];
+	// We use -1 here to discrimate a possibly empty sound frame
+	frame._audioNumSamples = uint32(-1);
+	if (_stream->read(frame._data, superchunkRemaining) != superchunkRemaining) {
+		delete[] frame._data;
 		error("Not enough data in file");
 	}
 
-	// We use -1 here to discrimate a possibly empty sound frame
-	uint32 audioNumSamples = uint32(-1);
-
-	byte *data_p = _dataBuffer;
+	// Hand the sound over straight away: the mixer needs it buffered well
+	// before the frame carrying it is due on screen. The picture waits its turn.
+	byte *data_p = frame._data;
 	while (superchunkRemaining > 0) {
 		if (superchunkRemaining < 8) {
+			delete[] frame._data;
 			error("Not enough data in superchunk");
 		}
 
 		uint32 chunkSize = READ_LE_UINT32(data_p);
-		data_p += sizeof(uint32);
-		uint16 chunkType = READ_BE_UINT16(data_p);
-		data_p += sizeof(uint16);
-		uint16 flags     = READ_LE_UINT16(data_p);
-		data_p += sizeof(uint16);
+		uint16 chunkType = READ_BE_UINT16(data_p + sizeof(uint32));
 
 		if (superchunkRemaining < chunkSize) {
+			delete[] frame._data;
 			error("Chunk has a bogus size");
 		}
 
-		if (chunkType == MKTAG16('S', 'D') ||
-		    chunkType == MKTAG16('A', 'A') ||
-		    chunkType == MKTAG16('B', 'B')) {
+		if (isHNMSoundChunk(chunkType)) {
 			if (_audioTrack) {
-				audioNumSamples = _audioTrack->decodeSound(chunkType, data_p, chunkSize - 8);
+				// A frame may carry several sound chunks; the first primes the
+				// double buffer. All of them count towards its duration.
+				uint32 numSamples = _audioTrack->decodeSound(chunkType,
+				                    data_p + 8, chunkSize - 8);
+				if (frame._audioNumSamples == uint32(-1)) {
+					frame._audioNumSamples = numSamples;
+				} else {
+					frame._audioNumSamples += numSamples;
+				}
 			} else {
 				warning("Got audio data without an audio track");
 			}
-		} else {
-			_videoTrack->decodeChunk(data_p, chunkSize - 8, chunkType, flags);
 		}
 
 		if (_alignedChunks) {
 			chunkSize = ((chunkSize + 3) / 4) * 4;
 		}
 
-		data_p += (chunkSize - 8);
+		data_p += chunkSize;
 		superchunkRemaining -= chunkSize;
 	}
-	_videoTrack->newFrame(audioNumSamples);
+
+	// Some movies start their sound a few frames in, or stop before the last
+	// frame. Frames are timed against the sound timeline, so pad the gaps or
+	// picture and sound drift apart permanently.
+	if (_audioTrack && frame._audioNumSamples == uint32(-1)) {
+		uint32 queued = _audioTrack->queueSilence(_audioSamplesPerFrame);
+		if (queued) {
+			frame._audioNumSamples = queued;
+		}
+	}
+
+	_demuxedFrames.push(frame);
+	return true;
+}
+
+void HNMDecoder::readNextPacket() {
+	// Demux ahead so the mixer has more than one frame of samples in hand,
+	// otherwise it falls silent whenever a frame is presented late. No read
+	// ahead while looping: the video track restarts where the loop is shown.
+	int readAhead = (_audioTrack && !_loop) ? (int)kDemuxReadAhead : 1;
+	while (_demuxedFrames.size() < readAhead) {
+		if (!demuxFrame()) {
+			break;
+		}
+	}
+
+	if (_demuxedFrames.empty()) {
+		error("End of file but still requesting data");
+	}
+
+	// Now decode the picture of the frame whose turn it is
+	DemuxedFrame frame = _demuxedFrames.pop();
+	byte *data_p = frame._data;
+	uint32 remaining = frame._size;
+	while (remaining > 0) {
+		uint32 chunkSize = READ_LE_UINT32(data_p);
+		uint16 chunkType = READ_BE_UINT16(data_p + sizeof(uint32));
+		uint16 flags     = READ_LE_UINT16(data_p + sizeof(uint32) + sizeof(uint16));
+
+		// The sound was dealt with while demuxing
+		if (!isHNMSoundChunk(chunkType)) {
+			_videoTrack->decodeChunk(data_p + 8, chunkSize - 8, chunkType, flags);
+		}
+
+		if (_alignedChunks) {
+			chunkSize = ((chunkSize + 3) / 4) * 4;
+		}
+
+		data_p += chunkSize;
+		remaining -= chunkSize;
+	}
+	delete[] frame._data;
+
+
+	_videoTrack->newFrame(frame._audioNumSamples);
 }
 
 HNMDecoder::HNMVideoTrack::HNMVideoTrack(uint32 frameCount,

--- a/video/hnm_decoder.h
+++ b/video/hnm_decoder.h
@@ -27,6 +27,7 @@
 #define VIDEO_HNM_DECODER_H
 
 #include "audio/audiostream.h"
+#include "common/queue.h"
 #include "common/rational.h"
 #include "graphics/palette.h"
 #include "graphics/surface.h"
@@ -46,6 +47,13 @@ class HNM6Decoder;
 }
 
 namespace Video {
+
+/** Whether a chunk holds sound. */
+inline bool isHNMSoundChunk(uint16 chunkType) {
+	return chunkType == MKTAG16('S', 'D') ||
+	       chunkType == MKTAG16('A', 'A') ||
+	       chunkType == MKTAG16('B', 'B');
+}
 
 /**
  * Decoder for HNM videos.
@@ -184,6 +192,14 @@ private:
 		HNMAudioTrack(Audio::Mixer::SoundType soundType) : AudioTrack(soundType) {}
 
 		virtual uint32 decodeSound(uint16 chunkType, byte *data, uint32 size) = 0;
+
+		/**
+		 * Fill in for a frame which carries no sound, so that a movie whose
+		 * sound doesn't run from end to end keeps one timeline for both.
+		 *
+		 * @return how many samples were queued, zero if the track can't.
+		 */
+		virtual uint32 queueSilence(uint32 numSamples) { return 0; }
 	};
 
 	class DPCMAudioTrack : public HNMAudioTrack {
@@ -218,6 +234,29 @@ private:
 		Audio::APCStream *_audioStream;
 	};
 
+	/** How many frames to demux ahead of the one being shown. */
+	static const uint kDemuxReadAhead = 8;
+
+	/**
+	 * A frame read from the container: its chunks as they were stored, plus how
+	 * many sound samples it lasts for. Its sound has already been passed on to
+	 * the audio track; its picture is decoded when the frame is due.
+	 */
+	struct DemuxedFrame {
+		byte *_data;
+		uint32 _size;
+		uint32 _audioNumSamples;
+	};
+
+	/** Read one frame from the container. False once there is none left. */
+	bool demuxFrame();
+
+	/** Set once the container has run out, so it is not read past its end. */
+	bool _endOfStream;
+
+	/** How many sound samples a frame lasts for when it carries none. */
+	uint32 _audioSamplesPerFrame;
+
 	Graphics::PixelFormat _format;
 	bool _loop;
 	byte *_initialPalette;
@@ -229,8 +268,7 @@ private:
 
 	Common::SeekableReadStream *_stream;
 	bool _alignedChunks;
-	byte *_dataBuffer;
-	uint32 _dataBufferAlloc;
+	Common::Queue<DemuxedFrame> _demuxedFrames;
 };
 
 } // End of namespace Video


### PR DESCRIPTION
The game was completed with a patch set that this set is based on. https://github.com/merbanan/scummvm/tree/cryo-rework (there is also a branch with a fix for the macintosh audio https://github.com/merbanan/scummvm/tree/cryo_eden_audio_video).

Known patch set issues:

* The video parts touches common code and the "HNM1" is placed outside of the engine.
* Some palette issues during transitions.
* Unimplemented UI logic in the game options screen.
* A few patches are not needed but provided as developer convenience
* The non interactive demo mode is not really needed but is now playable