### PR TITLE
M4: RIDDLE: Make Marshall Matt show up again

### DIFF
--- a/engines/m4/riddle/flags.h
+++ b/engines/m4/riddle/flags.h
@@ -37,9 +37,9 @@ enum Flag {
 	V002 =   2,
 	V003 =   3,
 	V004 =   4,
-	V005 =   5,
-	V006 =   6,
-	V007 =   7,
+	V005 =   5, // Warning level from Feng Li
+	V006 =   6, // Number of trips Ripley has taken (technically: Times foreign Posh Express offices entered)
+	V007 =   7, // Marshall Matt is waiting at the exit of room 301
 	V008 =   8,
 	V009 =   9,
 	V010 =  10,

--- a/engines/m4/riddle/rooms/room.cpp
+++ b/engines/m4/riddle/rooms/room.cpp
@@ -159,6 +159,12 @@ bool Room::setItemsPlacedFlags() {
 				(_G(flags)[V006] >= 5 && count < 3)) {
 			if (_G(flags)[V005] == 4)
 				_G(flags)[V005]++;
+
+			// Final warning level reached while Ripley is running out of
+			// money: Marshall Matt will be waiting at the travel agency.
+			// This is cleared again below as soon as enough items have been
+			// mailed home, so the arrest remains avoidable.
+			_G(flags)[V007] = 1;
 			return true;
 		}
 		break;

--- a/engines/m4/riddle/rooms/section3/room301.cpp
+++ b/engines/m4/riddle/rooms/section3/room301.cpp
@@ -696,7 +696,7 @@ void Room301::daemon() {
 		if (_marshallMode <= 0) {
 			if (_marshallShould <= 0) {
 				kernel_timing_trigger(30, 201);
-			} if (_marshallShould == 1) {
+			} else if (_marshallShould == 1) {
 				sendWSMessage_10000(1, _marshallMach, _marshalMatt, 17, 51, 201,
 					_marshalMatt, 51, 51, 0);
 				_marshallMode = 1;


### PR DESCRIPTION
V007 gates the arrest cutscene on exiting room 301, but it was only ever cleared, never set, in setItemsPlacedFlags(). Set it whenever the player reaches the final warning from Feng Li (V005).