### PR TITLE
MADS: NEBULAR: Fix Macintosh text rendering issues

### DIFF
--- a/engines/mads/core/inter.cpp
+++ b/engines/mads/core/inter.cpp
@@ -2187,10 +2187,8 @@ void inter_main_loop(int allow_input) {
 				((inter_input_mode == INTER_BUILDING_SENTENCES) || (inter_input_mode == INTER_LIMITED_SENTENCES))) {
 			use_font = font_main;
 			use_spacing = -1;
-			width = g_engine->getMacintoshTextWidth(use_font,
-				inter_sentence, use_spacing);
-			if (width < 0)
-				width = font_string_width(use_font, inter_sentence, use_spacing);
+			width = g_engine->getMessageTextWidth(use_font, inter_sentence,
+				use_spacing);
 
 			if (width > video_x) {
 				use_font = font_inter;

--- a/engines/mads/core/inter.cpp
+++ b/engines/mads/core/inter.cpp
@@ -137,7 +137,6 @@ int  picked_word = 0;           /* Word most recently picked.         */
 
 char inter_sentence[64];                /* Sentence building buffer            */
 int  inter_sentence_handle = -1;       /* Sentence message handle (for matte) */
-static int inter_sentence_shadow_handle = -1;
 static bool inter_macintosh_sentence_hidden = false;
 int  inter_sentence_changed = false;    /* Mark if sentence contents changed   */
 
@@ -246,7 +245,6 @@ void init_inter() {
 	picked_word = 0;
 	memset(inter_sentence, 0, sizeof(inter_sentence));
 	inter_sentence_handle = -1;
-	inter_sentence_shadow_handle = -1;
 	inter_macintosh_sentence_hidden = false;
 	inter_sentence_changed = false;
 	inter_look_around = 0;
@@ -1985,11 +1983,6 @@ void inter_hide_macintosh_sentence() {
 		inter_sentence_handle = -1;
 		changed = true;
 	}
-	if (inter_sentence_shadow_handle >= 0) {
-		matte_clear_message(inter_sentence_shadow_handle);
-		inter_sentence_shadow_handle = -1;
-		changed = true;
-	}
 	if (changed)
 		matte_frame(false, false);
 	inter_sentence_changed = true;
@@ -2179,10 +2172,6 @@ void inter_main_loop(int allow_input) {
 			matte_clear_message(inter_sentence_handle);
 			inter_sentence_handle = -1;
 		}
-		if (inter_sentence_shadow_handle >= 0) {
-			matte_clear_message(inter_sentence_shadow_handle);
-			inter_sentence_shadow_handle = -1;
-		}
 		if (g_engine->getGameID() != GType_Forest && (strlen(inter_sentence) > 0) &&
 				((inter_input_mode == INTER_BUILDING_SENTENCES) || (inter_input_mode == INTER_LIMITED_SENTENCES))) {
 			use_font = font_main;
@@ -2201,12 +2190,7 @@ void inter_main_loop(int allow_input) {
 
 			byte sentenceColor = g_engine->getGameID() == GType_RexNebular ?
 				INTER_MESSAGE_COLOR_REX : INTER_MESSAGE_COLOR;
-			byte shadowColor = 0;
-			if (g_engine->getInterfaceSentenceColors(sentenceColor, shadowColor)) {
-				inter_sentence_shadow_handle = matte_add_message(use_font,
-					inter_sentence, x + 1, y + 1, shadowColor,
-					use_spacing, g_engine->hasMacintoshInterface());
-			}
+			g_engine->getInterfaceSentenceColor(sentenceColor);
 			inter_sentence_handle = matte_add_message(use_font, inter_sentence, x, y,
 				sentenceColor,
 				use_spacing, g_engine->hasMacintoshInterface());

--- a/engines/mads/core/kernel.cpp
+++ b/engines/mads/core/kernel.cpp
@@ -2113,11 +2113,8 @@ static void kernel_message_update(KernelMessagePtr my_message) {
 		}
 	}
 
-	width = g_engine->getMacintoshTextWidth(kernel_message_font,
+	width = g_engine->getMessageTextWidth(kernel_message_font,
 		my_message->message, kernel_message_spacing);
-	if (width < 0)
-		width = font_string_width(kernel_message_font,
-			my_message->message, kernel_message_spacing);
 
 	if (my_message->flags & (KERNEL_MESSAGE_CENTER | KERNEL_MESSAGE_RIGHT)) {
 		if (my_message->flags & KERNEL_MESSAGE_CENTER) {

--- a/engines/mads/core/matte.cpp
+++ b/engines/mads/core/matte.cpp
@@ -257,10 +257,9 @@ int matte_add_message(FontPtr font, char *text, int x, int y,
 			message_list[message_handle].y = y;
 			message_list[message_handle].font = font;
 			message_list[message_handle].text = text;
-			const int macintoshWidth = useMacintoshFont ?
-				g_engine->getMacintoshTextWidth(font, text, auto_spacing) : -1;
-			message_list[message_handle].xs = macintoshWidth >= 0 ?
-				macintoshWidth : font_string_width(font, text, auto_spacing);
+			message_list[message_handle].xs = useMacintoshFont ?
+				g_engine->getMessageTextWidth(font, text, auto_spacing) :
+				font_string_width(font, text, auto_spacing);
 			message_list[message_handle].ys = font ? font->max_y_size : 0;
 			message_list[message_handle].main_color = message_color;
 			message_list[message_handle].spacing = (char)auto_spacing;

--- a/engines/mads/dragonsphere/rooms/room504.cpp
+++ b/engines/mads/dragonsphere/rooms/room504.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+#include "mads/mads.h"
 #include "mads/core/conv.h"
 #include "mads/core/game.h"
 #include "mads/core/imath.h"
@@ -1301,7 +1302,7 @@ static void process_conv_poem() {
 			local->lani_pid_action = PID_POEM;
 
 			if (local->working_on_line == 1) {
-				if (font_string_width(kernel_message_font, local->line_1, -1) > 278) {
+				if (g_engine->getMessageTextWidth(kernel_message_font, local->line_1, -1) > 278) {
 					++local->working_on_line;
 				} else {
 					if (local->line_1[0] != '\0') {
@@ -1315,7 +1316,7 @@ static void process_conv_poem() {
 			}
 
 			if (local->working_on_line == 2) {
-				if (font_string_width(kernel_message_font, local->line_2, -1) > 278) {
+				if (g_engine->getMessageTextWidth(kernel_message_font, local->line_2, -1) > 278) {
 					++local->working_on_line;
 				} else {
 					if (local->line_2[0] != '\0') {
@@ -1329,7 +1330,7 @@ static void process_conv_poem() {
 			}
 
 			if (local->working_on_line == 3) {
-				if (font_string_width(kernel_message_font, local->line_3, -1) > 278) {
+				if (g_engine->getMessageTextWidth(kernel_message_font, local->line_3, -1) > 278) {
 					++local->working_on_line;
 				} else {
 					if (local->line_3[0] != '\0') {

--- a/engines/mads/mads.cpp
+++ b/engines/mads/mads.cpp
@@ -134,6 +134,13 @@ void MADSEngine::readConfigFile() {
 		savegame_slot = ConfMan.getInt("save_slot");
 }
 
+int MADSEngine::getMessageTextWidth(FontPtr font, const char *text,
+		int spacing) const {
+	const int macintoshWidth = getMacintoshTextWidth(font, text, spacing);
+	return macintoshWidth >= 0 ? macintoshWidth :
+		font_string_width(font, text, spacing);
+}
+
 bool MADSEngine::canLoadGameStateCurrently(Common::U32String *msg) {
 	return game.going && !win_status && !kernel.activate_menu &&
 		inter_input_mode == INTER_BUILDING_SENTENCES &&

--- a/engines/mads/mads.h
+++ b/engines/mads/mads.h
@@ -180,6 +180,8 @@ public:
 	virtual void global_game_main_loop() {}
 	virtual void global_verb_filter() {}
 
+	int getMessageTextWidth(FontPtr font, const char *text, int spacing) const;
+
 	// Optional Macintosh presentation hooks. Defaults preserve the shared
 	// MADS rendering path used by DOS releases.
 	virtual bool hasInterfaceAnimations() const { return true; }

--- a/engines/mads/mads.h
+++ b/engines/mads/mads.h
@@ -193,7 +193,7 @@ public:
 	}
 	virtual bool drawMacintoshText(FontPtr, Buffer *, const char *, int,
 		int, int, int) const { return false; }
-	virtual bool getInterfaceSentenceColors(byte &, byte &) const {
+	virtual bool getInterfaceSentenceColor(byte &) const {
 		return false;
 	}
 	virtual bool hasMacintoshInterface() const { return false; }

--- a/engines/mads/nebular/mac_nebular.cpp
+++ b/engines/mads/nebular/mac_nebular.cpp
@@ -1340,6 +1340,24 @@ int MacNebular::runCopyProtectionDialog(const Common::String &title,
 		target, maxLength) : -1;
 }
 
+static Common::String getMacintoshDrawingText(const char *text) {
+	Common::String drawingText(text);
+	uint start = 0;
+	uint end = drawingText.size();
+
+	// The native renderer measures the markers as part of the string, but
+	// removes them immediately before the QuickDraw DrawString call.
+	if (end >= 2 && drawingText[0] == '1' && drawingText[1] == '~')
+		start = 2;
+	else if (end && drawingText[0] == '~')
+		start = 1;
+
+	if (end > start && drawingText[end - 1] == '~')
+		--end;
+
+	return drawingText.substr(start, end - start);
+}
+
 int MacNebular::getTextWidth(FontPtr font, const char *text, int) const {
 	if (!_resources || (font != font_main && font != font_conv))
 		return -1;
@@ -1362,8 +1380,12 @@ bool MacNebular::drawText(FontPtr font, Buffer *target, const char *text,
 	Graphics::Surface surface;
 	surface.init(target->x, target->y, target->x, target->data,
 		Graphics::PixelFormat::createFormatCLUT8());
-	macFont->drawString(&surface, text, x, y, MAX(0, target->x - x),
-		(byte)color);
+	const Common::String drawingText = getMacintoshDrawingText(text);
+	byte textColor = (byte)color;
+	if (!textColor)
+		textColor = (byte)(color >> 8);
+	macFont->drawString(&surface, drawingText, x, y,
+		MAX(0, target->x - x), textColor);
 	return true;
 }
 

--- a/engines/mads/nebular/mac_nebular.cpp
+++ b/engines/mads/nebular/mac_nebular.cpp
@@ -1570,12 +1570,11 @@ void RexNebularEngine::onPopupDestroyed() {
 		_macNebular->hidePopup();
 }
 
-bool RexNebularEngine::getInterfaceSentenceColors(byte &foreground, byte &shadow) const {
+bool RexNebularEngine::getInterfaceSentenceColor(byte &foreground) const {
 	if (!_macNebular)
 		return false;
 
 	foreground = kMacNormalTextColor;
-	shadow = kMacBlackColor;
 	return true;
 }
 

--- a/engines/mads/nebular/mac_nebular.cpp
+++ b/engines/mads/nebular/mac_nebular.cpp
@@ -78,6 +78,18 @@ enum {
 	kMacBlackColor = kMacRightSelectColor
 };
 
+bool setMacintoshMessageColors(int primaryR, int primaryG, int primaryB,
+		int secondaryR, int secondaryG, int secondaryB) {
+	if (!g_engine->hasMacintoshInterface())
+		return false;
+
+	pal_change_color(KERNEL_MESSAGE_COLOR_BASE,
+		primaryR, primaryG, primaryB);
+	pal_change_color(KERNEL_MESSAGE_COLOR_BASE + 1,
+		secondaryR, secondaryG, secondaryB);
+	return true;
+}
+
 struct MacPopupLine {
 	Common::String text;
 	word tab;

--- a/engines/mads/nebular/mac_nebular.h
+++ b/engines/mads/nebular/mac_nebular.h
@@ -25,6 +25,7 @@
 #include "common/rect.h"
 #include "common/str.h"
 #include "graphics/managed_surface.h"
+#include "mads/core/font.h"
 #include "mads/core/general.h"
 
 namespace Common {
@@ -43,6 +44,10 @@ enum MacNebularDisplaySize {
 	kMacNebularDisplay150 = 1,
 	kMacNebularDisplay200 = 2
 };
+
+// Returns true when the Macintosh palette replaced the DOS defaults.
+bool setMacintoshMessageColors(int primaryR, int primaryG, int primaryB,
+	int secondaryR, int secondaryG, int secondaryB);
 
 class MacNebular {
 private:

--- a/engines/mads/nebular/nebular.h
+++ b/engines/mads/nebular/nebular.h
@@ -104,7 +104,7 @@ public:
 		int spacing) const override;
 	bool drawMacintoshText(FontPtr font, Buffer *target, const char *text,
 		int x, int y, int color, int spacing) const override;
-	bool getInterfaceSentenceColors(byte &foreground, byte &shadow) const override;
+	bool getInterfaceSentenceColor(byte &foreground) const override;
 	bool hasMacintoshInterface() const override;
 	bool setMacintoshPalette(const RGBcolor *palette, int firstColor,
 		int numColors) override;

--- a/engines/mads/nebular/rooms/room102.cpp
+++ b/engines/mads/nebular/rooms/room102.cpp
@@ -297,7 +297,7 @@ static void room_102_parser() {
 		local._fridgeFirstOpenFl = false;
 		int quoteId = g_engine->getRandomNumber(QUOTE_ID(0), QUOTE_ID(4));
 		char *curQuote = quote_string(kernel.quotes, quoteId);
-		int width = font_string_width(kernel_message_font, curQuote, -1);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, -1);
 		kernel_message_purge();
 		kernel.trigger_setup_mode = KERNEL_TRIGGER_DAEMON;
 		kernel_message_add(curQuote, 210, 60, 0x1110, 120, 73, 0);

--- a/engines/mads/nebular/rooms/room106.cpp
+++ b/engines/mads/nebular/rooms/room106.cpp
@@ -22,6 +22,7 @@
 #include "mads/core/game.h"
 #include "mads/core/matte.h"
 #include "mads/nebular/global.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/mads/inventory.h"
 #include "mads/nebular/mads/words.h"
@@ -91,6 +92,7 @@ static void room_106_init() {
 	local._firstEmergingFl = false;
 
 	kernel.quotes = quote_load(49, 50, 52, 77, 78, 79, 80, 81, 0);
+	setMacintoshMessageColors(63, 50, 0, 63, 50, 0);
 	section_1_music();
 }
 

--- a/engines/mads/nebular/rooms/room202.cpp
+++ b/engines/mads/nebular/rooms/room202.cpp
@@ -21,6 +21,7 @@
 
 #include "mads/core/game.h"
 #include "mads/nebular/global.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/mads/inventory.h"
 #include "mads/nebular/mads/words.h"
@@ -168,6 +169,7 @@ static void room_202_init() {
 
 	local._meteorologistSpecial = false;
 
+	setMacintoshMessageColors(63, 10, 0, 63, 10, 0);
 	section_2_music();
 }
 

--- a/engines/mads/nebular/rooms/room210.cpp
+++ b/engines/mads/nebular/rooms/room210.cpp
@@ -549,7 +549,7 @@ static void handleConversations() {
 		kernel_message_purge();
 		player.commands_allowed = false;
 		char *curQuote = quote_string(kernel.quotes, player2.words[0]);
-		if (font_string_width(kernel_message_font, curQuote, kernel_message_spacing) > 200) {
+		if (g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing) > 200) {
 			static char line1[40], line2[40];
 			quote_split_string(curQuote, line1, line2);
 			Common::strcpy_s(local._subQuote2, line2);

--- a/engines/mads/nebular/rooms/room307.cpp
+++ b/engines/mads/nebular/rooms/room307.cpp
@@ -59,7 +59,7 @@ static Scratch local;
 
 static void handleRexDialog(int quote) {
 	char *curQuote = quote_string(kernel.quotes, quote);
-	if (font_string_width(kernel_message_font, curQuote, kernel_message_spacing) > 200) {
+	if (g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing) > 200) {
 		static char subQuote1[34], subQuote2[34];
 		quote_split_string(curQuote, subQuote1, subQuote2);
 		Common::strcpy_s(local._subQuote2, subQuote2);

--- a/engines/mads/nebular/rooms/room307.cpp
+++ b/engines/mads/nebular/rooms/room307.cpp
@@ -24,6 +24,7 @@
 #include "mads/core/matte.h"
 #include "mads/core/pal.h"
 #include "mads/nebular/global.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/mads/inventory.h"
 #include "mads/nebular/mads/words.h"
@@ -362,6 +363,7 @@ static void room_307_init() {
 
 	pal_change_color(252, 63, 30, 20);
 	pal_change_color(253, 45, 15, 12);
+	setMacintoshMessageColors(0, 30, 63, 0, 30, 63);
 
 	section_3_music();
 

--- a/engines/mads/nebular/rooms/room309.cpp
+++ b/engines/mads/nebular/rooms/room309.cpp
@@ -22,6 +22,7 @@
 #include "mads/core/game.h"
 #include "mads/core/pal.h"
 #include "mads/nebular/global.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/mads/inventory.h"
 #include "mads/nebular/mads/words.h"
@@ -63,8 +64,10 @@ static void room_309_init() {
 
 	pal_change_color(252, 63, 37, 26);
 	pal_change_color(253, 45, 24, 17);
-	pal_change_color(16, 63, 63, 63);
-	pal_change_color(17, 45, 45, 45);
+	if (!setMacintoshMessageColors(63, 63, 0, 63, 63, 0)) {
+		pal_change_color(16, 63, 63, 63);
+		pal_change_color(17, 45, 45, 45);
+	}
 	pal_change_color(250, 63, 20, 20);
 	pal_change_color(251, 45, 10, 10);
 

--- a/engines/mads/nebular/rooms/room316.cpp
+++ b/engines/mads/nebular/rooms/room316.cpp
@@ -22,6 +22,7 @@
 #include "mads/core/config.h"
 #include "mads/core/game.h"
 #include "mads/nebular/global.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/mads/inventory.h"
 #include "mads/nebular/mads/words.h"
@@ -308,6 +309,7 @@ static void room_316_init() {
 		player.y = 126;
 	}
 
+	setMacintoshMessageColors(63, 63, 0, 63, 63, 0);
 	section_3_music();
 	kernel.quotes = quote_load(253, 0);
 }
@@ -491,6 +493,7 @@ static void room_316_parser() {
 	else
 		return;
 
+	setMacintoshMessageColors(63, 63, 0, 63, 63, 0);
 	player.command_ready = false;
 }
 

--- a/engines/mads/nebular/rooms/room318.cpp
+++ b/engines/mads/nebular/rooms/room318.cpp
@@ -56,7 +56,7 @@ static void handleRexDialogs(int quote) {
 	kernel_message_purge();
 
 	char *curQuote = quote_string(kernel.quotes, quote);
-	if (font_string_width(kernel_message_font, curQuote, kernel_message_spacing) > 200) {
+	if (g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing) > 200) {
 		static char subQuote1[34], subQuote2[34];
 		quote_split_string(curQuote, subQuote1, subQuote2);
 
@@ -78,7 +78,7 @@ static void handleInternDialog(int quoteId, int quoteNum, uint32 timeout) {
 
 	int maxWidth = 0;
 	for (int i = 0; i < quoteNum; i++) {
-		maxWidth = MAX(maxWidth, font_string_width(kernel_message_font, quote_string(kernel.quotes, curQuoteId), -1));
+		maxWidth = MAX(maxWidth, g_engine->getMessageTextWidth(kernel_message_font, quote_string(kernel.quotes, curQuoteId), -1));
 		curQuoteId++;
 	}
 

--- a/engines/mads/nebular/rooms/room319.cpp
+++ b/engines/mads/nebular/rooms/room319.cpp
@@ -25,6 +25,7 @@
 #include "mads/core/mcga.h"
 #include "mads/core/pal.h"
 #include "mads/nebular/global.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/mads/inventory.h"
 #include "mads/nebular/mads/words.h"
@@ -120,6 +121,7 @@ static void room_319_init() {
 
 	pal_change_color(252, 63, 30, 2);
 	pal_change_color(253, 45, 15, 1);
+	setMacintoshMessageColors(0, 0, 63, 0, 0, 63);
 
 	local._slachePosY = 0;
 	local._slacheInitFl = false;

--- a/engines/mads/nebular/rooms/room319.cpp
+++ b/engines/mads/nebular/rooms/room319.cpp
@@ -60,7 +60,7 @@ static void handleRexDialogues(int quote) {
 	kernel_message_purge();
 
 	char *curQuote = quote_string(kernel.quotes, quote);
-	if (font_string_width(kernel_message_font, curQuote, kernel_message_spacing) > 200) {
+	if (g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing) > 200) {
 		static char subQuote1[34], subQuote2[34];
 		quote_split_string(curQuote, subQuote1, subQuote2);
 		Common::strcpy_s(local._subQuote2, subQuote2);

--- a/engines/mads/nebular/rooms/room351.cpp
+++ b/engines/mads/nebular/rooms/room351.cpp
@@ -21,6 +21,7 @@
 
 #include "mads/core/game.h"
 #include "mads/nebular/global.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/mads/inventory.h"
 #include "mads/nebular/mads/words.h"
@@ -95,6 +96,7 @@ static void room_351_init() {
 			kernel_run_animation(kernel_name(sepChar, suffixNum), trigger);
 	}
 
+	setMacintoshMessageColors(63, 0, 0, 63, 0, 0);
 	section_3_music();
 }
 

--- a/engines/mads/nebular/rooms/room352.cpp
+++ b/engines/mads/nebular/rooms/room352.cpp
@@ -22,6 +22,7 @@
 #include "mads/core/config.h"
 #include "mads/core/game.h"
 #include "mads/nebular/global.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/mads/inventory.h"
 #include "mads/nebular/mads/words.h"
@@ -181,6 +182,7 @@ static void room_352_init() {
 		player.y = 107;
 	}
 
+	setMacintoshMessageColors(63, 0, 0, 63, 0, 0);
 	section_3_music();
 
 	kernel.quotes = quote_load(255, 256, 257, 258, 259, 0);

--- a/engines/mads/nebular/rooms/room402.cpp
+++ b/engines/mads/nebular/rooms/room402.cpp
@@ -401,7 +401,7 @@ static void handleDialogs() {
 		kernel_message_purge();
 		player.commands_allowed = false;
 		char *curQuote = quote_string(kernel.quotes, player2.words[0]);
-		if (font_string_width(kernel_message_font, curQuote, kernel_message_spacing) > 200) {
+		if (g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing) > 200) {
 			static char subQuote1[34], subQuote2[34];
 			quote_split_string(curQuote, subQuote1, subQuote2);
 			kernel_message_add(subQuote1, 230, 42, 0x1110, 140, 0, 32);

--- a/engines/mads/nebular/rooms/room611.cpp
+++ b/engines/mads/nebular/rooms/room611.cpp
@@ -145,12 +145,12 @@ static void displayHermitQuestions(int question) {
 	case 1:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x281);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x282);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 14, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -159,12 +159,12 @@ static void displayHermitQuestions(int question) {
 	case 2:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x283);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x284);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 14, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -173,7 +173,7 @@ static void displayHermitQuestions(int question) {
 	case 3:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x285);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 14, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -182,7 +182,7 @@ static void displayHermitQuestions(int question) {
 	case 4:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x286);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 14, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -191,17 +191,17 @@ static void displayHermitQuestions(int question) {
 	case 5:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x297);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y - 14, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x298);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x299);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 14, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -210,12 +210,12 @@ static void displayHermitQuestions(int question) {
 	case 6:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x29A);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x29B);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 14, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -224,12 +224,12 @@ static void displayHermitQuestions(int question) {
 	case 7:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2A0);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2A1);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -238,17 +238,17 @@ static void displayHermitQuestions(int question) {
 	case 8:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2A2);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2A3);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2A4);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -257,12 +257,12 @@ static void displayHermitQuestions(int question) {
 	case 9:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2A5);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2A6);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -271,17 +271,17 @@ static void displayHermitQuestions(int question) {
 	case 10:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2A8);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2A9);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2AA);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -290,22 +290,22 @@ static void displayHermitQuestions(int question) {
 	case 11:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2AB);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 17, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2AC);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2AD);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2AE);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -314,22 +314,22 @@ static void displayHermitQuestions(int question) {
 	case 12:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2AF);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 17, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2B0);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2B1);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2B2);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -338,22 +338,22 @@ static void displayHermitQuestions(int question) {
 	case 13:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2B3);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 3, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2B4);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 17, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2B5);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2B6);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
@@ -366,22 +366,22 @@ static void displayHermitQuestions(int question) {
 	case 14:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2BA);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 17, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2BB);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2BC);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2BD);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -390,22 +390,22 @@ static void displayHermitQuestions(int question) {
 	case 15:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2BE);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 17, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2BF);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2C0);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2C1);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -414,27 +414,27 @@ static void displayHermitQuestions(int question) {
 	case 16:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2C2);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 3, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2C3);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 17, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2C4);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2C5);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2C6);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -443,22 +443,22 @@ static void displayHermitQuestions(int question) {
 	case 17:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2C7);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 17, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2C8);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2C9);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2CA);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -467,17 +467,17 @@ static void displayHermitQuestions(int question) {
 	case 18:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2CB);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2CC);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2CD);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -486,17 +486,17 @@ static void displayHermitQuestions(int question) {
 	case 19:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2CE);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2CF);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2D0);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -505,27 +505,27 @@ static void displayHermitQuestions(int question) {
 	case 20:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2E1);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 3, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2E2);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 17, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2E3);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2E4);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2E5);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, INDEFINITE_TIMEOUT, 0, 0);
 	}
@@ -534,27 +534,27 @@ static void displayHermitQuestions(int question) {
 	case 21:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2D3);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 3, 0xFDFC, 800, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2D4);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 17, 0xFDFC, 800, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2D5);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, 800, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2D6);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, 800, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2D7);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, 800, 0, 0);
 	}
@@ -563,22 +563,22 @@ static void displayHermitQuestions(int question) {
 	case 22:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2D8);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 17, 0xFDFC, 700, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2D9);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, 700, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2DA);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, 700, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2DB);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, 700, 0, 0);
 	}
@@ -587,27 +587,27 @@ static void displayHermitQuestions(int question) {
 	case 23:
 	{
 		char *curQuote = quote_string(kernel.quotes, 0x2DC);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 3, 0xFDFC, 700, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2DD);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 17, 0xFDFC, 700, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2DE);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 31, 0xFDFC, 700, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2DF);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 45, 0xFDFC, 700, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2E0);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 59, 0xFDFC, 700, 0, 0);
 	}
@@ -758,12 +758,12 @@ static void handleSubDialog1() {
 		kernel_message_purge();
 
 		char *curQuote = quote_string(kernel.quotes, 0x2D1);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y, 0xFDFC, 120, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x2D2);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 14, 0xFDFC, 120, 0, 0);
 
@@ -818,7 +818,7 @@ static void handleSubDialog1() {
 		kernel_message_purge();
 
 		char *curQuote = quote_string(kernel.quotes, 0x2E6);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 14, 0xFDFC, 120, 0, 0);
 
@@ -856,7 +856,7 @@ static void handleSubDialog2() {
 	{
 		kernel_message_purge();
 		char *curQuote = quote_string(kernel.quotes, 0x2A7);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 14, 0xFDFC, 120, 0, 0);
 		setDialogNode(0);
@@ -875,7 +875,7 @@ static void handleDialog() {
 		player.commands_allowed = false;
 
 		char *curQuote = quote_string(kernel.quotes, player2.words[0]);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 
 		if (width > 200) {
 			static char subQuote1[34], subQuote2[34];
@@ -1352,12 +1352,12 @@ static void room_611_parser() {
 		kernel_message_purge();
 
 		char *curQuote = quote_string(kernel.quotes, 0x323);
-		int width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		int width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		int quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y, 0xFDFC, 120, 0, 0);
 
 		curQuote = quote_string(kernel.quotes, 0x324);
-		width = font_string_width(kernel_message_font, curQuote, kernel_message_spacing);
+		width = g_engine->getMessageTextWidth(kernel_message_font, curQuote, kernel_message_spacing);
 		quotePosX = local._defaultDialogPos_x - (width / 2);
 		kernel_message_add(curQuote, quotePosX, local._defaultDialogPos_y + 14, 0xFDFC, 120, 0, 0);
 	} else if (kernel.trigger == 90) {

--- a/engines/mads/nebular/rooms/room612.cpp
+++ b/engines/mads/nebular/rooms/room612.cpp
@@ -21,6 +21,7 @@
 
 #include "mads/core/game.h"
 #include "mads/nebular/global.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/mads/inventory.h"
 #include "mads/nebular/mads/words.h"
@@ -125,6 +126,7 @@ static void room_612_init() {
 		kernel_run_animation(kernel_name('R', 1), 70);
 	}
 
+	setMacintoshMessageColors(63, 63, 0, 63, 63, 0);
 	section_6_music();
 
 	if (kernel.teleported_in)

--- a/engines/mads/nebular/rooms/section1.cpp
+++ b/engines/mads/nebular/rooms/section1.cpp
@@ -22,6 +22,7 @@
 #include "math/utils.h"
 #include "mads/core/config.h"
 #include "mads/core/pal.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/rooms/section1.h"
 #include "mads/nebular/sound/mac_sound.h"
@@ -69,8 +70,10 @@ void section_1_walker() {
 	}
 
 	player.scaling_velocity = 0;
-	pal_change_color(16, 10, 63, 63);
-	pal_change_color(17, 10, 45, 45);
+	if (!setMacintoshMessageColors(63, 63, 0, 63, 63, 0)) {
+		pal_change_color(16, 10, 63, 63);
+		pal_change_color(17, 10, 45, 45);
+	}
 }
 
 void section_1_interface() {

--- a/engines/mads/nebular/rooms/section2.cpp
+++ b/engines/mads/nebular/rooms/section2.cpp
@@ -22,6 +22,7 @@
 #include "mads/mads.h"
 #include "mads/core/config.h"
 #include "mads/core/pal.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/rooms/section2.h"
 #include "mads/nebular/global.h"
 
@@ -70,8 +71,10 @@ void section_2_walker() {
 	if ((new_room == 203 || new_room == 204) && global[kRhotundaStatus])
 		player.walker_loads_first = false;
 
-	pal_change_color(16, 10, 63, 63);
-	pal_change_color(17, 10, 45, 45);
+	if (!setMacintoshMessageColors(0, 0, 63, 0, 0, 63)) {
+		pal_change_color(16, 10, 63, 63);
+		pal_change_color(17, 10, 45, 45);
+	}
 }
 
 void section_2_interface() {

--- a/engines/mads/nebular/rooms/section3.cpp
+++ b/engines/mads/nebular/rooms/section3.cpp
@@ -21,6 +21,7 @@
 
 #include "mads/nebular/rooms/section3.h"
 #include "mads/nebular/global.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/core/config.h"
 #include "mads/core/game.h"
 #include "mads/core/global.h"
@@ -87,8 +88,10 @@ void section_3_walker() {
 	if (oldName != Common::String(player.series_name))
 		player.walker_must_reload = true;
 
-	pal_change_color(16, 10, 63, 63);
-	pal_change_color(17, 10, 45, 45);
+	if (!setMacintoshMessageColors(0, 0, 63, 0, 0, 63)) {
+		pal_change_color(16, 10, 63, 63);
+		pal_change_color(17, 10, 45, 45);
+	}
 }
 
 void section_3_interface() {

--- a/engines/mads/nebular/rooms/section4.cpp
+++ b/engines/mads/nebular/rooms/section4.cpp
@@ -25,6 +25,7 @@
 #include "mads/core/kernel.h"
 #include "mads/core/pal.h"
 #include "mads/core/player.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/rooms/section4.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/global.h"
@@ -60,8 +61,10 @@ void section_4_walker() {
 	if (oldName != Common::String(player.series_name))
 		player.walker_must_reload = true;
 
-	pal_change_color(16, 10, 63, 63);
-	pal_change_color(17, 10, 45, 45);
+	if (!setMacintoshMessageColors(30, 63, 63, 10, 63, 63)) {
+		pal_change_color(16, 10, 63, 63);
+		pal_change_color(17, 10, 45, 45);
+	}
 }
 
 void section_4_interface() {

--- a/engines/mads/nebular/rooms/section5.cpp
+++ b/engines/mads/nebular/rooms/section5.cpp
@@ -25,6 +25,7 @@
 #include "mads/core/kernel.h"
 #include "mads/core/pal.h"
 #include "mads/core/player.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/rooms/section5.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/global.h"
@@ -63,8 +64,10 @@ void section_5_walker() {
 	if (oldName != Common::String(player.series_name))
 		player.walker_must_reload = true;
 
-	pal_change_color(16, 10, 63, 63);
-	pal_change_color(17, 10, 45, 45);
+	if (!setMacintoshMessageColors(30, 63, 63, 10, 63, 63)) {
+		pal_change_color(16, 10, 63, 63);
+		pal_change_color(17, 10, 45, 45);
+	}
 }
 
 void section_5_interface() {

--- a/engines/mads/nebular/rooms/section6.cpp
+++ b/engines/mads/nebular/rooms/section6.cpp
@@ -25,6 +25,7 @@
 #include "mads/core/kernel.h"
 #include "mads/core/pal.h"
 #include "mads/core/player.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/rooms/section6.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/global.h"
@@ -61,8 +62,10 @@ void section_6_walker() {
 	if (oldName != Common::String(player.series_name))
 		player.walker_must_reload = true;
 
-	pal_change_color(16, 10, 63, 63);
-	pal_change_color(17, 10, 45, 45);
+	if (!setMacintoshMessageColors(30, 63, 63, 10, 63, 63)) {
+		pal_change_color(16, 10, 63, 63);
+		pal_change_color(17, 10, 45, 45);
+	}
 }
 
 void section_6_interface() {

--- a/engines/mads/nebular/rooms/section7.cpp
+++ b/engines/mads/nebular/rooms/section7.cpp
@@ -25,6 +25,7 @@
 #include "mads/core/kernel.h"
 #include "mads/core/pal.h"
 #include "mads/core/player.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/rooms/section7.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/global.h"
@@ -63,8 +64,10 @@ void section_7_walker() {
 	if (oldName != Common::String(player.series_name))
 		player.walker_must_reload = true;
 
-	pal_change_color(16, 10, 63, 63);
-	pal_change_color(17, 10, 45, 45);
+	if (!setMacintoshMessageColors(30, 63, 63, 10, 63, 63)) {
+		pal_change_color(16, 10, 63, 63);
+		pal_change_color(17, 10, 45, 45);
+	}
 }
 
 void section_7_interface() {

--- a/engines/mads/nebular/rooms/section8.cpp
+++ b/engines/mads/nebular/rooms/section8.cpp
@@ -25,6 +25,7 @@
 #include "mads/core/kernel.h"
 #include "mads/core/pal.h"
 #include "mads/core/player.h"
+#include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/rooms/section6.h"
 #include "mads/nebular/nebular.h"
 #include "mads/nebular/global.h"
@@ -53,8 +54,10 @@ void section_8_walker() {
 		Common::strcpy_s(player.series_name, global[kSexOfRex] == SEX_FEMALE ? "ROX" : "RXM");
 	}
 
-	pal_change_color(16, 0x0A, 0x3F, 0x3F);
-	pal_change_color(17, 0x0A, 0x2D, 0x2D);
+	if (!setMacintoshMessageColors(30, 63, 63, 10, 63, 63)) {
+		pal_change_color(16, 0x0A, 0x3F, 0x3F);
+		pal_change_color(17, 0x0A, 0x2D, 0x2D);
+	}
 }
 
 void section_8_interface() {


### PR DESCRIPTION
This PR makes the Macintosh Rex Nebular font rendering more accurate and faithful to the original:

[mac-comparison.webm](https://github.com/user-attachments/assets/d77f02d4-a1b6-4236-b8e9-99925a542730)

Hopefully throughout the game, but at least according to one screenshot. @eriktorbjorn 