### PR TITLE
MADS: Fix additional sound problems

### DIFF
--- a/engines/mads/core/speech.cpp
+++ b/engines/mads/core/speech.cpp
@@ -65,6 +65,7 @@ void speech_shutdown() {
 		speech_stream = nullptr;
 	}
 
+	global_speech_ready = -1;
 	speech_system_active = false;
 }
 
@@ -128,6 +129,7 @@ void speech_play(const char *resName, int id) {
 		g_engine->playSpeech(speech);
 
 	speech_stream = nullptr;
+	global_speech_ready = -1;
 }
 
 void speech_all_off() {
@@ -143,6 +145,7 @@ void speech_go() {
 		g_engine->playSpeech(speech_stream);
 		speech_stream = nullptr;
 	}
+	global_speech_ready = -1;
 }
 
 void global_speech(int id) {

--- a/engines/mads/core/speech.cpp
+++ b/engines/mads/core/speech.cpp
@@ -38,7 +38,7 @@ Audio::AudioStream *speech_stream;
 
 
 struct SpeechDir {
-	int16 field0 = 0;
+	int16 sampleRate = 0;
 	int16 compression = 0;
 	int16 field4 = 0, field6 = 0, field8 = 0;
 	int32 size = 0;
@@ -50,7 +50,8 @@ struct SpeechDir {
 
 
 void SpeechDir::load(Common::SeekableReadStream *src) {
-	src->readMultipleLE(field0, compression, field4, field6, field8, size, offset);
+	src->readMultipleLE(sampleRate, compression, field4, field6, field8, size,
+		offset);
 }
 
 void speech_init() {
@@ -108,7 +109,7 @@ Audio::AudioStream *speech_load(const char *resName, int id, bool) {
 
 	// At this point we have valid data
 	memStream = new Common::MemoryReadStream(load_buf, speechDir.size, DisposeAfterUse::YES);
-	audioStream = Audio::makeRawStream(memStream, g_engine->getGameID() == GType_RexNebular ? 8192 : 11025,
+	audioStream = Audio::makeRawStream(memStream, speechDir.sampleRate,
 		Audio::FLAG_UNSIGNED, DisposeAfterUse::YES);
 
 done:

--- a/engines/mads/dragonsphere/sound/asound.cpp
+++ b/engines/mads/dragonsphere/sound/asound.cpp
@@ -681,13 +681,10 @@ void ASound::writeFrequency() {
 	uint16 aReg = (uint16)chanNum + 0xA0;
 	uint16 bReg = (uint16)chanNum + 0xB0;
 
-	/* Note is 1-based; _octaveTranspose shifts by whole octaves. */
-	int note = (int)ch->_note + (int)ch->_octaveTranspose - 1;
+	/* The native driver performs this addition in an 8-bit register. */
+	byte note = (byte)(ch->_note + ch->_octaveTranspose - 1);
 	int octave = note / 12;
 	int semi = note % 12;
-	if (semi < 0) {
-		semi += 12; --octave;
-	}
 
 	/* F-number from table, with optional signed transpose offset. */
 	int16 fnum = (int16)SEMITONE_FREQ_TABLE[semi] + (int16)(int8)ch->_transpose;
@@ -726,14 +723,11 @@ void ASound::writeArpeggio() {
 	uint16 aReg = (uint16)chanNum + 0xA0;
 	uint16 bReg = (uint16)chanNum + 0xB0;
 
-	/* dl = _note + _octaveTranspose + _writeVolumePending - 1 */
-	int note = (int)ch->_note + (int)ch->_octaveTranspose
-		+ (int)ch->_writeVolumePending - 1;
+	/* The native driver performs these additions in an 8-bit register. */
+	byte note = (byte)(ch->_note + ch->_octaveTranspose
+		+ ch->_writeVolumePending - 1);
 	int octave = note / 12;
 	int semi = note % 12;
-	if (semi < 0) {
-		semi += 12; --octave;
-	}
 
 	uint16 freqEntry = SEMITONE_FREQ_TABLE[semi];
 	uint8  fnHigh = (uint8)((freqEntry >> 8) & 0x03);

--- a/engines/mads/dragonsphere/sound/gsound.cpp
+++ b/engines/mads/dragonsphere/sound/gsound.cpp
@@ -199,6 +199,13 @@ bool GSound::validateOverlay(const GSoundDriverData &driverData) {
 }
 
 bool GSound::contains(const byte *ptr, uint32 count) const {
+	// Fade completion redirects the channel to this native { 0, 0 }
+	// termination stream before the poller makes the channel inactive.
+	if (ptr == _silenceStream)
+		return count <= sizeof(_silenceStream);
+	if (ptr == _silenceStream + 1)
+		return count <= sizeof(_silenceStream) - 1;
+
 	if (_soundData.empty())
 		return false;
 	const byte *start = &_soundData[0];

--- a/engines/mads/dragonsphere/sound/gsound.cpp
+++ b/engines/mads/dragonsphere/sound/gsound.cpp
@@ -217,6 +217,11 @@ int8 GSound::readSignedByte(byte *&pSrc) {
 	return (int8)readByte(pSrc);
 }
 
+int GSound::readCenteredValue(byte *&pSrc) {
+	const int value = readSignedByte(pSrc);
+	return 64 + (value >= 0 ? value / 2 : (value - 1) / 2);
+}
+
 byte GSound::readByte(byte *&pSrc) {
 	if (!contains(pSrc + 1))
 		error("GSOUND bytecode read outside %s", _driverData.filename);
@@ -875,24 +880,24 @@ dispatch:
 			sendPan(channel);
 			goto dispatch;
 		case 0xF1:
+			channel._volume = readCenteredValue(pSrc);
+			channel._pSrc += 2;
+			sendVolume(channel);
+			goto dispatch;
+		case 0xF2:
 			channel._pitchBend = readByte(pSrc);
 			channel._pSrc += 2;
 			sendPitchBend(midiChannel, channel._pitchBend);
 			goto dispatch;
-		case 0xF2:
+		case 0xF3:
 			channel._volumeFadeReload = readByte(pSrc);
 			channel._volumeFadeStep = readSignedByte(pSrc);
 			channel._volumeFadeCounter = 1;
 			channel._pSrc += 3;
 			goto dispatch;
-		case 0xF3:
-			channel._velocity = readByte(pSrc);
-			channel._pSrc += 2;
-			goto dispatch;
 		case 0xF4:
-			channel._volume = readByte(pSrc);
+			channel._velocity = readCenteredValue(pSrc);
 			channel._pSrc += 2;
-			sendVolume(channel);
 			goto dispatch;
 		case 0xF5:
 			channel._pitchBendFadeReload = readByte(pSrc);

--- a/engines/mads/dragonsphere/sound/gsound.cpp
+++ b/engines/mads/dragonsphere/sound/gsound.cpp
@@ -168,6 +168,9 @@ bool GSound::validateOverlay(const GSoundDriverData &driverData) {
 	if (file.read(identity, 21) != 21)
 		return false;
 	identity[21] = 0;
+	if (identity[11] != '0' + driverData.section)
+		return false;
+	identity[11] = 'N';
 	if (Common::String(identity) != "Dragon GM  N12-21-93")
 		return false;
 

--- a/engines/mads/dragonsphere/sound/gsound.h
+++ b/engines/mads/dragonsphere/sound/gsound.h
@@ -190,6 +190,7 @@ private:
 	void applyFades(GSoundChannel &channel);
 
 	int8 readSignedByte(byte *&pSrc);
+	int readCenteredValue(byte *&pSrc);
 	byte readByte(byte *&pSrc);
 	uint16 readWord(byte *&pSrc);
 	byte *readRoot(byte *&pSrc);

--- a/engines/mads/dragonsphere/sound/rsound.cpp
+++ b/engines/mads/dragonsphere/sound/rsound.cpp
@@ -981,7 +981,7 @@ dispatch:
 				ch->_pSrc = ch->_outerLoopPtr;
 			}
 			ch->_innerLoopPtr = ch->_pSrc;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xFF: {
 			// End an inner loop. The restart pointer is the beginning of
@@ -1001,7 +1001,7 @@ dispatch:
 			} else {
 				ch->_pSrc = ch->_innerLoopPtr;
 			}
-			goto post_keyon;
+			goto dispatch;
 		}
 
 		// ---- Loop / restart-pointer opcodes ----
@@ -1014,7 +1014,7 @@ dispatch:
 				ch->_innerLoopPtr = ch->_soundData;
 				ch->_outerLoopPtr = ch->_soundData;
 			}
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xFC: {
 			byte *ptr = loadData(readScriptWord(pSrc));
@@ -1023,17 +1023,17 @@ dispatch:
 			ch->_innerLoopPtr = ptr;
 			ch->_outerLoopPtr = ptr;
 			ch->_soundData = ptr;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xFB: { // unconditional jump, no bookkeeping
 			ch->_pSrc = loadData(readScriptWord(pSrc));
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xFA: { // "call": jump, saving a resume point
 			byte *target = loadData(readScriptWord(pSrc));
 			ch->_branchTarget = ch->_pSrc + 3;
 			ch->_pSrc = target;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xF9: { // "return"
 			if (ch->_branchTarget) {
@@ -1042,25 +1042,25 @@ dispatch:
 			} else {
 				ch->_pSrc++;
 			}
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xF8: {
 			ch->_program = readScriptByte(pSrc);
 			ch->_pSrc += 2;
 			sendProgramChange(midiChannel, ch->_program);
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xF7: {
 			ch->_noteOffset = readScriptByte(pSrc);
 			ch->_keyOnDelayOverride = 0;
 			ch->_pSrc += 2;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xF6: {
 			ch->_keyOnDelayOverride = readScriptByte(pSrc);
 			ch->_noteOffset = 0;
 			ch->_pSrc += 2;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xF5: {
 			ch->_pitchBendFadeReload = readScriptByte(pSrc);
@@ -1068,51 +1068,50 @@ dispatch:
 			ch->_pitchBendFadeCount = readScriptByte(pSrc);
 			ch->_pitchBendFadeCounter = 1;
 			ch->_pSrc += 4;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xF4: {
-			ch->_volume = readScriptByte(pSrc);
-			ch->_pSrc += 2;
-			sendVolume(ch);
-			goto post_keyon;
-		}
-		case 0xF3: {
 			ch->_velocity = readScriptByte(pSrc);
 			ch->_pSrc += 2;
-			goto post_keyon;
+			goto dispatch;
 		}
-		case 0xF2: {
+		case 0xF3: {
 			ch->_volumeFadeReload = readScriptByte(pSrc);
 			ch->_volumeFadeStep = readScriptByte(pSrc);
 			ch->_volumeFadeCounter = 1;
 			ch->_pSrc += 3;
-			goto post_keyon;
+			goto dispatch;
 		}
-		case 0xF1: {
-			int pitchBend = readScriptByte(pSrc);
-			if (_usesDemoOpcodeSemantics || !ch->_pendingStop)
-				ch->_pitchBend = pitchBend;
+		case 0xF2: {
+			ch->_pitchBend = readScriptByte(pSrc);
 			ch->_pSrc += 2;
 			sendPitchBend(midiChannel, ch->_pitchBend);
-			goto post_keyon;
+			goto dispatch;
+		}
+		case 0xF1: {
+			if (!ch->_pendingStop)
+				ch->_volume = readScriptByte(pSrc);
+			ch->_pSrc += 2;
+			sendVolume(ch);
+			goto dispatch;
 		}
 		case 0xF0: {
 			ch->_pan = readScriptByte(pSrc);
 			sendPan(midiChannel, ch->_pan);
 			ch->_pSrc += 2;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xEF: {
 			ch->_panFadeReload = readScriptByte(pSrc);
 			ch->_panFadeStep = readScriptByte(pSrc);
 			ch->_panFadeCounter = 1;
 			ch->_pSrc += 3;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xEE: {
 			ch->_transpose = readScriptByte(pSrc);
 			ch->_pSrc += 2;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xED: {
 			// ---- Chord event: [count][note1..noteN][duration] ----

--- a/engines/mads/forest/sound/digi.cpp
+++ b/engines/mads/forest/sound/digi.cpp
@@ -106,8 +106,11 @@ void DigiPlayer::setInitialVolume(int vol) {
 	_initialVolume = (vol < 0 || vol > 100) ? MAX_DIGI_VOLUME : vol * 327;
 }
 
-void DigiPlayer::setVolume(int slot, int vol) {
-	_mixer->setChannelVolume(_channels[slot]._soundHandle, (vol == MAX_DIGI_VOLUME) ? 255 : vol * 255 / 327);
+void DigiPlayer::setVolume(int vol, int slot) {
+	assert(slot >= 1 && slot <= MAX_DIGI_CHANNELS);
+	const byte volume = (vol < 0 || vol > 100) ? Audio::Mixer::kMaxChannelVolume :
+		vol * Audio::Mixer::kMaxChannelVolume / 100;
+	_mixer->setChannelVolume(_channels[slot - 1]._soundHandle, volume);
 }
 
 void digi_play_build_ii(char thing, int num, int slot) {

--- a/engines/mads/phantom/sound/rsound.cpp
+++ b/engines/mads/phantom/sound/rsound.cpp
@@ -985,7 +985,7 @@ dispatch:
 				ch->_pSrc = ch->_outerLoopPtr;
 			}
 			ch->_innerLoopPtr = ch->_pSrc;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xFF: {
 			// End an inner loop. The restart pointer is the beginning of
@@ -1005,7 +1005,7 @@ dispatch:
 			} else {
 				ch->_pSrc = ch->_innerLoopPtr;
 			}
-			goto post_keyon;
+			goto dispatch;
 		}
 
 		// ---- Loop / restart-pointer opcodes ----
@@ -1018,7 +1018,7 @@ dispatch:
 				ch->_innerLoopPtr = ch->_soundData;
 				ch->_outerLoopPtr = ch->_soundData;
 			}
-			goto post_keyon; // tail used by this cluster
+			goto dispatch;
 		}
 		case 0xFC: {
 			byte *ptr = loadData(readScriptWord(pSrc));
@@ -1027,17 +1027,17 @@ dispatch:
 			ch->_innerLoopPtr = ptr;
 			ch->_outerLoopPtr = ptr;
 			ch->_soundData = ptr;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xFB: { // unconditional jump, no bookkeeping
 			ch->_pSrc = loadData(readScriptWord(pSrc));
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xFA: { // "call": jump, saving a resume point
 			byte *target = loadData(readScriptWord(pSrc));
 			ch->_branchTarget = ch->_pSrc + 3;
 			ch->_pSrc = target;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xF9: { // "return"
 			if (ch->_branchTarget) {
@@ -1046,25 +1046,25 @@ dispatch:
 			} else {
 				ch->_pSrc++;
 			}
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xF8: {
 			ch->_program = readScriptByte(pSrc);
 			ch->_pSrc += 2;
 			sendProgramChange(midiChannel, ch->_program);
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xF7: {
 			ch->_noteOffset = readScriptByte(pSrc);
 			ch->_keyOnDelayOverride = 0;
 			ch->_pSrc += 2;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xF6: {
 			ch->_keyOnDelayOverride = readScriptByte(pSrc);
 			ch->_noteOffset = 0;
 			ch->_pSrc += 2;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xF5: {
 			ch->_pitchBendFadeReload = readScriptByte(pSrc);
@@ -1072,49 +1072,49 @@ dispatch:
 			ch->_pitchBendFadeCount = readScriptByte(pSrc);
 			ch->_pitchBendFadeCounter = 1;
 			ch->_pSrc += 4;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xF4: {
-			ch->_volume = readScriptByte(pSrc);
-			ch->_pSrc += 2;
-			sendVolume(midiChannel, ch->_volume);
-			goto post_keyon;
-		}
-		case 0xF3: {
 			ch->_velocity = readScriptByte(pSrc);
 			ch->_pSrc += 2;
-			goto post_keyon;
+			goto dispatch;
 		}
-		case 0xF2: {
+		case 0xF3: {
 			ch->_volumeFadeReload = readScriptByte(pSrc);
 			ch->_volumeFadeStep = readScriptByte(pSrc);
 			ch->_volumeFadeCounter = 1;
 			ch->_pSrc += 3;
-			goto post_keyon;
+			goto dispatch;
 		}
-		case 0xF1: {
+		case 0xF2: {
 			ch->_pitchBend = readScriptByte(pSrc);
 			ch->_pSrc += 2;
 			sendPitchBend(midiChannel, ch->_pitchBend);
-			goto post_keyon;
+			goto dispatch;
+		}
+		case 0xF1: {
+			ch->_volume = readScriptByte(pSrc);
+			ch->_pSrc += 2;
+			sendVolume(midiChannel, ch->_volume);
+			goto dispatch;
 		}
 		case 0xF0: {
 			ch->_pan = readScriptByte(pSrc);
 			sendPan(midiChannel, ch->_pan);
 			ch->_pSrc += 2;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xEF: {
 			ch->_panFadeReload = readScriptByte(pSrc);
 			ch->_panFadeStep = readScriptByte(pSrc);
 			ch->_panFadeCounter = 1;
 			ch->_pSrc += 3;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xEE: {
 			ch->_transpose = readScriptByte(pSrc);
 			ch->_pSrc += 2;
-			goto post_keyon;
+			goto dispatch;
 		}
 		case 0xED: {
 			// ---- Chord event: [count][note1..noteN][duration] ----


### PR DESCRIPTION
This PR fixes several MADS audio issues across *Dragonsphere*, *Phantom*, and *Forest*:

**Dragonsphere**: Fixes RSOUND and GSOUND sequence decoding, including volume, pitch bend, fades, and velocity handling. Also fixes General MIDI driver validation and AdLib octave transposition.

**Phantom**: Fixes RSOUND sequence decoding and uses the playback rate stored per DSR sample, handling resources that mix 8000 and 11025 Hz audio.

**Forest**: Fixes digital volume/channel handling and correctly scales room-script volume percentages, restoring ambient fades without invalid channel access.

This hopefully solves two recent bug reports: https://bugs.scummvm.org/ticket/17097 & https://bugs.scummvm.org/ticket/17098

There's some work still ahead on *Forest*, even on existing sound... Nothing to delay any announcement, though. @dreammaster