### PR TITLE
SLUDGE: self-contained headers

### DIFF
--- a/engines/sludge/freeze.h
+++ b/engines/sludge/freeze.h
@@ -21,7 +21,10 @@
 #ifndef SLUDGE_FREEZE_H
 #define SLUDGE_FREEZE_H
 
-#include "graphics/surface.h"
+#include "common/list.h"
+#include "graphics/managed_surface.h"
+
+#include "sludge/graphics.h"
 
 namespace Sludge {
 

--- a/engines/sludge/imgloader.h
+++ b/engines/sludge/imgloader.h
@@ -24,6 +24,14 @@
 
 #include "common/file.h"
 
+namespace Common {
+class SeekableReadStream;
+}
+
+namespace Graphics {
+class ManagedSurface;
+}
+
 namespace Sludge {
 
 class ImgLoader {

--- a/engines/sludge/main_loop.h
+++ b/engines/sludge/main_loop.h
@@ -21,6 +21,10 @@
 #ifndef SLUDGE_MAIN_LOOP_H
 #define SLUDGE_MAIN_LOOP_H
 
+namespace Common { 
+class String; 
+}
+
 namespace Sludge {
 
 int main_loop(Common::String filename);

--- a/engines/sludge/moreio.h
+++ b/engines/sludge/moreio.h
@@ -21,6 +21,12 @@
 #ifndef SLUDGE_MOREIO_H
 #define SLUDGE_MOREIO_H
 
+namespace Common {
+class SeekableReadStream;
+class String;
+class WriteStream;
+}
+
 namespace Sludge {
 
 // Read & Write

--- a/engines/sludge/objtypes.h
+++ b/engines/sludge/objtypes.h
@@ -21,6 +21,14 @@
 #ifndef SLUDGE_OBJTYPES_H
 #define SLUDGE_OBJTYPES_H
 
+#include "common/list.h"
+#include "common/str.h"
+
+namespace Common {
+class SeekableReadStream;
+class WriteStream;
+}
+
 namespace Sludge {
 
 class SludgeEngine;

--- a/engines/sludge/people.h
+++ b/engines/sludge/people.h
@@ -23,6 +23,11 @@
 
 #include "common/list.h"
 
+namespace Common {
+class SeekableReadStream;
+class WriteStream;
+}
+
 namespace Sludge {
 
 struct FrozenStuffStruct;

--- a/engines/sludge/region.h
+++ b/engines/sludge/region.h
@@ -21,9 +21,18 @@
 #ifndef SLUDGE_REGION_H
 #define SLUDGE_REGION_H
 
+#include "common/list.h"
+
+namespace Common {
+class SeekableReadStream;
+class WriteStream;
+}
+
 namespace Sludge {
 
+struct FrozenStuffStruct;
 struct ObjectType;
+class SludgeEngine;
 
 struct ScreenRegion {
 	int x1, y1, x2, y2, sX, sY, di;

--- a/engines/sludge/savedata.h
+++ b/engines/sludge/savedata.h
@@ -21,6 +21,14 @@
 #ifndef SLUDGE_SAVEDATA_H
 #define SLUDGE_SAVEDATA_H
 
+#include "common/types.h"
+
+namespace Common {
+class SeekableReadStream;
+class String;
+class WriteStream;
+}
+
 namespace Sludge {
 
 struct StackHandler;

--- a/engines/sludge/saveload.h
+++ b/engines/sludge/saveload.h
@@ -23,6 +23,7 @@
 
 namespace Common {
 class OutSaveFile;
+class String;
 }
 
 namespace Sludge {

--- a/engines/sludge/speech.h
+++ b/engines/sludge/speech.h
@@ -23,9 +23,17 @@
 
 #include "sludge/sprites.h"
 
+namespace Common {
+class SeekableReadStream;
+class WriteStream;
+}
+
 namespace Sludge {
 
+struct FrozenStuffStruct;
 struct ObjectType;
+struct OnScreenPerson;
+class SludgeEngine;
 
 struct SpeechLine {
 	Common::String textLine;

--- a/engines/sludge/statusba.h
+++ b/engines/sludge/statusba.h
@@ -21,7 +21,16 @@
 #ifndef SLUDGE_STATUSBA_H
 #define SLUDGE_STATUSBA_H
 
+#include "sludge/sprites.h"
+
+namespace Common {
+class SeekableReadStream;
+class WriteStream;
+}
+
 namespace Sludge {
+
+class SludgeEngine;
 
 struct StatusBar {
 	Common::String text;

--- a/engines/sludge/timing.h
+++ b/engines/sludge/timing.h
@@ -21,6 +21,8 @@
 #ifndef SLUDGE_TIMING_H
 #define SLUDGE_TIMING_H
 
+#include "common/types.h"
+
 namespace Sludge {
 
 class Timer {

--- a/engines/sludge/variable.h
+++ b/engines/sludge/variable.h
@@ -21,8 +21,11 @@
 #ifndef SLUDGE_VARIABLE_H
 #define SLUDGE_VARIABLE_H
 
+#include "common/types.h"
+
 namespace Common {
 class SeekableReadStream;
+class String;
 class WriteStream;
 }
 

--- a/engines/sludge/zbuffer.h
+++ b/engines/sludge/zbuffer.h
@@ -21,6 +21,8 @@
 #ifndef SLUDGE_ZBUFFER_H
 #define SLUDGE_ZBUFFER_H
 
+#include "common/types.h"
+
 namespace Sludge {
 
 struct ZBufferData {


### PR DESCRIPTION
Add includes and declarations to make the headers self-contained. 

Self-containedness means that the header file contains all the declarations and includes needed for the material it references. A header is considered self-contained when this snippet would compile (but not necessarily link) without errors:
```
#include "headerfile.h"
int main() { return 0; }
```

The benefit is that code becomes insensitive to include order changes, and that headers can always be used directly without implicitly requiring previous includes.

This PR is a test balloon to check the general appetite for this subject matter. Are self-contained headers a helpful code quality goal or is it busywork adding commit noise?
Should we perhaps strive for this goal in the general subsystems like common and graphics, but not the individual engines?
