### PR TITLE
M4: RIDDLE: Fix Mei Chen hotspots in section 8

### DIFF
--- a/engines/m4/riddle/rooms/section8/room809.cpp
+++ b/engines/m4/riddle/rooms/section8/room809.cpp
@@ -29,6 +29,15 @@ namespace M4 {
 namespace Riddle {
 namespace Rooms {
 
+// The scene defines one "MEI CHEN" hotspot for each position Mei Chen can stop at.
+// They are told apart by their amount of trailing spaces, which matches the index
+// of the position in X_DESTS.
+static const char *const MEI_CHEN_HOTSPOTS[4] = {
+	"MEI CHEN", "MEI CHEN ", "MEI CHEN  ", "MEI CHEN   "
+};
+
+static const int32 X_DESTS[4] = { 160, 540, 960, 1282 };
+
 void Room809::preload() {
 	_G(player).walker_type = WALKER_ALT;
 	_G(player).shadow_type = SHADOW_ALT;
@@ -73,16 +82,22 @@ void Room809::init() {
 		series_unload(S8_SHADOW_DIRS1[3]);
 		series_unload(S8_SHADOW_DIRS1[4]);
 
-		hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN", false);
-		hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN ", false);
-		hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN  ", false);
-		hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN   ", false);
+		for (int i = 0; i < 4; ++i)
+			hotspot_set_active(_G(currentSceneDef).hotspots, MEI_CHEN_HOTSPOTS[i], false);
 
 		_mcTrekMach = triggerMachineByHash_3000(8, 4, *S8_SHADOW_DIRS2, *S8_SHADOW_DIRS1,
 			_mcPosX, 317, _mcFacing, Walker::player_walker_callback, "mc_trek");
 		setGlobals3(_mcHandsBehindBackSeries, 1, 17);
 		sendWSMessage_3840000(_mcTrekMach, 38);
-		_enableHotspotName = "MEI CHEN     ";
+
+		// The index isn't part of the savegame, recover it from Mei Chen's position
+		_field24_index = 0;
+		for (int i = 0; i < 4; ++i) {
+			if (X_DESTS[i] == _mcPosX)
+				_field24_index = i;
+		}
+
+		_enableHotspotName = MEI_CHEN_HOTSPOTS[_field24_index];
 		_byte1A1990[_field24_index] = 0;
 
 		kernel_timing_trigger(60, 36, "verify mc's position");
@@ -918,7 +933,6 @@ void Room809::syncGame(Common::Serializer &s) {
 int32 Room809::getMcDestX(int32 xPos, bool facing) {
 	static const uint16 X_THRESHOLDS1[3] = { 540, 960, 1282 };
 	static const uint16 X_THRESHOLDS2[4] = { 0x7fff, 160, 540, 960 };
-	static const uint16 X_DESTS[5] = { 160, 540, 960, 1282 };
 	int32 index;
 
 	if (facing) {
@@ -935,12 +949,11 @@ int32 Room809::getMcDestX(int32 xPos, bool facing) {
 		}
 	}
 
-	hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN", false);
-	hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN ", false);
-	hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN  ", false);
-	hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN   ", false);
+	for (int i = 0; i < 4; ++i)
+		hotspot_set_active(_G(currentSceneDef).hotspots, MEI_CHEN_HOTSPOTS[i], false);
 
-	_enableHotspotName = "MEI CHEN     ";
+	// The hotspot of the position Mei Chen is heading to is activated by daemon() case 38
+	_enableHotspotName = MEI_CHEN_HOTSPOTS[index];
 	_byte1A1990[index] = 0;
 	_field24_index = index;
 	_mcPosX = X_DESTS[index];

--- a/engines/m4/riddle/rooms/section8/room809.h
+++ b/engines/m4/riddle/rooms/section8/room809.h
@@ -46,7 +46,9 @@ private:
 
 	bool _field20Fl = false;
 
-	// CHECKME: The array and its index don't seem to be used
+	// _field24_index is the index of the position Mei Chen is standing at (or heading to).
+	// It selects the hotspot matching that position, see MEI_CHEN_HOTSPOTS in room809.cpp.
+	// CHECKME: The array itself doesn't seem to be used
 	byte _byte1A1990[4] = {0, 0, 0, 0};
 	int32 _field24_index = 0;
 

--- a/engines/m4/riddle/rooms/section8/section8_room.cpp
+++ b/engines/m4/riddle/rooms/section8/section8_room.cpp
@@ -32,6 +32,13 @@ namespace M4 {
 namespace Riddle {
 namespace Rooms {
 
+// The scenes of the rooms handled by this class define one "MEI CHEN" hotspot for each
+// position Mei Chen can stop at. They are told apart by their amount of trailing spaces,
+// which matches the index of the position (see the coordinates in daemonSub1).
+static const char *const MEI_CHEN_HOTSPOTS[5] = {
+	"MEI CHEN", "MEI CHEN ", "MEI CHEN  ", "MEI CHEN   ", "MEI CHEN    "
+};
+
 int32 Section8Room::getStatueIndex(int32 val1) {
 	if (val1 == _var2)
 		return 0;
@@ -97,12 +104,11 @@ int32 Section8Room::daemonSub1(int32 dx, bool ascendingFl) {
 		}
 	}
 
-	hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN", false);
-	hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN ", false);
-	hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN  ", false);
-	hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN   ", false);
-	hotspot_set_active(_G(currentSceneDef).hotspots, "MEI CHEN    ", false);
-	_guessHotspotName = Common::String("MEI CHEN      ");
+	for (int j = 0; j < 5; ++j)
+		hotspot_set_active(_G(currentSceneDef).hotspots, MEI_CHEN_HOTSPOTS[j], false);
+
+	// The hotspot of the position Mei Chen is heading to is activated by daemon() case 4
+	_guessHotspotName = MEI_CHEN_HOTSPOTS[i];
 	_unkArrayIndex = i;
 	_unkArray[_unkArrayIndex] = 0;
 	_guessX = fullArr[i];
@@ -681,7 +687,7 @@ void Section8Room::daemon() {
 			_meiHandsBehindBack = series_load("MEI CHIEN HANDS BEHIND BACK", -1, nullptr);
 			setGlobals3(_meiHandsBehindBack, 1, 17);
 			sendWSMessage_3840000(_mcTrekMach, 4);
-			_guessHotspotName = Common::String("MEI CHEN      ");
+			_guessHotspotName = MEI_CHEN_HOTSPOTS[_unkArrayIndex];
 			_unkArray[_unkArrayIndex] = 0;
 			kernel_timing_trigger(imath_ranged_rand(1200, 1800), 5, nullptr);
 			// CHECKME: CouldMakeMem();

--- a/engines/m4/riddle/rooms/section8/section8_room.h
+++ b/engines/m4/riddle/rooms/section8/section8_room.h
@@ -43,7 +43,9 @@ protected:
 	int32 _byte1A19BC = 0;
 	int32 _field68 = 0;
 
-	// The array seems to be set and never read. Idem for the index
+	// _unkArrayIndex is the index of the position Mei Chen is standing at (or heading to).
+	// It selects the hotspot matching that position, see MEI_CHEN_HOTSPOTS in section8_room.cpp.
+	// The array itself seems to be set and never read.
 	int32 _unkArrayIndex = 0;
 	int32 _unkArray[8];
 


### PR DESCRIPTION
Rooms 804, 809, 814, 824, 834 and 844 define one hotspot for each position Mei Chen can stop at, telling them apart by their amount of trailing spaces, which matches the index of the position. The code was activating a name padded with more spaces than any of those hotspots has, and since hotspot_set_active() compares the full name, no hotspot was activated at all.

The name is now derived from the index of the position, which was already computed and stored, but never used.