### PR TITLE
MADE: Preliminary v3.1 support, "rsbnde" game added

### DIFF
--- a/engines/made/database.h
+++ b/engines/made/database.h
@@ -34,6 +34,9 @@ namespace Made {
 
 class MadeEngine;
 
+
+/* Object */
+
 class Object {
 public:
 
@@ -92,8 +95,8 @@ public:
 
 class ObjectV3 : public Object {
 public:
-	int load(Common::SeekableReadStream &source) override;
-	int load(byte *source) override;
+	virtual int load(Common::SeekableReadStream &source) override;
+	virtual int load(byte *source) override;
 	int save(Common::WriteStream &dest) override;
 	uint16 getFlags() override;
 	uint16 getClass() override;
@@ -107,6 +110,15 @@ public:
 	}
 
 };
+
+class ObjectV3_1 : public ObjectV3 {
+public:
+	int load(Common::SeekableReadStream &source) override;
+	int load(byte *source) override;
+};
+
+
+/* GameDatabase */
 
 class GameDatabase {
 public:
@@ -180,7 +192,7 @@ protected:
 class GameDatabaseV3 : public GameDatabase {
 public:
 	GameDatabaseV3(MadeEngine *vm);
-	int16 *findObjectProperty(int16 objectIndex, int16 propertyId, int16 &propertyFlag) override;
+	virtual int16 *findObjectProperty(int16 objectIndex, int16 propertyId, int16 &propertyFlag) override;
 	const char *getString(uint16 offset) override;
 	bool getSavegameDescription(const char *filename, Common::String &description, int16 version) override;
 	int16 savegame(const char *filename, const char *description, int16 version) override;
@@ -188,8 +200,16 @@ public:
 protected:
 	char *_gameText;
 	uint32 _gameStateOffs;
-	void load(Common::SeekableReadStream &sourceS) override;
+	virtual void load(Common::SeekableReadStream &sourceS) override;
 	void reloadFromStream(Common::SeekableReadStream &sourceS) override;
+};
+
+class GameDatabaseV3_1 : public GameDatabaseV3 {
+public:
+	GameDatabaseV3_1(MadeEngine *vm) : GameDatabaseV3(vm) {}
+	int16 *findObjectProperty(int16 objectIndex, int16 propertyId, int16 &propertyFlag) override;
+protected:
+	void load(Common::SeekableReadStream &sourceS) override;
 };
 
 } // End of namespace Made

--- a/engines/made/database.h
+++ b/engines/made/database.h
@@ -55,7 +55,6 @@ public:
 	void setString(const char *str);
 
 	bool isObject();
-	bool isVector();
 
 	int16 getVectorSize();
 	int16 getVectorItem(int16 index);

--- a/engines/made/detection.cpp
+++ b/engines/made/detection.cpp
@@ -31,6 +31,7 @@ static const PlainGameDescriptor madeGames[] = {
 	{"rtz", "Return to Zork"},
 	{"lgop2", "Leather Goddesses of Phobos 2"},
 	{"rodney", "Rodney's Funscreen"},
+	{"rsbnde", "Richard Scarry's Best Neighborhood Disc Ever!"},
 	{nullptr, nullptr}
 };
 
@@ -67,6 +68,7 @@ ADDetectedGame MadeMetaEngineDetection::fallbackDetect(const FileMap &allFiles, 
 	Made::g_fallbackDesc.gameID = 0;
 	Made::g_fallbackDesc.features = 0;
 	Made::g_fallbackDesc.version = 3;
+	Made::g_fallbackDesc.subVersion = 0;
 
 	//return (const ADGameDescription *)&Made::g_fallbackDesc;
 	return ADDetectedGame();

--- a/engines/made/detection.cpp
+++ b/engines/made/detection.cpp
@@ -31,7 +31,8 @@ static const PlainGameDescriptor madeGames[] = {
 	{"rtz", "Return to Zork"},
 	{"lgop2", "Leather Goddesses of Phobos 2"},
 	{"rodney", "Rodney's Funscreen"},
-	{"rsbnde", "Richard Scarry's Best Neighborhood Disc Ever!"},
+	{"rsbestnde", "Richard Scarry's Best Neighborhood Disc Ever!"},
+	{"rsbusynde", "Richard Scarry's Busiest Neighborhood Disc Ever!"},
 	{nullptr, nullptr}
 };
 

--- a/engines/made/detection.h
+++ b/engines/made/detection.h
@@ -30,7 +30,8 @@ enum MadeGameID {
 	GID_RTZ		= 0,
 	GID_MANHOLE	= 1,
 	GID_LGOP2	= 2,
-	GID_RODNEY	= 3
+	GID_RODNEY	= 3,
+	GID_RSBNDE	= 4,
 };
 
 enum MadeGameFeatures {
@@ -48,7 +49,8 @@ struct MadeGameDescription {
 	int gameID;
 	int gameType;
 	uint32 features;
-	uint16 version;
+	uint8 version;
+	uint8 subVersion;
 };
 
 #define GAMEOPTION_INTRO_MUSIC_DIGITAL GUIO_GAMEOPTIONS1

--- a/engines/made/detection.h
+++ b/engines/made/detection.h
@@ -27,11 +27,12 @@
 namespace Made {
 
 enum MadeGameID {
-	GID_RTZ		= 0,
-	GID_MANHOLE	= 1,
-	GID_LGOP2	= 2,
-	GID_RODNEY	= 3,
-	GID_RSBNDE	= 4,
+	GID_RTZ			= 0,
+	GID_MANHOLE		= 1,
+	GID_LGOP2		= 2,
+	GID_RODNEY		= 3,
+	GID_RSBESTNDE	= 4,
+	GID_RSBUSYNDE	= 5
 };
 
 enum MadeGameFeatures {

--- a/engines/made/detection_tables.h
+++ b/engines/made/detection_tables.h
@@ -636,18 +636,15 @@ static const MadeGameDescription gameDescriptions[] = {
 		// Richard Scarry's Best Neighborhood Disc Ever!
 		// Hybrid CD, this is the MS-DOS version
 		{
-			"rsbnde",
+			"rsbestnde",
 			"",
-			{
-				{"best.dat", 0, "9c36e7ee85df0d049a106196683e0134", 38400},
-				{"best.prj", 0, "1aee8bb58c663fed120ff50856c83f16", 4316121},
-			 AD_LISTEND
-			},
+			AD_ENTRY1s("best.dat", "9c36e7ee85df0d049a106196683e0134", 38400),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_UNSTABLE,
-			GUIO0()},
-		GID_RSBNDE,
+			GUIO0()
+		},
+		GID_RSBESTNDE,
 		0,
 		0,
 		3, 1,
@@ -657,16 +654,35 @@ static const MadeGameDescription gameDescriptions[] = {
 		// Richard Scarry's Best Neighborhood Disc Ever! demo
 		// This is found on the Activision 1.1 RTZ CD-ROM for MS-DOS
 		{
-			"rsbnde",
+			"rsbestnde",
 			"Demo",
 			AD_ENTRY1s("bestdemo.dat", "6ef50ec61799d37ed75eada90a76d0e7", 12800),
 			Common::EN_ANY,
 			Common::kPlatformDOS,
 			ADGF_DEMO | ADGF_UNSTABLE,
-			GUIO0()},
-		GID_RSBNDE,
+			GUIO0()
+		},
+		GID_RSBESTNDE,
 		0,
 		GF_DEMO,
+		3, 1,
+	},
+
+	{
+		// Richard Scarry's Busiest Neighborhood Disc Ever!
+		// MS-DOS version
+		{
+			"rsbusynde",
+			"",
+			AD_ENTRY1s("busy.dat", "df793b06adb7944684e63f2af08bd48b", 43520),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE,
+			GUIO0()
+		},
+		GID_RSBUSYNDE,
+		0,
+		0,
 		3, 1,
 	},
 

--- a/engines/made/detection_tables.h
+++ b/engines/made/detection_tables.h
@@ -49,7 +49,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD,
-		3,
+		3, 0,
 	},
 
 	{
@@ -67,7 +67,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD_COMPRESSED,
-		3,
+		3, 0,
 	},
 
 	{
@@ -84,7 +84,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD,
-		3,
+		3, 0,
 	},
 
 	{
@@ -101,7 +101,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD_COMPRESSED,
-		3,
+		3, 0,
 	},
 
 	{
@@ -118,7 +118,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD_COMPRESSED,
-		3,
+		3, 0,
 	},
 
 	{
@@ -136,7 +136,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD,
-		3,
+		3, 0,
 	},
 
 	{
@@ -157,7 +157,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD_COMPRESSED,
-		3,
+		3, 0,
 	},
 
 	{
@@ -175,7 +175,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD,
-		3,
+		3, 0,
 	},
 
 	{
@@ -193,7 +193,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD_COMPRESSED,
-		3,
+		3, 0,
 	},
 
 	{
@@ -211,7 +211,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD,
-		3,
+		3, 0,
 	},
 
 	{
@@ -229,7 +229,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD_COMPRESSED,
-		3,
+		3, 0,
 	},
 
 	{
@@ -247,7 +247,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD,
-		3,
+		3, 0,
 	},
 
 	{
@@ -265,7 +265,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD_COMPRESSED,
-		3,
+		3, 0,
 	},
 
 	{
@@ -288,7 +288,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD_COMPRESSED,
-		3,
+		3, 0,
 	},
 
 	{
@@ -305,7 +305,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_FLOPPY,
-		3,
+		3, 0,
 	},
 
 	{
@@ -326,7 +326,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_DEMO,
-		3,
+		3, 0,
 	},
 
 	{
@@ -343,7 +343,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD_COMPRESSED,
-		3,
+		3, 0,
 	},
 
 	{
@@ -361,7 +361,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD_COMPRESSED,
-		3,
+		3, 0,
 	},
 
 	{
@@ -380,7 +380,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD_COMPRESSED,
-		3,
+		3, 0,
 	},
 
 	{
@@ -398,7 +398,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD,
-		3,
+		3, 0,
 	},
 
 	{
@@ -416,7 +416,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD,
-		3,
+		3, 0,
 	},
 
 	{
@@ -434,7 +434,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RTZ,
 		0,
 		GF_CD,
-		3,
+		3, 0,
 	},
 
 	// The Manhole: Masterpiece Edition is not a MADE engine and cannot be
@@ -453,7 +453,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_MANHOLE,
 		0,
 		GF_CD,
-		2,
+		2, 0,
 	},
 
 	// Bugreport #5855
@@ -470,7 +470,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_MANHOLE,
 		0,
 		GF_CD,
-		2,
+		2, 0,
 	},
 
 	{
@@ -487,7 +487,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_MANHOLE,
 		0,
 		GF_CD,
-		2,
+		2, 0,
 	},
 
 	{
@@ -504,7 +504,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_MANHOLE,
 		0,
 		GF_FLOPPY,
-		1,
+		1, 0,
 	},
 
 	{
@@ -521,7 +521,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_MANHOLE,
 		0,
 		GF_CD,
-		3,
+		3, 0,
 	},
 
 	{
@@ -540,7 +540,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_MANHOLE,
 		0,
 		GF_FLOPPY,
-		3,
+		3, 0,
 	},
 
 	{
@@ -557,7 +557,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_LGOP2,
 		0,
 		GF_FLOPPY,
-		2,
+		2, 0,
 	},
 
 	{
@@ -575,7 +575,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_LGOP2,
 		0,
 		GF_FLOPPY,
-		2,
+		2, 0,
 	},
 
 	{
@@ -593,7 +593,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_LGOP2,
 		0,
 		GF_FLOPPY,
-		2,
+		2, 0,
 	},
 
 	{
@@ -611,7 +611,7 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_LGOP2,
 		0,
 		GF_FLOPPY,
-		2,
+		2, 0,
 	},
 
 	{
@@ -629,10 +629,48 @@ static const MadeGameDescription gameDescriptions[] = {
 		GID_RODNEY,
 		0,
 		GF_FLOPPY,
-		2,
+		2, 0,
 	},
 
-	{ AD_TABLE_END_MARKER, 0, 0, 0, 0 }
+	{
+		// Richard Scarry's Best Neighborhood Disc Ever!
+		// Hybrid CD, this is the MS-DOS version
+		{
+			"rsbnde",
+			"",
+			{
+				{"best.dat", 0, "9c36e7ee85df0d049a106196683e0134", 38400},
+				{"best.prj", 0, "1aee8bb58c663fed120ff50856c83f16", 4316121},
+			 AD_LISTEND
+			},
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_UNSTABLE,
+			GUIO0()},
+		GID_RSBNDE,
+		0,
+		0,
+		3, 1,
+	},
+
+	{
+		// Richard Scarry's Best Neighborhood Disc Ever! demo
+		// This is found on the Activision 1.1 RTZ CD-ROM for MS-DOS
+		{
+			"rsbnde",
+			"Demo",
+			AD_ENTRY1s("bestdemo.dat", "6ef50ec61799d37ed75eada90a76d0e7", 12800),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_DEMO | ADGF_UNSTABLE,
+			GUIO0()},
+		GID_RSBNDE,
+		0,
+		GF_DEMO,
+		3, 1,
+	},
+
+	{ AD_TABLE_END_MARKER, 0, 0, 0, 0, 0 }
 };
 
 /**
@@ -652,7 +690,7 @@ static MadeGameDescription g_fallbackDesc = {
 	0,
 	0,
 	0,
-	0,
+	0, 0,
 };
 
 } // End of namespace Made

--- a/engines/made/graphics.h
+++ b/engines/made/graphics.h
@@ -44,7 +44,9 @@ protected:
 };
 
 void decompressImage(byte *source, Graphics::Surface &surface, uint16 cmdOffs, uint16 pixelOffs, uint16 maskOffs, uint16 lineSize, byte cmdFlags, byte pixelFlags, byte maskFlags, bool deltaFrame = false);
-void decompressMovieImage(byte *source, Graphics::Surface &surface, uint16 cmdOffs, uint16 pixelOffs, uint16 maskOffs, uint16 lineSize);
+void decompressMovieImage(byte *source, Graphics::Surface &surface, uint16 cmdOffs, uint16 pixelOffs, uint16 maskOffs,
+	uint16 cmdSize, uint16 pixelSize, uint16 maskSize, uint16 lineSize,
+	byte cmdFlags, byte pixelFlags, byte maskFlags);
 
 } // End of namespace Made
 

--- a/engines/made/made.cpp
+++ b/engines/made/made.cpp
@@ -73,6 +73,8 @@ MadeEngine::MadeEngine(OSystem *syst, const MadeGameDescription *gameDesc) : Eng
 		_dat = new GameDatabaseV2(this);
 	} else if (getGameID() == GID_RTZ) {
 		_dat = new GameDatabaseV3(this);
+	} else if (getGameID() == GID_RSBNDE) {
+		_dat = new GameDatabaseV3_1(this);
 	} else {
 		error("Unknown GameID");
 	}
@@ -111,6 +113,7 @@ MadeEngine::MadeEngine(OSystem *syst, const MadeGameDescription *gameDesc) : Eng
 		_soundRate = 8000;
 		break;
 	case GID_RTZ:
+	case GID_RSBNDE:
 		// Return to Zork sets it itself via a script function
 		break;
 	default:
@@ -464,6 +467,14 @@ Common::Error MadeEngine::run() {
 
 				delete exe;
 			}
+		}
+	} else if (getGameID() == GID_RSBNDE) {
+		if (getFeatures() & GF_DEMO) {
+			_dat->open("bestdemo.dat");
+			_res->open("bestdemo.prj");
+		} else {
+			_dat->open("best.dat");
+			_res->open("best.prj");
 		}
 	} else {
 		error ("Unknown MADE game");

--- a/engines/made/made.cpp
+++ b/engines/made/made.cpp
@@ -73,7 +73,7 @@ MadeEngine::MadeEngine(OSystem *syst, const MadeGameDescription *gameDesc) : Eng
 		_dat = new GameDatabaseV2(this);
 	} else if (getGameID() == GID_RTZ) {
 		_dat = new GameDatabaseV3(this);
-	} else if (getGameID() == GID_RSBNDE) {
+	} else if (getGameID() == GID_RSBESTNDE || getGameID() == GID_RSBUSYNDE) {
 		_dat = new GameDatabaseV3_1(this);
 	} else {
 		error("Unknown GameID");
@@ -113,8 +113,9 @@ MadeEngine::MadeEngine(OSystem *syst, const MadeGameDescription *gameDesc) : Eng
 		_soundRate = 8000;
 		break;
 	case GID_RTZ:
-	case GID_RSBNDE:
-		// Return to Zork sets it itself via a script function
+	case GID_RSBESTNDE:
+	case GID_RSBUSYNDE:
+		// Return to Zork and the Scarry games sets it via script function
 		break;
 	default:
 		break;
@@ -468,7 +469,7 @@ Common::Error MadeEngine::run() {
 				delete exe;
 			}
 		}
-	} else if (getGameID() == GID_RSBNDE) {
+	} else if (getGameID() == GID_RSBESTNDE) {
 		if (getFeatures() & GF_DEMO) {
 			_dat->open("bestdemo.dat");
 			_res->open("bestdemo.prj");
@@ -476,6 +477,9 @@ Common::Error MadeEngine::run() {
 			_dat->open("best.dat");
 			_res->open("best.prj");
 		}
+	} else if (getGameID() == GID_RSBUSYNDE) {
+		_dat->open("busy.dat");
+		_res->open("busy.prj");
 	} else {
 		error ("Unknown MADE game");
 	}

--- a/engines/made/made.h
+++ b/engines/made/made.h
@@ -83,7 +83,8 @@ public:
 	const MadeGameDescription *_gameDescription;
 	uint32 getGameID() const;
 	uint32 getFeatures() const;
-	uint16 getVersion() const;
+	uint8 getVersion() const;
+	uint8 getSubVersion() const;
 	Common::Platform getPlatform() const;
 	Common::Language getLanguage() const;
 

--- a/engines/made/metaengine.cpp
+++ b/engines/made/metaengine.cpp
@@ -84,8 +84,12 @@ Common::Platform MadeEngine::getPlatform() const {
 	return _gameDescription->desc.platform;
 }
 
-uint16 MadeEngine::getVersion() const {
+uint8 MadeEngine::getVersion() const {
 	return _gameDescription->version;
+}
+
+uint8 MadeEngine::getSubVersion() const {
+	return _gameDescription->subVersion;
 }
 
 Common::Language MadeEngine::getLanguage() const {

--- a/engines/made/pmvplayer.cpp
+++ b/engines/made/pmvplayer.cpp
@@ -232,7 +232,7 @@ bool PmvPlayer::play(const char *filename) {
 			uint16 soundChunkSize = READ_LE_UINT16(audioData + 4);
 			chunkCount = READ_LE_UINT16(audioData + 6);
 
-			debug(1, "chunkCount = %d; chunkSize = %d; total = %d\n", chunkCount, soundChunkSize, chunkCount * soundChunkSize);
+			debug(2, "SOUND: chunkCount = %d; chunkSize = %d; total = %d\n", chunkCount, soundChunkSize, chunkCount * soundChunkSize);
 
 			soundSize = chunkCount * soundChunkSize;
 			soundData = (byte *)malloc(soundSize);

--- a/engines/made/pmvplayer.cpp
+++ b/engines/made/pmvplayer.cpp
@@ -223,19 +223,20 @@ bool PmvPlayer::play(const char *filename) {
 			break;
 
 		soundChunkOfs = READ_LE_UINT32(frameData + 8);
+		uint32 imageDataOfs = READ_LE_UINT32(frameData + 12) - 8;
 		palChunkOfs = READ_LE_UINT32(frameData + 16);
 
 		// Handle audio
 		if (soundChunkOfs) {
 			audioData = frameData + soundChunkOfs - 8;
-			chunkSize = READ_LE_UINT16(audioData + 4);
+			uint16 soundChunkSize = READ_LE_UINT16(audioData + 4);
 			chunkCount = READ_LE_UINT16(audioData + 6);
 
-			debug(1, "chunkCount = %d; chunkSize = %d; total = %d\n", chunkCount, chunkSize, chunkCount * chunkSize);
+			debug(1, "chunkCount = %d; chunkSize = %d; total = %d\n", chunkCount, soundChunkSize, chunkCount * soundChunkSize);
 
-			soundSize = chunkCount * chunkSize;
+			soundSize = chunkCount * soundChunkSize;
 			soundData = (byte *)malloc(soundSize);
-			decompressSound(audioData + 8, soundData, chunkSize, chunkCount, nullptr, soundDecoderData);
+			decompressSound(audioData + 8, soundData, soundChunkSize, chunkCount, nullptr, soundDecoderData);
 			_audioStream->queueBuffer(soundData, soundSize, DisposeAfterUse::YES, Audio::FLAG_UNSIGNED);
 		}
 
@@ -248,25 +249,36 @@ bool PmvPlayer::play(const char *filename) {
 		}
 
 		// Handle video
-		imageData = frameData + READ_LE_UINT32(frameData + 12) - 8;
+		imageData = frameData + imageDataOfs;
 
 		// frameNum @0
+		uint32 imageChunkSize = READ_LE_UINT32(imageData) + 4;
+		// uint32 unknown = READ_LE_UINT32(imageData); // zero?
 		width = READ_LE_UINT16(imageData + 8);
 		height = READ_LE_UINT16(imageData + 10);
+
 		cmdOffs = READ_LE_UINT16(imageData + 12);
+		uint16 cmdFlags = READ_LE_UINT16(imageData + 14);
+
 		pixelOffs = READ_LE_UINT16(imageData + 16);
+		uint16 pixelFlags = READ_LE_UINT16(imageData + 18);
+
 		maskOffs = READ_LE_UINT16(imageData + 20);
+		uint16 maskFlags = READ_LE_UINT16(imageData + 22);
+
 		lineSize = READ_LE_UINT16(imageData + 24);
 
-		debug(2, "width = %d; height = %d; cmdOffs = %04X; pixelOffs = %04X; maskOffs = %04X; lineSize = %d\n",
-			width, height, cmdOffs, pixelOffs, maskOffs, lineSize);
+		debug(2, "width = %d; height = %d; cmdOffs = %04X; cmdFlags = %04X; pixelOffs = %04X; pixelFlags = %04X; maskOffs = %04X; maskFlags = %04X; lineSize = %d\n",
+			width, height, cmdOffs, cmdFlags, pixelOffs, pixelFlags, maskOffs, maskFlags, lineSize);
 
 		if (!_surface) {
 			_surface = new Graphics::Surface();
 			_surface->create(width, height, Graphics::PixelFormat::createFormatCLUT8());
 		}
 
-		decompressMovieImage(imageData, *_surface, cmdOffs, pixelOffs, maskOffs, lineSize);
+		decompressMovieImage(imageData, *_surface, cmdOffs, pixelOffs, maskOffs,
+							pixelOffs - cmdOffs, maskOffs - pixelOffs, imageChunkSize - maskOffs, lineSize,
+							cmdFlags, pixelFlags, maskFlags);
 
 		if (firstTime) {
 			_mixer->playStream(Audio::Mixer::kSFXSoundType, &_audioStreamHandle, _audioStream);

--- a/engines/made/pmvplayer.cpp
+++ b/engines/made/pmvplayer.cpp
@@ -126,7 +126,7 @@ bool PmvPlayer::play(const char *filename) {
 	_surface = nullptr;
 
 	_fd = new Common::File();
-	if (!_fd->open(filename)) {
+	if (!_fd->open(Common::Path(filename, '\\'))) {
 		delete _fd;
 		return false;
 	}

--- a/engines/made/resource.cpp
+++ b/engines/made/resource.cpp
@@ -253,7 +253,9 @@ SoundResource::~SoundResource() {
 }
 
 void SoundResource::load(byte *source, int size) {
-	uint16 chunkCount = READ_LE_UINT16(source + 8);
+	//uint32 iffType = READ_LE_UINT32(source);
+	//uint32 iffSize = READ_LE_UINT32(source + 4);
+	uint16 chunkCount = READ_LE_UINT16(source + 8); // perhaps should instead be UINT32?
 	uint16 chunkSize = READ_LE_UINT16(source + 12);
 
 	_soundSize = chunkCount * chunkSize;

--- a/engines/made/script.cpp
+++ b/engines/made/script.cpp
@@ -169,6 +169,8 @@ byte ScriptInterpreter::readByte() {
 }
 
 int16 ScriptInterpreter::readInt16() {
+	// Scripts are processed byte-by-byte,
+	//  so embedded values (constants, etc) are universally LE
 	int16 temp = (int16)READ_LE_UINT16(_codeIp);
 	_codeIp += 2;
 	debug(4, "readInt16() value = %04X", temp);
@@ -670,6 +672,9 @@ void ScriptInterpreter::dumpScript(int16 objectIndex, int *opcodeStats, int *ext
 					valueType = 2;
 					value = *code++;
 					break;
+				default:
+					error("Unknown signature '%c'", sig);
+					return;
 				}
 
 				Common::String tempStr;
@@ -688,6 +693,9 @@ void ScriptInterpreter::dumpScript(int16 objectIndex, int *opcodeStats, int *ext
 						tempStr = Common::String::format("invalid: %d", value);
 					}
 					break;
+				default:
+					error("Unknown valuetype '%d'", valueType);
+					return;
 				}
 				codeLine += tempStr;
 			}
@@ -696,11 +704,53 @@ void ScriptInterpreter::dumpScript(int16 objectIndex, int *opcodeStats, int *ext
 			error("ScriptInterpreter::dumpScript(%d) Unknown opcode %02X", objectIndex, opcode);
 		}
 	}
-	debug(1, "-------------------------------------------");
+}
+
+void ScriptInterpreter::dumpObject(int16 objectIndex) {
+
+	debug(1, "Dumping object %04X", objectIndex);
+
+	Object *obj = _vm->_dat->getObject(objectIndex);
+	debug(1, "Flags = %d[%04x], Size = %d[%04x]", obj->getFlags(), obj->getFlags(), obj->getSize(), obj->getSize());
+	debug(1, "Class = %d[%04x]", obj->getClass(), obj->getClass());
+	if (obj->getClass() == 0x7FFF) {
+		// byte array
+		bool looksLikeAscii = true;
+		Common::String bArray = "byteArray = [";
+		for (int i = 0; i < obj->getVectorSize(); i++) {
+			int16 c = obj->getVectorItem(i);
+			if (i == obj->getVectorSize() - 1) {
+				if (c != 0)
+					looksLikeAscii = false;
+			} else {
+				if (c != 10 && (c < 32 || c > 126))
+					looksLikeAscii = false;
+			}
+			bArray += Common::String::format("%d,", c);
+		}
+		bArray += "]";
+		debug(1, "%s", bArray.c_str());
+
+		if (looksLikeAscii)
+			debug(1, "ASCII = '%s'", obj->getData());
+	} else if (obj->getClass() == 0x7FFE) {
+		// word array
+		Common::String bArray = "wordArray = [";
+		for (int i = 0; i < obj->getVectorSize(); i++)
+			bArray += Common::String::format("%d,", obj->getVectorItem(i));
+		bArray += " ]";
+		debug(1, "%s", bArray.c_str());
+	} else {
+		debug(1, "Raw Data for object %04X (count1 = %d, count2 = %d)", objectIndex, obj->getCount1(), obj->getCount2());
+		Common::String bArray = "";
+		for (byte *i = obj->getData(); i < obj->getData() + obj->getSize(); i++)
+			bArray += Common::String::format("%02X", *i);
+		debug(1, "%s", bArray.c_str());
+	}
 }
 
 void ScriptInterpreter::dumpAllScripts() {
-	int *opcodeStats = new int[_commandsMax - 1];
+	int *opcodeStats = new int[_commandsMax];
 	int *externStats = new int[_functions->getCount()];
 
 	for (int i = 0; i < _commandsMax; i++)
@@ -710,14 +760,21 @@ void ScriptInterpreter::dumpAllScripts() {
 
 	for (uint objectIndex = 1; objectIndex <= _vm->_dat->getObjectCount(); objectIndex++) {
 		Object *obj = _vm->_dat->getObject(objectIndex);
+
+		debug(1, "-------------------------------------------");
+
 		// Check if it's a byte array which might contain code
-		if (obj->getClass() != 0x7FFF)
+		if (obj->getClass() != 0x7FFF) {
+			dumpObject(objectIndex);
 			continue;
+		}
 		// Code objects aren't excplicitly marked as such, we need to check if
 		// the last byte is a cmd_return opcode.
 		byte *retByte = obj->getData() + obj->getSize() - 1;
 		if (*retByte == 0x1F) {
 			dumpScript(objectIndex, opcodeStats, externStats);
+		} else {
+			dumpObject(objectIndex);
 		}
 	}
 

--- a/engines/made/script.cpp
+++ b/engines/made/script.cpp
@@ -743,7 +743,9 @@ void ScriptInterpreter::dumpObject(int16 objectIndex) {
 	} else {
 		debug(1, "Raw Data for object %04X (count1 = %d, count2 = %d)", objectIndex, obj->getCount1(), obj->getCount2());
 		Common::String bArray = "";
-		for (byte *i = obj->getData(); i < obj->getData() + obj->getSize(); i++)
+		// NOTE: for 3.1 objects, use the commented line here instead
+		//for (byte *i = obj->getData(); i < obj->getData() + obj->getSize() * 4; i++)
+		for (byte *i = obj->getData(); i < obj->getData() + (obj->getCount1() + obj->getCount2()) * 2; i++)
 			bArray += Common::String::format("%02X", *i);
 		debug(1, "%s", bArray.c_str());
 	}

--- a/engines/made/script.h
+++ b/engines/made/script.h
@@ -74,8 +74,11 @@ public:
 	ScriptInterpreter(MadeEngine *vm);
 	~ScriptInterpreter();
 	void runScript(int16 scriptObjectIndex);
+#ifdef DUMP_SCRIPTS
 	void dumpScript(int16 objectIndex, int *opcodeStats, int *externStats);
+	void dumpObject(int16 objectIndex);
 	void dumpAllScripts();
+#endif
 protected:
 	MadeEngine *_vm;
 

--- a/engines/made/scriptfuncs.cpp
+++ b/engines/made/scriptfuncs.cpp
@@ -139,7 +139,7 @@ void ScriptFunctions::setupExternalsTable() {
 	if (_vm->getGameID() == GID_MANHOLE || _vm->getGameID() == GID_LGOP2 || _vm->getGameID() == GID_RODNEY) {
 		External(sfAddScreenMask);
 		External(sfSetSpriteMask);
-	} else if (_vm->getGameID() == GID_RTZ || _vm->getGameID() == GID_RSBNDE) {
+	} else if (_vm->getGameID() == GID_RTZ || _vm->getGameID() == GID_RSBESTNDE || _vm->getGameID() == GID_RSBUSYNDE) {
 		External(sfSetClipArea);
 		External(sfSetSpriteClip);
 	}
@@ -148,7 +148,8 @@ void ScriptFunctions::setupExternalsTable() {
 	External(sfStopSound);
 	External(sfPlayVoice);
 
-	if (_vm->getGameID() == GID_MANHOLE || _vm->getGameID() == GID_RTZ || _vm->getGameID() == GID_RODNEY || _vm->getGameID() == GID_RSBNDE) {
+	if (_vm->getGameID() == GID_MANHOLE || _vm->getGameID() == GID_RTZ ||
+		_vm->getGameID() == GID_RODNEY || _vm->getGameID() == GID_RSBESTNDE || _vm->getGameID() == GID_RSBUSYNDE) {
 		External(sfPlayCd);
 		External(sfStopCd);
 		External(sfGetCdStatus);
@@ -156,7 +157,7 @@ void ScriptFunctions::setupExternalsTable() {
 		External(sfPlayCdSegment);
 	}
 
-	if (_vm->getGameID() == GID_RTZ || _vm->getGameID() == GID_RSBNDE) {
+	if (_vm->getGameID() == GID_RTZ || _vm->getGameID() == GID_RSBESTNDE || _vm->getGameID() == GID_RSBUSYNDE) {
 		External(sfPrintf);
 		External(sfClearMono);
 		External(sfGetSoundEnergy);
@@ -202,7 +203,7 @@ void ScriptFunctions::setupExternalsTable() {
 		External(sfIsSlowSystem);
 	}
 
-	if (_vm->getGameID() == GID_RSBNDE) {
+	if (_vm->getGameID() == GID_RSBESTNDE || _vm->getGameID() == GID_RSBUSYNDE) {
 		External(sfMovieCall);
 		External(sfCursorXY);
 		External(sfSoundFile);

--- a/engines/made/scriptfuncs.cpp
+++ b/engines/made/scriptfuncs.cpp
@@ -30,6 +30,7 @@
 
 #include "backends/audiocd/audiocd.h"
 
+#include "common/file.h"
 #include "common/config-manager.h"
 
 #include "graphics/wincursor.h"
@@ -46,6 +47,39 @@ ScriptFunctions::ScriptFunctions(MadeEngine *vm) : _vm(vm), _soundStarted(false)
 ScriptFunctions::~ScriptFunctions() {
 	for (uint i = 0; i < _externalFuncs.size(); ++i)
 		delete _externalFuncs[i];
+}
+
+// An inner function for playing a sound resource, either from a resource file
+//  or loaded externally
+void ScriptFunctions::playSound(SoundResource *soundRes, bool externalFile) {
+	_vm->_autoStopSound = false;
+	stopSound();
+
+	_vm->_mixer->playStream(Audio::Mixer::kSFXSoundType, &_audioStreamHandle,
+							soundRes->getAudioStream(_vm->_soundRate, false), -1, _gameAudioVolume);
+	_vm->_soundEnergyArray = soundRes->getSoundEnergyArray();
+	_vm->_soundEnergyIndex = 0;
+	_soundStarted = true;
+	_soundWasPlaying = true;
+	_soundResource = soundRes;
+	_soundExternalFile = externalFile;
+
+	// The sound length in milliseconds for purpose of checking if the
+	// sound is still playing. This is 100 ms shorter than the actual
+	// length (see sfSoundPlaying).
+	uint32 soundLength = (_soundResource->getSoundSize() * 1000 / _vm->_soundRate);
+	_soundCheckLength = soundLength > 100 ? soundLength - 100 : 0;
+}
+
+void ScriptFunctions::stopSound() {
+	_vm->_mixer->stopHandle(_audioStreamHandle);
+	if (_soundStarted) {
+		if (_soundExternalFile)
+			delete _soundResource;
+		else
+			_vm->_res->freeResource(_soundResource);
+		_soundStarted = false;
+	}
 }
 
 typedef Common::Functor2Mem<int16, int16*, int16, ScriptFunctions> ExternalScriptFunc;
@@ -253,21 +287,10 @@ int16 ScriptFunctions::sfPlaySound(int16 argc, int16 *argv) {
 		soundNum = argv[1];
 		_vm->_autoStopSound = (argv[0] == 1);
 	}
-	_soundWasPlaying = true;
-	if (soundNum > 0) {
-		SoundResource *soundRes = _vm->_res->getSound(soundNum);
-		_vm->_mixer->playStream(Audio::Mixer::kSFXSoundType, &_audioStreamHandle,
-			soundRes->getAudioStream(_vm->_soundRate, false), -1, _gameAudioVolume);
-		_vm->_soundEnergyArray = soundRes->getSoundEnergyArray();
-		_vm->_soundEnergyIndex = 0;
-		_soundStarted = true;
-		_soundResource = soundRes;
-		// The sound length in milliseconds for purpose of checking if the
-		// sound is still playing. This is 100 ms shorter than the actual
-		// length (see sfSoundPlaying).
-		uint32 soundLength = (_soundResource->getSoundSize() * 1000 / _vm->_soundRate);
-		_soundCheckLength = soundLength > 100 ? soundLength - 100 : 0;
-	}
+
+	if (soundNum > 0)
+		playSound(_vm->_res->getSound(soundNum), false);
+
 	return 0;
 }
 
@@ -719,16 +742,6 @@ int16 ScriptFunctions::sfSoundPlaying(int16 argc, int16 *argv) {
 
 }
 
-void ScriptFunctions::stopSound() {
-	_vm->_mixer->stopHandle(_audioStreamHandle);
-	if (_soundStarted) {
-		_vm->_res->freeResource(_soundResource);
-		_soundStarted = false;
-	}
-
-}
-
-
 int16 ScriptFunctions::sfStopSound(int16 argc, int16 *argv) {
 	stopSound();
 	_vm->_autoStopSound = false;
@@ -1157,19 +1170,40 @@ int16 ScriptFunctions::sfIsSlowSystem(int16 argc, int16 *argv) {
 }
 
 int16 ScriptFunctions::sfMovieCall(int16 argc, int16* argv) {
-	warning("Unimplemented opcode: sfMovieCall");
-
-	return 0;
+	warning("Unimplemented opcode: sfMovieCall (%d, %d)", argv[0], argv[1]);
+	// TODO: This is incorrect: it is supposed to play the movie in the _background_
+	//  rather than pausing the script and playing in the foreground
+	return sfPlayMovie(argc, argv);
 }
 
 int16 ScriptFunctions::sfCursorXY(int16 argc, int16 *argv) {
-	warning("Unimplemented opcode: sfCursorXY");
-
+	g_system->warpMouse(argv[1], argv[0]);
 	return 0;
 }
 
 int16 ScriptFunctions::sfSoundFile(int16 argc, int16 *argv) {
-	warning("Unimplemented opcode: sfSoundFile");
+	// Loads an external sound file (i.e. not from PRJ) and plays it
+	const char *soundName = _vm->_dat->getObjectString(argv[0]);
+
+	debug(1, "Playing external sound '%s'", soundName);
+
+	Common::File *_fd = new Common::File();
+	if (!_fd->open(Common::Path(soundName, '\\'))) {
+		delete _fd;
+		warning("Failed to open sound file '%s", soundName);
+		return 0;
+	}
+	byte *srcBuf = new byte[_fd->size()];
+	_fd->read(srcBuf, _fd->size());
+
+	// wrap this in a SoundResource
+	SoundResource *soundRes = new SoundResource();
+	soundRes->load(srcBuf, _fd->size());
+
+	// safe to free source now
+	delete[] srcBuf;
+
+	playSound(soundRes, true);
 
 	return 0;
 }

--- a/engines/made/scriptfuncs.cpp
+++ b/engines/made/scriptfuncs.cpp
@@ -105,7 +105,7 @@ void ScriptFunctions::setupExternalsTable() {
 	if (_vm->getGameID() == GID_MANHOLE || _vm->getGameID() == GID_LGOP2 || _vm->getGameID() == GID_RODNEY) {
 		External(sfAddScreenMask);
 		External(sfSetSpriteMask);
-	} else if (_vm->getGameID() == GID_RTZ) {
+	} else if (_vm->getGameID() == GID_RTZ || _vm->getGameID() == GID_RSBNDE) {
 		External(sfSetClipArea);
 		External(sfSetSpriteClip);
 	}
@@ -114,7 +114,7 @@ void ScriptFunctions::setupExternalsTable() {
 	External(sfStopSound);
 	External(sfPlayVoice);
 
-	if (_vm->getGameID() == GID_MANHOLE || _vm->getGameID() == GID_RTZ || _vm->getGameID() == GID_RODNEY) {
+	if (_vm->getGameID() == GID_MANHOLE || _vm->getGameID() == GID_RTZ || _vm->getGameID() == GID_RODNEY || _vm->getGameID() == GID_RSBNDE) {
 		External(sfPlayCd);
 		External(sfStopCd);
 		External(sfGetCdStatus);
@@ -122,7 +122,7 @@ void ScriptFunctions::setupExternalsTable() {
 		External(sfPlayCdSegment);
 	}
 
-	if (_vm->getGameID() == GID_RTZ) {
+	if (_vm->getGameID() == GID_RTZ || _vm->getGameID() == GID_RSBNDE) {
 		External(sfPrintf);
 		External(sfClearMono);
 		External(sfGetSoundEnergy);
@@ -168,6 +168,11 @@ void ScriptFunctions::setupExternalsTable() {
 		External(sfIsSlowSystem);
 	}
 
+	if (_vm->getGameID() == GID_RSBNDE) {
+		External(sfMovieCall);
+		External(sfCursorXY);
+		External(sfSoundFile);
+	}
 }
 #undef External
 
@@ -1149,6 +1154,24 @@ int16 ScriptFunctions::sfIsSlowSystem(int16 argc, int16 *argv) {
 	// An example is FINTRO00.PMV (with sound) and FINTRO01.PMV (without sound)
 	// One could maybe think about returning 1 here on actually slower systems.
 	return _vm->_introMusicDigital ? 0 : 1;
+}
+
+int16 ScriptFunctions::sfMovieCall(int16 argc, int16* argv) {
+	warning("Unimplemented opcode: sfMovieCall");
+
+	return 0;
+}
+
+int16 ScriptFunctions::sfCursorXY(int16 argc, int16 *argv) {
+	warning("Unimplemented opcode: sfCursorXY");
+
+	return 0;
+}
+
+int16 ScriptFunctions::sfSoundFile(int16 argc, int16 *argv) {
+	warning("Unimplemented opcode: sfSoundFile");
+
+	return 0;
 }
 
 } // End of namespace Made

--- a/engines/made/scriptfuncs.h
+++ b/engines/made/scriptfuncs.h
@@ -173,7 +173,9 @@ protected:
 	int16 sfSetSoundVolume(int16 argc, int16 *argv);
 	int16 sfGetSynthType(int16 argc, int16 *argv);
 	int16 sfIsSlowSystem(int16 argc, int16 *argv);
-
+	int16 sfMovieCall(int16 argc, int16 *argv);
+	int16 sfCursorXY(int16 argc, int16 *argv);
+	int16 sfSoundFile(int16 argc, int16 *argv);
 };
 
 } // End of namespace Made

--- a/engines/made/scriptfuncs.h
+++ b/engines/made/scriptfuncs.h
@@ -50,6 +50,9 @@ public:
 	void setupExternalsTable();
 	const char* getFuncName(int index) { return _externalFuncNames[index]; }
 	int getCount() const { return _externalFuncs.size(); }
+
+private:
+	void playSound(SoundResource *soundRes, bool externalFile);
 	void stopSound();
 
 protected:
@@ -59,6 +62,7 @@ protected:
 	SoundResource* _soundResource;
 	bool _soundStarted;
 	bool _soundWasPlaying;
+	bool _soundExternalFile;
 	// The sound length in milliseconds for purpose of checking if the sound is
 	// still playing.
 	int _soundCheckLength;


### PR DESCRIPTION
MADE: Preliminary v3.1 support, "rsbnde" game added

Adds some early support for version 3.1 MADE engine games.

The current engine supports versions 1, 2, and 3.  Version 3.1
is used in a handful of games: most notably, "Return to Zork"
(the Mac non-ReelMagic version), but also previously un-emulated
edutainment title "Richard Scarry's Best Neighborhood Disc Ever!"

Version 3.1 database differs in layout from version 3, so I have
enhanced the script-dumper utility a bit.  There are also three
new script opcodes added:

- sfCursorXY (warps the cursor),
- sfSoundFile (plays a sound from an external file), and
- sfMovieCall (plays a movie in the "background")

Unfortunately, sfMovieCall support is incomplete, because it
would require architecture changes: it is meant to play a movie,
but continue executing scripts in the "foreground", which is not
really supported by the current MADE script player.  For now,
I have it synonymed to sfPlayMovie, This is enough to properly
play the demo of RSBNDE correctly, but not the full version.

There is one other feature added in 3.1: support for RLE-compresed
movie frames.  The tables used for PMV playback are decompressed
and then passed to the existing PMVPlayer, when indicated by flags.
