### PR TITLE
DIRECTOR: Fix digital video stopped before it plays (Opera Fatal intro)

### DIFF
--- a/engines/director/castmember/digitalvideo.cpp
+++ b/engines/director/castmember/digitalvideo.cpp
@@ -577,7 +577,7 @@ uint DigitalVideoCastMember::getMovieCurrentTimeMillis() {
 	if (!_video)
 		return 0;
 	int ticks = _video->getTime();
-	int stamp = MIN<int>(ticks, getMovieTotalTime());
+	int stamp = MIN<int>(ticks, getMovieTotalTimeMillis());
 
 	return stamp;
 }

--- a/engines/director/castmember/digitalvideo.cpp
+++ b/engines/director/castmember/digitalvideo.cpp
@@ -471,8 +471,12 @@ bool DigitalVideoCastMember::endOfVideo() {
 	// No decoder or channel means nothing is playing; avoid a null deref.
 	if (!_video || !_channel)
 		return false;
-	return (_video->endOfVideo() ||
-			(getMovieCurrentTimeMillis() >= (uint)(_channel->_stopTime*1000/getTimeScale())));
+	if (_video->endOfVideo())
+		return true;
+	// _stopTime is 0 until the score or a script sets one
+	if (_channel->_stopTime <= 0)
+		return false;
+	return getMovieCurrentTimeMillis() >= (uint)(_channel->_stopTime * 1000 / getTimeScale());
 }
 
 Graphics::MacWidget *DigitalVideoCastMember::createWidget(Common::Rect &bbox, Channel *channel, SpriteType spriteType) {


### PR DESCRIPTION
The Opera Fatal intro (`OPERA/INTRO/INTRO.dir`) drives its 23 scene changes from `the movieTime` of an off-stage, audio-only QuickTime clock (`CON0822.MOV`, 110 s). The clock never advanced, so the intro froze on the first scene.

`DigitalVideoCastMember::endOfVideo()` compares the position against `the stopTime`, but `Channel::_stopTime` is 0 until the score or `startVideo()` sets one. A video started through `set the movieRate of sprite N to 1` never goes through `startVideo()`, so the comparison was `0 >= 0` and `isModified()` stopped the video again on every screen update (6551 `STOPPING VIDEO` in an 80 s run).

The first commit is a prerequisite: `getMovieCurrentTimeMillis()` clamped a millisecond value with `getMovieTotalTime()`, which is in timeScale units.

Verified headless (`SDL_VIDEODRIVER=dummy`): before, 0 scene changes in 240 s; after, all 23 scene changes at the authored marker times (`black` .. `maestro`), then the intro waits for the click that leaves for the game. Lingo test suite output identical to master; `loewe7-cd`, `tkkg7-cd` and `jman-demo` produce no new warnings against master.