### PR TITLE
BURIED: Fix buggy transition in Chateau Gaillard

### DIFF
--- a/engines/buried/scene_view.cpp
+++ b/engines/buried/scene_view.cpp
@@ -1089,16 +1089,21 @@ bool SceneViewWindow::videoTransition(const Location &location, DestinationScene
 		return true;
 	}
 
-	animationMovie.reset();
-
-	if (audioStream)
-		_vm->_sound->restart();
-
+	// Update `_preBuffer` with the destination background and push it to the screen BEFORE
+	// destroying the video window. Resetting animationMovie triggers an immediate window repaint.
+	// Blitting newBackground into _preBuffer here ensures that when the movie ends, the display
+	// shows the intended target destination frame rather than stale video content.
 	if (newBackground) {
 		_vm->_gfx->crossBlit(_preBuffer, 0, 0, 432, 189, newBackground, 0, 0);
 		newBackground->free();
 		delete newBackground;
+		newBackground = nullptr;
 	}
+
+	animationMovie.reset();
+
+	if (audioStream)
+		_vm->_sound->restart();
 
 	_paused = false;
 
@@ -2381,6 +2386,14 @@ void SceneViewWindow::onKeyUp(const Common::KeyState &key, uint flags) {
 }
 
 void SceneViewWindow::onPaint() {
+	// Bypass scene-specific painting while a transition animation or cutscene is playing.
+	// During active transitions, the scene view is in a transient state. Painting at that time
+	// can cause access of frame data with mismatched data e.g. post-transition still frame data
+	// indexed using pre-transition frame information.
+	if (_paused) {
+		return;
+	}
+
 	// Original didn't draw if the async movie was playing, but that doesn't seem right.
 	if (_currentScene && !_infoWindowDisplayed && !_bioChipWindowDisplayed) {
 		if (_currentScene->_staticData.navFrameIndex >= -1) {


### PR DESCRIPTION
Fix an issue that could cause an incorrect still frame to be drawn after a video transition. At the end of the `videoTransition` method, the movie's video window is deleted. VideoWindow extends form Window, which itself invalidates the screen's contents in its destructor. This causes an erroneous frame draw to the screen using the *new* still frames loaded during the transition but using the *old* scene's location data.

This fixes a bug in Chateau Gaillard that I can reproduce consistently
1. Progress to the catapult sequence (wall explosion)
2. Step forward, look to the right, then look down.
3. Navigate forward to descend the wall
4. Press ESC to skip the transition movie

EXPECTED: The viewport contents should be of the next area, right after going down the wall.
<img width="1802" height="1186" alt="Screenshot 2026-08-09 at 1 59 39 PM" src="https://github.com/user-attachments/assets/9ce08147-1c7c-4925-8580-379560bb890a" />

ACTUAL: The viewport contents is the first frame of the Bailey ascent scene (where the guards throw rocks at you). 
<img width="1802" height="1186" alt="Screenshot 2026-08-09 at 2 08 08 PM" src="https://github.com/user-attachments/assets/1f32943b-8381-47e1-b77d-cf16ae1cbbf1" />

The bug is resolved by the changes in this PR.
