### PR TITLE
M4: Fix the MIDI end trigger firing before the machine table exists

### DIFF
--- a/engines/m4/platform/sound/midi.cpp
+++ b/engines/m4/platform/sound/midi.cpp
@@ -34,14 +34,14 @@
 namespace M4 {
 namespace Sound {
 
-int Midi::_midiEndTrigger;
-
 Midi::Midi() {
 	_driver = nullptr;
 	_paused = false;
 	_deviceType = MT_NULL;
 	_midiParser = nullptr;
 	_midiData = nullptr;
+	_midiEndTrigger = -1;
+	_pendingEndTrigger = -1;
 }
 
 Midi::~Midi() {
@@ -261,7 +261,17 @@ void Midi::task() {
 }
 
 void Midi::loop() {
-	// No implementation
+	int trigger;
+
+	{
+		Common::StackLock lock(_mutex);
+		trigger = _pendingEndTrigger;
+		_pendingEndTrigger = -1;
+	}
+
+	// Dispatch a track-finished trigger recorded by onTimer()
+	if (trigger >= 0)
+		kernel_timing_trigger(10, trigger);
 }
 
 void Midi::midi_fade_volume(int targetVolume, int duration) {
@@ -277,10 +287,13 @@ void Midi::onTimer(void* data) {
 
 	if (m->_midiParser != nullptr) {
 		m->_midiParser->onTimer();
-		if (!m->_midiParser->isPlaying() && _midiEndTrigger >= 0) {
-			// FIXME Can this trigger a deadlock on the mutex?
-			kernel_timing_trigger(10, _midiEndTrigger);
-			_midiEndTrigger = -1;
+		if (!m->_midiParser->isPlaying() && m->_midiEndTrigger >= 0) {
+			// This runs on the audio thread, so only record the trigger here.
+			// loop() dispatches it from the main thread - kernel_timing_trigger()
+			// allocates a machine and links it into the WS machine list, which
+			// must not happen underneath the engine.
+			m->_pendingEndTrigger = m->_midiEndTrigger;
+			m->_midiEndTrigger = -1;
 		}
 	}
 }

--- a/engines/m4/platform/sound/midi.h
+++ b/engines/m4/platform/sound/midi.h
@@ -31,7 +31,10 @@ namespace Sound {
 
 class Midi {
 private:
-	static int _midiEndTrigger;
+	// Trigger to fire once the current track has finished, or -1 for none.
+	// _pendingEndTrigger hands it from the audio thread to the main thread.
+	int _midiEndTrigger;
+	int _pendingEndTrigger;
 
 	Common::Mutex _mutex;
 


### PR DESCRIPTION
Riddle apparently randomly does not launch.

Midi::_midiEndTrigger started at 0 instead of -1 without an initialiser. Midi::open() installs the driver timer callback while the parser already exists and nothing is playing, so on the first tick onTimer() saw "not playing" and a non-negative trigger and fired kernel_timing_trigger(10, 0).

That call happens on the audio thread, and at that point Vars::init() has only loaded walker script while timer machine comes from show script, which loads next. Whether the audio thread or the main thread wins the race decides whether the game starts AT ALL.