### PR TITLE
MACVENTURE: Sign the diploma and page the console with click to continue

### DIFF
--- a/engines/macventure/dialog.cpp
+++ b/engines/macventure/dialog.cpp
@@ -72,6 +72,7 @@ Dialog::Dialog(Gui *gui, Common::MacResManager *resourceManager, uint16 resID) {
 		stream->readUint32BE(); // reserved
 		PrebuiltDialogElement element;
 		element.action = kDANone;
+		element.title = "";
 		element.top = stream->readUint16BE();
 		element.left = stream->readUint16BE();
 		element.height = stream->readUint16BE() - element.top;

--- a/engines/macventure/dialog.cpp
+++ b/engines/macventure/dialog.cpp
@@ -154,6 +154,9 @@ void Dialog::handleDialogAction(DialogElement *trigger, DialogAction action) {
 		_gui->quitGame();
 		_gui->closeDialog();
 		break;
+	case kDAPrintDiploma:
+		_gui->printDiploma();
+		break;
 	default:
 		break;
 	}

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -1167,6 +1167,15 @@ void Gui::printText(const Common::String &text) {
 	_outConsoleWindow->scrollToBottom();
 }
 
+void Gui::scrollConsoleToRow(uint row) {
+	int lineHeight = _outConsoleWindow->getLineHeight(0) + _outConsoleWindow->getLineSpacing();
+	if (lineHeight <= 0) {
+		_outConsoleWindow->scrollToBottom();
+		return;
+	}
+	_outConsoleWindow->scrollTo(row * lineHeight);
+}
+
 uint Gui::getConsoleRowCount() {
 	return _outConsoleWindow->getRowCount();
 }

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -34,6 +34,7 @@
 #include "image/bmp.h"
 #include "graphics/macgui/macfontmanager.h"
 #include "graphics/macgui/mactextwindow.h"
+#include "gui/gui-manager.h"
 
 #include "macventure/gui.h"
 #include "macventure/dialog.h"
@@ -125,6 +126,9 @@ Gui::Gui(MacVentureEngine *engine, Common::MacResManager *resman) {
 	_graphics = nullptr;
 	_diplomaImage = nullptr;
 	_diplomaWindow = nullptr;
+	_diplomaFontId = Graphics::kMacFontSystem;
+	_diplomaFontSize = 12;
+	_diplomaNameBounds = Common::Rect();
 
 	_lassoStart = Common::Point(0, 0);
 	_lassoEnd = Common::Point(0, 0);
@@ -605,6 +609,20 @@ void Gui::loadDiploma() {
 	_dialog = new Dialog(this, _resourceManager, kDialogBoxDiplomaID);
 	DialogElement *quitButton = _dialog->getElement("Quit");
 	quitButton->setAction(kDAQuit);
+	DialogElement *printButton = _dialog->getElement("Print");
+	printButton->setAction(kDAPrintDiploma);
+
+	_diplomaName.clear();
+	Common::SeekableReadStream *geometry = _resourceManager->getResource(MKTAG('G', 'N', 'R', 'L'), kDiplomaGeometryID);
+	if (geometry) {
+		_diplomaFontId = geometry->readUint16BE();
+		_diplomaFontSize = geometry->readUint16BE();
+		_diplomaNameBounds.top = geometry->readUint16BE();
+		_diplomaNameBounds.left = geometry->readUint16BE();
+		_diplomaNameBounds.bottom = geometry->readUint16BE();
+		_diplomaNameBounds.right = geometry->readUint16BE();
+		delete geometry;
+	}
 
 	// Image
 	if (!_diplomaImage) {
@@ -802,6 +820,18 @@ void Gui::drawDiplomaWindow() {
 		0,
 		0,
 		kBlitDirect);
+
+	if (!_diplomaNameBounds.isEmpty()) {
+		const Graphics::Font *font = _wm._fontMan->getFont(Graphics::MacFont(_diplomaFontId, _diplomaFontSize));
+		font->drawString(
+			_diplomaWindow->getWindowSurface(),
+			_diplomaName,
+			_diplomaNameBounds.left,
+			_diplomaNameBounds.top,
+			_diplomaNameBounds.width(),
+			kColorBlack,
+			Graphics::kTextAlignCenter);
+	}
 
 	findWindow(kDiplomaWindow)->setDirty(true);
 }
@@ -1697,6 +1727,10 @@ bool Gui::processEvent(Common::Event &event) {
 		return true;
 	}
 
+	if (event.type == Common::EVENT_KEYDOWN && _diplomaWindow && processDiplomaKey(event)) {
+		return true;
+	}
+
 	if (event.type == Common::EVENT_MOUSEMOVE) {
 		if (_draggedObjects.size() && _draggedObjects[0].id != 0) {
 			moveDraggedObjects(event.mouse);
@@ -1837,6 +1871,42 @@ bool MacVenture::Gui::processDiplomaEvents(WindowClick click, Common::Event &eve
 		return true;
 
 	return getWindowData(kDiplomaWindow).visible;
+}
+
+void Gui::printDiploma() {
+	if (!_diplomaWindow)
+		return;
+
+	Graphics::ManagedSurface diploma;
+	diploma.copyFrom(*_diplomaWindow->getWindowSurface());
+	diploma.setPalette(_wm.getPalette(), 0, _wm.getPaletteSize());
+
+	g_gui.printImage(diploma);
+
+	markRedraw();
+}
+
+bool Gui::processDiplomaKey(Common::Event &event) {
+	if (_diplomaNameBounds.isEmpty())
+		return false;
+
+	if (event.kbd.keycode == Common::KEYCODE_BACKSPACE) {
+		if (_diplomaName.empty())
+			return false;
+		_diplomaName.deleteLastChar();
+		return true;
+	}
+
+	if (event.kbd.ascii < 0x20 || event.kbd.ascii > 0x7f)
+		return false;
+
+	const Graphics::Font *font = _wm._fontMan->getFont(Graphics::MacFont(_diplomaFontId, _diplomaFontSize));
+	Common::String candidate = _diplomaName + (char)event.kbd.ascii;
+	if (font->getStringWidth(candidate) > _diplomaNameBounds.width())
+		return true;
+
+	_diplomaName = candidate;
+	return true;
 }
 
 bool Gui::processInventoryEvents(WindowReference ref, WindowClick click, Common::Event &event) {

--- a/engines/macventure/gui.h
+++ b/engines/macventure/gui.h
@@ -131,6 +131,8 @@ public:
 	bool processSelfEvents(WindowClick click, Common::Event &event);
 	bool processExitsEvents(WindowClick click, Common::Event &event);
 	bool processDiplomaEvents(WindowClick click, Common::Event &event);
+	bool processDiplomaKey(Common::Event &event);
+	void printDiploma();
 	bool processInventoryEvents(WindowReference ref, WindowClick click, Common::Event &event);
 
 	const WindowData& getWindowData(WindowReference reference);
@@ -224,6 +226,10 @@ private: // Attributes
 	Container *_graphics;
 	Common::HashMap<ObjID, ImageAsset*> _assets;
 	ImageAsset *_diplomaImage;
+	Common::String _diplomaName;
+	Common::Rect _diplomaNameBounds;
+	uint16 _diplomaFontId;
+	uint16 _diplomaFontSize;
 
 	Common::Array<DraggedObj> _draggedObjects;
 	Common::Array<Graphics::ManagedSurface> _draggedSurfaces;

--- a/engines/macventure/gui.h
+++ b/engines/macventure/gui.h
@@ -166,6 +166,7 @@ public:
 	void setConsoleText(const Common::String &text);
 
 	void printText(const Common::String &text);
+	void scrollConsoleToRow(uint row);
 	uint getConsoleRowCount();
 	uint getConsoleVisibleRows();
 

--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -285,14 +285,23 @@ void MacVentureEngine::requestUnpause() {
 void MacVentureEngine::selectControl(ControlAction id) {
 	debugC(2, kMVDebugMain, "Select control %x", id);
 	if (id == kClickToContinue) {
+		if (_consoleRowsSincePause > _gui->getConsoleVisibleRows()) {
+			_consoleRowsSincePause -= _gui->getConsoleVisibleRows();
+			clickToContinue();
+			return;
+		}
+
 		_consoleRowsSincePause = 0;
 		_clickToContinue = false;
 		_enginePaused = false;
 		_paused = true;
+		_prepared = true;
 		return;
 	}
 
-	_consoleRowsSincePause = 0;
+	if (!_clickToContinue)
+		_consoleRowsSincePause = 0;
+
 	_selectedControl = id;
 	refreshReady();
 }
@@ -335,6 +344,9 @@ void MacVentureEngine::loseGame() {
 }
 
 void MacVentureEngine::clickToContinue() {
+	uint rowCount = _gui->getConsoleRowCount();
+
+	_gui->scrollConsoleToRow(rowCount > _consoleRowsSincePause ? rowCount - _consoleRowsSincePause : 0);
 	_clickToContinue = true;
 	_enginePaused = true;
 }
@@ -665,6 +677,9 @@ void MacVentureEngine::printTexts() {
 			break;
 		}
 	}
+
+	if (_consoleRowsSincePause > _gui->getConsoleVisibleRows())
+		clickToContinue();
 }
 
 void MacVentureEngine::playSounds(bool pause) {

--- a/engines/macventure/prebuilt_dialogs.h
+++ b/engines/macventure/prebuilt_dialogs.h
@@ -41,7 +41,8 @@ enum DialogAction {
 	kDASaveAs,
 	kDALoadGame,
 	kDAQuit,
-	kDANewGame
+	kDANewGame,
+	kDAPrintDiploma
 };
 
 enum PrebuiltDialogs {

--- a/graphics/macgui/mactextwindow.h
+++ b/graphics/macgui/mactextwindow.h
@@ -51,6 +51,7 @@ public:
 	void setMarkdownText(const Common::U32String &str);
 
 	void scrollToBottom() { _mactext->_scrollPos = MAX<int>(0, _mactext->getTextHeight() - getInnerDimensions().height()); }
+	void scrollTo(int pos) { _mactext->_scrollPos = CLIP<int>(pos, 0, MAX<int>(0, _mactext->getTextHeight() - getInnerDimensions().height())); _mactext->setDirty(true); }
 
 	void setEditable(bool editable) { _editable = editable; _mactext->setEditable(editable); }
 	void setActive(bool active) override { MacWindow::setActive(active); if (_editable) _mactext->setActive(active); }


### PR DESCRIPTION
Four commits, tested in Deja Vu.

Diploma Dialog Name Handling: The diploma dialog asks the player for a name, but the name belongs on the diploma itself rather than in a dialog field, and nothing handles it. The geometry resource that describes the name line is already known as kDiplomaGeometryID but is never read, so this reads the font, the size, and the bounds from it and hands the signed diploma to the printing manager.

DITL Dialog Title Initialization: A separate commit initializes the title of dialog elements read from DITL. An item whose title length is zero leaves the pointer uninitialized, and both the button and the plain text cases pass it to a Common::String.

Click-to-Continue Prompt Fix: The rest makes the click-to-continue prompt work. It is almost never shown because updateControls() and resetVars() call selectControl(kNoCommand) as an internal state reset and clear the counter that tracks the pause.

When it does appear, the game stops for good because the click never sets _prepared again, and the remaining text queue is stranded.

The console is also filled one whole message at a time, while the original stops printing as soon as the window is full, so a message taller than the window scrolls past the player. Each click now shows the next windowful of it.

Absolute Scroll Position (scrollTo): Paging needs an absolute scroll position, which MacTextWindow does not expose, so the first commit adds scrollTo() next to scrollToBottom(). Unlike that one, it marks the text dirty, since MacText::draw() returns early when nothing is dirty and scrolling without appending text would leave the previous position on screen.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

ATTENTION TO AI USERS:

EVERY WORD of your code, comments, commit log messages, PR description, must be re-read by a human and checked for sanity, correctness and common sense. At any sight of AI slop, including lengthy LLM-oriented explanations, your PR will be closed.

On top of that, we created AI-specific guidelines https://github.com/scummvm/scummvm/blob/master/AI-GUIDELINES.md

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not, please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

We require linear history, so no merge commits are allowed.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
