### PR TITLE
GOB: mark Addi Simule as stable

### DIFF
--- a/engines/gob/detection/tables_adi4.h
+++ b/engines/gob/detection/tables_adi4.h
@@ -148,7 +148,7 @@
 		AD_ENTRY1s("simule.stk", "66d97fe54bbf8ea4bbb18534cb28b13f", 2523796),
 		DE_DEU,
 		kPlatformWindows,
-		ADGF_UNSTABLE,
+		ADGF_NO_FLAGS,
 		GUIO1(GUIO_NOASPECT)
 	},
 	kFeaturesTrueColor | kFeatures640x480,


### PR DESCRIPTION
Addi Simule can be played now, the blackscreen issue is gone with the kFeaturesTrueColor fix and is fully playable