### PR TITLE
MADE: Unload music data when stopping playback

### DIFF
--- a/engines/made/music.cpp
+++ b/engines/made/music.cpp
@@ -182,8 +182,10 @@ void DOSMusicPlayer::resume() {
 }
 
 void DOSMusicPlayer::stop() {
+	// The parser reads the resource buffer directly, so unload it before the
+	// resource is freed below.
 	if (_parser)
-		_parser->stopPlaying();
+		_parser->unloadMusic();
 
 	if (_musicRes) {
 		_vm->_res->freeResource(_musicRes);


### PR DESCRIPTION
While testing my RTZ-RM version, I had some issues with skipping the intro / cutscenes properly due to the music not stopping properly. This small change stabilized that issue.

`DOSMusicPlayer::stop()` stops the parser and then frees the resource
whose buffer the parser reads directly. If playback is interrupted,
the timer callback can subsequently access that freed buffer.

This calls `unloadMusic()` before freeing the resource, clearing the
parser's reference through its existing unload path.

Testing:

- MADE-only release build on current master.
- Verified the parser is unloaded before the resource is released.

I created this while working on a Re[ea]lmagic patch for the MADE engine. I used Claude to help dig through various sets of RTZ binaries to work out what needed changing and how  (also odd differences like how cut scenes are skipped with escape vs mouse click in RTZ-RM). I used Codex to do final reviews, branch adjustments, etc.
