### PR TITLE
GUI: Prevent use-after-free in `_tooltip`

### DIFF
--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -701,12 +701,12 @@ void GuiManager::runLoop() {
 						wdg->handleTooltipUpdate(_lastMousePosition.x + activeDialog->_x - wdg->getAbsX(), _lastMousePosition.y + activeDialog->_y - wdg->getAbsY());
 
 					if (wdg->hasTooltip()) {
-						Tooltip *tooltip = new Tooltip();
-						tooltip->setup(activeDialog, wdg, _lastMousePosition.x, _lastMousePosition.y);
-						_tooltip = tooltip;
+						_tooltip = new Tooltip();
+						_tooltip->setup(activeDialog, wdg, _lastMousePosition.x, _lastMousePosition.y);
 						_tooltip->runModal();
 						// _tooltip is reset in closeTopDialog
-						delete tooltip;
+						delete _tooltip;
+						_tooltip = nullptr;
 					}
 				}
 			}


### PR DESCRIPTION
Modal dialog tooltips are created and then deleted, but the
_tooltip pointer is not reset to `nullptr` afterwards.

This can lead to use-after-free after deleting a tooltip.
(I did run into this with an "unsupported" game showing a modal dialog,
closing it triggers the UAF - found w/ ASAN on msvc build)