### PR TITLE
M4: RIDDLE: Fix Twelvetrees' head turn animation loop in room 605

### DIFF
--- a/engines/m4/riddle/rooms/section6/room605.cpp
+++ b/engines/m4/riddle/rooms/section6/room605.cpp
@@ -204,6 +204,7 @@ void Room605::daemon() {
 			case 6:
 			case 7:
 				sendWSMessage_10000(1, _tt, _605tt, 58, 66, 200, _605tt, 67, 67, 0);
+				_ttMode = 6;
 				break;
 
 			case 8:


### PR DESCRIPTION
Fix taking the obsidian disk with Twelvetrees present exposed unintended animation loop. _ttShould 6/7 branch of the idle state never set _ttMode, so every 200/201 round trip re-entered it and replayed frames 58-66.