### PR TITLE
DIRECTOR: Share sound channels across the Stage and MIAWs

### DIFF
--- a/engines/director/window.h
+++ b/engines/director/window.h
@@ -138,7 +138,14 @@ public:
 	// so getCurrentMovie()-based context (go, globals, events) points at it.
 	void setCurrentMovie(Movie *movie) { _currentMovie = movie; }
 	Common::String getCurrentPath() const { return _currentPath; }
-	DirectorSound *getSoundManager() const { return _soundManager; }
+	// Sound channels are shared by the Stage and every MIAW (Director in a Nutshell),
+	// so route every window through the Stage's manager.
+	DirectorSound *getSoundManager() const {
+		Window *stage = g_director->getStage();
+		if (stage && stage != this)
+			return stage->getSoundManager();
+		return _soundManager;
+	}
 
 	void setVisible(bool visible, bool silent = false);
 	bool setNextMovie(Common::String &movieFilenameRaw);


### PR DESCRIPTION
Each Window had its own DirectorSound, so sounds from different windows used independent channels and could not stop or replace each other. In Director the channels are one global resource shared by the Stage and every MIAW, so route every window through the Stage's manager.

Fixes sound overlapping in gusmuse.