### PR TITLE
GLK: ALAN3: use ASIZE macro where applicable

### DIFF
--- a/engines/glk/alan3/main.cpp
+++ b/engines/glk/alan3/main.cpp
@@ -118,11 +118,11 @@ Common::SeekableReadStream *codfil;
 static int crcStart(const byte version[4]) {
 	/* Some earlier versions had a shorter header */
 	if (isPreAlpha5(version))
-		return sizeof(Pre3_0alpha5Header) / sizeof(Aword);
+		return ASIZE(Pre3_0alpha5Header);
 	else if (isPreBeta2(version))
-		return sizeof(Pre3_0beta2Header) / sizeof(Aword);
+		return ASIZE(Pre3_0beta2Header);
 	else
-		return sizeof(ACodeHeader) / sizeof(Aword);
+		return ASIZE(ACodeHeader);
 }
 
 
@@ -357,7 +357,7 @@ static void load(CONTEXT) {
 	reverseHdr(&tmphdr);
 #endif
 
-	if (tmphdr.size <= sizeof(ACodeHeader) / sizeof(Aword))
+	if (tmphdr.size <= ASIZE(ACodeHeader))
 		syserr("Malformed game file. Too small.");
 
 	loadAndCheckMemory(tmphdr, crc, err);

--- a/engines/glk/alan3/reverse.cpp
+++ b/engines/glk/alan3/reverse.cpp
@@ -496,7 +496,7 @@ static void reversePreAlpha5Header(Pre3_0alpha5Header *hdr) {
 	uint i;
 
 	/* Reverse all words in the header except the tag */
-	for (i = 1; i < sizeof(*hdr) / sizeof(Aword); i++)
+	for (i = 1; i < ASIZE(*hdr); i++)
 		reverseWord(&((Aword *)hdr)[i]);
 }
 
@@ -536,7 +536,7 @@ static void reversePreBeta2Header(Pre3_0beta2Header *hdr) {
 	uint i;
 
 	/* Reverse all words in the header except the tag */
-	for (i = 1; i < sizeof(*hdr) / sizeof(Aword); i++)
+	for (i = 1; i < ASIZE(*hdr); i++)
 		reverseWord(&((Aword *)hdr)[i]);
 }
 
@@ -576,7 +576,7 @@ void reverseHdr(ACodeHeader *hdr) {
 	uint i;
 
 	/* Reverse all words in the header except the tag and the version marking */
-	for (i = 1; i < sizeof(*hdr) / sizeof(Aword); i++)
+	for (i = 1; i < ASIZE(*hdr); i++)
 		reverseWord(&((Aword *)hdr)[i]);
 }
 

--- a/engines/glk/alan3/types.h
+++ b/engines/glk/alan3/types.h
@@ -52,7 +52,7 @@ namespace Alan3 {
 #define addressOf(x) ((((long)x)-((long)memory))/sizeof(Aword))
 #define stringAt(x) ((char *)pointerTo(x))
 
-#define ASIZE(x) (sizeof(x)/sizeof(Aword))
+#define ASIZE(x) AwordSizeOf(x)
 
 /* The various tables */
 struct VerbEntry {  /* VERB TABLE */


### PR DESCRIPTION
- Broader usage of the `ASIZE` macro in ALAN3 for less bulky code and future improvement opportunities
- Deduplicate macro definition between `AwordSizeOf` and `ASIZE`