### PR TITLE
GOB: add kFeaturesTrueColor to german ADI4 variant

### DIFF
--- a/engines/gob/detection/tables_adi4.h
+++ b/engines/gob/detection/tables_adi4.h
@@ -177,7 +177,7 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kFeatures640x480,
+	kFeaturesTrueColor | kFeatures640x480,
 	0, 0, 0
 },
 {


### PR DESCRIPTION
<img width="1330" height="1047" alt="Bildschirmfoto vom 2026-08-21 14-27-49" src="https://github.com/user-attachments/assets/9d165b92-da28-48e6-b850-4dc34e7b9a95" />


The intro gets now loaded properly and titlescreen / adi room is now usable for german version 4.01

The issue was in 00001449:		o7_loadImage("A_PARCHE.TGA", 99, 0, 0, 640, 34, 0, 34, 0); (LIBAPPELL.TOT)

Without kFeaturesTrueColor it crash after creating the user while entering adis room on loading A_PARCHE.TGA due to unknown dithering error message 