### PR TITLE
M4: RIDDLE: Fix lockup in 605 when taking disk with Twelvetrees present

### DIFF
--- a/engines/m4/riddle/rooms/section6/room605.cpp
+++ b/engines/m4/riddle/rooms/section6/room605.cpp
@@ -741,6 +741,25 @@ bool Room605::sleeveDisk1() {
 		digi_play("605_S02", 2);
 		return true;
 
+	case 11:
+		_ttShould = 0;
+		kernel_timing_trigger(1, 200, KT_DAEMON, KT_PARSE);
+		inv_move_object("OBSIDIAN DISK", 605);
+		_pupil = series_show("605eye", 0x600, 16);
+		hotspot_set_active("PUPIL", true);
+		hotspot_set_active("OBSIDIAN DISK", true);
+		sendWSMessage_10000(1, _ripley, _ripGetsIrisWithCloth, 44, 75, 12,
+			_ripGetsIrisWithCloth, 75, 75, 1);
+		return true;
+
+	case 12:
+		terminateMachineAndNull(_ripley);
+		series_unload(_ripGetsIrisWithCloth);
+		digi_unload("605_s01");
+		digi_unload("605_s02");
+		player_set_commands_allowed(true);
+		return true;
+
 	default:
 		break;
 	}


### PR DESCRIPTION
sleeveDisk1() dispatched trigger 11 from case 10 but had no case 11, so the put-back ended with the player commands still disabled and the animation machine parked.

Returning false for the unhandled trigger also let parser() fall through its whole cascade to the final return, which is the one exit that leaves command_ready set, so the room answered the trigger with a default "that doesn't work" line on top of the lock up.