### PR TITLE
M4: RIDDLE: Fix blocker in room 603 when trying to take the pole

### DIFF
--- a/engines/m4/riddle/rooms/section6/room603.cpp
+++ b/engines/m4/riddle/rooms/section6/room603.cpp
@@ -2122,6 +2122,8 @@ bool Room603::takePole() {
 				player_set_commands_allowed(false);
 				_ttShould = _val5 ? 12 : 7;
 				_ripAction = series_load("RIP MED REACH 1HAND POS2");
+				setGlobals1(_ripAction, 1, 15, 15, 15);
+				sendWSMessage_110000(2);
 				return true;
 			}
 			break;


### PR DESCRIPTION
While Twelvetrees is still present at the dig site (any V203 value other than 0 and 4), case -1 of takePole() disabled the player commands and loaded the reach series but never dispatched a trigger, so case 2 never ran and the sequence was stuck.