### PR TITLE
DIRECTOR: Size a non-stretched digital video sprite from its cast

### DIFF
--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -630,14 +630,6 @@ void Sprite::setCast(CastMemberID memberID, bool replaceDims) {
 			case kCastShape:
 			case kCastText:
 				break;
-			case kCastDigitalVideo:
-				// A video the score sizes to 0x0 is intentionally invisible (a
-				// hidden timing/audio clock); keep it, don't force native size.
-				if (_width > 0 && _height > 0) {
-					_width = dims.width();
-					_height = dims.height();
-				}
-				break;
 			case kCastBitmap:
 			default:
 				_width = dims.width();


### PR DESCRIPTION
The Physicus intro logo (`Intro.dir`, `TIVOLA.MOV`, 640x480) has drawn nothing since b4e08769b39 — 28.5 s of black screen before the intro continues.

That commit skips the cast-dimension resize in `Sprite::setCast()` when a digital-video sprite is 0x0, to keep an off-stage timing clock invisible. Physicus authors sprite 8 as 0x0 in the score and relies on the normal rule — a non-stretched sprite takes the cast's dimensions — so the sprite stayed 0x0 and `createWidget()` returned on the empty bbox.

The hidden-clock case does not need the special case: a video used as a clock has no visual track, so its own cast rect is empty and the generic path still yields 0x0. Opera Fatal's `CON0822.MOV` clock stays off-stage with this commit applied.

Verified headless (`SDL_VIDEODRIVER=dummy`, `--debugflags=images,screenshot`): before, 0 rendered frames and uniformly black dumps for the whole logo; after, 145 frames at 640x480 in a 20 s window and the Tivola logo visible in the frame dumps. `loewe7-cd`, `tkkg7-cd`, `jman-demo` and the Lingo test suite show no new warnings against master.