### PR TITLE
SCUMM: RA: IO7: Fix virtual controller for Rebel Assault games

### DIFF
--- a/backends/platform/ios7/ios7_video.mm
+++ b/backends/platform/ios7/ios7_video.mm
@@ -92,6 +92,15 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	UILongPressGestureRecognizer *oneFingerLongPressGesture;
 	UILongPressGestureRecognizer *twoFingerLongPressGesture;
 	UILongPressGestureRecognizer *pencilTwoTapLongTouchGesture;
+	UIPinchGestureRecognizer *pinchKeyboard;
+	UISwipeGestureRecognizer *swipeRight;
+	UISwipeGestureRecognizer *swipeLeft;
+	UISwipeGestureRecognizer *swipeUp;
+	UISwipeGestureRecognizer *swipeDown;
+	UISwipeGestureRecognizer *swipeRight3;
+	UISwipeGestureRecognizer *swipeLeft3;
+	UISwipeGestureRecognizer *swipeUp3;
+	UISwipeGestureRecognizer *swipeDown3;
 	CGPoint touchesBegan;
 #endif
 }
@@ -255,51 +264,51 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	[pencilTwoTapLongTouchGesture setDelaysTouchesEnded:NO];
 	[pencilTwoTapLongTouchGesture setCancelsTouchesInView:NO];
 
-	UIPinchGestureRecognizer *pinchKeyboard = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(keyboardPinch:)];
+	pinchKeyboard = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(keyboardPinch:)];
 
-	UISwipeGestureRecognizer *swipeRight = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeRight:)];
+	swipeRight = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeRight:)];
 	swipeRight.direction = UISwipeGestureRecognizerDirectionRight;
 	swipeRight.numberOfTouchesRequired = 2;
 	swipeRight.delaysTouchesBegan = NO;
 	swipeRight.delaysTouchesEnded = NO;
 
-	UISwipeGestureRecognizer *swipeLeft = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeLeft:)];
+	swipeLeft = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeLeft:)];
 	swipeLeft.direction = UISwipeGestureRecognizerDirectionLeft;
 	swipeLeft.numberOfTouchesRequired = 2;
 	swipeLeft.delaysTouchesBegan = NO;
 	swipeLeft.delaysTouchesEnded = NO;
 
-	UISwipeGestureRecognizer *swipeUp = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeUp:)];
+	swipeUp = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeUp:)];
 	swipeUp.direction = UISwipeGestureRecognizerDirectionUp;
 	swipeUp.numberOfTouchesRequired = 2;
 	swipeUp.delaysTouchesBegan = NO;
 	swipeUp.delaysTouchesEnded = NO;
 
-	UISwipeGestureRecognizer *swipeDown = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeDown:)];
+	swipeDown = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(twoFingersSwipeDown:)];
 	swipeDown.direction = UISwipeGestureRecognizerDirectionDown;
 	swipeDown.numberOfTouchesRequired = 2;
 	swipeDown.delaysTouchesBegan = NO;
 	swipeDown.delaysTouchesEnded = NO;
 
-	UISwipeGestureRecognizer *swipeRight3 = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeRight:)];
+	swipeRight3 = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeRight:)];
 	swipeRight3.direction = UISwipeGestureRecognizerDirectionRight;
 	swipeRight3.numberOfTouchesRequired = 3;
 	swipeRight3.delaysTouchesBegan = NO;
 	swipeRight3.delaysTouchesEnded = NO;
 
-	UISwipeGestureRecognizer *swipeLeft3 = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeLeft:)];
+	swipeLeft3 = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeLeft:)];
 	swipeLeft3.direction = UISwipeGestureRecognizerDirectionLeft;
 	swipeLeft3.numberOfTouchesRequired = 3;
 	swipeLeft3.delaysTouchesBegan = NO;
 	swipeLeft3.delaysTouchesEnded = NO;
 
-	UISwipeGestureRecognizer *swipeUp3 = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeUp:)];
+	swipeUp3 = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeUp:)];
 	swipeUp3.direction = UISwipeGestureRecognizerDirectionUp;
 	swipeUp3.numberOfTouchesRequired = 3;
 	swipeUp3.delaysTouchesBegan = NO;
 	swipeUp3.delaysTouchesEnded = NO;
 
-	UISwipeGestureRecognizer *swipeDown3 = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeDown:)];
+	swipeDown3 = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(threeFingersSwipeDown:)];
 	swipeDown3.direction = UISwipeGestureRecognizerDirectionDown;
 	swipeDown3.numberOfTouchesRequired = 3;
 	swipeDown3.delaysTouchesBegan = NO;
@@ -583,6 +592,15 @@ bool iOS7_fetchEvent(InternalEvent *event) {
 	[twoFingerLongPressGesture setEnabled:enabled];
 	[pencilThreeTapGesture setEnabled:enabled];
 	[pencilTwoTapLongTouchGesture setEnabled:enabled];
+	[pinchKeyboard setEnabled:enabled];
+	[swipeLeft setEnabled:enabled];
+	[swipeRight setEnabled:enabled];
+	[swipeUp setEnabled:enabled];
+	[swipeDown setEnabled:enabled];
+	[swipeLeft3 setEnabled:enabled];
+	[swipeRight3 setEnabled:enabled];
+	[swipeUp3 setEnabled:enabled];
+	[swipeDown3 setEnabled:enabled];
 }
 #endif
 

--- a/engines/scumm/insane/rebel/rebel_gamepad.cpp
+++ b/engines/scumm/insane/rebel/rebel_gamepad.cpp
@@ -32,7 +32,7 @@ namespace {
 const char *const kIOSGamepadControllerKey = "gamepad_controller";
 const char *const kIOSGamepadControllerMinimalLayoutKey = "gamepad_controller_minimal_layout";
 const char *const kIOSGamepadControllerDirectionalInputKey = "gamepad_controller_directional_input";
-const int kIOSGamepadControllerDirectionalInputDpad = 1;
+const int kIOSGamepadControllerDirectionalInputThumbstick = 0;
 
 void saveDomainSetting(RebelIOSGamepadControllerState::SavedSetting &setting,
 		const Common::ConfigManager::Domain *domain, const char *key) {
@@ -84,10 +84,10 @@ void RebelIOSGamepadControllerState::enable() {
 	saveDomainSetting(_gamepadControllerMinimalLayout, domain, kIOSGamepadControllerMinimalLayoutKey);
 	saveDomainSetting(_gamepadControllerDirectionalInput, domain, kIOSGamepadControllerDirectionalInputKey);
 
-	// Same iOS virtual-controller profile used by Freescape: compact d-pad overlay.
+	// Same iOS virtual-controller profile used by Freescape: with thumbstick input for Rebel.
 	ConfMan.setBool(kIOSGamepadControllerKey, true, _domainName);
 	ConfMan.setBool(kIOSGamepadControllerMinimalLayoutKey, true, _domainName);
-	ConfMan.setInt(kIOSGamepadControllerDirectionalInputKey, kIOSGamepadControllerDirectionalInputDpad, _domainName);
+	ConfMan.setInt(kIOSGamepadControllerDirectionalInputKey, kIOSGamepadControllerDirectionalInputThumbstick, _domainName);
 	g_system->applyBackendSettings();
 	_active = true;
 #endif

--- a/engines/scumm/insane/rebel1/menu.cpp
+++ b/engines/scumm/insane/rebel1/menu.cpp
@@ -753,6 +753,11 @@ bool InsaneRebel1::notifyEvent(const Common::Event &event) {
 			event.joystick.button, event.type == Common::EVENT_JOYBUTTON_DOWN,
 			_menuActive, _interactiveVideoActive && !_menuActive,
 			_joystickAxisX, _joystickAxisY);
+		if (_interactiveVideoActive && !_menuActive &&
+			event.joystick.button == Common::JOYSTICK_BUTTON_A) {
+			_playerFired = event.type == Common::EVENT_JOYBUTTON_DOWN;
+			return true;
+		}
 	}
 
 	if (event.type == Common::EVENT_CUSTOM_BACKEND_ACTION_AXIS) {


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

ATTENTION TO AI USERS:

EVERY WORD of your code, comments, commit log messages, PR description, must be re-read by a human and checked for sanity, correctness and common sense. At any sight of AI slop, including lengthy LLM-oriented explanations, your PR will be closed.

On top of that, we created AI-specific guidelines https://github.com/scummvm/scummvm/blob/master/AI-GUIDELINES.md

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not, please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

We require linear history, so no merge commits are allowed.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->

This PR contains one fix for the virtual gamepad controller in the iOS backend where gesture recognisers interfered with the Apple virtual gamepad controller, causing problems to simultaneous button presses.

It also contain one fix in the RA engine to use the thumb stick controller element rather than the DPAD.
The A button is also used as shooting trigger whereas the X button is used to show/hide in the "on foot"-missions in RA2.