### PR TITLE
MADE: Report selected synthesiser type

### DIFF
--- a/engines/made/music.cpp
+++ b/engines/made/music.cpp
@@ -203,15 +203,9 @@ void DOSMusicPlayer::syncSoundSettings() {
 int16 DOSMusicPlayer::getSynthType() const {
 	switch (_driverType) {
 	case MT_MT32:
-	case MT_GM:
-		// The MIDI path always supplies MT-32 data. MidiDriver_MT32GM
-		// translates it when the selected output device is GM.
 		return 4;
 	case MT_ADLIB:
 		return 2;
-	case MT_PCSPK:
-	case MT_PCJR:
-		return 1;
 	default:
 		return 0;
 	}

--- a/engines/made/music.cpp
+++ b/engines/made/music.cpp
@@ -200,6 +200,23 @@ void DOSMusicPlayer::syncSoundSettings() {
 		_driver->syncSoundSettings();
 }
 
+int16 DOSMusicPlayer::getSynthType() const {
+	switch (_driverType) {
+	case MT_MT32:
+	case MT_GM:
+		// The MIDI path always supplies MT-32 data. MidiDriver_MT32GM
+		// translates it when the selected output device is GM.
+		return 4;
+	case MT_ADLIB:
+		return 2;
+	case MT_PCSPK:
+	case MT_PCJR:
+		return 1;
+	default:
+		return 0;
+	}
+}
+
 void DOSMusicPlayer::onTimer() {
 	if (_parser)
 		_parser->onTimer();

--- a/engines/made/music.cpp
+++ b/engines/made/music.cpp
@@ -200,14 +200,14 @@ void DOSMusicPlayer::syncSoundSettings() {
 		_driver->syncSoundSettings();
 }
 
-int16 DOSMusicPlayer::getSynthType() const {
+SynthType DOSMusicPlayer::getSynthType() const {
 	switch (_driverType) {
 	case MT_MT32:
-		return 4;
+		return kSynthTypeMT32;
 	case MT_ADLIB:
-		return 2;
+		return kSynthTypeAdLib;
 	default:
-		return 0;
+		return kSynthTypeDefault;
 	}
 }
 

--- a/engines/made/music.h
+++ b/engines/made/music.h
@@ -50,6 +50,14 @@ public:
 
 	virtual bool isPlaying() = 0;
 	virtual void syncSoundSettings() = 0;
+
+	/**
+	 * The synthesiser type the game scripts should see, using the values the
+	 * sfGetSynthType() script external is expected to return: 0 default,
+	 * 1 PC speaker, 2 AdLib / Sound Blaster FM, 3 AdLib Gold, 4 MT-32 on an
+	 * MPU-401. Return to Zork picks different music resources depending on it.
+	 */
+	virtual int16 getSynthType() const { return 0; }
 };
 
 class DOSMusicPlayer : public MusicPlayer {
@@ -70,6 +78,8 @@ public:
 
 	bool isPlaying() override;
 	void syncSoundSettings() override;
+
+	int16 getSynthType() const override;
 
 private:
 	MadeEngine *_vm;

--- a/engines/made/music.h
+++ b/engines/made/music.h
@@ -36,6 +36,15 @@ namespace Made {
 
 class GenericResource;
 
+/** Synthesizer types reported to game scripts. */
+enum SynthType {
+	kSynthTypeDefault = 0,
+	kSynthTypePCSpeaker = 1,
+	kSynthTypeAdLib = 2,
+	kSynthTypeAdLibGold = 3,
+	kSynthTypeMT32 = 4
+};
+
 class MusicPlayer {
 public:
 	virtual ~MusicPlayer() {}
@@ -51,13 +60,7 @@ public:
 	virtual bool isPlaying() = 0;
 	virtual void syncSoundSettings() = 0;
 
-	/**
-	 * The synthesiser type the game scripts should see, using the values the
-	 * sfGetSynthType() script external is expected to return: 0 default,
-	 * 1 PC speaker, 2 AdLib / Sound Blaster FM, 3 AdLib Gold, 4 MT-32 on an
-	 * MPU-401. Return to Zork picks different music resources depending on it.
-	 */
-	virtual int16 getSynthType() const { return 0; }
+	virtual SynthType getSynthType() const { return kSynthTypeDefault; }
 };
 
 class DOSMusicPlayer : public MusicPlayer {
@@ -79,7 +82,7 @@ public:
 	bool isPlaying() override;
 	void syncSoundSettings() override;
 
-	int16 getSynthType() const override;
+	SynthType getSynthType() const override;
 
 private:
 	MadeEngine *_vm;

--- a/engines/made/scriptfuncs.cpp
+++ b/engines/made/scriptfuncs.cpp
@@ -1133,11 +1133,7 @@ int16 ScriptFunctions::sfGetSynthType(int16 argc, int16 *argv) {
 	// 2 = SBFM/ADLIB
 	// 3 = ADLIBG
 	// 4 = MT32MPU
-
-	// There doesn't seem to be any difference in the music no matter what this returns
-
-	//warning("Unimplemented opcode: sfGetSynthType");
-	return 0;
+	return _vm->_music ? _vm->_music->getSynthType() : 0;
 }
 
 int16 ScriptFunctions::sfIsSlowSystem(int16 argc, int16 *argv) {

--- a/engines/made/scriptfuncs.cpp
+++ b/engines/made/scriptfuncs.cpp
@@ -1128,12 +1128,7 @@ int16 ScriptFunctions::sfSetSoundVolume(int16 argc, int16 *argv) {
 }
 
 int16 ScriptFunctions::sfGetSynthType(int16 argc, int16 *argv) {
-	// 0 = Default
-	// 1 = PCSPKR
-	// 2 = SBFM/ADLIB
-	// 3 = ADLIBG
-	// 4 = MT32MPU
-	return _vm->_music ? _vm->_music->getSynthType() : 0;
+	return _vm->_music ? _vm->_music->getSynthType() : kSynthTypeDefault;
 }
 
 int16 ScriptFunctions::sfIsSlowSystem(int16 argc, int16 *argv) {


### PR DESCRIPTION
Return to Zork seems to have two different musical arrangements: mt32, and everything else. Currently if mt32 is selected in scummvm, it still plays the "everything else" version.

`sfGetSynthType()` always returns 0, although Return to Zork uses the
value to choose between its MT-32 and alternate music resources. As a
result, the MT-32 arrangements are never selected.

This update make it return what type of device scummvm is emulating, so it can select the correct arrangement for it.

Testing:

- MADE-only release build on current master.
- Return to Zork V1.1 with `-e mt32`: external returns 4.
- Return to Zork V1.1 with `-e adlib`: external returns 2.

I created this while working on a Re[ea]lmagic patch for the MADE engine. I used Claude  to help dig through various sets of RTZ binaries to work out what needed changing and how (and noticing things like the two arrangements). I used Codex to do final reviews, branch adjustments, etc. 
