### PR TITLE
KINGDOM: Play stereo music in stereo mode

### DIFF
--- a/engines/kingdom/detection.cpp
+++ b/engines/kingdom/detection.cpp
@@ -54,7 +54,7 @@ static const ADGameDescription gameDescriptions[] = {
 		Common::EN_ANY,
 		Common::kPlatformDOS,
 		ADGF_NO_FLAGS,
-		GUIO0()
+		GUIO1(GUIO_GAMEOPTIONS1)
 	},
 
 	// Kingdom 3DO, provided by Strangerke

--- a/engines/kingdom/kingdom.cpp
+++ b/engines/kingdom/kingdom.cpp
@@ -63,6 +63,8 @@ KingdomGame::KingdomGame(OSystem *syst, const ADGameDescription *gameDesc) : Eng
 
 	_showHotspots = false;
 
+	_monoSound = false;
+
 	const Common::FSNode gameDataDir(ConfMan.getPath("path"));
 	SearchMan.addSubDirectoryMatching(gameDataDir, "MAPS");
 	SearchMan.addSubDirectoryMatching(gameDataDir, "PICS");
@@ -169,6 +171,8 @@ Common::Error KingdomGame::run() {
 	setDebugger(new Console(this));
 
 	_logic = new Logic(this);
+
+	_monoSound = ConfMan.getBool("mono_sound");
 
 	setupPics();
 	initTools();
@@ -926,10 +930,22 @@ void KingdomGame::playSound(int idx) {
 		return;
 
 	int realIdx = _soundNumber + 200; // Or +250, depending in the original on the sound card
+	byte audioFlags = Audio::FLAG_UNSIGNED | Audio::FLAG_LITTLE_ENDIAN;
+	if (_monoSound)
+		realIdx += 50;
+	else
+		audioFlags |= Audio::FLAG_STEREO;
+
+	if (realIdx <= 200 || realIdx > 300) {
+		warning("Invalid sound index %d", realIdx);
+		return;
+	}
+
 	debug("PlaySound %d : %s", idx, _rezNames[realIdx]);
 
 	Common::SeekableReadStream *soundStream = loadAResource(realIdx);
-	Audio::RewindableAudioStream *rewindableStream = Audio::makeRawStream(soundStream, 22050, Audio::FLAG_UNSIGNED | Audio::FLAG_LITTLE_ENDIAN, DisposeAfterUse::YES);
+	Audio::RewindableAudioStream *rewindableStream = Audio::makeRawStream(soundStream, 22050, audioFlags, DisposeAfterUse::YES);
+
 	_mixer->setVolumeForSoundType(Audio::Mixer::kMusicSoundType, Audio::Mixer::kMaxMixerVolume);
 	_mixer->playStream(Audio::Mixer::kMusicSoundType, &_soundHandle, rewindableStream);
 //  In the original, there's an array describing whether a sound should loop or not.

--- a/engines/kingdom/kingdom.h
+++ b/engines/kingdom/kingdom.h
@@ -160,6 +160,7 @@ namespace Kingdom {
 		int _mouseValue;
 		int _cursorDef; // TODO: Could be removed by using the return value of CursorTypeExit()
 		int _oldCursorDef; // CHECKME: Unused in our implementation?
+		bool _monoSound;
 
 		Common::Point _cursorPos;
 		Common::Point _oldCursorPos; // CHECKME: Unused in out implementation?

--- a/engines/kingdom/metaengine.cpp
+++ b/engines/kingdom/metaengine.cpp
@@ -24,6 +24,7 @@
 #include "common/savefile.h"
 #include "engines/advancedDetector.h"
 #include "common/file.h"
+#include "common/translation.h"
 
 #include "kingdom/kingdom.h"
 
@@ -34,6 +35,21 @@ namespace Kingdom {
 const char *KingdomGame::getGameId() const { return _gameDescription->gameId; }
 Common::Platform KingdomGame::getPlatform() const { return _gameDescription->platform; }
 
+static const ADExtraGuiOptionsMap optionsList[] = {
+	{
+		GUIO_GAMEOPTIONS1,
+		{
+			_s("Mono music"),
+			_s("Use monophonic music"),
+			"mono_sound",
+			false,
+			0,
+			0
+		}
+	},
+	AD_EXTRA_GUI_OPTIONS_TERMINATOR
+};
+
 } // End of namespace Kingdom
 
 
@@ -41,6 +57,10 @@ class KingdomMetaEngine : public AdvancedMetaEngine<ADGameDescription> {
 public:
 	const char *getName() const override {
 		return "kingdom";
+	}
+
+	const ADExtraGuiOptionsMap *getAdvancedExtraGuiOptions() const override {
+		return Kingdom::optionsList;
 	}
 
 	bool hasFeature(MetaEngineFeature f) const override;


### PR DESCRIPTION
Fixes music playback in DOS (tested with GOG) version

In DOS version there are two folders for sound (music) files. One is "SOUNDM" with MSD files (mono) and the other is "SOUNDS" with SSD files (stereo). Before the fix, the engine would use the stereo version of a sound resource, but would play it in MONO which resulted in bad sound, eg. in the menu screen after the intro cutscenes.

This PR introduces a GUI option to opt in for the mono music, but by default will use the stereo music files and fixes the bad sound when playing music.

Note that the PR assumes that all versions of the game have available the stereo version of the music.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

ATTENTION TO AI USERS:

EVERY WORD of your code, comments, commit log messages, PR description, must be re-read by a human and checked for sanity, correctness and common sense. At any sight of AI slop, including lengthy LLM-oriented explanations, your PR will be closed.

On top of that, we created AI-specific guidelines https://github.com/scummvm/scummvm/blob/master/AI-GUIDELINES.md

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not, please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

We require linear history, so no merge commits are allowed.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
