### PR TITLE
MADS: NEBULAR: Fix other minor Macintosh issues

### DIFF
--- a/engines/mads/core/magic.cpp
+++ b/engines/mads/core/magic.cpp
@@ -276,7 +276,8 @@ void magic_fade_to_grey(Palette &pal, byte *map_pointer,
 			g_system->updateScreen();
 
 		do {
-			g_engine->getScreen()->update();
+			if (!g_engine->hasMacintoshInterface())
+				g_engine->getScreen()->update();
 			now_timing = timer_read_600();
 		} while (now_timing < (base_timing + tick_delay));
 		base_timing = now_timing;
@@ -377,7 +378,8 @@ void magic_fade_from_grey(RGBcolor *pal, Palette target,
 			g_system->updateScreen();
 
 		do {
-			g_engine->getScreen()->update();
+			if (!g_engine->hasMacintoshInterface())
+				g_engine->getScreen()->update();
 			now_timing = timer_read_600();
 		} while (now_timing < (base_timing + tick_delay));
 		base_timing = now_timing;

--- a/engines/mads/nebular/mac_frontend.cpp
+++ b/engines/mads/nebular/mac_frontend.cpp
@@ -59,6 +59,11 @@ static void runTextViewContent(const char *resource) {
 	presentation.matteHeight = 156;
 	presentation.drawBoundaryLines = false;
 	presentation.macintoshFullFrame = true;
+	// CODE 133 initializes both TextView drawing colors to yellow.
+	presentation.textColor.r = 63;
+	presentation.textColor.g = 63;
+	presentation.textColor.b = 0;
+	presentation.shadowColor = presentation.textColor;
 
 	TextView::textview_main(resource, presentation);
 }

--- a/engines/mads/nebular/mac_menus.cpp
+++ b/engines/mads/nebular/mac_menus.cpp
@@ -613,7 +613,7 @@ bool MacNebularMenu::runPreferencesDialog(bool startup) {
 	_activeDialog = nullptr;
 	if (result == 1) {
 		const bool persist = dialog.isItemChecked(7);
-		_engine.setMacintoshHideMenuBar(dialog.isItemChecked(4), persist);
+		_engine.setMacintoshHideMenuBar(dialog.isItemChecked(4));
 		_engine.setMacintoshPreferencesAtStartup(dialog.isItemChecked(8),
 			persist);
 	}

--- a/engines/mads/nebular/mac_menus.cpp
+++ b/engines/mads/nebular/mac_menus.cpp
@@ -259,7 +259,11 @@ bool MacNebularMenu::loadMenuResource(uint16 resourceID,
 		const char shortcut = item.key == 0x1b ? 0 : item.key;
 		const int itemIndex = _menu->addMenuItem(submenu, item.text,
 			(resource.id << 16) | index, item.style, shortcut, item.enabled);
-		submenu->items[itemIndex]->checkSymbol = item.mark;
+		// Resource mark 18 is the native checkmark character. Let MacGUI
+		// select its equivalent built-in glyph, while preserving hierarchical
+		// submenu IDs stored in the same byte.
+		submenu->items[itemIndex]->checkSymbol =
+			item.mark == 18 ? 0 : item.mark;
 	}
 
 	return true;

--- a/engines/mads/nebular/mac_menus.cpp
+++ b/engines/mads/nebular/mac_menus.cpp
@@ -26,6 +26,7 @@
 #include "common/stream.h"
 #include "common/system.h"
 #include "common/translation.h"
+#include "graphics/cursorman.h"
 #include "graphics/macgui/macmenu.h"
 #include "graphics/macgui/macwindowmanager.h"
 #include "graphics/managed_surface.h"
@@ -35,6 +36,7 @@
 #include "mads/core/config.h"
 #include "mads/core/game.h"
 #include "mads/core/kernel.h"
+#include "mads/core/player.h"
 #include "mads/core/sound_manager.h"
 #include "mads/mads.h"
 #include "mads/nebular/mac_dialogs.h"
@@ -305,7 +307,10 @@ void MacNebularMenu::updateState() {
 				itemIndex < _menu->numberOfMenuItems(topLevel); ++itemIndex)
 			setItemState(_menu->getSubMenuItem(topLevel, itemIndex), false, false);
 	}
-	setItemState(getMenuItem(kAppleMenu, 0), true, false);
+	const bool canShowAbout = !_outerMenuActive && !_activeDialog &&
+		kernel_mode == KERNEL_ACTIVE_CODE && !kernel.fx &&
+		player.commands_allowed && cursor_id != CURSOR_WAIT;
+	setItemState(getMenuItem(kAppleMenu, 0), canShowAbout, false);
 	if (_activeDialog) {
 		setItemState(getMenuItem(kEditMenu, 0),
 			_activeDialog->isEditCommandEnabled(kMacDialogUndo), false);
@@ -368,9 +373,11 @@ void MacNebularMenu::updateState() {
 void MacNebularMenu::dispatchCommand(int commandId) {
 	switch (commandId) {
 	case kAppleAbout:
-		// Run the full-frame presentation after the menu event has unwound.
-		// Otherwise the closing menu window can be composited over room 990.
-		_aboutRequested = true;
+		if (!_outerMenuActive) {
+			// Run the presentation after the menu event has unwound. Otherwise
+			// the closing menu window can be composited over room 990.
+			_aboutRequested = true;
+		}
 		break;
 	case kFileOpen:
 		if (_engine.canLoadGameStateCurrently(nullptr))
@@ -554,8 +561,31 @@ void MacNebularMenu::waitForAboutDismissal() {
 				break;
 			}
 		}
+		// Software cursors are presented by updateScreen(). Keep the native
+		// arrow responsive while waiting for the press-and-release dismissal.
+		g_system->updateScreen();
 		g_system->delayMillis(10);
 	}
+}
+
+void MacNebularMenu::beginAboutPresentation(bool &cursorWasVisible,
+		bool &cursorPushed) {
+	cursorWasVisible = CursorMan.isVisible();
+	cursorPushed = initializeWindowManager();
+	if (cursorPushed) {
+		_windowManager->clearHandlingWidgets();
+		_windowManager->pushCursor(Graphics::kMacCursorArrow);
+	}
+	CursorMan.showMouse(true);
+}
+
+void MacNebularMenu::endAboutPresentation(bool cursorWasVisible,
+		bool cursorPushed) {
+	if (cursorPushed) {
+		_windowManager->clearHandlingWidgets();
+		_windowManager->popCursor();
+	}
+	CursorMan.showMouse(cursorWasVisible);
 }
 
 bool MacNebularMenu::takePreferencesRequest() {

--- a/engines/mads/nebular/mac_menus.h
+++ b/engines/mads/nebular/mac_menus.h
@@ -85,7 +85,9 @@ public:
 	void getMenuColors(byte &menuBlack, byte &menuWhite);
 	void setMenuBarHidden(bool hidden);
 	bool takeAboutRequest();
+	void beginAboutPresentation(bool &cursorWasVisible, bool &cursorPushed);
 	void waitForAboutDismissal();
+	void endAboutPresentation(bool cursorWasVisible, bool cursorPushed);
 	bool takePreferencesRequest();
 	bool runPreferencesDialog(bool startup);
 	void runOpenDialog();

--- a/engines/mads/nebular/mac_nebular.cpp
+++ b/engines/mads/nebular/mac_nebular.cpp
@@ -531,14 +531,12 @@ MacNebular::MacNebular(RexNebularEngine &engine) :
 		_preferencesAtStartup(false), _showPreferencesAtStartup(false),
 		_storyLocked(false) {
 	ConfMan.registerDefault("mac_nebular_display_size", kMacNebularDisplay200);
-	ConfMan.registerDefault("mac_nebular_hide_menu_bar", false);
 	ConfMan.registerDefault("mac_nebular_preferences_at_startup", false);
 	ConfMan.registerDefault("mac_nebular_story_locked", false);
 	ConfMan.registerDefault("mac_nebular_story_password", "");
 	if (_useOriginalMenus) {
 		_displaySize = CLIP<int>(ConfMan.getInt("mac_nebular_display_size"),
 			kMacNebularDisplay100, kMacNebularDisplay200);
-		_hideMenuBar = ConfMan.getBool("mac_nebular_hide_menu_bar");
 		_preferencesAtStartup =
 			ConfMan.getBool("mac_nebular_preferences_at_startup");
 		_showPreferencesAtStartup = _preferencesAtStartup;
@@ -586,16 +584,13 @@ void MacNebular::setDisplaySize(int displaySize, bool persist) {
 	}
 }
 
-void MacNebular::setHideMenuBar(bool hide, bool persist) {
+void MacNebular::setHideMenuBar(bool hide) {
 	if (!_useOriginalMenus)
 		return;
 	_hideMenuBar = hide;
 	if (_menus)
 		_menus->setMenuBarHidden(hide);
-	if (persist) {
-		ConfMan.setBool("mac_nebular_hide_menu_bar", hide);
-		ConfMan.flushToDisk();
-	}
+	// TODO: Persist this once startup can safely restore an autohidden menu.
 }
 
 void MacNebular::setPreferencesAtStartup(bool show, bool persist) {
@@ -1499,9 +1494,9 @@ void RexNebularEngine::setMacintoshDisplaySize(int displaySize,
 		_macNebular->setDisplaySize(displaySize, persist);
 }
 
-void RexNebularEngine::setMacintoshHideMenuBar(bool hide, bool persist) {
+void RexNebularEngine::setMacintoshHideMenuBar(bool hide) {
 	if (_macNebular)
-		_macNebular->setHideMenuBar(hide, persist);
+		_macNebular->setHideMenuBar(hide);
 }
 
 void RexNebularEngine::setMacintoshPreferencesAtStartup(bool show,

--- a/engines/mads/nebular/mac_nebular.cpp
+++ b/engines/mads/nebular/mac_nebular.cpp
@@ -35,13 +35,11 @@
 #include "mads/core/inter.h"
 #include "mads/core/kernel.h"
 #include "mads/core/magic.h"
+#include "mads/core/matte.h"
 #include "mads/core/mcga.h"
-#include "mads/core/mem.h"
 #include "mads/core/object.h"
 #include "mads/core/pal.h"
-#include "mads/core/room.h"
 #include "mads/core/screen.h"
-#include "mads/nebular/extra.h"
 #include "mads/nebular/mac_menus.h"
 #include "mads/nebular/mac_nebular.h"
 #include "mads/nebular/mac_resources.h"
@@ -113,76 +111,6 @@ static byte macGammaCorrect(byte color) {
 
 static byte macPaletteComponentToSixBit(byte color) {
 	return (color * 63 + 127) / 255;
-}
-
-static bool loadMacAboutRoom(Graphics::ManagedSurface &picture,
-		Palette &palette) {
-	Palette savedMasterPalette;
-	dword savedColorStatus[256];
-	int savedFlagUsed[PAL_MAXFLAGS];
-	const int savedPaletteLocked = palette_locked;
-	const int savedLowSearchLimit = palette_low_search_limit;
-	const int savedHighSearchLimit = palette_high_search_limit;
-	const int savedManagerActive = pal_manager_active;
-	const int savedManagerColors = pal_manager_colors;
-	void (*savedManagerUpdate)() = pal_manager_update;
-	ShadowListPtr savedMasterShadow = master_shadow;
-	const int savedRoomLoadError = room_load_error;
-	const byte savedRoomLoadedDepth = room_loaded_depth;
-
-	memcpy(savedMasterPalette, master_palette, sizeof(Palette));
-	memcpy(savedColorStatus, color_status, sizeof(color_status));
-	memcpy(savedFlagUsed, flag_used, sizeof(flag_used));
-
-	for (int color = 0; color < 256; ++color)
-		color_status[color] &= PAL_RESERVED;
-	for (int flag = 2; flag < PAL_MAXFLAGS; ++flag)
-		flag_used[flag] = false;
-	palette_locked = false;
-	palette_low_search_limit = 0;
-	palette_high_search_limit = 256;
-	pal_manager_active = false;
-	pal_manager_colors = 0;
-	pal_manager_update = nullptr;
-	master_shadow = nullptr;
-
-	Buffer roomPicture = {};
-	Buffer roomDepth = {};
-	RoomPtr aboutRoom = RexNebular::room_load(990, 0, nullptr,
-		&roomPicture, &roomDepth, nullptr, nullptr, nullptr, nullptr,
-		nullptr, nullptr, -1, -1, 0);
-	const bool loaded = aboutRoom && roomPicture.data &&
-		roomPicture.x == kMacLogicalSceneWidth &&
-		roomPicture.y == kMacLogicalSceneHeight;
-	if (loaded) {
-		picture.create(roomPicture.x, roomPicture.y,
-			Graphics::PixelFormat::createFormatCLUT8());
-		for (int y = 0; y < roomPicture.y; ++y)
-			memcpy(picture.getBasePtr(0, y),
-				roomPicture.data + y * roomPicture.x, roomPicture.x);
-		memcpy(palette, master_palette, sizeof(Palette));
-	}
-
-	if (aboutRoom) {
-		pal_deallocate(aboutRoom->color_handle);
-		mem_free(aboutRoom);
-	}
-	buffer_free(&roomPicture);
-	buffer_free(&roomDepth);
-
-	memcpy(master_palette, savedMasterPalette, sizeof(Palette));
-	memcpy(color_status, savedColorStatus, sizeof(color_status));
-	memcpy(flag_used, savedFlagUsed, sizeof(flag_used));
-	palette_locked = savedPaletteLocked;
-	palette_low_search_limit = savedLowSearchLimit;
-	palette_high_search_limit = savedHighSearchLimit;
-	pal_manager_active = savedManagerActive;
-	pal_manager_colors = savedManagerColors;
-	pal_manager_update = savedManagerUpdate;
-	master_shadow = savedMasterShadow;
-	room_load_error = savedRoomLoadError;
-	room_loaded_depth = savedRoomLoadedDepth;
-	return loaded;
 }
 
 static void drawMacAboutText(Graphics::ManagedSurface &surface,
@@ -525,6 +453,26 @@ static bool isMacInterfaceScrollbarPixel(int x, int y) {
 		.contains(x, y);
 }
 
+static byte getMacAboutTextColor(const Palette &palette, byte menuBlack,
+		byte menuWhite) {
+	int bestColor = 0;
+	int bestDistance = 3 * 63 * 63 + 1;
+	for (int color = 0; color < Graphics::PALETTE_COUNT; ++color) {
+		if (color == menuBlack || color == menuWhite)
+			continue;
+		const int redDistance = 63 - palette[color].r;
+		const int greenDistance = 63 - palette[color].g;
+		const int blueDistance = 63 - palette[color].b;
+		const int distance = redDistance * redDistance +
+			greenDistance * greenDistance + blueDistance * blueDistance;
+		if (distance < bestDistance) {
+			bestColor = color;
+			bestDistance = distance;
+		}
+	}
+	return bestColor;
+}
+
 MacNebular::MacNebular(RexNebularEngine &engine) :
 		_engine(engine), _useOriginalMenus(ConfMan.getBool("original_mac_menus")),
 		_displaySize(kMacNebularDisplay200), _hideMenuBar(false),
@@ -546,6 +494,7 @@ MacNebular::MacNebular(RexNebularEngine &engine) :
 			ConfMan.setBool("naughtiness", false);
 	}
 	memset(_palette, 0, sizeof(_palette));
+	memset(_aboutPalette, 0, sizeof(_aboutPalette));
 }
 
 int MacNebular::getSceneWidth() const {
@@ -651,9 +600,7 @@ void MacNebular::showAbout() {
 	if (!_useOriginalMenus || !_resources || !_menus)
 		return;
 
-	Graphics::ManagedSurface picture;
-	Palette aboutPalette;
-	if (!loadMacAboutRoom(picture, aboutPalette)) {
+	if (!_aboutRoomLoaded) {
 		warning("Could not load Macintosh About room 990");
 		return;
 	}
@@ -715,12 +662,16 @@ void MacNebular::showAbout() {
 		break;
 	}
 
-	const Graphics::Font *titleFont = _resources->getAboutFont(titleSize);
-	const Graphics::Font *textFont = _resources->getAboutFont(textSize);
+	const Graphics::Font *titleFont = _resources->getAboutFont(titleSize, true);
+	const Graphics::Font *textFont = _resources->getAboutFont(textSize, false);
 	if (!titleFont || !textFont) {
 		warning("Could not load Macintosh About fonts");
 		return;
 	}
+
+	bool cursorWasVisible;
+	bool cursorPushed;
+	_menus->beginAboutPresentation(cursorWasVisible, cursorPushed);
 
 	Graphics::ManagedSurface savedOutput;
 	savedOutput.copyFrom(_output);
@@ -739,61 +690,59 @@ void MacNebular::showAbout() {
 	const int sceneX = getSceneX();
 	const int sceneWidth = getSceneWidth();
 	const int sceneHeight = getSceneHeight();
-	// About owns the full 320x200 viewer and has no inventory panel. Center
-	// its 320x156 room inside that viewer instead of using gameplay's
-	// panel-relative scene position.
-	const int sceneY = kMacDesktopSceneY +
-		(kMacFullFrameHeight - sceneHeight) / 2;
-	drawMacAboutRoom(_output, picture, sceneX, sceneY, sceneWidth,
+	// CODE 6 opens About from gameplay and uses the current game-window size.
+	// It does not use the outer front-end's centered full-frame placement.
+	const int sceneY = getSceneY();
+	drawMacAboutRoom(_output, _aboutPicture, sceneX, sceneY, sceneWidth,
 		sceneHeight, 0);
+	_menus->draw();
 	g_system->copyRectToScreen(_output.getPixels(), _output.pitch,
 		0, 0, _output.w, _output.h);
 	g_system->updateScreen();
-	magic_fade_from_grey((RGBcolor *)transitionPalette, aboutPalette,
+	magic_fade_from_grey((RGBcolor *)transitionPalette, _aboutPalette,
 		0, 256, 0, 1, 1, 16);
 
 	byte blackColor;
 	byte whiteColor;
 	_menus->getMenuColors(blackColor, whiteColor);
-	drawMacAboutRoom(_output, picture, sceneX, sceneY, sceneWidth,
+	const byte textColor = getMacAboutTextColor(_aboutPalette, blackColor,
+		whiteColor);
+	drawMacAboutRoom(_output, _aboutPicture, sceneX, sceneY, sceneWidth,
 		sceneHeight, blackColor);
 	// CODE 6 selects Palette Manager entry zero before drawing the About
 	// strings. That semantic entry is the light text color; it is not the
 	// room picture's indexed-color slot zero, which is black in this port.
+	// Use the closest light room color rather than the menu's reserved white
+	// entry so the text participates in the game-window palette fades.
 	drawMacAboutText(_output, *titleFont, "From MicroProse Software.",
-		sceneX + titleX, sceneY + titleY, whiteColor);
+		sceneX + titleX, sceneY + titleY, textColor);
 	drawMacAboutText(_output, *textFont, "For hints and help call:",
-		sceneX + textX, sceneY + firstTextY, whiteColor);
+		sceneX + textX, sceneY + firstTextY, textColor);
 	drawMacAboutText(_output, *textFont, "1 - 900 - 933 - PLAY",
-		sceneX + helpX, sceneY + helpY, whiteColor);
+		sceneX + helpX, sceneY + helpY, textColor);
 	drawMacAboutText(_output, *textFont, "For customer service call:",
-		sceneX + serviceX, sceneY + serviceY, whiteColor);
+		sceneX + serviceX, sceneY + serviceY, textColor);
 	drawMacAboutText(_output, *textFont, "1 - 410 - 771 - 1151",
-		sceneX + phoneX, sceneY + phoneY, whiteColor);
+		sceneX + phoneX, sceneY + phoneY, textColor);
 	_menus->draw();
 	g_system->copyRectToScreen(_output.getPixels(), _output.pitch,
 		0, 0, _output.w, _output.h);
 	g_system->updateScreen();
 	_menus->waitForAboutDismissal();
 
-	if (!_engine.shouldQuit()) {
-		memcpy(transitionPalette, aboutPalette, sizeof(Palette));
-		magic_fade_to_grey(transitionPalette, nullptr,
-			0, 256, 0, 1, 1, 16);
-	}
+	// Native CODE 6 returns by showing the saved game window. There is no
+	// second fade: restore its palette and composition before submitting one
+	// complete frame, so menu palette entries cannot expose partial panel data.
+	mcga_setpal(&savedPalette);
 	_output.copyFrom(savedOutput);
+	_menus->draw();
 	g_system->copyRectToScreen(_output.getPixels(), _output.pitch,
 		0, 0, _output.w, _output.h);
 	g_system->updateScreen();
-	if (!_engine.shouldQuit()) {
-		magic_fade_from_grey((RGBcolor *)transitionPalette, savedPalette,
-			0, 256, 0, 1, 1, 16);
-	} else {
-		mcga_setpal(&savedPalette);
-	}
 	setFullFrameActive(savedFullFrameActive);
 	_aboutActive = false;
 	_engine._screen->markAllDirty();
+	_menus->endAboutPresentation(cursorWasVisible, cursorPushed);
 }
 
 MacNebular::~MacNebular() {
@@ -890,6 +839,18 @@ void MacNebular::setOuterMenuActive(bool active) {
 }
 
 void MacNebular::notifyOuterMenuFrameReady() {
+	if (_useOriginalMenus && !_aboutRoomLoaded && scr_orig.data &&
+			scr_orig.x == kMacLogicalSceneWidth &&
+			scr_orig.y == kMacLogicalSceneHeight) {
+		_aboutPicture.create(scr_orig.x, scr_orig.y,
+			Graphics::PixelFormat::createFormatCLUT8());
+		for (int y = 0; y < scr_orig.y; ++y)
+			memcpy(_aboutPicture.getBasePtr(0, y),
+				scr_orig.data + y * scr_orig.x, scr_orig.x);
+		memcpy(_aboutPalette, master_palette, sizeof(Palette));
+		_aboutRoomLoaded = true;
+	}
+
 	if (_useOriginalMenus && _showPreferencesAtStartup)
 		_startupPreferencesReady = true;
 }

--- a/engines/mads/nebular/mac_nebular.h
+++ b/engines/mads/nebular/mac_nebular.h
@@ -103,7 +103,7 @@ public:
 	bool getStoryLocked() const { return _storyLocked; }
 	bool verifyStoryPassword(const Common::String &password) const;
 	void setDisplaySize(int displaySize, bool persist);
-	void setHideMenuBar(bool hide, bool persist);
+	void setHideMenuBar(bool hide);
 	void setPreferencesAtStartup(bool show, bool persist);
 	void setStoryLocked(bool locked, const Common::String &password);
 	void setFullFrameActive(bool active);

--- a/engines/mads/nebular/mac_nebular.h
+++ b/engines/mads/nebular/mac_nebular.h
@@ -56,8 +56,10 @@ private:
 	MacNebularMenu *_menus = nullptr;
 	Graphics::ManagedSurface _output;
 	Graphics::ManagedSurface _popup;
+	Graphics::ManagedSurface _aboutPicture;
 	Common::Rect _popupRect;
 	RGBcolor _palette[256];
+	RGBcolor _aboutPalette[256];
 	bool _useOriginalMenus;
 	int _displaySize;
 	bool _hideMenuBar;
@@ -68,6 +70,7 @@ private:
 	Common::String _storyPassword;
 	bool _fullFrameActive = false;
 	bool _aboutActive = false;
+	bool _aboutRoomLoaded = false;
 	bool _gameplayHandoffPending = false;
 	bool _gameplayHandoffEffectSeen = false;
 	bool _popupActive = false;

--- a/engines/mads/nebular/mac_resources.cpp
+++ b/engines/mads/nebular/mac_resources.cpp
@@ -252,12 +252,13 @@ const Graphics::Font *MacResourceProvider::getGameFont() {
 		Graphics::kMacFontGeneva, 10, Graphics::kMacFontBold));
 }
 
-const Graphics::Font *MacResourceProvider::getAboutFont(int size) {
+const Graphics::Font *MacResourceProvider::getAboutFont(int size, bool bold) {
 	if (!_fontManager)
 		return nullptr;
 
 	return _fontManager->getFont(Graphics::MacFont(
-		Graphics::kMacFontGeneva, size, Graphics::kMacFontRegular));
+		Graphics::kMacFontGeneva, size,
+		bold ? Graphics::kMacFontBold : Graphics::kMacFontRegular));
 }
 
 MacResourceProvider::ResourceID MacResourceProvider::mapResource(const Common::String &filename) {

--- a/engines/mads/nebular/mac_resources.h
+++ b/engines/mads/nebular/mac_resources.h
@@ -86,7 +86,7 @@ public:
 	const Graphics::Font *getDialogFont();
 	const Graphics::Font *getInterfaceFont();
 	const Graphics::Font *getGameFont();
-	const Graphics::Font *getAboutFont(int size);
+	const Graphics::Font *getAboutFont(int size, bool bold);
 	const byte *getNativeInterfacePalette() const { return _nativeInterfacePalette; }
 
 	static ResourceID mapResource(const Common::String &filename);

--- a/engines/mads/nebular/nebular.h
+++ b/engines/mads/nebular/nebular.h
@@ -73,7 +73,7 @@ public:
 	bool getMacintoshStoryLocked() const;
 	bool verifyMacintoshStoryPassword(const Common::String &password) const;
 	void setMacintoshDisplaySize(int displaySize, bool persist);
-	void setMacintoshHideMenuBar(bool hide, bool persist);
+	void setMacintoshHideMenuBar(bool hide);
 	void setMacintoshPreferencesAtStartup(bool show, bool persist);
 	void setMacintoshStoryLocked(bool locked,
 		const Common::String &password);

--- a/engines/mads/textview/textview.cpp
+++ b/engines/mads/textview/textview.cpp
@@ -67,6 +67,8 @@ static int visibleHeight;
 static int matteHeight;
 static bool drawBoundaryLines;
 static bool macintoshFullFrame;
+static RGBcolor textColor;
+static RGBcolor shadowColor;
 
 static void present_matte_frame(int specialEffect, int fullScreen) {
 	if (!macintoshFullFrame) {
@@ -166,12 +168,8 @@ static void load_background(const char *value) {
 
 	pal_init(8, 8);
 	pal_white(master_palette);
-	master_palette[5].r = 0;
-	master_palette[5].g = 63;
-	master_palette[5].b = 63;
-	master_palette[6].r = 0;
-	master_palette[6].g = 45;
-	master_palette[6].b = 45;
+	master_palette[5] = textColor;
+	master_palette[6] = shadowColor;
 
 	room = room_load(room_id, 0, nullptr, &scr_orig, &scr_depth, &scr_walk,
 		&scr_special, &picture_map, &depth_map, &picture_resource,
@@ -486,6 +484,12 @@ void textview_main(const char *resName) {
 	presentation.matteHeight = presentation.visibleHeight;
 	presentation.drawBoundaryLines = true;
 	presentation.macintoshFullFrame = false;
+	presentation.textColor.r = 0;
+	presentation.textColor.g = 63;
+	presentation.textColor.b = 63;
+	presentation.shadowColor.r = 0;
+	presentation.shadowColor.g = 45;
+	presentation.shadowColor.b = 45;
 	textview_main(resName, presentation);
 }
 
@@ -495,6 +499,8 @@ void textview_main(const char *resName, const Presentation &presentation) {
 	matteHeight = presentation.matteHeight;
 	drawBoundaryLines = presentation.drawBoundaryLines;
 	macintoshFullFrame = presentation.macintoshFullFrame;
+	textColor = presentation.textColor;
+	shadowColor = presentation.shadowColor;
 	assert(bufferHeight >= 156 && visibleHeight > 0 &&
 		visibleHeight <= bufferHeight && visibleHeight <= 200 &&
 		matteHeight > 0 && matteHeight <= visibleHeight);

--- a/engines/mads/textview/textview.h
+++ b/engines/mads/textview/textview.h
@@ -33,6 +33,8 @@ struct Presentation {
 	int matteHeight;
 	bool drawBoundaryLines;
 	bool macintoshFullFrame;
+	RGBcolor textColor;
+	RGBcolor shadowColor;
 };
 
 // Main textview function


### PR DESCRIPTION
This PR restores several Macintosh-specific Rex Nebular behaviors.

The About presentation is now confined to the active game viewport, with the expected menu, cursor, palette, and restoration behavior. The fade-out is instant (somewhat), which I assume matches the original game behavior.

The Macintosh composition path is also adjusted for the recent upstream MADS fade changes so fades no longer overwrite the separately composed Mac output.

The Story Line menu behavior is hopefully fixed (thanks for pinning it down!), and menu-bar hiding is now session-only. In particular, the Hide Menu Bar preference is no longer written to the config, avoiding a persisted hidden state that could break subsequent launches when original Mac menus are enabled.

TextView colors are now configurable so the Macintosh frontend can use its native yellow palette while preserving the shared DOS defaults. Some Mac TextView discrepancies affecting how Credits are displayed still remain. I will try to address them.