### PR TITLE
VIDEO: Add opt-in single-frame MPEG decoding

### DIFF
--- a/image/codecs/mpeg.cpp
+++ b/image/codecs/mpeg.cpp
@@ -24,6 +24,7 @@
 #include "common/stream.h"
 #include "common/system.h"
 #include "common/textconsole.h"
+#include "common/util.h"
 #include "graphics/surface.h"
 #include "graphics/yuv_to_rgb.h"
 
@@ -39,6 +40,9 @@ MPEGDecoder::MPEGDecoder() : Codec() {
 	_pixelFormat = getDefaultYUVFormat();
 
 	_surface = 0;
+	_pendingPos = 0;
+	_stopAtFirstFrame = false;
+	_reachedSequenceEnd = false;
 
 	_mpegDecoder = mpeg2_init();
 
@@ -63,7 +67,28 @@ const Graphics::Surface *MPEGDecoder::decodeFrame(Common::SeekableReadStream &st
 	return _surface;
 }
 
+void MPEGDecoder::convertFrame(Graphics::Surface *dst) {
+	const mpeg2_sequence_t *sequence = _mpegInfo->sequence;
+
+	if (!dst) {
+		// If no destination is specified, use our internal storage
+		if (!_surface) {
+			_surface = new Graphics::Surface();
+			_surface->create(sequence->picture_width, sequence->picture_height, _pixelFormat);
+		}
+
+		dst = _surface;
+	}
+
+	YUVToRGBMan.convert420(dst, Graphics::YUVToRGBManager::kScaleITU, _mpegInfo->display_fbuf->buf[0],
+			_mpegInfo->display_fbuf->buf[1], _mpegInfo->display_fbuf->buf[2], sequence->picture_width,
+			sequence->picture_height, sequence->width, sequence->chroma_width);
+}
+
 bool MPEGDecoder::decodePacket(Common::SeekableReadStream &packet, uint32 &framePeriod, Graphics::Surface *dst) {
+	if (_stopAtFirstFrame)
+		return decodeFirstFrame(packet, framePeriod, dst);
+
 	// Decode as much as we can out of this packet
 	uint32 size = 0xFFFFFFFF;
 	mpeg2_state_t state;
@@ -78,8 +103,14 @@ bool MPEGDecoder::decodePacket(Common::SeekableReadStream &packet, uint32 &frame
 			size = packet.read(_buffer, BUFFER_SIZE);
 			mpeg2_buffer(_mpegDecoder, _buffer, _buffer + size);
 			break;
-		case STATE_SLICE:
+		case STATE_SEQUENCE:
+		case STATE_SEQUENCE_REPEATED:
+			_reachedSequenceEnd = false;
+			break;
 		case STATE_END:
+			_reachedSequenceEnd = true;
+			// fall through
+		case STATE_SLICE:
 			if (_mpegInfo->display_fbuf) {
 				foundFrame = true;
 				const mpeg2_sequence_t *sequence = _mpegInfo->sequence;
@@ -91,19 +122,7 @@ bool MPEGDecoder::decodePacket(Common::SeekableReadStream &packet, uint32 &frame
 
 				}
 
-				if (!dst) {
-					// If no destination is specified, use our internal storage
-					if (!_surface) {
-						_surface = new Graphics::Surface();
-						_surface->create(sequence->picture_width, sequence->picture_height, _pixelFormat);
-					}
-
-					dst = _surface;
-				}
-
-				YUVToRGBMan.convert420(dst, Graphics::YUVToRGBManager::kScaleITU, _mpegInfo->display_fbuf->buf[0],
-						_mpegInfo->display_fbuf->buf[1], _mpegInfo->display_fbuf->buf[2], sequence->picture_width,
-						sequence->picture_height, sequence->width, sequence->chroma_width);
+				convertFrame(dst);
 			}
 			break;
 		default:
@@ -112,6 +131,101 @@ bool MPEGDecoder::decodePacket(Common::SeekableReadStream &packet, uint32 &frame
 	} while (size != 0);
 
 	return foundFrame;
+}
+
+bool MPEGDecoder::decodeFirstFrame(Common::SeekableReadStream &packet, uint32 &framePeriod, Graphics::Surface *dst) {
+	// Queue whatever the caller handed us. Anything left over from an earlier
+	// call is still in front of it, so the stream order is kept.
+	const int64 remaining = packet.size() - packet.pos();
+	if (remaining > 0) {
+		const uint32 oldSize = _pendingData.size();
+		if ((uint64)remaining > 0xFFFFFFFFU - oldSize) {
+			warning("MPEGDecoder: queued packet data is too large");
+			framePeriod = 0;
+			return false;
+		}
+
+		const uint32 requested = (uint32)remaining;
+		_pendingData.resize(oldSize + requested);
+		const uint32 bytesRead = packet.read(&_pendingData[oldSize], requested);
+		if (bytesRead != requested)
+			_pendingData.resize(oldSize + bytesRead);
+	}
+
+	return decodeQueuedFrame(framePeriod, dst);
+}
+
+bool MPEGDecoder::decodePendingFrame(uint32 &framePeriod, Graphics::Surface *dst) {
+	if (!_stopAtFirstFrame) {
+		framePeriod = 0;
+		return false;
+	}
+
+	return decodeQueuedFrame(framePeriod, dst);
+}
+
+bool MPEGDecoder::decodeQueuedFrame(uint32 &framePeriod, Graphics::Surface *dst) {
+	framePeriod = 0;
+
+	for (;;) {
+		const mpeg2_state_t state = mpeg2_parse(_mpegDecoder);
+
+		switch (state) {
+		case STATE_BUFFER: {
+			// libmpeg2 has consumed all of _buffer and wants more. Only ever
+			// refill it here, so that returning early with data still inside it
+			// is safe: the decoder picks up where it left off on the next call.
+			const uint32 available = _pendingData.size() - _pendingPos;
+			if (available == 0) {
+				_pendingData.clear();
+				_pendingPos = 0;
+				return false;	// Needs another packet to make progress
+			}
+
+			const uint32 chunk = MIN<uint32>(available, BUFFER_SIZE);
+
+			memcpy(_buffer, &_pendingData[_pendingPos], chunk);
+			_pendingPos += chunk;
+
+			// Drop consumed data from time to time to bound the queue
+			if (_pendingPos >= BUFFER_SIZE * 4) {
+				const uint32 keep = _pendingData.size() - _pendingPos;
+				if (keep > 0)
+					memmove(&_pendingData[0], &_pendingData[_pendingPos], keep);
+				_pendingData.resize(keep);
+				_pendingPos = 0;
+			}
+
+			mpeg2_buffer(_mpegDecoder, _buffer, _buffer + chunk);
+			break;
+		}
+		case STATE_SEQUENCE:
+		case STATE_SEQUENCE_REPEATED:
+			_reachedSequenceEnd = false;
+			break;
+		case STATE_END:
+			_reachedSequenceEnd = true;
+			// fall through
+		case STATE_SLICE:
+			if (_mpegInfo->display_fbuf) {
+				const mpeg2_sequence_t *sequence = _mpegInfo->sequence;
+				const mpeg2_picture_t *picture = _mpegInfo->display_picture;
+
+				framePeriod = sequence->frame_period;
+				if (picture->nb_fields > 2)
+					framePeriod += (sequence->frame_period / 2);
+
+				convertFrame(dst);
+
+				// Hand this frame over instead of decoding the rest of the
+				// packet on top of it; the remainder stays queued.
+				return true;
+			}
+			break;
+		default:
+			break;
+		}
+	}
 }
 
 } // End of namespace Image

--- a/image/codecs/mpeg.h
+++ b/image/codecs/mpeg.h
@@ -22,6 +22,8 @@
 #ifndef IMAGE_CODECS_MPEG_H
 #define IMAGE_CODECS_MPEG_H
 
+#include "common/array.h"
+
 #include "image/codecs/codec.h"
 #include "graphics/pixelformat.h"
 
@@ -61,7 +63,33 @@ public:
 	// MPEGPSDecoder call
 	bool decodePacket(Common::SeekableReadStream &packet, uint32 &framePeriod, Graphics::Surface *dst = 0);
 
+	/** Decode one frame already buffered by a previous decodePacket() call. */
+	bool decodePendingFrame(uint32 &framePeriod, Graphics::Surface *dst = 0);
+
+	/** Return whether the decoder has parsed an MPEG sequence-end code. */
+	bool reachedSequenceEnd() const { return _reachedSequenceEnd; }
+
+	/**
+	 * Return as soon as one frame is ready to show, keeping the rest of the
+	 * packet for the calls that follow, instead of decoding every frame in the
+	 * packet on top of the same surface.
+	 *
+	 * Off by default, since it changes when frames come out and existing callers
+	 * are tuned to the old behaviour. It matters for streams whose packets carry
+	 * more than one frame: those lose all but the last frame of every packet
+	 * otherwise. This is particularly visible in streams with bidirectionally
+	 * predicted pictures, where several displayable frames may share a packet.
+	 */
+	void setStopAtFirstFrame(bool stop) { _stopAtFirstFrame = stop; }
+
 private:
+	bool decodeFirstFrame(Common::SeekableReadStream &packet, uint32 &framePeriod, Graphics::Surface *dst);
+	bool decodeQueuedFrame(uint32 &framePeriod, Graphics::Surface *dst);
+	void convertFrame(Graphics::Surface *dst);
+
+	bool _stopAtFirstFrame;
+	bool _reachedSequenceEnd;
+
 	Graphics::PixelFormat _pixelFormat;
 	Graphics::Surface *_surface;
 
@@ -72,6 +100,11 @@ private:
 	byte _buffer[BUFFER_SIZE];
 	mpeg2dec_t *_mpegDecoder;
 	const mpeg2_info_t *_mpegInfo;
+
+	// When one-frame-per-call decoding is enabled, a packet which holds more than
+	// one frame keeps its remainder queued here for the calls that follow.
+	Common::Array<byte> _pendingData;
+	uint32 _pendingPos;
 };
 
 } // End of namespace Image

--- a/video/mpegps_decoder.cpp
+++ b/video/mpegps_decoder.cpp
@@ -29,6 +29,7 @@
 #include "common/memstream.h"
 #include "common/system.h"
 #include "common/textconsole.h"
+#include "common/util.h"
 
 #include "video/mpegps_decoder.h"
 #include "image/codecs/mpeg.h"
@@ -80,6 +81,10 @@ bool MPEGPSDecoder::loadStream(Common::SeekableReadStream *stream) {
 
 void MPEGPSDecoder::setPrebufferedPackets(int packets) {
 	_demuxer->setPrebufferedPackets(packets);
+}
+
+void MPEGPSDecoder::setAudioLeadTime(uint32 ms) {
+	_demuxer->setAudioLeadTime(ms);
 }
 
 void MPEGPSDecoder::close() {
@@ -171,16 +176,28 @@ MPEGPSDecoder::MPEGStream *MPEGPSDecoder::getStream(uint32 startCode, Common::Se
 }
 
 void MPEGPSDecoder::readNextPacket() {
+	// A video packet may contain several pictures. When the codec is configured
+	// to return one at a time, consume those already-buffered pictures before
+	// asking the demuxer for another packet.
+	for (TrackListIterator it = getTrackListBegin(); it != getTrackListEnd(); it++) {
+		if ((*it)->getTrackType() == Track::kTrackTypeVideo &&
+			((MPEGVideoTrack *)*it)->decodePendingFrame())
+			return;
+	}
+
 	for (;;) {
 		int32 startCode;
 		uint32 pts, dts;
 		Common::SeekableReadStream *packet = _demuxer->getNextPacket(getTime(), startCode, pts, dts);
 
 		if (!packet) {
-			// End of stream
-			for (TrackListIterator it = getTrackListBegin(); it != getTrackListEnd(); it++)
-				if ((*it)->getTrackType() == Track::kTrackTypeVideo)
-					((MPEGVideoTrack *)*it)->setEndOfTrack();
+			// End of the demuxed stream. Give the codec a sequence-end marker so
+			// delayed pictures are displayed before the track is marked finished.
+			for (TrackListIterator it = getTrackListBegin(); it != getTrackListEnd(); it++) {
+				if ((*it)->getTrackType() == Track::kTrackTypeVideo &&
+					((MPEGVideoTrack *)*it)->finish())
+					return;
+			}
 			return;
 		}
 
@@ -211,6 +228,7 @@ bool MPEGPSDecoder::addFirstVideoTrack() {
 	// Can be MPEG-1/2 or MPEG-4/h.264. We'll assume the former and
 	// I hope we never need the latter.
 	MPEGVideoTrack *track = new MPEGVideoTrack(packet);
+	track->setStopAtFirstFrame(_stopAtFirstFrame);
 	addTrack(track);
 	_streamMap[startCode] = track;
 
@@ -251,8 +269,6 @@ MPEGPSDecoder::PrivateStreamType MPEGPSDecoder::detectPrivateStreamType(Common::
 // first audio packet, even though the timestamp indicated that the audio
 // should start slightly before the video.
 // --------------------------------------------------------------------------
-
-#define AUDIO_THRESHOLD     100
 
 MPEGPSDecoder::MPEGPSDemuxer::MPEGPSDemuxer() {
 	_stream = 0;
@@ -345,7 +361,7 @@ Common::SeekableReadStream *MPEGPSDecoder::MPEGPSDemuxer::getNextPacket(uint32 c
 			if (packet._pts >= _firstAudioPacketPts)
 				packet._pts -= _firstAudioPacketPts;
 			uint32 packetTime = packet._pts / 90;
-			if (packetTime <= currentTime || packetTime - currentTime < AUDIO_THRESHOLD || _videoQueue.empty()) {
+			if (packetTime <= currentTime || packetTime - currentTime < _audioLeadTime || _videoQueue.empty()) {
 				// The packet is overdue, or will be soon.
 				//
 				// TODO: We should pad or trim the first audio
@@ -640,6 +656,8 @@ void MPEGPSDecoder::MPEGPSDemuxer::parseProgramStreamMap(int length) {
 MPEGPSDecoder::MPEGVideoTrack::MPEGVideoTrack(Common::SeekableReadStream *firstPacket) {
 	_surface = 0;
 	_endOfTrack = false;
+	_stopAtFirstFrame = false;
+	_endSequenceQueued = false;
 	_curFrame = -1;
 	_framePts = 0xFFFFFFFF;
 	_nextFrameStartTime = Audio::Timestamp(0, 27000000); // 27 MHz timer
@@ -648,6 +666,13 @@ MPEGPSDecoder::MPEGVideoTrack::MPEGVideoTrack(Common::SeekableReadStream *firstP
 
 #ifdef USE_MPEG2
 	_mpegDecoder = new Image::MPEGDecoder();
+#endif
+}
+
+void MPEGPSDecoder::MPEGVideoTrack::setStopAtFirstFrame(bool stop) {
+	_stopAtFirstFrame = stop;
+#ifdef USE_MPEG2
+	_mpegDecoder->setStopAtFirstFrame(stop);
 #endif
 }
 
@@ -681,39 +706,94 @@ bool MPEGPSDecoder::MPEGVideoTrack::setOutputPixelFormat(const Graphics::PixelFo
 	return true;
 }
 
-const Graphics::Surface *MPEGPSDecoder::MPEGVideoTrack::decodeNextFrame() {
-	return _surface;
-}
-
-bool MPEGPSDecoder::MPEGVideoTrack::sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts) {
-#ifdef USE_MPEG2
+void MPEGPSDecoder::MPEGVideoTrack::ensureSurface() {
 	if (!_surface) {
 		_surface = new Graphics::Surface();
 		_surface->create(_width, _height, _pixelFormat);
 	}
+}
 
-	if (pts != 0xFFFFFFFF) {
+bool MPEGPSDecoder::MPEGVideoTrack::accountFrame(bool foundFrame, uint32 framePeriod) {
+	if (!foundFrame)
+		return false;
+
+	_curFrame++;
+
+	// If there has been a timestamp since the previous frame, use that for
+	// syncing. Usually it will be the timestamp from the current packet, but it
+	// may be from a packet which needed more input before producing its frame.
+	if (_framePts != 0xFFFFFFFF)
+		_nextFrameStartTime = Audio::Timestamp(_framePts / 90, 27000000);
+	else
+		_nextFrameStartTime = _nextFrameStartTime.addFrames(framePeriod);
+
+	_framePts = 0xFFFFFFFF;
+	return true;
+}
+
+bool MPEGPSDecoder::MPEGVideoTrack::decodePendingFrame() {
+#ifdef USE_MPEG2
+	if (!_stopAtFirstFrame)
+		return false;
+
+	ensureSurface();
+	uint32 framePeriod;
+	const bool foundFrame = _mpegDecoder->decodePendingFrame(framePeriod, _surface);
+	return accountFrame(foundFrame, framePeriod);
+#else
+	return false;
+#endif
+}
+
+bool MPEGPSDecoder::MPEGVideoTrack::finish() {
+#ifdef USE_MPEG2
+	if (_stopAtFirstFrame) {
+		ensureSurface();
+
+		if (!_mpegDecoder->reachedSequenceEnd() && !_endSequenceQueued) {
+			static const byte kSequenceEnd[] = { 0x00, 0x00, 0x01, 0xB7 };
+			Common::MemoryReadStream packet(kSequenceEnd, sizeof(kSequenceEnd));
+			_endSequenceQueued = true;
+
+			uint32 framePeriod;
+			const bool foundFrame = _mpegDecoder->decodePacket(packet, framePeriod, _surface);
+			if (accountFrame(foundFrame, framePeriod))
+				return true;
+		}
+
+		uint32 framePeriod;
+		const bool foundFrame = _mpegDecoder->decodePendingFrame(framePeriod, _surface);
+		if (accountFrame(foundFrame, framePeriod))
+			return true;
+	}
+#endif
+
+	_endOfTrack = true;
+	return false;
+}
+
+const Graphics::Surface *MPEGPSDecoder::MPEGVideoTrack::decodeNextFrame() {
+	// In one-frame-per-call mode, readNextPacket() can discover EOF without
+	// decoding a new picture. The generic VideoDecoder still calls this method
+	// through the track selected before that read, so do not return the previous
+	// surface a second time. Preserve the established default-path behaviour.
+	return (_stopAtFirstFrame && _endOfTrack) ? nullptr : _surface;
+}
+
+bool MPEGPSDecoder::MPEGVideoTrack::sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts) {
+#ifdef USE_MPEG2
+	ensureSurface();
+
+	// One-frame-per-call decoding may need several packets before producing a
+	// picture, so keep the oldest applicable timestamp in that mode. Preserve
+	// the established last-packet timestamp behaviour on the default path.
+	if (pts != 0xFFFFFFFF && (!_stopAtFirstFrame || _framePts == 0xFFFFFFFF)) {
 		_framePts = pts;
 	}
 
 	uint32 framePeriod;
 	bool foundFrame = _mpegDecoder->decodePacket(*packet, framePeriod, _surface);
-
-	if (foundFrame) {
-		_curFrame++;
-
-		// If there has been a timestamp since the previous frame, use that for
-		// syncing. Usually it will be the timestamp from the current packet,
-		// but it might not be.
-
-		if (_framePts != 0xFFFFFFFF) {
-			_nextFrameStartTime = Audio::Timestamp(_framePts / 90, 27000000);
-		} else {
-			_nextFrameStartTime = _nextFrameStartTime.addFrames(framePeriod);
-		}
-
-		_framePts = 0xFFFFFFFF;
-	}
+	accountFrame(foundFrame, framePeriod);
 #endif
 
 	delete packet;

--- a/video/mpegps_decoder.h
+++ b/video/mpegps_decoder.h
@@ -64,6 +64,17 @@ public:
 	// Used only by qdEngine
 	void setPrebufferedPackets(int packets);
 
+	// How far ahead of the playback clock audio packets are handed to the mixer,
+	// in milliseconds. The default remains 100 ms.
+	void setAudioLeadTime(uint32 ms);
+
+	// Hand over each frame as it becomes ready rather than decoding a whole
+	// packet onto one surface, which loses every frame of a packet but its last.
+	// Off by default: it changes when frames come out, and the callers that do
+	// not need it are tuned to the existing behaviour. Must be set before
+	// loadStream(), which is where the video track is built.
+	void setStopAtFirstFrame(bool stop) { _stopAtFirstFrame = stop; }
+
 protected:
 	void readNextPacket() override;
 	bool useAudioSync() const override { return false; }
@@ -81,6 +92,7 @@ private:
 		Common::SeekableReadStream *getNextPacket(uint32 currentTime, int32 &startCode, uint32 &pts, uint32 &dts);
 
 		void setPrebufferedPackets(int packets) { _prebufferedPackets = packets; }
+		void setAudioLeadTime(uint32 ms) { _audioLeadTime = ms; }
 
 	private:
 		class Packet {
@@ -109,6 +121,7 @@ private:
 		uint32 _firstVideoPacketPts = 0xFFFFFFFF;
 
 		int _prebufferedPackets = 150;
+		uint32 _audioLeadTime = 100;
 	};
 
 	// Base class for handling MPEG streams
@@ -129,6 +142,7 @@ private:
 	class MPEGVideoTrack : public VideoTrack, public MPEGStream {
 	public:
 		MPEGVideoTrack(Common::SeekableReadStream *firstPacket);
+		void setStopAtFirstFrame(bool stop);
 		~MPEGVideoTrack();
 
 		bool endOfTrack() const override { return _endOfTrack; }
@@ -143,10 +157,13 @@ private:
 		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts) override;
 		StreamType getStreamType() const override { return kStreamTypeVideo; }
 
-		void setEndOfTrack() { _endOfTrack = true; }
+		bool decodePendingFrame();
+		bool finish();
 
 	private:
 		bool _endOfTrack;
+		bool _stopAtFirstFrame;
+		bool _endSequenceQueued;
 		int _curFrame;
 		uint32 _framePts;
 		Audio::Timestamp _nextFrameStartTime;
@@ -157,6 +174,8 @@ private:
 		Graphics::PixelFormat _pixelFormat;
 
 		void findDimensions(Common::SeekableReadStream *firstPacket);
+		void ensureSurface();
+		bool accountFrame(bool foundFrame, uint32 framePeriod);
 
 #ifdef USE_MPEG2
 		Image::MPEGDecoder *_mpegDecoder;
@@ -243,6 +262,7 @@ private:
 	MPEGStream *getStream(uint32 startCode, Common::SeekableReadStream *packet);
 
 	MPEGPSDemuxer *_demuxer;
+	bool _stopAtFirstFrame = false;
 
 	// A map from stream types to stream handlers
 	typedef Common::HashMap<int, MPEGStream *> StreamMap;


### PR DESCRIPTION
The ReelMagic version of Return to Zork uses a modified MPG format. 

My thinking here is:
Try not to just make a whole new mpeg decoder
Try not to fill the standard decoder full of ReelMagic specific bits

So, what is done here, is to allow us to request decodes one picture at a time from the decoder. Maybe this is stupid and backwards, I leave that to you. I will happily rewrite this and the MADE patch to either split out the RM decoder or add more RM features to the main decoder to avoid the awkwardness. Just let me know.

Without this, the RM version has issues like:
  - The intro exposes only about 2,030 of its 3,128 pictures.
  - It finishes roughly 37 seconds early, skipping motion and falling badly out of sync with its audio.
  - Looping room backgrounds cycle too quickly, and scripts can see movies finish prematurely.
  - Delayed MPEG pictures at EOF may also be lost.
  - Basically, it's a mess

This adds an opt-in mode that returns one picture at a time and queues
the remaining packet data. The demuxer drains queued pictures before
reading another packet and flushes delayed pictures at EOF. Packet
sizes, short reads, timestamps, stale surfaces, and consumed queue
storage are handled explicitly. Existing callers keep the current
behavior unless they enable the mode.

The existing 100 ms audio lead also becomes configurable, retaining
100 ms as the default.


After you let me know how this should really be implemented, I can adjust this one, and the RTZ-RM PR and Scummvm can have the realmagic version of RtZ ready for testing.

Testing:

- Sword2-only release build with libmpeg2 enabled.
- MADE-only release build with the new mode disabled.
- Return to Zork ReelMagic intro with the mode enabled: all 3128
  pictures displayed over its 104-second duration, including delayed
  final pictures.

I created this while working on a Re[ea]lmagic patch for the MADE engine. I used Claude to help dig through various sets of RTZ binaries to work out what needed changing and how (diagnosing the MPEG deviations, etc). I used Codex to do final reviews, branch adjustments, etc.
