### PR TITLE
MACVENTURE: Bug Fixes

### DIFF
--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -846,15 +846,7 @@ void Gui::drawInventories() {
 		drawObjectsInWindow(data, srf);
 
 		if (data.refcon == _lassoWinRef && _lassoBeingDrawn) {
-			Common::Point topLeft(_lassoStart);
-			topLeft.y -= 12;
-			Common::Point bottomRight(_lassoEnd);
-			bottomRight.y -= 12;
-			if (topLeft.x > bottomRight.x)
-				SWAP(topLeft.x, bottomRight.x);
-			if (topLeft.y > bottomRight.y)
-				SWAP(topLeft.y, bottomRight.y);
-			Common::Rect lassoRect(topLeft, bottomRight);
+			Common::Rect lassoRect = calculateLassoRect(win);
 
 			Graphics::MacPlotData plotData(srf, nullptr, &_wm.getBuiltinPatterns(), kPatternCheckers2, 0, 0, {1, 1}, kColorWhite, false);
 			Graphics::Primitives &primitives = _wm.getDrawPrimitives();
@@ -1434,6 +1426,23 @@ void Gui::handleDragRelease(bool shiftPressed, bool isDoubleClick) {
 	}
 }
 
+Common::Rect Gui::calculateLassoRect(Graphics::MacWindow *win) {
+	Common::Point topLeft(_lassoStart);
+	Common::Point bottomRight(_lassoEnd);
+	if (topLeft.x > bottomRight.x)
+		SWAP(topLeft.x, bottomRight.x);
+	if (topLeft.y > bottomRight.y)
+		SWAP(topLeft.y, bottomRight.y);
+
+	Common::Rect lassoRect(topLeft, bottomRight);
+
+	const Common::Rect &innerDims = win->getInnerDimensions();
+	const Common::Rect &outerDims = win->getDimensions();
+	lassoRect.translate(outerDims.left - innerDims.left, outerDims.top - innerDims.top);
+
+	return lassoRect;
+}
+
 Common::Rect Gui::calculateClickRect(Common::Point clickPos, Common::Rect windowBounds) {
 	int left = clickPos.x - windowBounds.left;
 	int top = clickPos.y - windowBounds.top;
@@ -1869,13 +1878,8 @@ bool Gui::processInventoryEvents(WindowReference ref, WindowClick click, Common:
 		if (_lassoBeingDrawn && !_draggedObjects.size()) {
 			WindowData &data = findWindowData((WindowReference)ref);
 
-			Common::Point topLeft(_lassoStart);
-			Common::Point bottomRight(_lassoEnd);
-			if (topLeft.x > bottomRight.x)
-				SWAP(topLeft.x, bottomRight.x);
-			if (topLeft.y > bottomRight.y)
-				SWAP(topLeft.y, bottomRight.y);
-			Common::Rect lassoArea(topLeft, bottomRight);
+			Common::Rect lassoArea = calculateLassoRect(findWindow(ref));
+			lassoArea.translate(data.scrollPos.x, data.scrollPos.y);
 
 			Common::Array<ObjID> &selectedObjects = _engine->getSelectedObjects();
 			bool selectSelfWindow = true;

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -1137,6 +1137,18 @@ void Gui::printText(const Common::String &text) {
 	_outConsoleWindow->scrollToBottom();
 }
 
+uint Gui::getConsoleRowCount() {
+	return _outConsoleWindow->getRowCount();
+}
+
+uint Gui::getConsoleVisibleRows() {
+	int lineHeight = _outConsoleWindow->getLineHeight(0) + _outConsoleWindow->getLineSpacing();
+	if (lineHeight <= 0) {
+		return 1;
+	}
+	return MAX(1, _outConsoleWindow->getInnerDimensions().height() / lineHeight);
+}
+
 void Gui::setWaitCursor(bool wait) {
 	_wm.replaceCursor(wait ? Graphics::kMacCursorWatch : Graphics::kMacCursorArrow);
 	g_system->updateScreen();

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -506,17 +506,13 @@ WindowReference Gui::createInventoryWindow(ObjID objRef) {
 	}
 	newData.refcon = _objToInvRef[objRef];
 
-	if (_windowData->back().refcon < 0x80) { // There is already another inventory window
-		newData.bounds = _windowData->back().bounds; // Inventory windows are always last
-		newData.bounds.translate(newData.bounds.left + settings._invOffsetX, newData.bounds.top + settings._invOffsetY);
-	} else {
-		newData.bounds = Common::Rect(
-			settings._invLeft,
-			settings._invTop,
-			settings._invLeft + settings._invWidth,
-			settings._invTop + settings._invHeight
-		);
-	}
+	int cascade = _inventoryWindows.size();
+	newData.bounds = Common::Rect(
+		settings._invLeft + cascade * settings._invOffsetX,
+		settings._invTop + cascade * settings._invOffsetY,
+		settings._invLeft + cascade * settings._invOffsetX + settings._invWidth,
+		settings._invTop + cascade * settings._invOffsetY + settings._invHeight
+	);
 	newData.type = kInvWindow;
 	newData.hasCloseBox = true;
 	newData.visible = true;

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -121,6 +121,7 @@ Gui::Gui(MacVentureEngine *engine, Common::MacResManager *resman) {
 	_cursor = new Cursor(this);
 
 	_consoleText = new ConsoleText(this);
+	_needsRedraw = true;
 	_graphics = nullptr;
 	_diplomaImage = nullptr;
 	_diplomaWindow = nullptr;
@@ -192,10 +193,13 @@ void Gui::reloadInternals() {
 }
 
 void Gui::draw() {
-	// Will be performance-improved after the milestone
-	_wm.setFullRefresh(true);
+	if (_needsRedraw) {
+		_wm.setFullRefresh(true);
 
-	drawWindows();
+		drawWindows();
+
+		_needsRedraw = false;
+	}
 
 	_wm.draw();
 
@@ -203,6 +207,10 @@ void Gui::draw() {
 	drawDialog();
 	// TODO: When window titles with custom borders are in MacGui, this should be used.
 	//drawWindowTitle(kMainGameWindow, _mainGameWindow->getWindowSurface());
+}
+
+void Gui::markRedraw() {
+	_needsRedraw = true;
 }
 
 void Gui::drawMenu() {
@@ -1680,6 +1688,9 @@ Common::Point Gui::getObjMeasures(ObjID obj) {
 bool Gui::processEvent(Common::Event &event) {
 	bool processed = false;
 
+	if (event.type != Common::EVENT_MOUSEMOVE)
+		markRedraw();
+
 	processed |= _cursor->processEvent(event);
 
 	if (_dialog && _dialog->processEvent(event)) {
@@ -1689,7 +1700,10 @@ bool Gui::processEvent(Common::Event &event) {
 	if (event.type == Common::EVENT_MOUSEMOVE) {
 		if (_draggedObjects.size() && _draggedObjects[0].id != 0) {
 			moveDraggedObjects(event.mouse);
+			markRedraw();
 		}
+		if (_lassoBeingDrawn)
+			markRedraw();
 		processed = true;
 	} else if (event.type == Common::EVENT_LBUTTONUP) {
 		clearDraggedObjects();

--- a/engines/macventure/gui.h
+++ b/engines/macventure/gui.h
@@ -99,6 +99,7 @@ public:
 	void reloadInternals();
 
 	void draw();
+	void markRedraw();
 	void drawMenu();
 	void drawTitle();
 
@@ -230,6 +231,8 @@ private: // Attributes
 	Cursor *_cursor;
 
 	ConsoleText *_consoleText;
+
+	bool _needsRedraw;
 
 	WindowReference _lassoWinRef;
 	Common::Point _lassoStart;

--- a/engines/macventure/gui.h
+++ b/engines/macventure/gui.h
@@ -280,6 +280,7 @@ private: // Methods
 	bool isRectInsideObject(Common::Rect target, ObjID obj);
 	void selectDraggable(ObjID child, WindowReference origin, Common::Point startPos);
 	void handleDragRelease(bool shiftPressed, bool isDoubleClick);
+	Common::Rect calculateLassoRect(Graphics::MacWindow *win);
 	Common::Rect calculateClickRect(Common::Point clickPos, Common::Rect windowBounds);
 	Common::Point localizeTravelledDistance(Common::Point point, WindowReference origin, WindowReference target);
 	void removeInventoryWindow(WindowReference ref);

--- a/engines/macventure/gui.h
+++ b/engines/macventure/gui.h
@@ -163,6 +163,8 @@ public:
 	void setConsoleText(const Common::String &text);
 
 	void printText(const Common::String &text);
+	uint getConsoleRowCount();
+	uint getConsoleVisibleRows();
 
 	void setWaitCursor(bool wait);
 

--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -46,6 +46,10 @@ enum {
 	kMaxMenuTitleLength = 30
 };
 
+enum {
+	kFrameDelay = 20
+};
+
 MacVentureEngine::MacVentureEngine(OSystem *syst, const ADGameDescription *gameDesc) : Engine(syst) {
 	_gameDescription = gameDesc;
 	_rnd = new Common::RandomSource("macventure");
@@ -65,6 +69,8 @@ MacVentureEngine::MacVentureEngine(OSystem *syst, const ADGameDescription *gameD
 	_soundManager = nullptr;
 
 	_dataBundle = nullptr;
+
+	_nextFrameTime = 0;
 
 	debug("MacVenture::MacVentureEngine()");
 }
@@ -208,7 +214,11 @@ Common::Error MacVentureEngine::run() {
 void MacVentureEngine::refreshScreen() {
 	_gui->draw();
 	g_system->updateScreen();
-	g_system->delayMillis(50);
+
+	uint32 now = g_system->getMillis();
+	if (now < _nextFrameTime)
+		g_system->delayMillis(_nextFrameTime - now);
+	_nextFrameTime = g_system->getMillis() + kFrameDelay;
 }
 
 void MacVentureEngine::newGame() {

--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -239,6 +239,7 @@ void MacVentureEngine::setInitialFlags(GameState gameState) {
 	_destObject = 0;
 	_prepared = true;
 	_enginePaused = false;
+	_consoleRowsSincePause = 0;
 }
 
 void MacVentureEngine::setNewGameState() {
@@ -281,12 +282,14 @@ void MacVentureEngine::requestUnpause() {
 void MacVentureEngine::selectControl(ControlAction id) {
 	debugC(2, kMVDebugMain, "Select control %x", id);
 	if (id == kClickToContinue) {
+		_consoleRowsSincePause = 0;
 		_clickToContinue = false;
 		_enginePaused = false;
 		_paused = true;
 		return;
 	}
 
+	_consoleRowsSincePause = 0;
 	_selectedControl = id;
 	refreshReady();
 }
@@ -631,7 +634,11 @@ void MacVentureEngine::runObjQueue() {
 }
 
 void MacVentureEngine::printTexts() {
-	for (uint i = 0; i < _textQueue.size(); i++) {
+	while (!_textQueue.empty()) {
+		if (_consoleRowsSincePause >= _gui->getConsoleVisibleRows()) {
+			clickToContinue();
+			return;
+		}
 		QueuedText text = _textQueue.front();
 		_textQueue.remove_at(0);
 		switch (text.id) {
@@ -639,11 +646,14 @@ void MacVentureEngine::printTexts() {
 			_currentConsoleText += Common::String::format("%d", text.asset);
 			gameChanged();
 			break;
-		case kTextNewLine:
+		case kTextNewLine: {
+			uint rows = _gui->getConsoleRowCount();
 			_gui->printText(_currentConsoleText);
+			_consoleRowsSincePause += _gui->getConsoleRowCount() - rows;
 			_currentConsoleText.clear();
 			gameChanged();
 			break;
+		}
 		case kTextPlain:
 			_currentConsoleText += _world->getText(text.asset, text.source, text.destination);
 			gameChanged();

--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -546,6 +546,9 @@ bool MacVenture::MacVentureEngine::runScriptEngine() {
 	while (!_currentSelection.empty()) {
 		ObjID obj = _currentSelection.front();
 		_currentSelection.remove_at(0);
+		if (getInvolvedObjects() > 1 && obj == _destObject) {
+			continue;
+		}
 		if (isGameRunning() && _world->isObjActive(obj)) {
 			if (_scriptEngine->runControl(_selectedControl, obj, _destObject, _deltaPoint)) {
 				_haltedInSelection = true;

--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -203,6 +203,8 @@ Common::Error MacVentureEngine::run() {
 
 				if (busy)
 					_gui->setWaitCursor(false);
+
+				_gui->markRedraw();
 			}
 		}
 		refreshScreen();
@@ -266,6 +268,7 @@ void MacVentureEngine::resetGui() {
 	_gui->reloadInternals();
 	updateControls();
 	updateExits();
+	_gui->markRedraw();
 	refreshScreen();
 }
 

--- a/engines/macventure/macventure.h
+++ b/engines/macventure/macventure.h
@@ -396,6 +396,7 @@ private: // Attributes
 	bool _gameChanged;
 	bool _clickToContinue;
 	bool _enginePaused;
+	uint32 _nextFrameTime;
 
 	Common::Array<QueuedObject> _objQueue;
 	Common::Array<QueuedObject> _inQueue;

--- a/engines/macventure/macventure.h
+++ b/engines/macventure/macventure.h
@@ -397,6 +397,7 @@ private: // Attributes
 	bool _clickToContinue;
 	bool _enginePaused;
 	uint32 _nextFrameTime;
+	uint _consoleRowsSincePause;
 
 	Common::Array<QueuedObject> _objQueue;
 	Common::Array<QueuedObject> _inQueue;

--- a/engines/macventure/script.cpp
+++ b/engines/macventure/script.cpp
@@ -475,7 +475,7 @@ bool ScriptEngine::runFunc(EngineFrame *frame) {
 				break;
 			case 0xde: //update screen
 				opdeUPSC(state, frame);
-				break;
+				return true;
 			case 0xdf: //flash main window
 				opdfFMAI(state, frame);
 				return true;
@@ -1171,6 +1171,7 @@ void ScriptEngine::opddRTQ(EngineState *state, EngineFrame *frame) {
 
 void ScriptEngine::opdeUPSC(EngineState *state, EngineFrame *frame) {
 	_engine->updateState(true);
+	_engine->preparedToRun();
 }
 
 void ScriptEngine::opdfFMAI(EngineState *state, EngineFrame *frame) {


### PR DESCRIPTION
New inventory windows are placed and sized correctly instead of piling up

Scripted animations show their intermediate frames (elevator doors); the main loop now paces frames by elapsed time instead of a fixed 50 ms delay

Two-object commands no longer run a second time with the destination as the source, which prints a bogus "X does not have any effect on X"

Console output pauses with "click to continue" once it fills the window, instead of scrolling long messages past the player

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

ATTENTION TO AI USERS:

EVERY WORD of your code, comments, commit log messages, PR description, must be re-read by a human and checked for sanity, correctness and common sense. At any sight of AI slop, including lengthy LLM-oriented explanations, your PR will be closed.

On top of that, we created AI-specific guidelines https://github.com/scummvm/scummvm/blob/master/AI-GUIDELINES.md

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not, please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

We require linear history, so no merge commits are allowed.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
