### PR TITLE
WATCHMAKER: make more structs constexpr-capable

### DIFF
--- a/engines/watchmaker/struct.h
+++ b/engines/watchmaker/struct.h
@@ -463,12 +463,8 @@ struct SD3DBitmap {
 	int32 rtype = 0;
 };
 struct SDDBitmap {
-	int32 tnum;
-	int32 px, py, ox, oy, dx, dy;
-
-	SDDBitmap() {
-		reset();
-	}
+	int32 tnum = 0;
+	int32 px = 0, py = 0, ox = 0, oy = 0, dx = 0, dy = 0;
 
 	void reset() {
 		tnum =0;
@@ -482,9 +478,7 @@ struct SDDBitmap {
 };
 
 struct SDDText {
-	SDDText() {
-		reset();
-	}
+	constexpr SDDText() = default;
 
 	SDDText(const char *_text, FontKind _font, FontColor _color, int32 _tnum) : font(_font),
 																			color(_color),
@@ -499,10 +493,10 @@ struct SDDText {
 		tnum = 0;
 	}
 
-	char text[MAX_STRING_LEN];
-	FontKind font;
-	FontColor color;
-	int32 tnum;
+	char text[MAX_STRING_LEN] = {};
+	FontKind font = FontKind::Standard;
+	FontColor color = FontColor::WHITE_FONT;
+	int32 tnum = 0;
 };
 
 struct SScript {
@@ -597,7 +591,7 @@ struct SRoomInfo {
 	int32 tnum = 0;               //bitmap
 	char *letter_ptr = nullptr;    //puntatore alla lettera corrente
 	int16 t_next_letter = 0;      //quando deve apparire la nuova lettera
-	FontKind f;     //il font
+	FontKind f = FontKind::Standard; //il font
 };
 
 } // End of namespace Watchmaker

--- a/engines/watchmaker/t2d/t2d_internal.h
+++ b/engines/watchmaker/t2d/t2d_internal.h
@@ -499,13 +499,9 @@
 namespace Watchmaker {
 
 struct t2dBUTTON {
-	uint8 on;                                                                                   // on/off
-	struct SRect lim;                                                                           // limiti del bottone
-	int32 tnum;                                                                                 // numero bitmap col tooltip
-
-	t2dBUTTON() {
-		reset();
-	}
+	uint8 on = 0u;                                                                                  // on/off
+	struct SRect lim = {};                                                                          // limiti del bottone
+	int32 tnum = 0;                                                                                 // numero bitmap col tooltip
 
 	void reset() {
 		on = 0;
@@ -515,16 +511,12 @@ struct t2dBUTTON {
 };
 
 struct t2dWINDOW {
-	int32 px, py;                                                                               // poszione finestra
-	int32 sy;                                                                                   // scroll interno finestra
-	struct SDDBitmap bm[T2D_MAX_BITMAPS_IN_WIN];                                                // bitmaps ordinate
-	struct SDDText text[T2D_MAX_TEXTS_IN_WIN];                                                  // testi
-	t2dBUTTON bt[T2D_MAX_BUTTONS_IN_WIN];                                                       // bottoni ordinati
-	bool NOTSTRETCHED;
-
-	t2dWINDOW() {
-		reset();
-	}
+	int32 px = 0, py = 0;                                                                           // poszione finestra
+	int32 sy = 0;                                                                                   // scroll interno finestra
+	struct SDDBitmap bm[T2D_MAX_BITMAPS_IN_WIN] = {};                                               // bitmaps ordinate
+	struct SDDText text[T2D_MAX_TEXTS_IN_WIN] = {};                                                 // testi
+	t2dBUTTON bt[T2D_MAX_BUTTONS_IN_WIN] = {};                                                      // bottoni ordinati
+	bool NOTSTRETCHED = false;
 
 	void reset() {
 		px = 0;

--- a/engines/watchmaker/walk/ball.h
+++ b/engines/watchmaker/walk/ball.h
@@ -41,22 +41,22 @@ struct SPhys {
 	t3dF32 Ts = 0.0f;                                           // tempo trascorso dall'ultimo impatto
 	t3dF32 Tb = 0.0f;                                           // tempo di carica del braccio
 
-	t3dV3F Fb;                                                  // forza braccio
-	t3dV3F Vb;                                                  // velocita' braccio
-	t3dV3F Fv;                                                  // forza del vento
-	t3dV3F V0;                                                  // velocita' iniziale palla
-	t3dV3F S0;                                                  // posizione iniziale palla
+	t3dV3F Fb = {};                                             // forza braccio
+	t3dV3F Vb = {};                                             // velocita' braccio
+	t3dV3F Fv = {};                                             // forza del vento
+	t3dV3F V0 = {};                                             // velocita' iniziale palla
+	t3dV3F S0 = {};                                             // posizione iniziale palla
 
-	t3dV3F St;                                                  // posizione attuale
-	t3dV3F Vt;                                                  // velocita' attuale
-	t3dV3F At;                                                  // accelerazione attuale
+	t3dV3F St= {};                                              // posizione attuale
+	t3dV3F Vt= {};                                              // velocita' attuale
+	t3dV3F At = {};                                             // accelerazione attuale
 	t3dF32 MVt = 0.0f;                                          // modulo della velocita' attuale
 	t3dF32 MAt = 0.0f;                                          // modulo dell'accelerazione attuale
 
-	uint8 InAir;                                                // Se e' in volo
-	t3dV3F Angle;                                               // Angolazione colpo
+	uint8 InAir = 0u;                                           // Se e' in volo
+	t3dV3F Angle = {};                                          // Angolazione colpo
 	t3dF32 TimeLeft = 0.0f;                                     // Tempo Riamente
-	SD3DTriangle ViewCone;                              // Cono visivo
+	SD3DTriangle ViewCone = {};                                 // Cono visivo
 };
 
 void InitPhys(struct SPhys *p);


### PR DESCRIPTION
Make some more structs in Watchmaker capable of constexpr-construction in order to cut down on global constructor warnings in that engine.