### PR TITLE
NANCY: Fix chroma-keyed Bink videos not being keyed

### DIFF
--- a/engines/nancy/movieplayer.cpp
+++ b/engines/nancy/movieplayer.cpp
@@ -26,6 +26,7 @@
 
 #include "engines/nancy/nancy.h"
 #include "engines/nancy/video.h"
+#include "engines/nancy/graphics.h"
 #include "engines/nancy/util.h"
 #include "engines/nancy/commontypes.h"
 
@@ -71,6 +72,21 @@ bool MoviePlayer::loadFile(const Common::Path &name, bool bidirectionalCache) {
 	if (!_decoder->loadFile(_videoType == kVideoPlaytypeAVF ? avfPath : bikPath)) {
 		_decoder.reset();
 		return false;
+	}
+
+	// Bink decodes YUV into Codec::getDefaultYUVFormat(), i.e. the *screen* format, but
+	// our surfaces - and the transparent colour derived from the BSUM chunk - use the
+	// *input* format. Those differ before Nancy13 (screen RGB565, input RGB555), so a
+	// chroma-keyed video such as Nancy11's Nigel_Fidget.bik ends up storing its key
+	// colour as 0x07E0 while the engine keys on 0x03E0, and the green background is
+	// never keyed out. From Nancy13 both formats are BGRA32 and this is a no-op.
+	// Has to come after loadFile(): setOutputPixelFormat() walks the decoder's tracks,
+	// and those only exist once the file is loaded.
+	if (_videoType == kVideoPlaytypeBink) {
+		const Graphics::PixelFormat &inputFormat = g_nancy->_graphics->getInputPixelFormat();
+		if (inputFormat.bytesPerPixel == 2 || inputFormat.bytesPerPixel == 4) {
+			_decoder->setOutputPixelFormat(inputFormat);
+		}
 	}
 
 	// The AVF decoder caches frames itself, so only the Bink path needs ours.


### PR DESCRIPTION
Chroma-keyed Bink videos in the nancy engine are never keyed: their key colour is
drawn fully opaque. In Nancy Drew 11: Curse of Blackmoor Manor, Nigel's ambient loop
in the library (`CDVideo/Nigel_Fidget.bik`) renders as a solid green rectangle with
the character composited on top.

The cause is a pixel format mismatch. `Video::BinkDecoder` decodes to RGB565, while
nancy's surfaces and the transparent colour derived from the BSUM chunk use the
engine's input pixel format, which is RGB555 (`_inputPixelFormat16`) for games before
Nancy13. Frames reach the surface through `GraphicsManager::copyToManaged()`, which is
a `memcpy` and performs no conversion, so full green is stored as `0x07E0` while the
engine keys on `0x03E0`. `ManagedSurface` keys on an exact match, so nothing is keyed.

`BinkDecoder` already implements `setOutputPixelFormat()`, but `MoviePlayer::loadFile()`
never called it. This asks the decoder for the engine's own input format instead.

Verified with temporary instrumentation in `PlaySecondaryVideo::init()`:

```
before:  frame fmt=RGB565@2  cornerPix=000007e0  surfFmt=RGB555@2  trans=000003e0
after:   frame fmt=RGB555@2  cornerPix=000003e0  surfFmt=RGB555@2  trans=000003e0
```

Tested on nancy11 (English Windows retail, `ciftree.dat` md5
`3c406d4f391b6536982c6081f2dd1f4e`, 55960641 bytes) in a
`--disable-all-engines --enable-engine=nancy` build on macOS/arm64. The green
background is gone and the video composites correctly.

Scanning the first-frame corner pixel of all 907 `.bik` files in `CDVideo/` and
`HDVideo/` found exactly one chroma-keyed video in this game, which is probably why
this went unnoticed. Other game types are unaffected in practice: the call is a no-op
whenever the requested format already matches what the decoder produces.

One follow-up that this patch deliberately does not address: because Bink is lossy,
pixels along the subject's silhouette are blends of the key colour and the subject and
do not exactly equal the key, so a thin green fringe remains once the background is
correctly keyed. That needs tolerance somewhere in the keying path rather than a
format fix, and the right design is your call. I have a local workaround that snaps a
greenish pixel to the key colour only when it directly touches an already-keyed pixel,
confining erosion to the boundary; happy to submit it separately if that approach is
wanted.
