### PR TITLE
DIRECTOR: Fix Lingo point/rect operations and bitmap picture assignment

### DIFF
--- a/engines/director/castmember/bitmap.cpp
+++ b/engines/director/castmember/bitmap.cpp
@@ -33,9 +33,11 @@
 #include "director/director.h"
 #include "director/cast.h"
 #include "director/images.h"
+#include "director/channel.h"
 #include "director/movie.h"
 #include "director/picture.h"
 #include "director/score.h"
+#include "director/sprite.h"
 #include "director/types.h"
 #include "director/window.h"
 #include "director/castmember/bitmap.h"
@@ -1100,10 +1102,24 @@ void BitmapCastMember::setField(int field, const Datum &d) {
 			// This is a random PICT from somewhere,
 			// set the external flag so we remap the palette.
 			_external = true;
-			// Remove the canvas-space transformation
-			_regX -= _initialRect.left;
-			_regY -= _initialRect.top;
+			// Recenter the registration point on the new image, rounded to nearest.
 			_initialRect = Common::Rect(_picture->_surface.w, _picture->_surface.h);
+			_regX = (_picture->_surface.w + 1) / 2;
+			_regY = (_picture->_surface.h + 1) / 2;
+
+			// The castId is unchanged, so resize the sprites showing this cast.
+			Movie *movie = g_director->getCurrentMovie();
+			Score *score = movie ? movie->getScore() : nullptr;
+			if (score) {
+				for (uint i = 0; i < score->_channels.size(); i++) {
+					Channel *ch = score->_channels[i];
+					if (ch && ch->_sprite && ch->_sprite->_cast == this && !ch->_sprite->_stretch) {
+						ch->_sprite->_width = _initialRect.width();
+						ch->_sprite->_height = _initialRect.height();
+						ch->setDirty();
+					}
+				}
+			}
 		} else {
 			warning("BitmapCastMember::setField(): Wrong Datum type %d for kThePicture (or nullptr)", d.type);
 		}

--- a/engines/director/channel.cpp
+++ b/engines/director/channel.cpp
@@ -772,8 +772,10 @@ void Channel::replaceWidget(CastMemberID previousCastId, bool force) {
 			_widget->_priority = _priority;
 			_widget->draw();
 
-			if (_sprite->_cast->_type == kCastText || _sprite->_cast->_type == kCastButton) {
-
+			// Only auto-expanding text (and buttons) size the sprite from the widget:
+			// fixed text would re-add its shadow chrome each rebuild and creep larger.
+			if (_sprite->_cast->_type == kCastButton ||
+					(_sprite->_cast->_type == kCastText && !((Graphics::MacText *)_widget)->getFixDims())) {
 				_sprite->_width = _widget->_dims.width();
 				_sprite->_height = _widget->_dims.height();
 			}

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -3855,8 +3855,15 @@ void LB::b_inside(int nargs) {
 	Datum d;
 	Datum r2 = g_lingo->pop();
 	Datum p1 = g_lingo->pop();
-	TYPECHECK(r2, RECT);
-	TYPECHECK(p1, POINT);
+
+	// A sprite reference can be void before its init handler runs, giving a void
+	// rect; return FALSE rather than aborting the builtin with no value.
+	if (p1.type != POINT || r2.type != RECT) {
+		warning("LB::b_inside(): expected a point and a rect, got %s and %s", p1.type2str(), r2.type2str());
+		d = 0;
+		g_lingo->push(d);
+		return;
+	}
 
 	Common::Rect rect2(r2.u.farr->arr[0].asInt(), r2.u.farr->arr[1].asInt(), r2.u.farr->arr[2].asInt(), r2.u.farr->arr[3].asInt());
 	Common::Point point1(p1.u.farr->arr[0].asInt(), p1.u.farr->arr[1].asInt());

--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -3817,7 +3817,15 @@ void LB::b_intersect(int nargs) {
 	Common::Rect rect1(r1.u.farr->arr[0].asInt(), r1.u.farr->arr[1].asInt(), r1.u.farr->arr[2].asInt(), r1.u.farr->arr[3].asInt());
 	Common::Rect rect2(r2.u.farr->arr[0].asInt(), r2.u.farr->arr[1].asInt(), r2.u.farr->arr[2].asInt(), r2.u.farr->arr[3].asInt());
 
-	d = rect1.intersects(rect2);
+	// Return the overlapping area as a rect (rect(0,0,0,0) if none).
+	Common::Rect inter = rect1.findIntersectingRect(rect2);
+
+	d.type = RECT;
+	d.u.farr = new FArray;
+	d.u.farr->arr.push_back(Datum((int)inter.left));
+	d.u.farr->arr.push_back(Datum((int)inter.top));
+	d.u.farr->arr.push_back(Datum((int)inter.right));
+	d.u.farr->arr.push_back(Datum((int)inter.bottom));
 
 	g_lingo->push(d);
 }

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -1465,6 +1465,17 @@ int Datum::equalTo(const Datum &d, bool ignoreCase) const {
 		} else {
 			return compareStringEquality(asString(), d.asString());
 		}
+	case ARRAY:
+	case POINT:
+	case RECT:
+		// Compare element by element.
+		if (u.farr->arr.size() != d.u.farr->arr.size())
+			return 0;
+		for (uint i = 0; i < u.farr->arr.size(); i++) {
+			if (!u.farr->arr[i].equalTo(d.u.farr->arr[i], ignoreCase))
+				return 0;
+		}
+		return 1;
 	case MEDIA:
 	case OBJECT:
 		return u.obj == d.u.obj;

--- a/engines/director/lingo/xlibs/m/movutils.cpp
+++ b/engines/director/lingo/xlibs/m/movutils.cpp
@@ -20,8 +20,11 @@
  */
 
 #include "common/util.h"
+#include "graphics/managed_surface.h"
 
 #include "director/director.h"
+#include "director/picture.h"
+#include "director/window.h"
 #include "director/lingo/lingo.h"
 #include "director/lingo/lingo-object.h"
 #include "director/lingo/lingo-utils.h"
@@ -371,7 +374,45 @@ XOBJSTUB(MovUtilsXObj::m_bitOr, 0)
 XOBJSTUB(MovUtilsXObj::m_bitXOr, 0)
 XOBJSTUB(MovUtilsXObj::m_bitNot, 0)
 XOBJSTUB(MovUtilsXObj::m_bitStringToNumber, 0)
-XOBJSTUB(MovUtilsXObj::m_stageToCast, 0)
+void MovUtilsXObj::m_stageToCast(int nargs) {
+	Datum result(0);
+	if (nargs != 1) {
+		warning("MovUtilsXObj::m_stageToCast(): expected 1 arg");
+		g_lingo->dropStack(nargs);
+	} else {
+		Datum rectArg = g_lingo->pop();
+		if (rectArg.type != RECT) {
+			warning("MovUtilsXObj::m_stageToCast(): expected a rect, got %s", rectArg.type2str());
+		} else {
+			Graphics::ManagedSurface *stage = g_director->getStage()->getSurface();
+			Common::Rect rect(rectArg.u.farr->arr[0].asInt(), rectArg.u.farr->arr[1].asInt(),
+				rectArg.u.farr->arr[2].asInt(), rectArg.u.farr->arr[3].asInt());
+			rect.clip(Common::Rect(stage->w, stage->h));
+
+			if (rect.isEmpty()) {
+				warning("MovUtilsXObj::m_stageToCast(): capture rect is empty");
+			} else {
+				// Snapshot the requested region of the stage into a picture.
+				Picture *pic = new Picture();
+				pic->_surface.copyFrom(stage->getSubArea(rect));
+
+				const byte *palette = g_director->_wm->getPalette();
+				if (palette) {
+					int numColors = MIN<int>(g_director->_wm->getPaletteSize(), 256);
+					pic->_paletteColors = numColors;
+					memcpy(pic->_palette, palette, numColors * 3);
+				}
+
+				PictureReference *ref = new PictureReference;
+				ref->_picture = pic;
+				result.type = PICTUREREF;
+				result.u.picture = ref;
+			}
+		}
+	}
+	g_lingo->push(result);
+}
+
 XOBJSTUB(MovUtilsXObj::m_stageToDIB, 0)
 XOBJSTUB(MovUtilsXObj::m_stageToPICT, 0)
 XOBJSTUB(MovUtilsXObj::m_cRtoCRLF, "")


### PR DESCRIPTION
- Lingo point/rect/list equality:`Datum::equalTo()` had no case for POINT, RECT or ARRAY, so `rect = rect` (and point/list equality) always returned false. Now compared element by element.
- `intersect()` returned a boolean instead of the overlapping rectangle. Now returns the intersection as a rect (`rect(0,0,0,0)` when disjoint).
- `inside()` no longer aborts the builtin on a non-point/rect argument; returns FALSE instead.
- `set the picture of member`: recenter the registration point on the new image and resize the unstretched sprites showing the cast, so a resized picture no longer renders off-centre and clipped.
- `MovUtils::mStageToCast` implemented (was a stub returning 0); captures a stage region into a picture and returns it as a picture reference.
- Fixed text sprites no longer grow on every widget rebuild.
