### PR TITLE
M4: RIDDLE: Fix looping sound in room 806

### DIFF
--- a/engines/m4/riddle/rooms/section8/room806.cpp
+++ b/engines/m4/riddle/rooms/section8/room806.cpp
@@ -1024,7 +1024,7 @@ void Room806::parser() {
 		digi_play("com042", 1, 255, -1, 997);
 
 	else if (!gearFl && player_said_any("MEI CHEN", "MEI CHEN "))
-		digi_play("com017", 1, 255, 997);
+		digi_play("com017", 1, 255, -1, 997);
 
 	else if (((walkFl && player_said("    ")) || (!walkFl && player_said("east"))) && _G(flags)[V266] == 0) {
 		switch (_G(kernel).trigger) {


### PR DESCRIPTION
digi_play("com017", 1, 255, 997) passed 997 as the trigger instead of the sound room number, when interacting with Mei Chen, so when the sample finished, the trigger was dispatched in KT_PARSE mode and kept re-running Room806::parser(), looping the response.