### PR TITLE
M4: RIDDLE: Fix crash when crossing Moca Moche tree

### DIFF
--- a/engines/m4/riddle/rooms/section5/room504.cpp
+++ b/engines/m4/riddle/rooms/section5/room504.cpp
@@ -1640,7 +1640,7 @@ void Room504::daemon() {
 
 	case 642:
 		setVines();
-		terminateMachineAndNull(_vineMachine1);
+		terminateMachineAndNull(_vine);
 		series_unload(_vineTie);
 		sendWSMessage_150000(643);
 		break;
@@ -2125,7 +2125,7 @@ void Room504::daemon() {
 	case 727:
 		player_set_commands_allowed(false);
 		_ripMedReach = series_load("RIP TREK MED REACH HAND POS1");
-		setGlobals1(_ripHiReach2Handed, 1, 10, 10, 10);
+		setGlobals1(_ripMedReach, 1, 10, 10, 10);
 		sendWSMessage_110000(728);
 		break;
 
@@ -3524,7 +3524,7 @@ void Room504::addHotspot(int x1, int y1, int x2, int y2,
 	hotspot_newVerb(hs, verb);
 	hotspot_newVocab(hs, vocab);
 	hs->cursor_number = 6;
-	hotspot_add(_G(currentSceneDef).hotspots, hs, true);
+	_G(currentSceneDef).hotspots = hotspot_add(_G(currentSceneDef).hotspots, hs, true);
 }
 
 void Room504::addShovel() {


### PR DESCRIPTION
Crash when crossing the tree at Moca Moche.

Daemon case 727 loaded "RIP TREK MED REACH HAND POS1" into _ripMedReach (case 729 unloads it), but passed _ripHiReach2Handed to setGlobals1().

Also fix two nearby defects in the same room:
- case 642 terminated _vineMachine1 instead of _vine, the machine that case 641 created.
- addHotspot() dropped the head returned by hotspot_add(), so the rope and vine hotspots were never linked into the scene list. addShovel() below it already does this correctly.