### PR TITLE
GOB: add kFeaturesTrueColor to ADI4 variants

### DIFF
--- a/engines/gob/detection/tables_adi4.h
+++ b/engines/gob/detection/tables_adi4.h
@@ -138,7 +138,7 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kFeatures640x480,
+	kFeaturesTrueColor | kFeatures640x480,
 	0, "GA2INTRO.TOT", 0
 },
 {
@@ -151,7 +151,7 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kFeatures640x480,
+	kFeaturesTrueColor | kFeatures640x480,
 	"simule.stk", "INTRODD.TOT", 0 // INTRODD.TOT brings up a main menu to select various environmental learning tasks.
 },
 {
@@ -177,7 +177,7 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kFeatures640x480,
+	kFeaturesTrueColor | kFeatures640x480,
 	0, 0, 0
 },
 {

--- a/engines/gob/detection/tables_adi4.h
+++ b/engines/gob/detection/tables_adi4.h
@@ -222,7 +222,7 @@
 		ADGF_DEMO | ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kFeatures640x480,
+	kFeaturesTrueColor | kFeatures640x480,
 	0, 0, 0
 },
 {
@@ -235,7 +235,7 @@
 		ADGF_DEMO | ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kFeatures640x480,
+	kFeaturesTrueColor | kFeatures640x480,
 	0, 0, 0
 },
 

--- a/engines/gob/detection/tables_adi4.h
+++ b/engines/gob/detection/tables_adi4.h
@@ -44,7 +44,7 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kFeatures640x480,
+	kFeaturesTrueColor | kFeatures640x480,
 	0, 0, 0
 },
 {
@@ -70,7 +70,7 @@
 		ADGF_UNSTABLE,
 		GUIO1(GUIO_NOASPECT)
 	},
-	kFeatures640x480,
+	kFeaturesTrueColor | kFeatures640x480,
 	0, 0, 0
 },
 {

--- a/engines/gob/detection/tables_adi4.h
+++ b/engines/gob/detection/tables_adi4.h
@@ -232,7 +232,7 @@
 		AD_ENTRY1s("intro.stk", "d41d8cd98f00b204e9800998ecf8427e", 0),
 		FR_FRA,
 		kPlatformWindows,
-		ADGF_DEMO | ADGF_UNSTABLE,
+		ADGF_DEMO,
 		GUIO1(GUIO_NOASPECT)
 	},
 	kFeaturesTrueColor | kFeatures640x480,


### PR DESCRIPTION
Now everything is correct and all my german variants have kFeaturesTrueColor

Followup from #7859 

Sorry for the trouble :)


<img width="1330" height="1047" alt="Bildschirmfoto vom 2026-08-21 14-27-49" src="https://github.com/user-attachments/assets/9d165b92-da28-48e6-b850-4dc34e7b9a95" />


The intro gets now loaded properly and titlescreen / adi room is now usable for german version 4.01

The issue was in 00001449:		o7_loadImage("A_PARCHE.TGA", 99, 0, 0, 640, 34, 0, 34, 0); (LIBAPPELL.TOT)

Without kFeaturesTrueColor it crash after creating the user while entering adis room on loading A_PARCHE.TGA due to unknown dithering error message 