### PR TITLE
SHERLOCK: Fix Tattoo scale zone fallback

### DIFF
--- a/engines/sherlock/tattoo/tattoo_scene.cpp
+++ b/engines/sherlock/tattoo/tattoo_scene.cpp
@@ -595,7 +595,7 @@ int TattooScene::getScaleVal(const Point32 &pt) {
 		if (sz.contains(pos)) {
 			int n = (sz._bottomNumber - sz._topNumber) * 100 / sz.height() * (pos.y - sz.top) / 100 + sz._topNumber;
 			result = 25600L / n;
-			// CHECKME: Shouldn't we set 'found' at this place?
+			found = true;
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fix `TattooScene::getScaleVal()` so an exact scale-zone match sets `found`.

## Root cause

The method is structured as a two-stage lookup:

1. find a scale zone containing both the X and Y coordinate;
2. only if that fails, fall back to a zone matching the Y coordinate, for positions outside the room horizontally.

Both loops are already guarded by `!found`, and the fallback comment explicitly describes it as applying only when no exact match was found. However, the first loop never assigned `found = true`. The fallback therefore always ran and overwrote an exact 2D match with the last Y-compatible zone, effectively discarding the exact match's horizontal bounds.

Setting `found` at the successful exact match activates the existing control flow: the first matching full rectangle wins, and the Y-only fallback remains available only when no full match exists.

## Validation

- `git diff --check`
- Built the change successfully in a configured ScummVM worktree.
