### PR TITLE
GUI: Let Ctrl and Alt hotkeys through when a list has focus

### DIFF
--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -556,10 +556,13 @@ bool ListWidget::handleKeyDown(Common::KeyState state) {
 	bool dirty = false;
 	int oldSelectedItem = _selectedItem;
 
-	if (!_editMode && state.keycode <= Common::KEYCODE_z && Common::isPrint(state.ascii)) {
+	if (!_editMode && !(state.flags & (Common::KBD_CTRL | Common::KBD_ALT)) &&
+			state.keycode <= Common::KEYCODE_z && Common::isPrint(state.ascii)) {
 		// Quick selection mode: Go to first list item starting with this key
 		// (or a substring accumulated from the last couple key presses).
 		// Only works in a useful fashion if the list entries are sorted.
+		// Keys held with Ctrl or Alt are left alone, so that they can still
+		// reach the dialog's hotkey handling.
 		uint32 time = g_system->getMillis();
 		if (_quickSelectTime < time) {
 			_quickSelectStr = (char)state.ascii;


### PR DESCRIPTION
`ListWidget`'s quick selection mode claims every printable key without checking for modifiers, and reports the key as handled. Because `Dialog::handleKeyDown()` gives the focused widget first refusal on key presses, no dialog hotkey works while a list holds the focus.

In the launcher the game list has the focus by default, so `Ctrl+O` for Global Options, `Ctrl+G` for Game Options and `Ctrl+S` to start a game all do nothing — `Ctrl+O` is picked up by quick selection instead and moves the selection to a different game.

This skips quick selection for keys held with Ctrl or Alt, so they reach the hotkey handling further down `Dialog::handleKeyDown()`. Plain letters still quick-select as before.

Tested on Windows (MinGW/SDL2): `Ctrl+O` now opens Global Options with the game list focused, and typing a letter still jumps to the matching entry.
