### PR TITLE
MADE: Support Return to Zork ReelMagic

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,9 @@ For a more comprehensive changelog of the latest experimental code, see:
    - Fixed original game bug where conversations with Wolf could freeze the game.
    - Added original game cheat codes for bypassing the maze.
 
+ MADE:
+   - Added support for the ReelMagic MPEG release of Return to Zork.
+
  MM:
    - Fix multiple M&M1 classic combat crashes.
    - Implement M&M1 classic PC speaker sound.

--- a/engines/made/configure.engine
+++ b/engines/made/configure.engine
@@ -1,3 +1,3 @@
 # This file is included from the main "configure" script
 # add_engine [name] [desc] [build-by-default] [subengines] [base games] [deps] [components]
-add_engine made "MADE" yes "" "" "" "midi"
+add_engine made "MADE" yes "" "" "" "midi mpeg2 mad"

--- a/engines/made/detection.h
+++ b/engines/made/detection.h
@@ -37,7 +37,8 @@ enum MadeGameFeatures {
 	GF_DEMO				= 1 << 0,
 	GF_CD				= 1 << 1,
 	GF_CD_COMPRESSED	= 1 << 2,
-	GF_FLOPPY			= 1 << 3
+	GF_FLOPPY			= 1 << 3,
+	GF_REELMAGIC		= 1 << 4
 };
 
 struct MadeGameDescription {
@@ -54,6 +55,7 @@ struct MadeGameDescription {
 #define GAMEOPTION_INTRO_MUSIC_DIGITAL GUIO_GAMEOPTIONS1
 #define GAMEOPTION_TTS                 GUIO_GAMEOPTIONS2
 #define GAMEOPTION_WINDOWS_CURSORS     GUIO_GAMEOPTIONS3
+#define GAMEOPTION_REELMAGIC_REDUCE    GUIO_GAMEOPTIONS4
 
 } // End of namespace Made
 

--- a/engines/made/detection_tables.h
+++ b/engines/made/detection_tables.h
@@ -122,6 +122,42 @@ static const MadeGameDescription gameDescriptions[] = {
 	},
 
 	{
+		// Return to Zork - English ReelMagic MPEG version 1.00 5/25/94 (installed)
+		// This release replaces most of the animations with MPEG-1 video which was
+		// decoded by a Sigma Designs ReelMagic card.
+		{
+			"rtz",
+			"ReelMagic V1.00, 5/25/94, installed, CD",
+			AD_ENTRY1s("rtzrm.dat", "2cb1a9fa63536cf56f104a729aa72a91", 506368),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_CD,
+			GUIO2(GAMEOPTION_INTRO_MUSIC_DIGITAL, GAMEOPTION_REELMAGIC_REDUCE)
+		},
+		GID_RTZ,
+		0,
+		GF_CD | GF_REELMAGIC,
+		3,
+	},
+
+	{
+		// Return to Zork - English ReelMagic MPEG version 1.00 5/25/94
+		{
+			"rtz",
+			"ReelMagic V1.00, 5/25/94, CD",
+			AD_ENTRY1s("rtzrm.red", "861470fa722260217127c7e5c1b1ff4a", 278708),
+			Common::EN_ANY,
+			Common::kPlatformDOS,
+			ADGF_CD,
+			GUIO2(GAMEOPTION_INTRO_MUSIC_DIGITAL, GAMEOPTION_REELMAGIC_REDUCE)
+		},
+		GID_RTZ,
+		0,
+		GF_CD_COMPRESSED | GF_REELMAGIC,
+		3,
+	},
+
+	{
 		// Return to Zork - English CD version 1.2 9/29/94 (installed)
 		// Supplied by Dark-Star in the ScummVM forums
 		{

--- a/engines/made/made.cpp
+++ b/engines/made/made.cpp
@@ -22,6 +22,7 @@
 #include "made/made.h"
 #include "made/console.h"
 #include "made/pmvplayer.h"
+#include "made/mpegplayer.h"
 #include "made/resource.h"
 #include "made/screen.h"
 #include "made/database.h"
@@ -66,6 +67,7 @@ MadeEngine::MadeEngine(OSystem *syst, const MadeGameDescription *gameDesc) : Eng
 	_system->getAudioCDManager()->open();
 
 	_pmvPlayer = new PmvPlayer(this, _mixer);
+	_mpegPlayer = (getFeatures() & GF_REELMAGIC) ? new MpegPlayer(this) : nullptr;
 	_res = new ResourceReader();
 	_screen = new Screen(this);
 
@@ -123,6 +125,7 @@ MadeEngine::~MadeEngine() {
 
 	delete _rnd;
 	delete _pmvPlayer;
+	delete _mpegPlayer;
 	delete _res;
 	delete _screen;
 	delete _dat;
@@ -297,7 +300,7 @@ void MadeEngine::handleEvents() {
 
 		case Common::EVENT_MOUSEMOVE:
 			_eventMouseX = event.mouse.x;
-			_eventMouseY = event.mouse.y;
+			_eventMouseY = _screen->screenToGameY(event.mouse.y);
 
 #ifdef USE_TTS
 			checkHoveringSaveLoadScreen();
@@ -342,19 +345,19 @@ void MadeEngine::handleEvents() {
 			switch (event.customType) {
 			case kActionCursorUp:
 				_eventMouseY = MAX<int16>(0, _eventMouseY - 1);
-				g_system->warpMouse(_eventMouseX, _eventMouseY);
+				g_system->warpMouse(_eventMouseX, _screen->gameToScreenY(_eventMouseY));
 				break;
 			case kActionCursorDown:
 				_eventMouseY = MIN<int16>(199, _eventMouseY + 1);
-				g_system->warpMouse(_eventMouseX, _eventMouseY);
+				g_system->warpMouse(_eventMouseX, _screen->gameToScreenY(_eventMouseY));
 				break;
 			case kActionCursorLeft:
 				_eventMouseX = MAX<int16>(0, _eventMouseX - 1);
-				g_system->warpMouse(_eventMouseX, _eventMouseY);
+				g_system->warpMouse(_eventMouseX, _screen->gameToScreenY(_eventMouseY));
 				break;
 			case kActionCursorRight:
 				_eventMouseX = MIN<int16>(319, _eventMouseX + 1);
-				g_system->warpMouse(_eventMouseX, _eventMouseY);
+				g_system->warpMouse(_eventMouseX, _screen->gameToScreenY(_eventMouseY));
 				break;
 			case kActionMenu:
 				_eventNum = 5;
@@ -393,8 +396,21 @@ Common::Error MadeEngine::run() {
 		_music = new DOSMusicPlayer(this, getGameID() == GID_RTZ);
 	syncSoundSettings();
 
-	// Initialize backend
-	initGraphics(320, 200);
+	// Initialize backend. The ReelMagic release mixes its MPEG picture in under
+	// the paletted graphics, which needs a true colour screen to blend into.
+	if (getFeatures() & GF_REELMAGIC) {
+		Graphics::PixelFormat format(2, 5, 6, 5, 0, 11, 5, 0, 0);
+		Common::List<Graphics::PixelFormat> formats = _system->getSupportedFormats();
+		for (Common::List<Graphics::PixelFormat>::const_iterator it = formats.begin(); it != formats.end(); ++it) {
+			if (it->bytesPerPixel == 2 || it->bytesPerPixel == 4) {
+				format = *it;
+				break;
+			}
+		}
+		initGraphics(320, _screen->getOutputHeight(), &format);
+	} else {
+		initGraphics(320, 200);
+	}
 
 	resetAllTimers();
 
@@ -419,6 +435,12 @@ Common::Error MadeEngine::run() {
 		if (getFeatures() & GF_DEMO) {
 			_dat->open("demo.dat");
 			_res->open("demo.prj");
+		} else if (getFeatures() & GF_REELMAGIC) {
+			if (getFeatures() & GF_CD_COMPRESSED)
+				_dat->openFromRed("rtzrm.red", "rtzrm.dat");
+			else
+				_dat->open("rtzrm.dat");
+			_res->open("rtzrm.prj");
 		} else if (getFeatures() & GF_CD) {
 			_dat->open("rtzcd.dat");
 			_res->open("rtzcd.prj");
@@ -469,7 +491,10 @@ Common::Error MadeEngine::run() {
 		error ("Unknown MADE game");
 	}
 
-	if ((getFeatures() & GF_CD) || (getFeatures() & GF_CD_COMPRESSED)) {
+	// The ReelMagic disc has no audio tracks; its music comes from the XMIDI
+	// resources instead, since the MPEG assets take up the whole disc.
+	if (((getFeatures() & GF_CD) || (getFeatures() & GF_CD_COMPRESSED)) &&
+		!(getFeatures() & GF_REELMAGIC)) {
 		if (!existExtractedCDAudioFiles()
 		    && !isDataAndCDAudioReadFromSameCD()) {
 			warnMissingExtractedCDAudio();

--- a/engines/made/made.h
+++ b/engines/made/made.h
@@ -47,6 +47,7 @@ const uint32 kTimerResolution = 40;
 
 class ResourceReader;
 class PmvPlayer;
+class MpegPlayer;
 class Screen;
 class ScriptInterpreter;
 class GameDatabase;
@@ -89,6 +90,7 @@ public:
 
 public:
 	PmvPlayer *_pmvPlayer;
+	MpegPlayer *_mpegPlayer;
 	ResourceReader *_res;
 	Screen *_screen;
 	GameDatabase *_dat;
@@ -120,7 +122,6 @@ public:
 	bool _voiceText;
 	bool _forceVoiceText;
 	bool _forceQueueText;
-
 #ifdef USE_TTS
 	Common::String _rtzSaveLoadButtonText[2];
 	uint8 _rtzFirstSaveSlot;

--- a/engines/made/magical_mpeg.cpp
+++ b/engines/made/magical_mpeg.cpp
@@ -1,0 +1,432 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "made/magical_mpeg.h"
+
+#include "common/array.h"
+#include "common/debug.h"
+#include "common/memstream.h"
+#include "common/stream.h"
+#include "common/textconsole.h"
+#include "common/util.h"
+
+namespace Made {
+
+// MPEG-1 start codes (ISO/IEC 11172), preceded by the 00 00 01 prefix
+enum {
+	kStartCodePicture  = 0x00,
+	kStartCodeSequence = 0xB3,
+	kStartCodeEnd      = 0xB9,
+	kStartCodePack     = 0xBA,
+	kStartCodeVideoMin = 0xE0,
+	kStartCodeVideoMax = 0xEF,
+	kStartCodeAudioMin = 0xC0,
+	kStartCodeAudioMax = 0xDF
+};
+
+enum {
+	kPictureTypeP = 2,
+	kPictureTypeB = 3
+};
+
+// The card sets the high bit of the four-bit frame-rate code as its marker.
+// Codes 9-15 are reserved by MPEG-1; the low three bits retain the real rate.
+static const byte kMagicalFrameRateCode = 0x9;
+
+struct MagicKeyPattern {
+	uint32 key;
+	byte evenPattern[4];
+};
+
+static const MagicKeyPattern kMagicKeyPatterns[] = {
+	{ 0x40044041, { 4, 3, 2, 3 } },
+	{ 0xC39D7088, { 1, 3, 3, 3 } }
+};
+
+static const uint kDeltaPeriod = 56;
+
+// ReelMagic encodes each forward/backward f_code by subtracting a value which
+// advances with the picture's temporal sequence number. The two known card
+// keys select the increment pattern used for even sequence numbers; odd ones
+// always add six. Both the pattern and the MPEG f_code value repeat modulo 7,
+// giving this table a 56-picture period.
+static byte computeDeltaFCode(uint tsn, const byte *evenPattern) {
+	uint result = 2;
+	for (uint i = 0; i <= tsn; i++) {
+		if ((i & 1) == 0)
+			result += evenPattern[(i >> 1) & 3];
+		else
+			result += 6;
+	}
+	return result % 7;
+}
+
+static byte recoverFCode(byte encoded, byte delta) {
+	int value = ((int)encoded - 1 + (int)delta) % 7;
+	if (value < 0)
+		value += 7;
+	return (byte)(value + 1);
+}
+
+struct PayloadRange {
+	uint32 offset;
+	uint32 size;
+};
+
+/** Collect video or audio payload ranges from an MPEG-1 program stream. */
+static void collectPesRanges(const byte *data, uint32 size, bool audio,
+		Common::Array<PayloadRange> &ranges) {
+	const byte streamMin = audio ? kStartCodeAudioMin : kStartCodeVideoMin;
+	const byte streamMax = audio ? kStartCodeAudioMax : kStartCodeVideoMax;
+
+	// The game's short overlay animations are bare video elementary streams.
+	if (size >= 4 && data[0] == 0 && data[1] == 0 && data[2] == 1 && data[3] != kStartCodePack) {
+		if (!audio) {
+			PayloadRange range = { 0, size };
+			ranges.push_back(range);
+		}
+		return;
+	}
+
+	uint32 pos = 0;
+	while (pos + 4 <= size) {
+		if (data[pos] != 0 || data[pos + 1] != 0 || data[pos + 2] != 1) {
+			pos++;
+			continue;
+		}
+
+		const byte streamId = data[pos + 3];
+		pos += 4;
+
+		if (streamId == kStartCodePack) {
+			if (size - pos < 8)
+				break;
+			pos += 8;
+			continue;
+		}
+
+		if (streamId == kStartCodeEnd)
+			break;
+
+		if (pos + 2 > size)
+			break;
+
+		const uint32 packetSize = (data[pos] << 8) | data[pos + 1];
+		pos += 2;
+		if (packetSize > size - pos)
+			break;
+
+		if (streamId >= streamMin && streamId <= streamMax) {
+			// Skip stuffing, an optional buffer size, and optional PTS/DTS.
+			uint32 skip = 0;
+			while (skip < packetSize && data[pos + skip] == 0xFF)
+				skip++;
+			if (skip < packetSize && (data[pos + skip] & 0xC0) == 0x40)
+				skip += 2;
+			if (skip < packetSize) {
+				const byte flags = data[pos + skip] & 0xF0;
+				if (flags == 0x20)
+					skip += 5;
+				else if (flags == 0x30)
+					skip += 10;
+				else if (data[pos + skip] == 0x0F)
+					skip++;
+			}
+
+			if (skip < packetSize) {
+				PayloadRange range = { pos + skip, packetSize - skip };
+				ranges.push_back(range);
+			}
+		}
+
+		pos += packetSize;
+	}
+}
+
+static const uint16 kLayer2BitRates[] = {
+	0, 32, 48, 56, 64, 80, 96, 112, 128, 160, 192, 224, 256, 320, 384, 0
+};
+
+static const uint32 kLayer2SampleRates[] = { 44100, 48000, 32000, 0 };
+
+static bool isLayer2Header(const byte *p) {
+	return p[0] == 0xFF && (p[1] & 0xE0) == 0xE0 &&
+		((p[1] >> 3) & 0x03) == 0x03 && ((p[1] >> 1) & 0x03) == 0x02;
+}
+
+uint32 MagicalMpeg::fixAudioPadding(byte *data, uint32 size) {
+	Common::Array<PayloadRange> ranges;
+	collectPesRanges(data, size, true, ranges);
+	if (ranges.empty())
+		return 0;
+
+	// Reassemble the payload so frames crossing packet boundaries stay intact.
+	uint64 totalAudioSize = 0;
+	for (uint i = 0; i < ranges.size(); i++)
+		totalAudioSize += ranges[i].size;
+	if (totalAudioSize > 0xFFFFFFFFU)
+		return 0;
+	const uint32 audioSize = (uint32)totalAudioSize;
+
+	Common::Array<byte> audio;
+	audio.resize(audioSize);
+
+	Common::Array<uint32> starts;
+	starts.reserve(ranges.size());
+	uint32 audioPos = 0;
+	for (uint i = 0; i < ranges.size(); i++) {
+		starts.push_back(audioPos);
+		memcpy(&audio[audioPos], data + ranges[i].offset, ranges[i].size);
+		audioPos += ranges[i].size;
+	}
+
+	uint rangeHint = 0;
+	auto audioToSource = [&](uint32 offset) -> uint32 {
+		while (rangeHint + 1 < ranges.size() && starts[rangeHint + 1] <= offset)
+			rangeHint++;
+		return ranges[rangeHint].offset + offset - starts[rangeHint];
+	};
+
+	uint32 patched = 0;
+	uint32 pos = 0;
+	while (pos + 4 <= audioSize) {
+		if (!isLayer2Header(&audio[pos])) {
+			pos++;
+			continue;
+		}
+
+		const uint16 bitRate = kLayer2BitRates[(audio[pos + 2] >> 4) & 0x0F];
+		const uint32 sampleRate = kLayer2SampleRates[(audio[pos + 2] >> 2) & 0x03];
+		if (bitRate == 0 || sampleRate == 0) {
+			pos++;
+			continue;
+		}
+
+		const bool padded = (audio[pos + 2] & 0x02) != 0;
+		const uint32 base = (144 * (uint32)bitRate * 1000) / sampleRate;
+		uint32 length = base + (padded ? 1 : 0);
+
+		// Some ReelMagic assets set the padding bit without adding the byte.
+		if (padded && pos + length + 4 <= audioSize &&
+			!isLayer2Header(&audio[pos + length]) &&
+			isLayer2Header(&audio[pos + length - 1])) {
+			data[audioToSource(pos + 2)] &= ~0x02;
+			audio[pos + 2] &= ~0x02;
+			length--;
+			patched++;
+		}
+
+		pos += length;
+	}
+
+	return patched;
+}
+
+uint32 MagicalMpeg::unlockBuffer(byte *data, uint32 size, uint32 magicKey) {
+	const byte *evenPattern = nullptr;
+	for (uint i = 0; i < ARRAYSIZE(kMagicKeyPatterns); i++) {
+		if (kMagicKeyPatterns[i].key == magicKey) {
+			evenPattern = kMagicKeyPatterns[i].evenPattern;
+			break;
+		}
+	}
+
+	if (!evenPattern) {
+		warning("MagicalMpeg: unknown magic key 0x%08X, using the default", magicKey);
+		evenPattern = kMagicKeyPatterns[0].evenPattern;
+	}
+
+	byte deltaTable[kDeltaPeriod];
+	for (uint tsn = 0; tsn < kDeltaPeriod; tsn++)
+		deltaTable[tsn] = computeDeltaFCode(tsn, evenPattern);
+
+	Common::Array<PayloadRange> ranges;
+	collectPesRanges(data, size, false, ranges);
+	if (ranges.empty())
+		return 0;
+
+	uint64 totalVideoSize = 0;
+	for (uint i = 0; i < ranges.size(); i++)
+		totalVideoSize += ranges[i].size;
+	if (totalVideoSize > 0xFFFFFFFFU)
+		return 0;
+	const uint32 videoSize = (uint32)totalVideoSize;
+
+	Common::Array<byte> video;
+	video.resize(videoSize);
+
+	Common::Array<uint32> starts;
+	starts.reserve(ranges.size());
+	uint32 videoPos = 0;
+	for (uint i = 0; i < ranges.size(); i++) {
+		starts.push_back(videoPos);
+		memcpy(&video[videoPos], data + ranges[i].offset, ranges[i].size);
+		videoPos += ranges[i].size;
+	}
+
+	uint rangeHint = 0;
+	auto videoToSource = [&](uint32 offset) -> uint32 {
+		while (rangeHint + 1 < ranges.size() && starts[rangeHint + 1] <= offset)
+			rangeHint++;
+		return ranges[rangeHint].offset + offset - starts[rangeHint];
+	};
+
+	uint32 patchedPictures = 0;
+	for (uint32 pos = 0; pos + 9 <= videoSize; pos++) {
+		if (video[pos] != 0 || video[pos + 1] != 0 || video[pos + 2] != 1)
+			continue;
+
+		const byte streamId = video[pos + 3];
+		const byte *header = &video[pos + 4];
+		if (streamId == kStartCodeSequence) {
+			if ((header[3] & 0x0F) >= kMagicalFrameRateCode)
+				data[videoToSource(pos + 7)] = header[3] & 0xF7;
+			continue;
+		}
+
+		if (streamId != kStartCodePicture)
+			continue;
+
+		const uint tsn = (header[0] << 2) | (header[1] >> 6);
+		const byte pictureType = (header[1] >> 3) & 0x07;
+		if (pictureType != kPictureTypeP && pictureType != kPictureTypeB)
+			continue;
+
+		const byte delta = deltaTable[tsn % kDeltaPeriod];
+		// P pictures carry a three-bit forward f_code split across bytes 3 and
+		// 4. B pictures add a three-bit backward f_code in byte 4.
+		const byte forward = ((header[3] & 0x03) << 1) | (header[4] >> 7);
+		const byte backward = (header[4] >> 3) & 0x07;
+		const byte newForward = recoverFCode(forward, delta);
+		const byte byte3 = (header[3] & 0xFC) | ((newForward >> 1) & 0x03);
+		byte byte4 = (header[4] & 0x7F) | ((newForward & 0x01) << 7);
+
+		if (pictureType == kPictureTypeB) {
+			const byte newBackward = recoverFCode(backward, delta);
+			byte4 = (byte4 & 0xC7) | ((newBackward & 0x07) << 3);
+		}
+
+		data[videoToSource(pos + 7)] = byte3;
+		data[videoToSource(pos + 8)] = byte4;
+		patchedPictures++;
+	}
+
+	return patchedPictures;
+}
+
+static bool readFrameRateCode(Common::SeekableReadStream &stream, byte &code) {
+	const int64 startPos = stream.pos();
+	const int64 remaining = stream.size() - startPos;
+	if (remaining <= 0)
+		return false;
+
+	const uint32 kScanSize = 16 * 1024;
+	const uint32 size = (uint32)MIN<int64>(kScanSize, remaining);
+	Common::Array<byte> buffer;
+	buffer.resize(size);
+
+	bool found = false;
+	const uint32 read = stream.read(&buffer[0], size);
+	for (uint32 i = 0; i + 8 <= read; i++) {
+		if (buffer[i] == 0 && buffer[i + 1] == 0 && buffer[i + 2] == 1 &&
+			buffer[i + 3] == kStartCodeSequence) {
+			code = buffer[i + 7] & 0x0F;
+			found = true;
+			break;
+		}
+	}
+
+	stream.seek(startPos);
+	return found;
+}
+
+bool MagicalMpeg::isProgramStream(Common::SeekableReadStream &stream) {
+	const int64 startPos = stream.pos();
+	const bool programStream = stream.readUint32BE() == 0x000001BA;
+	stream.seek(startPos);
+	return programStream;
+}
+
+bool MagicalMpeg::isMagical(Common::SeekableReadStream &stream) {
+	byte code = 0;
+	return readFrameRateCode(stream, code) && code >= kMagicalFrameRateCode;
+}
+
+bool MagicalMpeg::getFrameDuration(Common::SeekableReadStream &stream, uint32 &num, uint32 &den) {
+	static const struct {
+		uint32 num;
+		uint32 den;
+	} kFrameDurations[] = {
+		{    0,  0 },
+		{ 1001, 24 },
+		{ 1000, 24 },
+		{ 1000, 25 },
+		{ 1001, 30 },
+		{ 1000, 30 },
+		{ 1000, 50 },
+		{ 1001, 60 },
+		{ 1000, 60 }
+	};
+
+	byte code = 0;
+	if (!readFrameRateCode(stream, code))
+		return false;
+
+	// ReelMagic sets bit 3 as its marker; the low three bits are the real rate.
+	code &= 0x07;
+	if (code == 0 || code >= ARRAYSIZE(kFrameDurations))
+		return false;
+
+	num = kFrameDurations[code].num;
+	den = kFrameDurations[code].den;
+	return true;
+}
+
+Common::SeekableReadStream *MagicalMpeg::unlock(Common::SeekableReadStream &stream,
+		uint32 magicKey, bool magical) {
+	const int64 startPos = stream.pos();
+	const int64 streamSize = stream.size() - startPos;
+	if (streamSize <= 0 || streamSize > 0xFFFFFFFFU)
+		return nullptr;
+
+	const uint32 size = (uint32)streamSize;
+	byte *data = (byte *)malloc(size);
+	if (!data)
+		return nullptr;
+
+	if (stream.read(data, size) != size) {
+		free(data);
+		return nullptr;
+	}
+
+	if (magical) {
+		const uint32 patched = unlockBuffer(data, size, magicKey);
+		debug(1, "MagicalMpeg: restored %u picture headers", patched);
+	}
+
+	const uint32 repadded = fixAudioPadding(data, size);
+	if (repadded)
+		debug(1, "MagicalMpeg: corrected %u audio padding bits", repadded);
+
+	return new Common::MemoryReadStream(data, size, DisposeAfterUse::YES);
+}
+
+} // End of namespace Made

--- a/engines/made/magical_mpeg.h
+++ b/engines/made/magical_mpeg.h
@@ -1,0 +1,71 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MADE_MAGICAL_MPEG_H
+#define MADE_MAGICAL_MPEG_H
+
+#include "common/scummsys.h"
+
+namespace Common {
+class SeekableReadStream;
+}
+
+namespace Made {
+
+/**
+ * Repairs the nonstandard MPEG-1 streams used by ReelMagic games.
+ *
+ * Their sequence headers use a reserved frame-rate code, and their P/B picture
+ * headers contain scrambled f_code fields. Both are fixed-position bit fields,
+ * so restoring them with the key provisioned by the game does not require
+ * re-encoding any picture data. Some assets also have incorrect Layer II audio
+ * padding bits, which are repaired in the same in-memory pass.
+ */
+class MagicalMpeg {
+public:
+	/** Default key of the card, and the one Return to Zork provisions. */
+	static const uint32 kDefaultMagicKey = 0x40044041;
+
+	/** Return whether the stream starts with an MPEG program-stream pack. The stream position is preserved. */
+	static bool isProgramStream(Common::SeekableReadStream &stream);
+
+	/** Return whether the sequence header contains ReelMagic's marker bit. The stream position is preserved. */
+	static bool isMagical(Common::SeekableReadStream &stream);
+
+	/**
+	 * Read a stream into memory, restore its scrambled picture headers when
+	 * @p magical is true, and correct malformed MPEG audio padding bits. Returns
+	 * nullptr if the stream cannot be read. The caller owns the returned stream.
+	 */
+	static Common::SeekableReadStream *unlock(Common::SeekableReadStream &stream,
+		uint32 magicKey, bool magical);
+
+	/** Read the sequence-header frame duration as @p num / @p den ms. */
+	static bool getFrameDuration(Common::SeekableReadStream &stream, uint32 &num, uint32 &den);
+
+private:
+	static uint32 unlockBuffer(byte *data, uint32 size, uint32 magicKey);
+	static uint32 fixAudioPadding(byte *data, uint32 size);
+};
+
+} // End of namespace Made
+
+#endif // MADE_MAGICAL_MPEG_H

--- a/engines/made/metaengine.cpp
+++ b/engines/made/metaengine.cpp
@@ -68,6 +68,18 @@ static const ADExtraGuiOptionsMap optionsList[] = {
 			0
 		}
 	},
+	{
+		GAMEOPTION_REELMAGIC_REDUCE,
+		{
+			_s("Reduce ReelMagic video to 200 lines"),
+			_s("If selected, the 240-line MPEG video is reduced to the game's 200-line graphics height. "
+				"Otherwise, the graphics are stretched to preserve the full video frame."),
+			"reelmagic_video_reduce",
+			false,
+			0,
+			0
+		}
+	},
 
 	AD_EXTRA_GUI_OPTIONS_TERMINATOR
 };

--- a/engines/made/module.mk
+++ b/engines/made/module.mk
@@ -5,6 +5,7 @@ MODULE_OBJS := \
 	database.o \
 	graphics.o \
 	made.o \
+	mpegplayer.o \
 	metaengine.o \
 	music.o \
 	pmvplayer.o \
@@ -16,6 +17,9 @@ MODULE_OBJS := \
 	scriptfuncs.o \
 	sound.o
 
+ifdef USE_MPEG2
+MODULE_OBJS += magical_mpeg.o
+endif
 
 # This module can be built as a plugin
 ifeq ($(ENABLE_MADE), DYNAMIC_PLUGIN)

--- a/engines/made/mpegplayer.cpp
+++ b/engines/made/mpegplayer.cpp
@@ -1,0 +1,346 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "made/mpegplayer.h"
+#include "made/made.h"
+#include "made/screen.h"
+
+#include "common/debug.h"
+#include "common/file.h"
+#include "common/memstream.h"
+#include "common/system.h"
+#include "common/textconsole.h"
+
+#include "graphics/surface.h"
+
+#ifdef USE_MPEG2
+#include "made/magical_mpeg.h"
+#include "video/mpegps_decoder.h"
+#endif
+
+namespace Made {
+
+MpegPlayer::MpegPlayer(MadeEngine *vm) :
+		_vm(vm), _decoder(nullptr), _looping(false), _passComplete(false), _paused(false),
+		_videoLayer(nullptr), _startTime(0), _framesDrawn(0), _loopFrames(0), _loops(0),
+		_playToken(0), _frameDurNum(1001), _frameDurDen(30) {
+}
+
+MpegPlayer::~MpegPlayer() {
+	stop();
+
+	// stop() leaves the last picture attached to the screen, but the surface is
+	// about to be freed.
+	_vm->_screen->setVideoLayer(nullptr);
+
+	if (_videoLayer) {
+		_videoLayer->free();
+		delete _videoLayer;
+	}
+}
+
+#ifdef USE_MPEG2
+
+/** Expose the protected video-track EOF query needed by these assets. */
+class MadeMpegDecoder : public Video::MPEGPSDecoder {
+public:
+	bool videoTracksEnded() const { return endOfVideoTracks(); }
+};
+
+void MpegPlayer::drawFrame(const Graphics::Surface *frame) {
+	if (!_videoLayer)
+		return;
+
+	const uint bytesPerPixel = _videoLayer->format.bytesPerPixel;
+	const int width = MIN<int>(_videoLayer->w, frame->w);
+
+	// The common path is a 320x240 frame in the active screen format.
+	if (_videoLayer->w == frame->w && _videoLayer->h == frame->h &&
+		_videoLayer->pitch == frame->pitch) {
+		memcpy(_videoLayer->getPixels(), frame->getPixels(), frame->pitch * frame->h);
+		return;
+	}
+
+	_videoLayer->fillRect(_videoLayer->getRect(), 0);
+	int srcY = 0;
+	for (int y = 0; y < _videoLayer->h && srcY < frame->h; y++) {
+		memcpy(_videoLayer->getBasePtr(0, y), frame->getBasePtr(0, srcY), width * bytesPerPixel);
+
+		srcY++;
+		if (!_vm->_screen->isGraphicsStretched() && (srcY % 6) == 5)
+			srcY++;
+	}
+}
+
+bool MpegPlayer::openDecoder() {
+	if (!_loopData.empty()) {
+		return openDecoderFrom(new Common::MemoryReadStream(
+			&_loopData[0], _loopData.size(), DisposeAfterUse::NO));
+	}
+
+	Common::File *file = new Common::File();
+	if (!file->open(_filename.c_str())) {
+		warning("MpegPlayer: could not open '%s'", _filename.c_str());
+		delete file;
+		return false;
+	}
+
+	// Program streams need their audio padding repaired even when their video
+	// headers are not scrambled. Bare elementary streams carry no audio.
+	const bool magical = MagicalMpeg::isMagical(*file);
+	const bool programStream = MagicalMpeg::isProgramStream(*file);
+
+	Common::SeekableReadStream *stream = file;
+	if (magical || programStream) {
+		stream = MagicalMpeg::unlock(*file, MagicalMpeg::kDefaultMagicKey, magical);
+		delete file;
+		if (!stream) {
+			warning("MpegPlayer: could not prepare '%s'", _filename.c_str());
+			return false;
+		}
+	}
+
+	// Cache a prepared looping stream, avoiding disk I/O and both repair passes
+	// at every loop boundary.
+	if (_looping && _loopData.empty()) {
+		if (stream->size() <= 0 || stream->size() > 0xFFFFFFFFU) {
+			warning("MpegPlayer: invalid stream size for '%s'", _filename.c_str());
+			delete stream;
+			return false;
+		}
+
+		_loopData.resize((uint32)stream->size());
+		stream->seek(0);
+		if (stream->read(&_loopData[0], _loopData.size()) == _loopData.size()) {
+			delete stream;
+			stream = new Common::MemoryReadStream(
+				&_loopData[0], _loopData.size(), DisposeAfterUse::NO);
+		} else {
+			_loopData.clear();
+			stream->seek(0);
+		}
+	}
+
+	return openDecoderFrom(stream);
+}
+
+bool MpegPlayer::openDecoderFrom(Common::SeekableReadStream *stream) {
+	// Pace from the sequence header. The PTS values in these assets do not map
+	// reliably to the displayed pictures.
+	_frameDurNum = 1001;
+	_frameDurDen = 30;
+	MagicalMpeg::getFrameDuration(*stream, _frameDurNum, _frameDurDen);
+	stream->seek(0);
+
+	_decoder = new MadeMpegDecoder();
+	_decoder->setPrebufferedPackets(600);
+	_decoder->setStopAtFirstFrame(true);
+	_decoder->setAudioLeadTime(750);
+
+	if (!_decoder->loadStream(stream)) {
+		warning("MpegPlayer: could not load '%s'", _filename.c_str());
+		delete _decoder;
+		_decoder = nullptr;
+		return false;
+	}
+
+	// Frames are copied directly into the screen's video layer, so the formats
+	// must match exactly rather than merely use the same bytes per pixel.
+	if (!_decoder->setOutputPixelFormat(_vm->_system->getScreenFormat())) {
+		warning("MpegPlayer: unsupported screen format for '%s'", _filename.c_str());
+		delete _decoder;
+		_decoder = nullptr;
+		return false;
+	}
+
+	_decoder->start();
+	return true;
+}
+
+bool MpegPlayer::start(const char *filename, int16 playMode) {
+	if (!filename || !*filename) {
+		warning("MpegPlayer: no filename supplied");
+		return false;
+	}
+	if (playMode < kPlayOnce || playMode > kPlayBlocking) {
+		warning("MpegPlayer: invalid play mode %d for '%s'", playMode, filename);
+		return false;
+	}
+
+	stop();
+
+	if (!_loopData.empty() && _filename != filename)
+		_loopData.clear();
+
+	_filename = filename;
+	_looping = (playMode == kPlayLoop);
+	_passComplete = false;
+	_paused = false;
+	_playToken++;
+
+	if (!openDecoder()) {
+		_looping = false;
+		return false;
+	}
+
+	if (!_videoLayer) {
+		_videoLayer = new Graphics::Surface();
+		_videoLayer->create(320, _vm->_screen->getOutputHeight(),
+			_vm->_system->getScreenFormat());
+	}
+
+	// The first cutscene after the opening credits finishes them, as in PmvPlayer.
+	if (scumm_stricmp(filename, "FWIZ01XX.MPG") == 0)
+		_vm->_openingCreditsOpen = false;
+
+	_vm->_screen->setVideoLayer(_videoLayer);
+
+	_startTime = _vm->_system->getMillis();
+	_framesDrawn = 0;
+	_loopFrames = 0;
+	_loops = 0;
+
+	// Prime the decoder before the mixer starts consuming its empty audio queue.
+	update();
+	return true;
+}
+
+bool MpegPlayer::restartForLoop() {
+	if (_framesDrawn == _loopFrames)
+		return false;
+
+	delete _decoder;
+	_decoder = nullptr;
+	if (!openDecoder())
+		return false;
+
+	// Exclude decoder restart time from the frame schedule.
+	_startTime = _vm->_system->getMillis() -
+		(uint32)((uint64)_framesDrawn * _frameDurNum / _frameDurDen);
+	_loopFrames = _framesDrawn;
+	_loops++;
+	return true;
+}
+
+void MpegPlayer::update() {
+	if (!_decoder)
+		return;
+
+	if (!_decoder->isPlaying() || _decoder->videoTracksEnded()) {
+		_passComplete = true;
+		_paused = true;
+		if (_looping && restartForLoop())
+			return;
+
+		stop();
+		return;
+	}
+
+	const uint32 now = _vm->_system->getMillis();
+	const uint32 due = _startTime +
+		(uint32)((uint64)_framesDrawn * _frameDurNum / _frameDurDen);
+	if (now < due)
+		return;
+
+	const uint32 kMaxCatchUpFrames = 10;
+	uint32 backlog = (uint32)(((uint64)(now - _startTime) * _frameDurDen) / _frameDurNum);
+	backlog = (backlog > _framesDrawn) ? backlog - _framesDrawn : 0;
+	backlog = MIN(backlog, kMaxCatchUpFrames);
+
+	while (backlog > 1) {
+		backlog--;
+		if (!_decoder->decodeNextFrame() || _decoder->videoTracksEnded())
+			break;
+		_framesDrawn++;
+	}
+
+	const Graphics::Surface *frame = _decoder->decodeNextFrame();
+	if (!frame)
+		return;
+
+	_framesDrawn++;
+	drawFrame(frame);
+	_vm->_screen->presentWorkScreen();
+	_vm->_system->updateScreen();
+}
+
+void MpegPlayer::stop() {
+	if (!_decoder)
+		return;
+
+	const uint32 elapsed = _vm->_system->getMillis() - _startTime;
+	debug(1, "MpegPlayer: '%s' %s, %u frames in %u ms, %u loop(s)",
+		_filename.c_str(), _looping ? "looping" : "once", _framesDrawn, elapsed, _loops);
+
+	delete _decoder;
+	_decoder = nullptr;
+
+	// The card retains the current picture when playback stops.
+	_vm->_screen->setVideoLayer(_videoLayer);
+}
+
+void MpegPlayer::pause() {
+	if (!_decoder)
+		return;
+
+	_paused = true;
+	_passComplete = true;
+	stop();
+}
+
+void MpegPlayer::close() {
+	_paused = false;
+	stop();
+}
+
+int16 MpegPlayer::playState() const {
+	if (_decoder && !_passComplete)
+		return kStatePlaying;
+	return _paused ? kStatePaused : kStateClosed;
+}
+
+#else
+
+bool MpegPlayer::start(const char *filename, int16 playMode) {
+	warning("MpegPlayer: cannot play '%s'; ScummVM was built without MPEG-2 support",
+		filename ? filename : "");
+	return false;
+}
+
+void MpegPlayer::update() {
+}
+
+void MpegPlayer::stop() {
+}
+
+void MpegPlayer::pause() {
+}
+
+void MpegPlayer::close() {
+}
+
+int16 MpegPlayer::playState() const {
+	return kStateClosed;
+}
+
+#endif // USE_MPEG2
+
+} // End of namespace Made

--- a/engines/made/mpegplayer.h
+++ b/engines/made/mpegplayer.h
@@ -1,0 +1,141 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MADE_MPEGPLAYER_H
+#define MADE_MPEGPLAYER_H
+
+#include "common/array.h"
+#include "common/scummsys.h"
+#include "common/str.h"
+
+namespace Common {
+class SeekableReadStream;
+}
+
+namespace Graphics {
+struct Surface;
+}
+
+namespace Made {
+
+class MadeEngine;
+
+class MadeMpegDecoder;
+
+class MpegPlayer {
+public:
+	explicit MpegPlayer(MadeEngine *vm);
+	~MpegPlayer();
+
+	/**
+	 * Play mode the script asks for, its second argument to PLAYMPEGMOVIE. The
+	 * original interpreter tells the card to pause on completion for anything
+	 * but mode 2, which loops; mode 3 additionally sits in a loop of its own
+	 * until the movie has finished rather than letting the script carry on.
+	 */
+	enum PlayMode {
+		kPlayOnce = 1,		// runs through once and its last picture stays up
+		kPlayLoop = 2,		// runs until something else replaces it
+		kPlayBlocking = 3	// as kPlayOnce, but the script waits here for the end
+	};
+
+	/**
+	 * Starts a movie and returns at once. The game keeps drawing and stays
+	 * responsive while it runs, which is how the ReelMagic driver behaved: the
+	 * script fires a movie off and then polls whether it is still going.
+	 */
+	bool start(const char *filename, int16 playMode = kPlayOnce);
+
+	/**
+	 * True while a movie still has its first pass to finish. A looping overlay
+	 * reports false once it has been through once, so that a script waiting for
+	 * it is answered while the animation carries on behind the scene.
+	 */
+	bool isPlaying() const { return _decoder != nullptr && !_passComplete; }
+
+	/**
+	 * Counts the movies started so far. A caller waiting for one to end can
+	 * watch this to notice that something else has taken the player over in the
+	 * meantime, rather than sit there waiting for a movie that is long gone.
+	 */
+	uint32 playToken() const { return _playToken; }
+
+	/**
+	 * The play state as the card reported it, which is what the script polls:
+	 * 2 when a movie has been left paused on its current picture, 1 while one
+	 * is running, 0 once the handle has been closed. The
+	 * script tells a movie that finished from one that was cut short by exactly
+	 * this, so 0 and 2 are not interchangeable.
+	 */
+	enum { kStateClosed = 0, kStatePlaying = 1, kStatePaused = 2 };
+	int16 playState() const;
+
+	/** Decodes and shows whatever is due. Cheap when nothing is. */
+	void update();
+
+	/** Ends playback and lets go of the decoder. */
+	void stop();
+
+	/** Pauses playback on the current picture. */
+	void pause();
+
+	/** Closes the emulated media handle, making its state 0. */
+	void close();
+
+private:
+	void drawFrame(const Graphics::Surface *frame);
+
+	/** Builds a decoder for _filename. Used to start, and to go round again. */
+	bool openDecoder();
+
+	/** Builds the decoder itself, over an already prepared stream. */
+	bool openDecoderFrom(Common::SeekableReadStream *stream);
+
+	/** Reloads the stream so a looping overlay carries on. */
+	bool restartForLoop();
+
+	MadeEngine *_vm;
+
+	MadeMpegDecoder *_decoder;
+	bool _looping;
+	bool _passComplete;
+	bool _paused;
+
+	// The decoded picture, scaled to the size of the game screen. Screen mixes
+	// it in underneath the graphics layer.
+	Graphics::Surface *_videoLayer;
+
+	uint32 _startTime;
+	uint32 _framesDrawn;
+	uint32 _loopFrames;	// _framesDrawn at the last time round
+	uint32 _loops;
+	uint32 _playToken;
+
+	// A looping movie is read and patched once and then kept, avoiding another
+	// disk read and both repair passes at every loop boundary.
+	Common::Array<byte> _loopData;
+	uint32 _frameDurNum, _frameDurDen;
+	Common::String _filename;
+};
+
+} // End of namespace Made
+
+#endif // MADE_MPEGPLAYER_H

--- a/engines/made/screen.cpp
+++ b/engines/made/screen.cpp
@@ -20,10 +20,13 @@
  */
 
 #include "made/screen.h"
+
 #include "made/made.h"
+#include "made/mpegplayer.h"
 #include "made/screenfx.h"
 #include "made/database.h"
 
+#include "common/config-manager.h"
 #include "common/system.h"
 
 #include "graphics/surface.h"
@@ -31,6 +34,10 @@
 #include "graphics/cursorman.h"
 
 namespace Made {
+
+// The ReelMagic card treated the first palette entry of the graphics layer as
+// transparent, letting the MPEG picture behind it show through.
+static const byte kTransparentIndex = 0;
 
 enum TextChannelIndex {
 	kTapeRecorderName = 84,
@@ -81,6 +88,21 @@ Screen::Screen(MadeEngine *vm) : _vm(vm) {
 	_screenLock = false;
 	_paletteLock = false;
 
+	_trueColor = (_vm->getFeatures() & GF_REELMAGIC) != 0;
+	// Preserve all 240 video lines by default and stretch the 200-line graphics
+	// over them. Reducing the video instead is available as an option.
+	_stretchGraphics = _trueColor && !ConfMan.getBool("reelmagic_video_reduce");
+	_outputHeight = _stretchGraphics ? 240 : 200;
+	_outputScreen = nullptr;
+	_videoLayer = nullptr;
+	_fxScreen = nullptr;
+	if (_trueColor) {
+		_fxScreen = new Graphics::Surface();
+		_fxScreen->create(320, 200, Graphics::PixelFormat::createFormatCLUT8());
+	}
+	memset(_outputPalette, 0, sizeof(_outputPalette));
+	memset(_outputColors, 0, sizeof(_outputColors));
+
 	_paletteInitialized = false;
 	_needPalette = false;
 	_oldPaletteColorCount = 256;
@@ -123,6 +145,14 @@ Screen::~Screen() {
 
 	delete _backgroundScreen;
 	delete _workScreen;
+	if (_outputScreen) {
+		_outputScreen->free();
+		delete _outputScreen;
+	}
+	if (_fxScreen) {
+		_fxScreen->free();
+		delete _fxScreen;
+	}
 	if (_vm->getGameID() != GID_RTZ)
 		delete _screenMask;
 	delete _fx;
@@ -242,6 +272,33 @@ void Screen::drawSurface(Graphics::Surface *sourceSurface, int x, int y, int16 f
 }
 
 void Screen::setRGBPalette(byte *palRGB, int start, int count) {
+	if (_trueColor) {
+		// There is no backend palette in true colour; presentWorkScreen() looks
+		// the colours up itself.
+		memcpy(_outputPalette + start * 3, palRGB, count * 3);
+
+		const Graphics::PixelFormat format = _vm->_system->getScreenFormat();
+		for (int i = start; i < start + count && i < 256; i++) {
+			const byte *rgb = _outputPalette + i * 3;
+			_outputColors[i] = format.RGBToColor(rgb[0], rgb[1], rgb[2]);
+		}
+
+		// The cursor is paletted too, so it follows the screen palette
+		CursorMan.replaceCursorPalette(_outputPalette, 0, 256);
+
+		// A paletted screen recolours whatever is already on it the moment the
+		// palette changes, and the game leans on that: ScreenEffects::flash()
+		// makes lightning by swapping in an inverted palette and back, and the
+		// fades work the same way. Nothing would come of either here unless the
+		// picture is built again with the new colours. _fxScreen is the mirror
+		// of what is currently showing, which is what a palette change acts on -
+		// not the work screen, which may be part way through being drawn.
+		if (_fxScreen)
+			blitTrueColorRect((const byte *)_fxScreen->getPixels(), _fxScreen->pitch,
+				0, 0, _fxScreen->w, _fxScreen->h);
+		return;
+	}
+
 	_vm->_system->getPaletteManager()->setPalette(palRGB, start, count);
 }
 
@@ -381,7 +438,7 @@ void Screen::updateSprites() {
 	drawSpriteChannels(_backgroundScreenDrawCtx, 3, 0);
 	drawSpriteChannels(_workScreenDrawCtx, 1, 2);
 
-	_vm->_system->copyRectToScreen(_workScreen->getPixels(), _workScreen->pitch, 0, 0, _workScreen->w, _workScreen->h);
+	presentWorkScreen();
 	_vm->_screen->updateScreenAndWait(10);
 }
 
@@ -930,22 +987,119 @@ int16 Screen::getTextWidth(int16 fontNum, const char *text) {
 }
 
 Graphics::Surface *Screen::lockScreen() {
-	return _vm->_system->lockScreen();
+	if (!_trueColor)
+		return _vm->_system->lockScreen();
+
+	// copyFxRect() reveals the new picture over the old one a few pixels at a
+	// time, so it needs to read and write the screen as 8 bit paletted pixels.
+	// Hand it the mirror, which still holds what is showing.
+	return _fxScreen;
 }
 
 void Screen::unlockScreen() {
-	_vm->_system->unlockScreen();
+	if (!_trueColor) {
+		_vm->_system->unlockScreen();
+		return;
+	}
+
+	blitTrueColorRect((const byte *)_fxScreen->getPixels(), _fxScreen->pitch,
+		0, 0, _fxScreen->w, _fxScreen->h);
 }
 
 void Screen::showWorkScreen() {
-	_vm->_system->copyRectToScreen(_workScreen->getPixels(), _workScreen->pitch, 0, 0, _workScreen->w, _workScreen->h);
+	presentWorkScreen();
+}
+
+void Screen::presentWorkScreen() {
+	if (!_trueColor) {
+		_vm->_system->copyRectToScreen(_workScreen->getPixels(), _workScreen->pitch, 0, 0, _workScreen->w, _workScreen->h);
+		return;
+	}
+
+	// The ReelMagic card mixed its MPEG picture in as an underlay: wherever the
+	// graphics layer holds the transparent palette index the video shows
+	// through, everywhere else the graphics win.
+	const Graphics::PixelFormat format = _vm->_system->getScreenFormat();
+	if (!_outputScreen) {
+		_outputScreen = new Graphics::Surface();
+		_outputScreen->create(_workScreen->w, _outputHeight, format);
+	}
+
+	blitTrueColorRect((const byte *)_workScreen->getPixels(), _workScreen->pitch,
+		0, 0, _workScreen->w, _workScreen->h);
+
+	// Keep the mirror the screen effects draw on in step with what is showing
+	if (_fxScreen)
+		memcpy(_fxScreen->getPixels(), _workScreen->getPixels(), _workScreen->pitch * _workScreen->h);
+}
+
+void Screen::blitTrueColorRect(const byte *src, int srcPitch, int x, int y, int w, int h) {
+	const Graphics::PixelFormat format = _vm->_system->getScreenFormat();
+	if (!_outputScreen) {
+		_outputScreen = new Graphics::Surface();
+		_outputScreen->create(_workScreen->w, _outputHeight, format);
+	}
+
+	// Work out which output lines the source lines land on. Without stretching
+	// that is one for one; with it, every 5th line is a duplicate of the
+	// previous one, bringing the 200-line graphics up to 240 lines.
+	int firstY = y, lastY = y + h;
+	if (_stretchGraphics) {
+		firstY = MAX(0, y * 240 / 200 - 1);
+		lastY = MIN(_outputHeight, (y + h) * 240 / 200 + 1);
+	} else {
+		firstY = MAX(0, firstY);
+		lastY = MIN(_outputHeight, lastY);
+	}
+
+	for (int outY = firstY; outY < lastY; outY++) {
+		const int srcY = _stretchGraphics ? MIN(outY * 200 / 240, _workScreen->h - 1) : outY;
+		if (srcY < y || srcY >= y + h)
+			continue;
+
+		const byte *srcLine = src + (srcY - y) * srcPitch;
+
+		if (format.bytesPerPixel == 2) {
+			const uint16 *video = _videoLayer ? (const uint16 *)_videoLayer->getBasePtr(x, outY) : nullptr;
+			uint16 *dst = (uint16 *)_outputScreen->getBasePtr(x, outY);
+			for (int i = 0; i < w; i++)
+				dst[i] = (video && srcLine[i] == kTransparentIndex) ? video[i] : (uint16)_outputColors[srcLine[i]];
+		} else {
+			const uint32 *video = _videoLayer ? (const uint32 *)_videoLayer->getBasePtr(x, outY) : nullptr;
+			uint32 *dst = (uint32 *)_outputScreen->getBasePtr(x, outY);
+			for (int i = 0; i < w; i++)
+				dst[i] = (video && srcLine[i] == kTransparentIndex) ? video[i] : _outputColors[srcLine[i]];
+		}
+	}
+
+	if (lastY > firstY)
+		_vm->_system->copyRectToScreen(_outputScreen->getBasePtr(x, firstY), _outputScreen->pitch,
+			x, firstY, w, lastY - firstY);
 }
 
 void Screen::copyRectToScreen(const void *buf, int pitch, int x, int y, int w, int h) {
-	_vm->_system->copyRectToScreen(buf, pitch, x, y, w, h);
+	if (!_trueColor) {
+		_vm->_system->copyRectToScreen(buf, pitch, x, y, w, h);
+		return;
+	}
+
+	// The effects hand over 8 bit graphics, which the backend cannot take here.
+	// Convert them, and remember them, since an effect builds its picture up out
+	// of many of these and may go on to draw on the mirror directly.
+	blitTrueColorRect((const byte *)buf, pitch, x, y, w, h);
+
+	if (_fxScreen) {
+		const byte *src = (const byte *)buf;
+		for (int i = 0; i < h; i++)
+			memcpy(_fxScreen->getBasePtr(x, y + i), src + i * pitch, w);
+	}
 }
 
 void Screen::updateScreenAndWait(int delay) {
+	// Keep any background movie moving while the script goes about its business
+	if (_vm->_mpegPlayer)
+		_vm->_mpegPlayer->update();
+
 	_vm->_system->updateScreen();
 	uint32 startTime = _vm->_system->getMillis();
 	while (_vm->_system->getMillis() < startTime + delay) {

--- a/engines/made/screen.h
+++ b/engines/made/screen.h
@@ -194,6 +194,24 @@ public:
 	void setMouseCursor(const Graphics::Cursor *cursor);
 	void setDefaultMouseCursor();
 
+	/**
+	 * Pushes the work screen to the backend. For the ReelMagic release the
+	 * screen is a true colour one and the MPEG picture is mixed in underneath.
+	 */
+	void presentWorkScreen();
+
+	/** True when the graphics layer is stretched to a 240 line screen. */
+	bool isGraphicsStretched() const { return _stretchGraphics; }
+	int getOutputHeight() const { return _outputHeight; }
+	int screenToGameY(int y) const { return y * 200 / _outputHeight; }
+	int gameToScreenY(int y) const { return (y * _outputHeight + 199) / 200; }
+
+	/**
+	 * Set the MPEG picture which the ReelMagic release mixes underneath the
+	 * paletted graphics.
+	 */
+	void setVideoLayer(const Graphics::Surface *videoLayer) { _videoLayer = videoLayer; }
+
 protected:
 	MadeEngine *_vm;
 	ScreenEffects *_fx;
@@ -218,6 +236,29 @@ protected:
 	int _visualEffectNum;
 
 	Graphics::Surface *_backgroundScreen, *_workScreen, *_screenMask;
+
+	// The ReelMagic release runs on a true colour screen so that the MPEG
+	// picture can be mixed in under the paletted graphics; the palette is then
+	// applied here rather than by the backend.
+	bool _trueColor;
+	bool _stretchGraphics;
+	int _outputHeight;
+	byte _outputPalette[256 * 3];
+	uint32 _outputColors[256];	// _outputPalette in the screen format
+	Graphics::Surface *_outputScreen;
+	const Graphics::Surface *_videoLayer;
+	// What the screen effects draw on. They expect to reach the visible screen
+	// as 8 bit paletted pixels, which a true colour backend cannot give them, so
+	// they get this mirror of the graphics layer instead and it is converted on
+	// the way out.
+	Graphics::Surface *_fxScreen;
+
+	/**
+	 * Converts a rect of 8 bit graphics into the true colour output screen,
+	 * mixing the MPEG picture in where the graphics are transparent, and hands
+	 * the result to the backend. @p src points at the top left of the rect.
+	 */
+	void blitTrueColorRect(const byte *src, int srcPitch, int x, int y, int w, int h);
 	ClipInfo _clipArea, _backgroundScreenDrawCtx, _workScreenDrawCtx, _maskDrawCtx;
 
 	ClipInfo _excludeClipArea[4];

--- a/engines/made/scriptfuncs.cpp
+++ b/engines/made/scriptfuncs.cpp
@@ -25,6 +25,7 @@
 #include "made/music.h"
 #include "made/database.h"
 #include "made/pmvplayer.h"
+#include "made/mpegplayer.h"
 
 #include "audio/sine.h"
 
@@ -166,6 +167,18 @@ void ScriptFunctions::setupExternalsTable() {
 		External(sfSetSoundVolume);
 		External(sfGetSynthType);
 		External(sfIsSlowSystem);
+
+		// The ReelMagic release appends seven MPEG playback functions to the
+		// table; everything below index 100 is shared with the other releases.
+		if (_vm->getFeatures() & GF_REELMAGIC) {
+			External(sfPlayMpegMovie);
+			External(sfMpegMovieGetState);
+			External(sfMpegMovieClose);
+			External(sfMpegDriverInit);
+			External(sfMpegDriverShutdown);
+			External(sfMpegMoviePause);
+			External(sfMpegMovieGetUserData);
+		}
 	}
 
 }
@@ -1149,6 +1162,112 @@ int16 ScriptFunctions::sfIsSlowSystem(int16 argc, int16 *argv) {
 	// An example is FINTRO00.PMV (with sound) and FINTRO01.PMV (without sound)
 	// One could maybe think about returning 1 here on actually slower systems.
 	return _vm->_introMusicDigital ? 0 : 1;
+}
+
+int16 ScriptFunctions::sfPlayMpegMovie(int16 argc, int16 *argv) {
+	if (argc < 3) {
+		warning("sfPlayMpegMovie: expected 3 arguments, got %d", argc);
+		return 0;
+	}
+
+	// The original builds the file name by prefixing the string of the object
+	// in argv[2] with the path given by the "-P:" command line switch. Under
+	// ScummVM the game directory is searched instead, so the name is enough.
+	const char *movieName = _vm->_dat->getObjectString(argv[2]);
+	if (!movieName || !*movieName) {
+		// The original prints "** Plaympegmovie nil" in this case
+		warning("sfPlayMpegMovie: object %d holds no movie name", argv[2]);
+		return 0;
+	}
+
+	debug(1, "sfPlayMpegMovie(%d, %d, '%s')", argv[0], argv[1], movieName);
+
+	// argv[1] is the play mode the card's driver took per handle: 2 loops the
+	// movie, 1 runs it through once and leaves its last picture standing, which
+	// is how the still room backgrounds are done. It cannot be worked out from
+	// the file, since FLHILK20 is a program stream with audio and still loops.
+	// Playback runs on in the background; the script polls sfMpegMovieGetState to
+	// find out when it has finished.
+	if (!_vm->_mpegPlayer->start(movieName, argv[1]))
+		return 0;
+
+	// Mode 3 is played out here and now. The original interpreter does not hand
+	// control back for this one: it loops on the card's play state until the
+	// movie is no longer running. Returning straight away instead lets the
+	// script run on and the movie is replaced before it is ever seen.
+	if (argv[1] == MpegPlayer::kPlayBlocking) {
+		// Only ever wait for the movie just started. Escape can end it and bring
+		// an overlay back in its place, and waiting on that one would never
+		// return, since an overlay loops for as long as it is left alone.
+		const uint32 token = _vm->_mpegPlayer->playToken();
+		while (_vm->_mpegPlayer->playToken() == token &&
+			_vm->_mpegPlayer->isPlaying() && !_vm->shouldQuit()) {
+			_vm->handleEvents();
+			_vm->_mpegPlayer->update();
+			_vm->_system->delayMillis(10);
+		}
+	}
+
+	return 1;
+}
+
+int16 ScriptFunctions::sfMpegMovieGetState(int16 argc, int16 *argv) {
+	// Polled in a loop while a movie runs, and the only one of the seven whose
+	// return value the original passes through untransformed: a "still playing?"
+	// query. Decode whatever is due before answering, so that the picture keeps
+	// moving while the script waits here. Events are pumped as well, since a
+	// script that does nothing but poll would otherwise never see the Escape
+	// key that ends a cutscene.
+	_vm->handleEvents();
+	_vm->_mpegPlayer->update();
+
+	return _vm->_mpegPlayer->playState();
+}
+
+// The remaining five are what the ReelMagic interpreter does with the card's
+// driver, read out of MADERM.EXE: each is a thin wrapper around one driver_call
+// (BH command, BL media handle, CX subfunction), and the commands are the ones
+// documented for FMPDRV.EXE. None of them takes an argument.
+
+int16 ScriptFunctions::sfMpegMovieClose(int16 argc, int16 *argv) {
+	// Command 02h, close the media handle, after which the interpreter forgets
+	// it. Closing the card's handle is what stopped playback, so the player is
+	// stopped here too. The original returns 0 and every caller discards it.
+	debug(1, "sfMpegMovieClose: close media handle");
+	_vm->_mpegPlayer->close();
+	return 0;
+}
+
+int16 ScriptFunctions::sfMpegDriverInit(int16 argc, int16 *argv) {
+	// Brings the driver up: command 0Eh reset, then a 16K buffer is allocated
+	// and the whole thing fails if that cannot be had. Nothing to do here, but
+	// the answer matters: the script clears its own MPEG flag if this says 0.
+	debug(1, "sfMpegDriverInit");
+	return 1;
+}
+
+int16 ScriptFunctions::sfMpegDriverShutdown(int16 argc, int16 *argv) {
+	// Shuts the driver down: closes the handle through the very same code as
+	// 102, resets the driver and frees the buffer 103 allocated.
+	debug(1, "sfMpegDriverShutdown");
+	_vm->_mpegPlayer->close();
+	return 1;
+}
+
+int16 ScriptFunctions::sfMpegMoviePause(int16 argc, int16 *argv) {
+	// Command 04h pauses the media handle on its current picture. The wrapper
+	// hands back 1 regardless of the driver's result.
+	debug(1, "sfMpegMoviePause");
+	_vm->_mpegPlayer->pause();
+	return 1;
+}
+
+int16 ScriptFunctions::sfMpegMovieGetUserData(int16 argc, int16 *argv) {
+	// Reads back the arbitrary "user data" kept against the handle (command 0Ah
+	// subfunction 0208h). Nothing ever stores any, and the wrapper returns 1
+	// regardless of what comes back.
+	debug(1, "sfMpegMovieGetUserData");
+	return 1;
 }
 
 } // End of namespace Made

--- a/engines/made/scriptfuncs.h
+++ b/engines/made/scriptfuncs.h
@@ -174,6 +174,14 @@ protected:
 	int16 sfGetSynthType(int16 argc, int16 *argv);
 	int16 sfIsSlowSystem(int16 argc, int16 *argv);
 
+	// Only present in the ReelMagic release of Return to Zork
+	int16 sfPlayMpegMovie(int16 argc, int16 *argv);
+	int16 sfMpegMovieGetState(int16 argc, int16 *argv);
+	int16 sfMpegMovieClose(int16 argc, int16 *argv);
+	int16 sfMpegDriverInit(int16 argc, int16 *argv);
+	int16 sfMpegDriverShutdown(int16 argc, int16 *argv);
+	int16 sfMpegMoviePause(int16 argc, int16 *argv);
+	int16 sfMpegMovieGetUserData(int16 argc, int16 *argv);
 };
 
 } // End of namespace Made

--- a/image/codecs/mpeg.cpp
+++ b/image/codecs/mpeg.cpp
@@ -24,6 +24,7 @@
 #include "common/stream.h"
 #include "common/system.h"
 #include "common/textconsole.h"
+#include "common/util.h"
 #include "graphics/surface.h"
 #include "graphics/yuv_to_rgb.h"
 
@@ -39,6 +40,9 @@ MPEGDecoder::MPEGDecoder() : Codec() {
 	_pixelFormat = getDefaultYUVFormat();
 
 	_surface = 0;
+	_pendingPos = 0;
+	_stopAtFirstFrame = false;
+	_reachedSequenceEnd = false;
 
 	_mpegDecoder = mpeg2_init();
 
@@ -63,7 +67,28 @@ const Graphics::Surface *MPEGDecoder::decodeFrame(Common::SeekableReadStream &st
 	return _surface;
 }
 
+void MPEGDecoder::convertFrame(Graphics::Surface *dst) {
+	const mpeg2_sequence_t *sequence = _mpegInfo->sequence;
+
+	if (!dst) {
+		// If no destination is specified, use our internal storage
+		if (!_surface) {
+			_surface = new Graphics::Surface();
+			_surface->create(sequence->picture_width, sequence->picture_height, _pixelFormat);
+		}
+
+		dst = _surface;
+	}
+
+	YUVToRGBMan.convert420(dst, Graphics::YUVToRGBManager::kScaleITU, _mpegInfo->display_fbuf->buf[0],
+			_mpegInfo->display_fbuf->buf[1], _mpegInfo->display_fbuf->buf[2], sequence->picture_width,
+			sequence->picture_height, sequence->width, sequence->chroma_width);
+}
+
 bool MPEGDecoder::decodePacket(Common::SeekableReadStream &packet, uint32 &framePeriod, Graphics::Surface *dst) {
+	if (_stopAtFirstFrame)
+		return decodeFirstFrame(packet, framePeriod, dst);
+
 	// Decode as much as we can out of this packet
 	uint32 size = 0xFFFFFFFF;
 	mpeg2_state_t state;
@@ -78,8 +103,14 @@ bool MPEGDecoder::decodePacket(Common::SeekableReadStream &packet, uint32 &frame
 			size = packet.read(_buffer, BUFFER_SIZE);
 			mpeg2_buffer(_mpegDecoder, _buffer, _buffer + size);
 			break;
-		case STATE_SLICE:
+		case STATE_SEQUENCE:
+		case STATE_SEQUENCE_REPEATED:
+			_reachedSequenceEnd = false;
+			break;
 		case STATE_END:
+			_reachedSequenceEnd = true;
+			// fall through
+		case STATE_SLICE:
 			if (_mpegInfo->display_fbuf) {
 				foundFrame = true;
 				const mpeg2_sequence_t *sequence = _mpegInfo->sequence;
@@ -91,19 +122,7 @@ bool MPEGDecoder::decodePacket(Common::SeekableReadStream &packet, uint32 &frame
 
 				}
 
-				if (!dst) {
-					// If no destination is specified, use our internal storage
-					if (!_surface) {
-						_surface = new Graphics::Surface();
-						_surface->create(sequence->picture_width, sequence->picture_height, _pixelFormat);
-					}
-
-					dst = _surface;
-				}
-
-				YUVToRGBMan.convert420(dst, Graphics::YUVToRGBManager::kScaleITU, _mpegInfo->display_fbuf->buf[0],
-						_mpegInfo->display_fbuf->buf[1], _mpegInfo->display_fbuf->buf[2], sequence->picture_width,
-						sequence->picture_height, sequence->width, sequence->chroma_width);
+				convertFrame(dst);
 			}
 			break;
 		default:
@@ -112,6 +131,101 @@ bool MPEGDecoder::decodePacket(Common::SeekableReadStream &packet, uint32 &frame
 	} while (size != 0);
 
 	return foundFrame;
+}
+
+bool MPEGDecoder::decodeFirstFrame(Common::SeekableReadStream &packet, uint32 &framePeriod, Graphics::Surface *dst) {
+	// Queue whatever the caller handed us. Anything left over from an earlier
+	// call is still in front of it, so the stream order is kept.
+	const int64 remaining = packet.size() - packet.pos();
+	if (remaining > 0) {
+		const uint32 oldSize = _pendingData.size();
+		if ((uint64)remaining > 0xFFFFFFFFU - oldSize) {
+			warning("MPEGDecoder: queued packet data is too large");
+			framePeriod = 0;
+			return false;
+		}
+
+		const uint32 requested = (uint32)remaining;
+		_pendingData.resize(oldSize + requested);
+		const uint32 bytesRead = packet.read(&_pendingData[oldSize], requested);
+		if (bytesRead != requested)
+			_pendingData.resize(oldSize + bytesRead);
+	}
+
+	return decodeQueuedFrame(framePeriod, dst);
+}
+
+bool MPEGDecoder::decodePendingFrame(uint32 &framePeriod, Graphics::Surface *dst) {
+	if (!_stopAtFirstFrame) {
+		framePeriod = 0;
+		return false;
+	}
+
+	return decodeQueuedFrame(framePeriod, dst);
+}
+
+bool MPEGDecoder::decodeQueuedFrame(uint32 &framePeriod, Graphics::Surface *dst) {
+	framePeriod = 0;
+
+	for (;;) {
+		const mpeg2_state_t state = mpeg2_parse(_mpegDecoder);
+
+		switch (state) {
+		case STATE_BUFFER: {
+			// libmpeg2 has consumed all of _buffer and wants more. Only ever
+			// refill it here, so that returning early with data still inside it
+			// is safe: the decoder picks up where it left off on the next call.
+			const uint32 available = _pendingData.size() - _pendingPos;
+			if (available == 0) {
+				_pendingData.clear();
+				_pendingPos = 0;
+				return false;	// Needs another packet to make progress
+			}
+
+			const uint32 chunk = MIN<uint32>(available, BUFFER_SIZE);
+
+			memcpy(_buffer, &_pendingData[_pendingPos], chunk);
+			_pendingPos += chunk;
+
+			// Drop consumed data from time to time to bound the queue
+			if (_pendingPos >= BUFFER_SIZE * 4) {
+				const uint32 keep = _pendingData.size() - _pendingPos;
+				if (keep > 0)
+					memmove(&_pendingData[0], &_pendingData[_pendingPos], keep);
+				_pendingData.resize(keep);
+				_pendingPos = 0;
+			}
+
+			mpeg2_buffer(_mpegDecoder, _buffer, _buffer + chunk);
+			break;
+		}
+		case STATE_SEQUENCE:
+		case STATE_SEQUENCE_REPEATED:
+			_reachedSequenceEnd = false;
+			break;
+		case STATE_END:
+			_reachedSequenceEnd = true;
+			// fall through
+		case STATE_SLICE:
+			if (_mpegInfo->display_fbuf) {
+				const mpeg2_sequence_t *sequence = _mpegInfo->sequence;
+				const mpeg2_picture_t *picture = _mpegInfo->display_picture;
+
+				framePeriod = sequence->frame_period;
+				if (picture->nb_fields > 2)
+					framePeriod += (sequence->frame_period / 2);
+
+				convertFrame(dst);
+
+				// Hand this frame over instead of decoding the rest of the
+				// packet on top of it; the remainder stays queued.
+				return true;
+			}
+			break;
+		default:
+			break;
+		}
+	}
 }
 
 } // End of namespace Image

--- a/image/codecs/mpeg.h
+++ b/image/codecs/mpeg.h
@@ -22,6 +22,8 @@
 #ifndef IMAGE_CODECS_MPEG_H
 #define IMAGE_CODECS_MPEG_H
 
+#include "common/array.h"
+
 #include "image/codecs/codec.h"
 #include "graphics/pixelformat.h"
 
@@ -61,7 +63,33 @@ public:
 	// MPEGPSDecoder call
 	bool decodePacket(Common::SeekableReadStream &packet, uint32 &framePeriod, Graphics::Surface *dst = 0);
 
+	/** Decode one frame already buffered by a previous decodePacket() call. */
+	bool decodePendingFrame(uint32 &framePeriod, Graphics::Surface *dst = 0);
+
+	/** Return whether the decoder has parsed an MPEG sequence-end code. */
+	bool reachedSequenceEnd() const { return _reachedSequenceEnd; }
+
+	/**
+	 * Return as soon as one frame is ready to show, keeping the rest of the
+	 * packet for the calls that follow, instead of decoding every frame in the
+	 * packet on top of the same surface.
+	 *
+	 * Off by default, since it changes when frames come out and existing callers
+	 * are tuned to the old behaviour. It matters for streams whose packets carry
+	 * more than one frame: those lose all but the last frame of every packet
+	 * otherwise. This is particularly visible in streams with bidirectionally
+	 * predicted pictures, where several displayable frames may share a packet.
+	 */
+	void setStopAtFirstFrame(bool stop) { _stopAtFirstFrame = stop; }
+
 private:
+	bool decodeFirstFrame(Common::SeekableReadStream &packet, uint32 &framePeriod, Graphics::Surface *dst);
+	bool decodeQueuedFrame(uint32 &framePeriod, Graphics::Surface *dst);
+	void convertFrame(Graphics::Surface *dst);
+
+	bool _stopAtFirstFrame;
+	bool _reachedSequenceEnd;
+
 	Graphics::PixelFormat _pixelFormat;
 	Graphics::Surface *_surface;
 
@@ -72,6 +100,11 @@ private:
 	byte _buffer[BUFFER_SIZE];
 	mpeg2dec_t *_mpegDecoder;
 	const mpeg2_info_t *_mpegInfo;
+
+	// When one-frame-per-call decoding is enabled, a packet which holds more than
+	// one frame keeps its remainder queued here for the calls that follow.
+	Common::Array<byte> _pendingData;
+	uint32 _pendingPos;
 };
 
 } // End of namespace Image

--- a/video/mpegps_decoder.cpp
+++ b/video/mpegps_decoder.cpp
@@ -29,6 +29,7 @@
 #include "common/memstream.h"
 #include "common/system.h"
 #include "common/textconsole.h"
+#include "common/util.h"
 
 #include "video/mpegps_decoder.h"
 #include "image/codecs/mpeg.h"
@@ -80,6 +81,10 @@ bool MPEGPSDecoder::loadStream(Common::SeekableReadStream *stream) {
 
 void MPEGPSDecoder::setPrebufferedPackets(int packets) {
 	_demuxer->setPrebufferedPackets(packets);
+}
+
+void MPEGPSDecoder::setAudioLeadTime(uint32 ms) {
+	_demuxer->setAudioLeadTime(ms);
 }
 
 void MPEGPSDecoder::close() {
@@ -171,16 +176,28 @@ MPEGPSDecoder::MPEGStream *MPEGPSDecoder::getStream(uint32 startCode, Common::Se
 }
 
 void MPEGPSDecoder::readNextPacket() {
+	// A video packet may contain several pictures. When the codec is configured
+	// to return one at a time, consume those already-buffered pictures before
+	// asking the demuxer for another packet.
+	for (TrackListIterator it = getTrackListBegin(); it != getTrackListEnd(); it++) {
+		if ((*it)->getTrackType() == Track::kTrackTypeVideo &&
+			((MPEGVideoTrack *)*it)->decodePendingFrame())
+			return;
+	}
+
 	for (;;) {
 		int32 startCode;
 		uint32 pts, dts;
 		Common::SeekableReadStream *packet = _demuxer->getNextPacket(getTime(), startCode, pts, dts);
 
 		if (!packet) {
-			// End of stream
-			for (TrackListIterator it = getTrackListBegin(); it != getTrackListEnd(); it++)
-				if ((*it)->getTrackType() == Track::kTrackTypeVideo)
-					((MPEGVideoTrack *)*it)->setEndOfTrack();
+			// End of the demuxed stream. Give the codec a sequence-end marker so
+			// delayed pictures are displayed before the track is marked finished.
+			for (TrackListIterator it = getTrackListBegin(); it != getTrackListEnd(); it++) {
+				if ((*it)->getTrackType() == Track::kTrackTypeVideo &&
+					((MPEGVideoTrack *)*it)->finish())
+					return;
+			}
 			return;
 		}
 
@@ -211,6 +228,7 @@ bool MPEGPSDecoder::addFirstVideoTrack() {
 	// Can be MPEG-1/2 or MPEG-4/h.264. We'll assume the former and
 	// I hope we never need the latter.
 	MPEGVideoTrack *track = new MPEGVideoTrack(packet);
+	track->setStopAtFirstFrame(_stopAtFirstFrame);
 	addTrack(track);
 	_streamMap[startCode] = track;
 
@@ -251,8 +269,6 @@ MPEGPSDecoder::PrivateStreamType MPEGPSDecoder::detectPrivateStreamType(Common::
 // first audio packet, even though the timestamp indicated that the audio
 // should start slightly before the video.
 // --------------------------------------------------------------------------
-
-#define AUDIO_THRESHOLD     100
 
 MPEGPSDecoder::MPEGPSDemuxer::MPEGPSDemuxer() {
 	_stream = 0;
@@ -345,7 +361,7 @@ Common::SeekableReadStream *MPEGPSDecoder::MPEGPSDemuxer::getNextPacket(uint32 c
 			if (packet._pts >= _firstAudioPacketPts)
 				packet._pts -= _firstAudioPacketPts;
 			uint32 packetTime = packet._pts / 90;
-			if (packetTime <= currentTime || packetTime - currentTime < AUDIO_THRESHOLD || _videoQueue.empty()) {
+			if (packetTime <= currentTime || packetTime - currentTime < _audioLeadTime || _videoQueue.empty()) {
 				// The packet is overdue, or will be soon.
 				//
 				// TODO: We should pad or trim the first audio
@@ -640,6 +656,8 @@ void MPEGPSDecoder::MPEGPSDemuxer::parseProgramStreamMap(int length) {
 MPEGPSDecoder::MPEGVideoTrack::MPEGVideoTrack(Common::SeekableReadStream *firstPacket) {
 	_surface = 0;
 	_endOfTrack = false;
+	_stopAtFirstFrame = false;
+	_endSequenceQueued = false;
 	_curFrame = -1;
 	_framePts = 0xFFFFFFFF;
 	_nextFrameStartTime = Audio::Timestamp(0, 27000000); // 27 MHz timer
@@ -648,6 +666,13 @@ MPEGPSDecoder::MPEGVideoTrack::MPEGVideoTrack(Common::SeekableReadStream *firstP
 
 #ifdef USE_MPEG2
 	_mpegDecoder = new Image::MPEGDecoder();
+#endif
+}
+
+void MPEGPSDecoder::MPEGVideoTrack::setStopAtFirstFrame(bool stop) {
+	_stopAtFirstFrame = stop;
+#ifdef USE_MPEG2
+	_mpegDecoder->setStopAtFirstFrame(stop);
 #endif
 }
 
@@ -681,39 +706,94 @@ bool MPEGPSDecoder::MPEGVideoTrack::setOutputPixelFormat(const Graphics::PixelFo
 	return true;
 }
 
-const Graphics::Surface *MPEGPSDecoder::MPEGVideoTrack::decodeNextFrame() {
-	return _surface;
-}
-
-bool MPEGPSDecoder::MPEGVideoTrack::sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts) {
-#ifdef USE_MPEG2
+void MPEGPSDecoder::MPEGVideoTrack::ensureSurface() {
 	if (!_surface) {
 		_surface = new Graphics::Surface();
 		_surface->create(_width, _height, _pixelFormat);
 	}
+}
 
-	if (pts != 0xFFFFFFFF) {
+bool MPEGPSDecoder::MPEGVideoTrack::accountFrame(bool foundFrame, uint32 framePeriod) {
+	if (!foundFrame)
+		return false;
+
+	_curFrame++;
+
+	// If there has been a timestamp since the previous frame, use that for
+	// syncing. Usually it will be the timestamp from the current packet, but it
+	// may be from a packet which needed more input before producing its frame.
+	if (_framePts != 0xFFFFFFFF)
+		_nextFrameStartTime = Audio::Timestamp(_framePts / 90, 27000000);
+	else
+		_nextFrameStartTime = _nextFrameStartTime.addFrames(framePeriod);
+
+	_framePts = 0xFFFFFFFF;
+	return true;
+}
+
+bool MPEGPSDecoder::MPEGVideoTrack::decodePendingFrame() {
+#ifdef USE_MPEG2
+	if (!_stopAtFirstFrame)
+		return false;
+
+	ensureSurface();
+	uint32 framePeriod;
+	const bool foundFrame = _mpegDecoder->decodePendingFrame(framePeriod, _surface);
+	return accountFrame(foundFrame, framePeriod);
+#else
+	return false;
+#endif
+}
+
+bool MPEGPSDecoder::MPEGVideoTrack::finish() {
+#ifdef USE_MPEG2
+	if (_stopAtFirstFrame) {
+		ensureSurface();
+
+		if (!_mpegDecoder->reachedSequenceEnd() && !_endSequenceQueued) {
+			static const byte kSequenceEnd[] = { 0x00, 0x00, 0x01, 0xB7 };
+			Common::MemoryReadStream packet(kSequenceEnd, sizeof(kSequenceEnd));
+			_endSequenceQueued = true;
+
+			uint32 framePeriod;
+			const bool foundFrame = _mpegDecoder->decodePacket(packet, framePeriod, _surface);
+			if (accountFrame(foundFrame, framePeriod))
+				return true;
+		}
+
+		uint32 framePeriod;
+		const bool foundFrame = _mpegDecoder->decodePendingFrame(framePeriod, _surface);
+		if (accountFrame(foundFrame, framePeriod))
+			return true;
+	}
+#endif
+
+	_endOfTrack = true;
+	return false;
+}
+
+const Graphics::Surface *MPEGPSDecoder::MPEGVideoTrack::decodeNextFrame() {
+	// In one-frame-per-call mode, readNextPacket() can discover EOF without
+	// decoding a new picture. The generic VideoDecoder still calls this method
+	// through the track selected before that read, so do not return the previous
+	// surface a second time. Preserve the established default-path behaviour.
+	return (_stopAtFirstFrame && _endOfTrack) ? nullptr : _surface;
+}
+
+bool MPEGPSDecoder::MPEGVideoTrack::sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts) {
+#ifdef USE_MPEG2
+	ensureSurface();
+
+	// One-frame-per-call decoding may need several packets before producing a
+	// picture, so keep the oldest applicable timestamp in that mode. Preserve
+	// the established last-packet timestamp behaviour on the default path.
+	if (pts != 0xFFFFFFFF && (!_stopAtFirstFrame || _framePts == 0xFFFFFFFF)) {
 		_framePts = pts;
 	}
 
 	uint32 framePeriod;
 	bool foundFrame = _mpegDecoder->decodePacket(*packet, framePeriod, _surface);
-
-	if (foundFrame) {
-		_curFrame++;
-
-		// If there has been a timestamp since the previous frame, use that for
-		// syncing. Usually it will be the timestamp from the current packet,
-		// but it might not be.
-
-		if (_framePts != 0xFFFFFFFF) {
-			_nextFrameStartTime = Audio::Timestamp(_framePts / 90, 27000000);
-		} else {
-			_nextFrameStartTime = _nextFrameStartTime.addFrames(framePeriod);
-		}
-
-		_framePts = 0xFFFFFFFF;
-	}
+	accountFrame(foundFrame, framePeriod);
 #endif
 
 	delete packet;

--- a/video/mpegps_decoder.h
+++ b/video/mpegps_decoder.h
@@ -64,6 +64,17 @@ public:
 	// Used only by qdEngine
 	void setPrebufferedPackets(int packets);
 
+	// How far ahead of the playback clock audio packets are handed to the mixer,
+	// in milliseconds. The default remains 100 ms.
+	void setAudioLeadTime(uint32 ms);
+
+	// Hand over each frame as it becomes ready rather than decoding a whole
+	// packet onto one surface, which loses every frame of a packet but its last.
+	// Off by default: it changes when frames come out, and the callers that do
+	// not need it are tuned to the existing behaviour. Must be set before
+	// loadStream(), which is where the video track is built.
+	void setStopAtFirstFrame(bool stop) { _stopAtFirstFrame = stop; }
+
 protected:
 	void readNextPacket() override;
 	bool useAudioSync() const override { return false; }
@@ -81,6 +92,7 @@ private:
 		Common::SeekableReadStream *getNextPacket(uint32 currentTime, int32 &startCode, uint32 &pts, uint32 &dts);
 
 		void setPrebufferedPackets(int packets) { _prebufferedPackets = packets; }
+		void setAudioLeadTime(uint32 ms) { _audioLeadTime = ms; }
 
 	private:
 		class Packet {
@@ -109,6 +121,7 @@ private:
 		uint32 _firstVideoPacketPts = 0xFFFFFFFF;
 
 		int _prebufferedPackets = 150;
+		uint32 _audioLeadTime = 100;
 	};
 
 	// Base class for handling MPEG streams
@@ -129,6 +142,7 @@ private:
 	class MPEGVideoTrack : public VideoTrack, public MPEGStream {
 	public:
 		MPEGVideoTrack(Common::SeekableReadStream *firstPacket);
+		void setStopAtFirstFrame(bool stop);
 		~MPEGVideoTrack();
 
 		bool endOfTrack() const override { return _endOfTrack; }
@@ -143,10 +157,13 @@ private:
 		bool sendPacket(Common::SeekableReadStream *packet, uint32 pts, uint32 dts) override;
 		StreamType getStreamType() const override { return kStreamTypeVideo; }
 
-		void setEndOfTrack() { _endOfTrack = true; }
+		bool decodePendingFrame();
+		bool finish();
 
 	private:
 		bool _endOfTrack;
+		bool _stopAtFirstFrame;
+		bool _endSequenceQueued;
 		int _curFrame;
 		uint32 _framePts;
 		Audio::Timestamp _nextFrameStartTime;
@@ -157,6 +174,8 @@ private:
 		Graphics::PixelFormat _pixelFormat;
 
 		void findDimensions(Common::SeekableReadStream *firstPacket);
+		void ensureSurface();
+		bool accountFrame(bool foundFrame, uint32 framePeriod);
 
 #ifdef USE_MPEG2
 		Image::MPEGDecoder *_mpegDecoder;
@@ -243,6 +262,7 @@ private:
 	MPEGStream *getStream(uint32 startCode, Common::SeekableReadStream *packet);
 
 	MPEGPSDemuxer *_demuxer;
+	bool _stopAtFirstFrame = false;
 
 	// A map from stream types to stream handlers
 	typedef Common::HashMap<int, MPEGStream *> StreamMap;


### PR DESCRIPTION
Please don't bother reviewing this until #7848 has been sorted out. That outcome could lead to major changes.



This adds the ReelMagic MPEG release of Return to Zork as a distinct
MADE game variant. It has its own database, resources, script
externals, and MPEG-1 assets.

The implementation:

- Repairs reserved frame-rate codes and scrambled P/B picture fields
  as streams are read.
- Corrects Layer II frames whose padding bit is set without a padding
  byte.
- Composites video beneath paletted graphics where palette index 0 is
  transparent.
- Implements ReelMagic externals 100-106 and the asynchronous,
  looping, and blocking playback modes used by the scripts.
- Keeps MPEG libraries optional for the other MADE games.

The default display preserves the MPEG's complete 240-line frame and
stretches the 200-line graphics over it. An engine option provides the
alternative 200-line video presentation.

Testing:

- MADE-only release builds with MPEG support enabled and disabled.
- Full intro playback: 3128 frames in about 104.3 seconds, with 2867
  picture headers and 245 audio padding bits repaired.
- Default 240-line and optional 200-line display modes.
- Interactive testing through the intro and opening scene.

This is stacked on #7848. Once that dependency lands, this PR will
contain only the MADE changes.
