### PR TITLE
COMMON: add missing return statement to non-void function

### DIFF
--- a/common/ptr.h
+++ b/common/ptr.h
@@ -614,6 +614,7 @@ public:
 	 */
 	ScopedPtr &operator=(std::nullptr_t) {
 		reset(nullptr);
+		return *this;
 	}
 
 	/**


### PR DESCRIPTION
Add missing return statement to non-void `operator=` function.