### PR TITLE
MACVENTURE: dejavu2 fixes

### DIFF
--- a/engines/macventure/cursor.cpp
+++ b/engines/macventure/cursor.cpp
@@ -46,6 +46,7 @@ static const ClickState _transitionTable[kCursorStateCount][kCursorInputCount] =
 Cursor::Cursor(Gui *gui) {
 	_gui = gui;
 	_state = kCursorIdle;
+	_shiftPressed = false;
 }
 Cursor::~Cursor() {}
 
@@ -59,6 +60,7 @@ bool Cursor::processEvent(const Common::Event &event) {
 		return true;
 	}
 	if (event.type == Common::EVENT_LBUTTONDOWN) {
+		_shiftPressed = (g_system->getEventManager()->getModifierState() & Common::KBD_SHIFT) != 0;
 		changeState(kButtonDownCol);
 		return true;
 	}
@@ -91,11 +93,10 @@ void Cursor::executeStateIn() {
 	switch (_state) {
 	case kCursorSCStart:
 		g_system->getTimerManager()->installTimerProc(&cursorTimerHandler, 300000, this, "macVentureCursor");
-		_gui->select(_pos, false, false);
+		_gui->select(_pos, _shiftPressed, false);
 		break;
 	case kCursorDCStart:
 		g_system->getTimerManager()->installTimerProc(&cursorTimerHandler, 300000, this, "macVentureCursor");
-		_gui->select(_pos, false, true);
 		break;
 	case kCursorSCSink:
 		_gui->handleSingleClick();

--- a/engines/macventure/dialog.cpp
+++ b/engines/macventure/dialog.cpp
@@ -280,15 +280,30 @@ const Common::String &DialogElement::doGetText() {
 // CONCRETE DIALOG ELEMENTS
 
 DialogButton::DialogButton(Dialog *dialog, Common::String title, DialogAction action, Common::Point position, uint width, uint height):
-	DialogElement(dialog, title, action, position, width, height, Graphics::kTextAlignCenter) {}
+	DialogElement(dialog, title, action, position, width, height, Graphics::kTextAlignCenter),
+	_pressed(false), _mouseOverPressed(false) {}
 
 bool DialogButton::doProcessEvent(MacVenture::Dialog *dialog, Common::Event event) {
 	Common::Point mouse = event.mouse;
+	dialog->localize(mouse);
+
 	if (event.type == Common::EVENT_LBUTTONDOWN) {
-		dialog->localize(mouse);
 		if (_bounds.contains(mouse)) {
-			debugC(2, kMVDebugGUI, "Click! Button: %s", _text.c_str());
-			dialog->handleDialogAction(this, _action);
+			_pressed = true;
+			_mouseOverPressed = true;
+			return true;
+		}
+	} else if (event.type == Common::EVENT_MOUSEMOVE) {
+		if (_pressed) {
+			_mouseOverPressed = _bounds.contains(mouse);
+		}
+	} else if (event.type == Common::EVENT_LBUTTONUP) {
+		if (_pressed) {
+			_pressed = false;
+			if (_bounds.contains(mouse)) {
+				debugC(2, kMVDebugGUI, "Click! Button: %s", _text.c_str());
+				dialog->handleDialogAction(this, _action);
+			}
 			return true;
 		}
  	}
@@ -296,11 +311,13 @@ bool DialogButton::doProcessEvent(MacVenture::Dialog *dialog, Common::Event even
 }
 
 void DialogButton::doDraw(MacVenture::Dialog *dialog, Graphics::ManagedSurface &target) {
-	target.fillRect(_bounds, kColorWhite);
+	bool invert = _pressed && _mouseOverPressed;
+
+	target.fillRect(_bounds, invert ? kColorBlack : kColorWhite);
 	target.frameRect(_bounds, kColorBlack);
 	// Draw title
 	dialog->getFont().drawString(
-		&target, _text, _bounds.left, _bounds.top, _bounds.width(), kColorBlack, Graphics::kTextAlignCenter);
+		&target, _text, _bounds.left, _bounds.top, _bounds.width(), invert ? kColorWhite : kColorBlack, Graphics::kTextAlignCenter);
 }
 
 DialogPlainText::DialogPlainText(Dialog *dialog, Common::String content, Common::Point position, int width, int height, Graphics::TextAlign alignment) :

--- a/engines/macventure/dialog.h
+++ b/engines/macventure/dialog.h
@@ -113,6 +113,9 @@ public:
 private:
 	bool doProcessEvent(Dialog *dialog, Common::Event event) override;
 	void doDraw(MacVenture::Dialog *dialog, Graphics::ManagedSurface &target) override;
+
+	bool _pressed;
+	bool _mouseOverPressed;
 };
 
 class DialogPlainText : public DialogElement {

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -1212,9 +1212,6 @@ void Gui::closeDialog() {
 }
 
 void Gui::getTextFromUser(Common::String &title) {
-	if (_dialog) {
-		delete _dialog;
-	}
 	showPrebuiltDialog(kSpeakDialog, title);
 }
 

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -1372,7 +1372,7 @@ void Gui::checkSelect(const WindowData &data, Common::Point pos, const Common::R
 		}
 	}
 	if (child != 0 || data.refcon == kMainGameWindow) {
-		if (!isDoubleClick)
+		if (!isDoubleClick && !shiftPressed)
 			selectDraggable(child, ref, pos);
 		_engine->handleObjectSelect(child, ref, shiftPressed, isDoubleClick);
 		bringToFront(ref);
@@ -1934,8 +1934,10 @@ bool Gui::processInventoryEvents(WindowReference ref, WindowClick click, Common:
 		WindowData &data = findWindowData((WindowReference)ref);
 
 		if (click == kBorderInner && !_draggedObjects.size()) {
-			_engine->unselectAll();
-			_engine->getSelectedObjects().clear();
+			if (!(g_system->getEventManager()->getModifierState() & Common::KBD_SHIFT)) {
+				_engine->unselectAll();
+				_engine->getSelectedObjects().clear();
+			}
 
 			_lassoStart = event.mouse;
 			_lassoEnd = _lassoStart;
@@ -2012,7 +2014,7 @@ void Gui::select(Common::Point cursorPosition, bool shiftPressed, bool isDoubleC
 	WindowData &data = findWindowData((WindowReference)ref);
 
 	Common::Rect clickRect = calculateClickRect(cursorPosition + data.scrollPos, win->getInnerDimensions());
-	checkSelect(data, cursorPosition, clickRect, (WindowReference)ref, isDoubleClick, shiftPressed);
+	checkSelect(data, cursorPosition, clickRect, (WindowReference)ref, shiftPressed, isDoubleClick);
 }
 
 void Gui::handleSingleClick() {

--- a/engines/macventure/gui.h
+++ b/engines/macventure/gui.h
@@ -344,6 +344,7 @@ private:
 
 	Common::Point _pos;
 	ClickState _state;
+	bool _shiftPressed;
 };
 
 

--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -1167,7 +1167,7 @@ void MacVentureEngine::zoomObject(ObjID objID) {
 bool MacVentureEngine::isObjEnqueued(ObjID objID) {
 	Common::Array<QueuedObject>::const_iterator it;
 	for (it = _objQueue.begin(); it != _objQueue.end(); it++) {
-		if ((*it).object == objID) {
+		if ((*it).id == kUpdateObject && (*it).object == objID) {
 			return true;
 		}
 	}

--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -405,17 +405,10 @@ void MacVentureEngine::handleObjectSelect(ObjID objID, WindowReference win, bool
 			objID = windata.objRef;
 		}
 		if (objID > 0) {
-			int selectedIndex = findObjectInArray(objID, _selectedObjs);
 			if (findObjectInArray(objID, _currentSelection) != -1) {
 				unselectObject(objID);
-				if (selectedIndex != -1) {
-					_selectedObjs.remove_at(selectedIndex);
-				}
 			} else {
 				selectObject(objID);
-				if (selectedIndex == -1) {
-					_selectedObjs.push_back(objID);
-				}
 			}
 			refreshReady();
 			preparedToRun();
@@ -582,9 +575,6 @@ bool MacVenture::MacVentureEngine::runScriptEngine() {
 	while (!_currentSelection.empty()) {
 		ObjID obj = _currentSelection.front();
 		_currentSelection.remove_at(0);
-		if (getInvolvedObjects() > 1 && obj == _destObject) {
-			continue;
-		}
 		if (isGameRunning() && _world->isObjActive(obj)) {
 			if (_scriptEngine->runControl(_selectedControl, obj, _destObject, _deltaPoint)) {
 				_haltedInSelection = true;
@@ -939,14 +929,20 @@ void MacVentureEngine::selectObject(ObjID objID) {
 	}
 	if (findObjectInArray(objID, _currentSelection) == -1) {
 		_currentSelection.push_back(objID);
+	}
+	if (findObjectInArray(objID, _selectedObjs) == -1) {
+		_selectedObjs.push_back(objID);
 		highlightExit(objID);
 	}
 }
 
 void MacVentureEngine::unselectObject(ObjID objID) {
-	int idxCur = findObjectInArray(objID, _currentSelection);
-	if (idxCur != -1) {
-		_currentSelection.remove_at(idxCur);
+	int idx = findObjectInArray(objID, _currentSelection);
+	if (idx != -1) {
+		_currentSelection.remove_at(idx);
+	}
+	if ((idx = findObjectInArray(objID, _selectedObjs)) != -1) {
+		_selectedObjs.remove_at(idx);
 		highlightExit(objID);
 	}
 }
@@ -1015,12 +1011,15 @@ void MacVentureEngine::selectPrimaryObject(ObjID objID) {
 	int idx;
 	debugC(4, kMVDebugMain, "Select primary object (%d)", objID);
 	if (_destObject > 0 &&
-		(idx = findObjectInArray(_destObject, _currentSelection)) != -1) {
-		unselectAll();
+		(idx = findObjectInArray(_destObject, _selectedObjs)) != -1 &&
+		findObjectInArray(_destObject, _currentSelection) == -1) {
+		_selectedObjs.remove_at(idx);
+		highlightExit(_destObject);
 	}
 	_destObject = objID;
-	if (findObjectInArray(_destObject, _currentSelection) == -1) {
-		selectObject(_destObject);
+	if (findObjectInArray(_destObject, _selectedObjs) == -1) {
+		_selectedObjs.push_back(_destObject);
+		highlightExit(_destObject);
 	}
 
 	_cmdReady = true;
@@ -1153,10 +1152,9 @@ void MacVentureEngine::reflectSwap(ObjID fromID, ObjID toID) {
 }
 
 void MacVentureEngine::toggleExits() {
-	Common::Array<ObjID> exits = _currentSelection;
-	while (!exits.empty()) {
-		ObjID obj = exits.front();
-		exits.remove_at(0);
+	while (!_selectedObjs.empty()) {
+		ObjID obj = _selectedObjs.back();
+		_selectedObjs.pop_back();
 		highlightExit(obj);
 		updateWindow(findParentWindow(obj));
 	}
@@ -1258,7 +1256,7 @@ bool MacVentureEngine::isObjDraggable(ObjID objID) {
 }
 
 bool MacVentureEngine::isObjSelected(ObjID objID) {
-	int idx = findObjectInArray(objID, _currentSelection);
+	int idx = findObjectInArray(objID, _selectedObjs);
 	return idx != -1;
 }
 

--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -401,7 +401,25 @@ void MacVentureEngine::handleObjectSelect(ObjID objID, WindowReference win, bool
 	const WindowData &windata = _gui->getWindowData(win);
 
 	if (shiftPressed) {
-		// TODO: Implement shift functionality.
+		if (objID == 0) {
+			objID = windata.objRef;
+		}
+		if (objID > 0) {
+			int selectedIndex = findObjectInArray(objID, _selectedObjs);
+			if (findObjectInArray(objID, _currentSelection) != -1) {
+				unselectObject(objID);
+				if (selectedIndex != -1) {
+					_selectedObjs.remove_at(selectedIndex);
+				}
+			} else {
+				selectObject(objID);
+				if (selectedIndex == -1) {
+					_selectedObjs.push_back(objID);
+				}
+			}
+			refreshReady();
+			preparedToRun();
+		}
 	} else {
 		if (_selectedControl && _currentSelection.size() > 0 && getInvolvedObjects() > 1) {
 			if (objID == 0) {

--- a/engines/macventure/script.cpp
+++ b/engines/macventure/script.cpp
@@ -966,10 +966,13 @@ bool ScriptEngine::opbcCALL(EngineState *state, EngineFrame *frame, ScriptAsset 
 	ScriptAsset newfun = ScriptAsset(id, _scripts);
 	ScriptAsset current = script;
 	debugC(2, kMVDebugScript, "Call function: %d", id);
+	uint32 depth = frame->scripts.size();
 	if (loadScript(frame, id))
 		return true;
-	frame->scripts.pop_front();
-	script = frame->scripts.front();
+	if (frame->scripts.size() > depth) {
+		frame->scripts.pop_front();
+		script = frame->scripts.front();
+	}
 	debugC(2, kMVDebugScript, "Return from fuction %d", id);
 	return false;
 }

--- a/engines/macventure/script.cpp
+++ b/engines/macventure/script.cpp
@@ -604,7 +604,7 @@ void ScriptEngine::op8bSGLO(EngineState *state, EngineFrame *frame) {
 
 void ScriptEngine::op8cRAND(EngineState *state, EngineFrame *frame) {
 	int16 max = state->pop();
-	state->push(_engine->randBetween(0, max));
+	state->push(max > 0 ? _engine->randBetween(0, max - 1) : 0);
 }
 
 void ScriptEngine::op8dCOPY(EngineState *state, EngineFrame *frame) {


### PR DESCRIPTION
Double free on Hit. The CALL opcode pops the script list even when the called function does not exist, freeing the caller out from under the reference runFunc() holds. Crashes on any object without a hit handler.

Double delete of the speak dialog. getTextFromUser() deletes it without clearing the pointer, then showPrebuiltDialog() deletes it again.

Shift click multi-select, which is still a stub. Shift now toggles an object in and out of the selection, so several can be picked and dragged together. Dragging already handles groups; only the selecting is missing.

Random opcode range. It returns 0..max instead of 0..max-1.

<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

ATTENTION TO AI USERS:

EVERY WORD of your code, comments, commit log messages, PR description, must be re-read by a human and checked for sanity, correctness and common sense. At any sight of AI slop, including lengthy LLM-oriented explanations, your PR will be closed.

On top of that, we created AI-specific guidelines https://github.com/scummvm/scummvm/blob/master/AI-GUIDELINES.md

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not, please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

We require linear history, so no merge commits are allowed.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
