### PR TITLE
SHERLOCK: TATTOO: Fix delta.x sign during vertical walks

### DIFF
--- a/engines/sherlock/tattoo/tattoo_people.cpp
+++ b/engines/sherlock/tattoo/tattoo_people.cpp
@@ -479,7 +479,7 @@ void TattooPerson::setWalking() {
 			else
 				_delta.x = (delta.x * FIXED_INT_MULTIPLIER) / delta.y;
 
-			if (_walkDest.x < _position.y / FIXED_INT_MULTIPLIER)
+			if (_walkDest.x < _position.x / FIXED_INT_MULTIPLIER)
 				_delta.x = -_delta.x;
 
 			// Set how many times we should add the delta's to the players position


### PR DESCRIPTION
## Bug

In `TattooPerson::setWalking()` (Rose Tattoo / Sherlock engine), the
vertical-movement branch determines the sign of `_delta.x` by comparing
`_walkDest.x` against `_position.y / FIXED_INT_MULTIPLIER`:

```cpp
if (_walkDest.x < _position.y / FIXED_INT_MULTIPLIER)
    _delta.x = -_delta.x;
```

This looks like a copy/paste typo: the mirrored horizontal-movement branch
a few lines above correctly compares `_walkDest.x` against `_position.x`:

```cpp
if (_walkDest.x < (_position.x / FIXED_INT_MULTIPLIER)) {
```

## Symptom

When Holmes needs to walk mostly *vertically* to reach a destination
(e.g. approaching an NPC whose talk position requires more vertical than
horizontal travel), `_delta.x` can end up with the wrong sign. This makes
Holmes drift sideways in the wrong direction, which then causes
`setWalking()` to re-fire on the very next frame and flip the direction
back — producing a visible left-right oscillation. In practice this
looks like Holmes spinning/stepping in place instead of walking to the
clicked destination (reproducible in "The Lost Files of Sherlock Holmes:
The Case of the Rose Tattoo" by clicking on certain NPCs to talk to
them).

## Fix

Compare against `_position.x` instead of `_position.y`, matching the
logic of the horizontal branch.

## Testing

Built and tested locally against a `sherlock`-only build
(`./configure --enable-engine=sherlock --disable-all-engines`); confirmed
the file compiles cleanly. Verified in-game that Holmes now walks
directly to NPCs requiring a vertical approach instead of oscillating in
place.