### PR TITLE
GRAPHICS: MACGUI: fix md indent leaking from lists into following content

### DIFF
--- a/graphics/macgui/mactext-canvas.cpp
+++ b/graphics/macgui/mactext-canvas.cpp
@@ -284,6 +284,11 @@ const Common::U32String::value_type *MacTextCanvas::splitString(const Common::U3
 	while (*s) {
 		firstLineIndent = 0;
 
+		// Freeze the line indent at its first text, so a later indent tag
+		// belonging to the next line does not retroactively change this one.
+		int lineIndent = indentSize;
+		bool lineIndentLocked = false;
+
 		tmp.clear();
 
 		MacTextLine *curTextLine = &_text[curLine];
@@ -344,6 +349,12 @@ const Common::U32String::value_type *MacTextCanvas::splitString(const Common::U3
 			curTextLine = &_text[curLine];
 
 			firstLineIndent = curTextLine->firstLineIndent;
+
+			// Once real text has been added to the line, freeze its indent.
+			if (!lineIndentLocked && !tmp.empty()) {
+				lineIndent = indentSize;
+				lineIndentLocked = true;
+			}
 
 			tmp.clear();
 
@@ -590,7 +601,8 @@ const Common::U32String::value_type *MacTextCanvas::splitString(const Common::U3
 
 			D(9, "*** splitString: text[%d] indent: %d, fi: %d", curLine, indentSize, firstLineIndent);
 
-			curTextLine->indent = indentSize;
+			// Use the frozen per-line indent (see above).
+			curTextLine->indent = lineIndent;
 			curTextLine->firstLineIndent = firstLineIndent;
 
 			// Push new formatting
@@ -624,8 +636,13 @@ const Common::U32String::value_type *MacTextCanvas::splitString(const Common::U3
 
 			curTextLine = &_text[curLine];
 
-			curTextLine->indent = indentSize;
-			curTextLine->firstLineIndent = firstLineIndent;
+			curTextLine->indent = lineIndent;
+			// Clear the bullet's negative firstLineIndent once outside a list, so a
+			// heading following a list is not shifted left. Kept while inside a list.
+			if (indentSize == 0)
+				curTextLine->firstLineIndent = 0;
+			else
+				curTextLine->firstLineIndent = firstLineIndent;
 		}
 	}
 


### PR DESCRIPTION
Freeze the per-line indent at first text and clear the bullet compensation once outside a list, so text after a list is not shifted out of alignment.

Examples of the issue are the following:
<img width="475" height="950" alt="image" src="https://github.com/user-attachments/assets/97486e87-184a-409f-83c3-f5cfa68a8200" />
(negative indent for plain text following a list)

<img width="428" height="753" alt="image" src="https://github.com/user-attachments/assets/29396442-8009-4988-be99-0574cf240334" />

(posiitive indent of a ## heading, supposed to be 0)

Both cases are fixed with this PR
