### PR TITLE
MADS: Fix additional sound problems, part 2 (Forest)

### DIFF
--- a/audio/midiparser_hmp.cpp
+++ b/audio/midiparser_hmp.cpp
@@ -35,6 +35,7 @@ MidiParser_HMP::MidiParser_HMP(int8 source) : MidiParser_SMF(source) {
 	_songLength = 0;
 	memset(_channelPriorities, 0, sizeof(_channelPriorities));
 	memset(_deviceTrackMappings, 0, sizeof(_deviceTrackMappings));
+	_hmiDevice = kHmiDeviceNone;
 	memset(_restoreControllers, 0, sizeof(_restoreControllers));
 	_callbackPointer = 0;
 	_callbackSegment = 0;
@@ -77,7 +78,12 @@ bool MidiParser_HMP::loadMusic(const byte *data, uint32 size) {
 	}
 
 	_numTracks = 1;
-	_numSubtracks[0] = readWord(pos, _version);
+	const uint32 sourceSubtrackCount = readWord(pos, _version);
+	if (sourceSubtrackCount > MAXIMUM_SUBTRACKS) {
+		warning("HMI/HMP data has too many subtracks (%u)", sourceSubtrackCount);
+		return false;
+	}
+	_numSubtracks[0] = sourceSubtrackCount;
 	// Doesn't seem like this field is actually used...
 	//uint32 ppqn = readWord(pos, _version);
 	_ppqn = 60;
@@ -89,9 +95,15 @@ bool MidiParser_HMP::loadMusic(const byte *data, uint32 size) {
 	for (int i = 0; i < 16; i++) {
 		_channelPriorities[i] = readWord(pos, _version);
 	}
-	for (int i = 0; i < 5; i++) {
-		for (int j = 0; j < 32; j++) {
-			_deviceTrackMappings[j][i] = readWord(pos, _version);
+	if (isHmi) {
+		for (int track = 0; track < 32; track++) {
+			for (int device = 0; device < 5; device++)
+				_deviceTrackMappings[track][device] = readWord(pos, _version);
+		}
+	} else {
+		for (int device = 0; device < 5; device++) {
+			for (int track = 0; track < 32; track++)
+				_deviceTrackMappings[track][device] = readWord(pos, _version);
 		}
 	}
 	if (_version == HmpVersion::VERSION_HMP_013195) {
@@ -103,20 +115,45 @@ bool MidiParser_HMP::loadMusic(const byte *data, uint32 size) {
 	_callbackSegment = readWord(pos, _version);
 
 	// Read the tracks
-	for (uint currTrack = 0; currTrack < _numSubtracks[0]; currTrack++) {
+	_numSubtracks[0] = 0;
+	for (uint currTrack = 0; currTrack < sourceSubtrackCount; currTrack++) {
 		//uint32 chunkNumber = readWord(pos, _version);
 		pos += isHmi ? 2 : 4;
 		uint32 chunkSize = readWord(pos, _version);
 		//uint32 trackNumber = readWord(pos, _version);
 		pos += isHmi ? 2 : 4;
 
-		_tracks[0][currTrack] = pos;
+		if (!isHmi || isHmiTrackCompatible(currTrack))
+			_tracks[0][_numSubtracks[0]++] = pos;
 		pos += (chunkSize - (isHmi ? 6 : 12));
 	}
 
 	// TODO Read branching data
 
 	return true;
+}
+
+bool MidiParser_HMP::isHmiTrackCompatible(uint track) const {
+	if (_hmiDevice == kHmiDeviceNone)
+		return true;
+
+	bool hasMapping = false;
+	for (int device = 0; device < 5; device++) {
+		const uint32 mappedDevice = _deviceTrackMappings[track][device];
+		if (!mappedDevice)
+			continue;
+
+		hasMapping = true;
+		if (mappedDevice == _hmiDevice ||
+				(mappedDevice == kHmiDeviceSoundMasterII &&
+						(_hmiDevice == kHmiDeviceMpu401 ||
+						 _hmiDevice == kHmiDeviceAwe32)) ||
+				(mappedDevice == kHmiDeviceAdLib &&
+						_hmiDevice == kHmiDeviceOpl3))
+			return true;
+	}
+
+	return !hasMapping;
 }
 
 int32 MidiParser_HMP::determineDataSize(Common::SeekableReadStream *stream) {

--- a/audio/midiparser_hmp.h
+++ b/audio/midiparser_hmp.h
@@ -28,7 +28,7 @@
  * MIDI parser for the HMI SOS formats HMI and HMP.
  * 
  * Implementation is incomplete. Currently only the track chunks are read and
- * played back. Not implemented yet: device track mapping, branching, callbacks, etc.
+ * played back. Not implemented yet: branching, callbacks, etc.
  */
 class MidiParser_HMP : public MidiParser_SMF {
 protected:
@@ -48,11 +48,29 @@ protected:
 	HmpVersion determineVersion(const byte *pos);
 
 public:
+	enum HmiDevice {
+		kHmiDeviceNone = 0,
+		kHmiDeviceSoundMasterII = 0xA000,
+		kHmiDeviceMpu401 = 0xA001,
+		kHmiDeviceAdLib = 0xA002,
+		kHmiDeviceMt32 = 0xA004,
+		kHmiDevicePcSpeaker = 0xA006,
+		kHmiDeviceAwe32 = 0xA008,
+		kHmiDeviceOpl3 = 0xA009,
+		kHmiDeviceGus = 0xA00A
+	};
+
 	MidiParser_HMP(int8 source = -1);
 
 	bool loadMusic(const byte *data, uint32 size) override;
 
 	int32 determineDataSize(Common::SeekableReadStream *stream) override;
+
+	/**
+	 * Select the native device used to filter early HMI subtracks.
+	 * The default value leaves every subtrack enabled.
+	 */
+	void setHmiDevice(HmiDevice device) { _hmiDevice = device; }
 
 protected:
 	HmpVersion _version;
@@ -61,6 +79,7 @@ protected:
 	uint32 _songLength;
 	uint32 _channelPriorities[16];
 	uint32 _deviceTrackMappings[32][5];
+	uint16 _hmiDevice;
 	uint8 _restoreControllers[128];
 	uint32 _callbackPointer;
 	uint32 _callbackSegment;
@@ -69,6 +88,7 @@ protected:
 	// version (i.e. 2 bytes for HMI, 4 bytes for HMP)
 	uint32 readWord(const byte *&data, HmpVersion version);
 	uint32 readWord(Common::SeekableReadStream *stream, HmpVersion version);
+	bool isHmiTrackCompatible(uint track) const;
 };
 
 #endif

--- a/engines/mads/console.cpp
+++ b/engines/mads/console.cpp
@@ -163,6 +163,10 @@ bool Console::cmdSoundCommand(int argc, const char **argv) {
 		debugPrintf("Usage: %s <command> [parameter]\n", argv[0]);
 		return true;
 	}
+	if (!g_engine->_soundManager) {
+		debugPrintf("This game does not use MADS section sound drivers.\n");
+		return true;
+	}
 	if (!g_engine->_soundManager->isLoaded()) {
 		debugPrintf("No section sound driver is loaded. Use soundsection first.\n");
 		return true;
@@ -195,6 +199,10 @@ bool Console::cmdPlaySound(int argc, const char **argv) {
 		debugPrintf("Section must be between 1 and 9.\n");
 		return true;
 	}
+	if (!g_engine->_soundManager) {
+		debugPrintf("This game does not use MADS section sound drivers.\n");
+		return true;
+	}
 
 	g_engine->_soundManager->init(section);
 	if (!g_engine->_soundManager->isLoaded()) {
@@ -219,6 +227,10 @@ bool Console::cmdSoundSection(int argc, const char **argv) {
 		debugPrintf("Section must be between 1 and 9.\n");
 		return true;
 	}
+	if (!g_engine->_soundManager) {
+		debugPrintf("This game does not use MADS section sound drivers.\n");
+		return true;
+	}
 
 	g_engine->_soundManager->init(section);
 	debugPrintf(
@@ -232,6 +244,10 @@ bool Console::cmdSoundSection(int argc, const char **argv) {
 bool Console::cmdSoundStop(int argc, const char **argv) {
 	if (argc != 1) {
 		debugPrintf("Usage: %s\n", argv[0]);
+		return true;
+	}
+	if (!g_engine->_soundManager) {
+		debugPrintf("This game does not use MADS section sound drivers.\n");
 		return true;
 	}
 

--- a/engines/mads/forest/console.cpp
+++ b/engines/mads/forest/console.cpp
@@ -1,0 +1,196 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "common/file.h"
+#include "mads/core/concat.h"
+#include "mads/core/config.h"
+#include "mads/core/env.h"
+#include "mads/forest/console.h"
+#include "mads/forest/global.h"
+#include "mads/forest/sound/digi.h"
+#include "mads/forest/sound/midi.h"
+
+namespace MADS {
+namespace Forest {
+
+Console::Console() : MADS::Console() {
+	registerCmd("forestmusic", WRAP_METHOD(Console, cmdForestMusic));
+	registerCmd("forestsample", WRAP_METHOD(Console, cmdForestSample));
+	registerCmd("forestsounds", WRAP_METHOD(Console, cmdForestSounds));
+}
+
+bool Console::cmdForestMusic(int argc, const char **argv) {
+	if (argc == 1 || (argc == 2 && !scumm_stricmp(argv[1], "list"))) {
+		for (int id = 1; id <= 15; ++id)
+			debugPrintf("%2d: %s\n", id, global_midi_name(id));
+		return true;
+	}
+
+	if (argc != 2) {
+		debugPrintf("Usage: %s <1-15|list|stop>\n", argv[0]);
+		return true;
+	}
+
+	if (!scumm_stricmp(argv[1], "stop")) {
+		midi_stop();
+		debugPrintf("Stopped Forest music.\n");
+		return true;
+	}
+
+	const int id = strToInt(argv[1]);
+	const char *name = global_midi_name(id);
+	if (!name) {
+		debugPrintf("Music ID must be between 1 and 15.\n");
+		return true;
+	}
+	if (!config_file.music_flag) {
+		debugPrintf("Forest music is muted in the current game settings.\n");
+		return true;
+	}
+
+	global_midi_play(id);
+	debugPrintf("Started Forest music %d (%s).\n", id, name);
+	return true;
+}
+
+bool Console::cmdForestSample(int argc, const char **argv) {
+	if (argc < 2 || argc > 3) {
+		debugPrintf("Usage: %s <resource|stop> [slot 1-3|all]\n", argv[0]);
+		return true;
+	}
+
+	if (!scumm_stricmp(argv[1], "stop")) {
+		if (argc == 3 && !scumm_stricmp(argv[2], "all")) {
+			for (int slot = 1; slot <= MAX_DIGI_CHANNELS; ++slot)
+				digi_stop(slot);
+			debugPrintf("Stopped all Forest digital channels.\n");
+			return true;
+		}
+
+		const int slot = argc == 3 ? strToInt(argv[2]) : 1;
+		if (slot < 1 || slot > MAX_DIGI_CHANNELS) {
+			debugPrintf("Slot must be between 1 and %d.\n", MAX_DIGI_CHANNELS);
+			return true;
+		}
+
+		digi_stop(slot);
+		debugPrintf("Stopped Forest digital channel %d.\n", slot);
+		return true;
+	}
+
+	const int slot = argc == 3 ? strToInt(argv[2]) : 1;
+	if (slot < 1 || slot > MAX_DIGI_CHANNELS) {
+		debugPrintf("Slot must be between 1 and %d.\n", MAX_DIGI_CHANNELS);
+		return true;
+	}
+
+	Common::String name(argv[1]);
+	if (name.hasSuffixIgnoreCase(".rac") || name.hasSuffixIgnoreCase(".raw"))
+		name.erase(name.size() - 4);
+	const Common::String racName = Common::String::format("*%s.rac", name.c_str());
+	const Common::String rawName = Common::String::format("*%s.raw", name.c_str());
+	if (!env_exist(racName.c_str()) && !env_exist(rawName.c_str())) {
+		debugPrintf("Forest sample %s was not found.\n", name.c_str());
+		return true;
+	}
+
+	digi_play(name.c_str(), slot);
+	debugPrintf("Started Forest sample %s on channel %d.\n",
+		name.c_str(), slot);
+	return true;
+}
+
+bool Console::cmdForestSounds(int argc, const char **argv) {
+	if (argc > 3) {
+		debugPrintf("Usage: %s [speech|effects|all] [name filter]\n", argv[0]);
+		return true;
+	}
+
+	char type = 0;
+	if (argc >= 2) {
+		if (!scumm_stricmp(argv[1], "speech"))
+			type = 'S';
+		else if (!scumm_stricmp(argv[1], "effects"))
+			type = 'D';
+		else if (scumm_stricmp(argv[1], "all")) {
+			debugPrintf("Sound type must be speech, effects, or all.\n");
+			return true;
+		}
+	}
+
+	Common::String filter = argc == 3 ? argv[2] : "";
+	filter.toUppercase();
+
+	Common::File index;
+	if (!index.open("SPEECH.IDX") && !index.open("SPEECH.HAG")) {
+		debugPrintf("Could not open the Forest speech archive index.\n");
+		return true;
+	}
+
+	char header[CONCAT_ID_LENGTH];
+	if (index.read(header, sizeof(header)) != sizeof(header)) {
+		debugPrintf("The Forest speech archive index is truncated.\n");
+		return true;
+	}
+
+	for (int i = 0; i < CONCAT_ID_CHECK; ++i) {
+		if (header[i] != CONCAT_ID_STRING[i]) {
+			debugPrintf("The Forest speech archive index is invalid.\n");
+			return true;
+		}
+	}
+
+	const uint count = index.readUint16LE();
+	if (count > CONCAT_MAX_FILES ||
+			index.size() < CONCAT_ID_LENGTH + 2 + count * Concat::record_size()) {
+		debugPrintf("The Forest speech archive directory is invalid.\n");
+		return true;
+	}
+
+	uint matches = 0;
+	for (uint i = 0; i < count; ++i) {
+		Concat entry;
+		entry.load(&index);
+
+		Common::String name(entry.name);
+		name.toUppercase();
+		if (type && name[0] != type)
+			continue;
+		if (!filter.empty() && !name.contains(filter))
+			continue;
+		if (name.hasSuffixIgnoreCase(".rac") || name.hasSuffixIgnoreCase(".raw"))
+			name.erase(name.size() - 4);
+
+		if (matches && matches % 6 == 0)
+			debugPrintf("\n");
+		debugPrintf("%-12s", name.c_str());
+		++matches;
+	}
+
+	if (matches)
+		debugPrintf("\n%u matching resources.\n", matches);
+	else
+		debugPrintf("No matching resources.\n");
+	return true;
+}
+
+} // namespace Forest
+} // namespace MADS

--- a/engines/mads/forest/console.h
+++ b/engines/mads/forest/console.h
@@ -1,0 +1,44 @@
+/* ScummVM - Graphic Adventure Engine
+ *
+ * ScummVM is the legal property of its developers, whose names
+ * are too numerous to list here. Please refer to the COPYRIGHT
+ * file distributed with this source distribution.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef MADS_FOREST_CONSOLE_H
+#define MADS_FOREST_CONSOLE_H
+
+#include "mads/console.h"
+
+namespace MADS {
+namespace Forest {
+
+class Console : public MADS::Console {
+private:
+	bool cmdForestMusic(int argc, const char **argv);
+	bool cmdForestSample(int argc, const char **argv);
+	bool cmdForestSounds(int argc, const char **argv);
+
+public:
+	Console();
+	~Console() override {}
+};
+
+} // namespace Forest
+} // namespace MADS
+
+#endif

--- a/engines/mads/forest/forest.cpp
+++ b/engines/mads/forest/forest.cpp
@@ -19,9 +19,11 @@
  *
  */
 
+#include "common/config-manager.h"
 #include "engines/util.h"
 #include "mads/console.h"
 #include "mads/core/attr.h"
+#include "mads/core/config.h"
 #include "mads/core/conv.h"
 #include "mads/core/env.h"
 #include "mads/core/game.h"
@@ -94,6 +96,11 @@ Common::Error ForestEngine::run() {
 
 void ForestEngine::syncSoundSettings() {
 	Engine::syncSoundSettings();
+
+	_musicFlag = !ConfMan.getBool("mute") && !ConfMan.getBool("music_mute");
+	config_file.music_flag = _musicFlag;
+	if (!_musicFlag)
+		midi_stop();
 
 	_midiPlayer.syncSoundSettings();
 }

--- a/engines/mads/forest/forest.cpp
+++ b/engines/mads/forest/forest.cpp
@@ -21,7 +21,7 @@
 
 #include "common/config-manager.h"
 #include "engines/util.h"
-#include "mads/console.h"
+#include "mads/forest/console.h"
 #include "mads/core/attr.h"
 #include "mads/core/config.h"
 #include "mads/core/conv.h"

--- a/engines/mads/forest/global.cpp
+++ b/engines/mads/forest/global.cpp
@@ -1017,6 +1017,9 @@ void global_midi_play(int num) {
 	};
 
 	assert(num >= 1 && num <= 15);
+	if (!config_file.music_flag)
+		return;
+
 	Common::String name = Common::String::format("*%s.hmi", NAMES[num - 1]);
 
 	midi_play(name.c_str());

--- a/engines/mads/forest/global.cpp
+++ b/engines/mads/forest/global.cpp
@@ -1010,19 +1010,24 @@ void global_error_code() {
 		text_show(text_id);
 }
 
-void global_midi_play(int num) {
+const char *global_midi_name(int num) {
 	static const char *NAMES[15] = {
 		"adven2", "foolarnd", "homeag", "humorus1", "humorus2", "pianogtr", "raindrop",
 		"xad", "xcarey", "xuspens1", "travels1", "xcarey2", "birdsong", "adventur", "action1"
 	};
 
-	assert(num >= 1 && num <= 15);
+	return num >= 1 && num <= 15 ? NAMES[num - 1] : nullptr;
+}
+
+void global_midi_play(int num) {
+	const char *name = global_midi_name(num);
+	assert(name);
 	if (!config_file.music_flag)
 		return;
 
-	Common::String name = Common::String::format("*%s.hmi", NAMES[num - 1]);
+	Common::String resourceName = Common::String::format("*%s.hmi", name);
 
-	midi_play(name.c_str());
+	midi_play(resourceName.c_str());
 }
 
 void global_daemon_code() {

--- a/engines/mads/forest/global.h
+++ b/engines/mads/forest/global.h
@@ -273,6 +273,7 @@ extern void global_anim1(int arg_0, int arg_2, int arg_4, int16 *arg_6);
 extern void global_anim2(int arg_0, int arg_2, int arg_4, int16 *arg_6);
 extern void global_anim3(int handle, int16 *frame);
 extern void global_midi_play(int num);
+extern const char *global_midi_name(int num);
 extern void global_daemon_code();
 extern void global_game_main_loop();
 

--- a/engines/mads/forest/menus.cpp
+++ b/engines/mads/forest/menus.cpp
@@ -312,7 +312,6 @@ static void global_menu_main() {
 
 void global_game_menu() {
 	bool loaded = false;
-	bool music = true;
 
 	if (box_param.series == NULL) {
 		Common::strcpy_s(box_param.name, "*BOX");
@@ -348,10 +347,8 @@ void global_game_menu() {
 			}
 			break;
 		case GAME_OPTIONS_MENU:
-			if (section_id != 9) {
+			if (section_id != 9)
 				global_menu_options();
-				music = config_file.music_flag != 0;
-			}
 			break;
 		default:
 			kernel.activate_menu = GAME_NO_MENU;
@@ -368,12 +365,7 @@ void global_game_menu() {
 	}
 
 done:
-	if (!music) {
-		config_file.music_flag = true;
-		midi_stop();
-		config_file.music_flag = false;
-		midi_playing = false;
-	}
+	g_engine->syncSoundSettings();
 }
 
 } // namespace Forest

--- a/engines/mads/forest/sound/digi.cpp
+++ b/engines/mads/forest/sound/digi.cpp
@@ -72,7 +72,9 @@ void DigiPlayer::play(const char *name, int slot) {
 	int vol = (_initialVolume == MAX_DIGI_VOLUME) ? 255 : _initialVolume * 255 / 327 / 100;
 	_initialVolume = MAX_DIGI_VOLUME;
 
-	_mixer->playStream(Audio::Mixer::kSpeechSoundType, &c._soundHandle, audioStream, -1, vol);
+	const Audio::Mixer::SoundType soundType = (name[0] == 's' || name[0] == 'S') ?
+		Audio::Mixer::kSpeechSoundType : Audio::Mixer::kSFXSoundType;
+	_mixer->playStream(soundType, &c._soundHandle, audioStream, -1, vol);
 	c._isPlaying = true;
 }
 

--- a/engines/mads/forest/sound/midi.cpp
+++ b/engines/mads/forest/sound/midi.cpp
@@ -90,11 +90,12 @@ int MidiPlayer::open() {
 
 		break;
 	case MT_GM:
-	case MT_MT32:
-		// Forest sends GM data through this driver even when the selected
-		// backend is MT-32, so use the native MPU-401 track mapping.
 		hmiDevice = MidiParser_HMP::kHmiDeviceMpu401;
 		_driver = new MidiDriver_MT32GM(MusicType::MT_GM);
+		break;
+	case MT_MT32:
+		hmiDevice = MidiParser_HMP::kHmiDeviceMt32;
+		_driver = new MidiDriver_MT32GM(MusicType::MT_MT32);
 		break;
 	default:
 		_driver = new MidiDriver_NULL_Multisource();

--- a/engines/mads/forest/sound/midi.cpp
+++ b/engines/mads/forest/sound/midi.cpp
@@ -69,10 +69,14 @@ int MidiPlayer::open() {
 	if (_deviceType == MT_GM && ConfMan.getBool("native_mt32"))
 		_deviceType = MT_MT32;
 
+	MidiParser_HMP::HmiDevice hmiDevice = MidiParser_HMP::kHmiDeviceNone;
 	OPL::Config::OplType oplType;
 	switch (_deviceType) {
 	case MT_ADLIB:
 		oplType = MidiDriver_ADLIB_Multisource::detectOplType(OPL::Config::kOpl3) ? OPL::Config::kOpl3 : OPL::Config::kOpl2;
+		hmiDevice = oplType == OPL::Config::kOpl3 ?
+				MidiParser_HMP::kHmiDeviceOpl3 :
+				MidiParser_HMP::kHmiDeviceAdLib;
 		MidiDriver_ADLIB_HMISOS *adLibDriver;
 		adLibDriver = new MidiDriver_ADLIB_HMISOS(oplType);
 		_driver = adLibDriver;
@@ -87,6 +91,9 @@ int MidiPlayer::open() {
 		break;
 	case MT_GM:
 	case MT_MT32:
+		// Forest sends GM data through this driver even when the selected
+		// backend is MT-32, so use the native MPU-401 track mapping.
+		hmiDevice = MidiParser_HMP::kHmiDeviceMpu401;
 		_driver = new MidiDriver_MT32GM(MusicType::MT_GM);
 		break;
 	default:
@@ -94,7 +101,9 @@ int MidiPlayer::open() {
 		break;
 	}
 
-	_parser = new MidiParser_HMP(0);
+	MidiParser_HMP *parser = new MidiParser_HMP(0);
+	parser->setHmiDevice(hmiDevice);
+	_parser = parser;
 	_driver->property(MidiDriver::PROP_USER_VOLUME_SCALING, true);
 	_parser->property(MidiParser::mpDisableAutoStartPlayback, true);
 

--- a/engines/mads/module.mk
+++ b/engines/mads/module.mk
@@ -374,6 +374,7 @@ MODULE_OBJS := \
 	dragonsphere/sound/rsound_dragonsphere.o \
 	dragonsphere/sound/sound.o \
 	forest/forest.o \
+	forest/console.o \
 	forest/extra.o \
 	forest/global.o \
 	forest/inventory.o \


### PR DESCRIPTION
This PR will initially be kept as draft, because (1) the initial *Forest* commit in the [first PR](https://github.com/scummvm/scummvm/pull/7865) is useful for the rest; (2) needs thoughtful review; (3) needs testing.

Do I want to mess in `/audio/` yet again? Nope. But what can I do? I'm worried that the `HmiDevice` enum is not universal enough, and might end up being changed to suit whatever game needs it next, potentially to the detriment of this one. But maybe that's not something to address in this PR.

#### 1) The Forest commit in the [other PR](https://github.com/scummvm/scummvm/pull/7865) solves the following problem: 

Forest owns three digital channels, exposed to game code as slots 1 through 3. The established public order is `(volume, slot)`. The old implementation read the arguments as `(slot, volume)`, indexed the array without subtracting one, and divided percentage values by 327.

Room 306 passes fade values from 30 through 101 for slot 3. The old code used those values as indexes into a three-element array. The corrected boundary:

- validates slots 1 through 3;
- uses `_channels[slot - 1]`;
- maps 0 through 100 to the mixer range; and
- treats out-of-range values as full volume, matching the existing initial volume behavior and the terminal value 101.

#### 2) The current PR attempts to fix the following problems:

a) Forest had two music-disable states: its original option and ScummVM's `music_mute`. They are now synchronized before driver settings are applied. Disabling music stops active playback, and subsequent room polling cannot restart it while muted.

b) We separate digital dialogue and sound effects in ScummVM's mixer. The game already identifies the two classes consistently: dialogue resources begin with `S`, while effects begin with `D`:

- 71 resources begin with `S` and are dialogue;
- 296 begin with `D` and are sound effects;
- the remaining `NULL` member is the existing no-sound sentinel;
- `digi_play_build()` deliberately emits `s` only when its separator is `_`,   while every named character/effect emits `d`.

ScummVM previously routed all 368 digital resources through the speech mixer category. The change preserves the native channels, triggers and playback data, but sends `S...` resources to speech and `D...` resources to sound effects so the corresponding volume controls work independently.

c) We give Forest a native MT-32 music path. The game stores hardware-specific arrangements in its early HMI track table and identifies MT-32 as device `A004`, separately from MPU-401/General MIDI device `A001`.

ScummVM previously selected the MPU-401 rows and constructed its shared MIDI wrapper in GM mode even when an MT-32 device was active. The new path selects the MT-32 rows and uses MT-32 mode, while leaving General MIDI and AdLib routing unchanged.

d) We give the game its own sound debugger. The shared MADS `soundsection`, `soundcommand`, `playsound` and `soundstop` commands operate on `SoundManager` section overlays. Forest does not construct that manager. It owns a `MidiPlayer` for HMI resources and a `DigiPlayer` for the three digital channels instead.

Calling the shared commands in Forest therefore could not test Forest audio and previously risked dereferencing a null manager. They now report that the game does not use MADS section sound drivers. The Forest commands below use the same players and selected audio device as normal gameplay.

#### 3) Sound debugger commands:

***a) Music***

```
forestmusic
forestmusic list
forestmusic <1-15>
forestmusic stop
```

The list contains the 15 names used by `global_midi_play()`. A numeric command loads the corresponding HMI resource through the normal Forest music path, so native AdLib, OPL3, General MIDI and MT-32 filtering remains active. Music is not forced through muted game settings.

***b) Digital samples***

```
forestsounds [speech|effects|all] [name-filter]
forestsample <resource> [slot]
forestsample stop [slot|all]
```

`forestsounds` reads the installed `SPEECH.IDX` directory, falling back to the self-indexed `SPEECH.HAG`. It does not contain a compiled-in resource catalog.
The optional category uses the native resource convention:

- `S...` is speech;
- `D...` is an effect; and
- `NULL` is the archive sentinel.

The listed extension may be omitted when passing a name to `forestsample`.
Slots are the game's native one-based channels 1 through 3, with slot 1 used when omitted.

---

Info dump follows:

#### 4) HMI routing and native MT-32

***File layout***

Forest has 16 early HMI files containing 77 source subtracks. Their native header contains a 32 by 5 table at offset `0x42`. Each row lists up to five driver IDs that may play that source subtrack. The table ends at `0x182`; the next four bytes are callback fields, which are zero in every supplied file.

The native loader checks rows against its loaded-driver slots and applies two one-way aliases:

- row `A000` is accepted for loaded `A001` or `A008`;
- row `A002` is accepted for loaded `A009`.

An all-zero row is universal. No native alias maps `A000` to MT-32 `A004`.

***Verified profile totals***

| Profile | Included | Excluded |
| --- | ---: | ---: |
| Unfiltered diagnostic | 77 | 0 |
| OPL2 `A002` | 76 | 1 |
| OPL3 `A009` | 76 | 1 |
| MPU-401 `A001` | 74 | 3 |
| MT-32 `A004` | 41 | 36 |
| AWE32 `A008` | 74 | 3 |

The sparse MT-32 total is apparently native data, not parser loss. MT-32 rows are usually the melodic arrangement beside hardware-specific percussion or generic MIDI rows. Combining `A001` and `A004` would likely play competing arrangements together. It is therefore not a substitute for recovering a multi-driver configuration.

The complete row-by-row result is below at the end.

***Native selection***

Forest's installer identifies MT-32 as `A004`, distinct from MPU-401 `A001`.
ScummVM now selects the same ID and creates `MidiDriver_MT32GM` in MT-32 mode.
GM devices retain `A001` and GM mode. OPL2 and OPL3 are unchanged.

Two installer-generated 52-byte `CONFIG.FOR` files confirm this.
The files differ at exactly one byte:

| Profile | Bytes 0-1 |
| --- | --- |
| General MIDI / MPU-401 | `01 A0` (`A001`) | 
| General MIDI card, MT-32 MIDI type | `04 A0` (`A004`) | 

The HMI parser remains a one-device interface. The native executable can load up to five drivers because that is a generic HMI runtime facility. The MT-32 configuration file proves that Forest stores one music profile, not a union of MPU-401 and MT-32 IDs, and the resource rows show that merging those arrangements would be wrong.

***`mpu401.com` and `mt32.com`***

Neither driver contains an MT-32 patch bank or a custom SysEx payload. The native distinction relevant to ScummVM is the HMI arrangement ID and the backend's MT-32/GM interpretation. ScummVM's MIDI backend already owns port, emulator, initialization and reset behavior, so copying DOS hardware polling would be incorrect.

The MT-32 driver's block-write export contains an `INT 3` byte not present in the MPU-401 variant. Unresolved and not copied into the ScummVM event path.

***HMP isolation***

HMP files do not contain this early HMI mapping table. Device filtering is applied only after identifying `HMIMIDIR`; existing HMP parsing remains unfiltered.

***HMI Device Mappings***

| File | Subtrack | ChunkNumber | NativeTrack | ChunkSize | Mapping1 | Mapping2 | Mapping3 | Mapping4 | Mapping5 | OPL2 | OPL3 | MPU401 | MT32 | AWE32 |
| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
| ACTION1.HMI | 0 | 0 | 0 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| ACTION1.HMI | 1 | 1 | 9 | 3182 | 0xA000 | 0xA00A | 0xA005 | 0xA002 |  | True | True | True | False | True |
| ADVEN2.HMI | 0 | 0 | 0 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| ADVEN2.HMI | 1 | 1 | 0 | 314 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVEN2.HMI | 2 | 2 | 0 | 108 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVEN2.HMI | 3 | 3 | 1 | 306 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVEN2.HMI | 4 | 4 | 2 | 1041 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVEN2.HMI | 5 | 5 | 3 | 108 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVEN2.HMI | 6 | 6 | 4 | 307 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVEN2.HMI | 7 | 7 | 5 | 346 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVEN2.HMI | 8 | 8 | 7 | 338 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVEN2.HMI | 9 | 9 | 6 | 114 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVEN2.HMI | 10 | 10 | 8 | 51 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVEN2.HMI | 11 | 11 | 14 | 236 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVEN2.HMI | 12 | 12 | 9 | 1009 | 0xA000 | 0xA00A | 0xA005 | 0xA002 |  | True | True | True | False | True |
| ADVEN2.HMI | 13 | 13 | 9 | 33 | 0xA000 | 0xA00A | 0xA005 | 0xA002 |  | True | True | True | False | True |
| ADVENTUR.HMI | 0 | 0 | 0 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| ADVENTUR.HMI | 1 | 1 | 0 | 612 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVENTUR.HMI | 2 | 2 | 0 | 108 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVENTUR.HMI | 3 | 3 | 1 | 604 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVENTUR.HMI | 4 | 4 | 2 | 2353 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVENTUR.HMI | 5 | 5 | 3 | 189 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVENTUR.HMI | 6 | 6 | 4 | 308 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVENTUR.HMI | 7 | 7 | 5 | 347 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVENTUR.HMI | 8 | 8 | 7 | 339 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVENTUR.HMI | 9 | 9 | 6 | 114 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVENTUR.HMI | 10 | 10 | 8 | 85 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVENTUR.HMI | 11 | 11 | 14 | 255 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| ADVENTUR.HMI | 12 | 12 | 9 | 1897 | 0xA000 | 0xA00A | 0xA005 | 0xA002 |  | True | True | True | False | True |
| ADVENTUR.HMI | 13 | 13 | 9 | 61 | 0xA000 | 0xA00A | 0xA005 | 0xA002 |  | True | True | True | False | True |
| BIRDSONG.HMI | 0 | 0 | 0 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| BIRDSONG.HMI | 1 | 1 | 0 | 713 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| FOOLARND.HMI | 0 | 0 | 9 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| FOOLARND.HMI | 1 | 1 | 0 | 2281 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| FOOLARND.HMI | 2 | 2 | 1 | 905 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| HOMEAG.HMI | 0 | 0 | 1 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| HOMEAG.HMI | 1 | 1 | 0 | 1180 | 0xA00A | 0xA000 | 0xA002 | 0xA004 |  | True | True | True | True | True |
| HOMEAG.HMI | 2 | 2 | 1 | 932 | 0xA00A | 0xA000 | 0xA002 | 0xA004 |  | True | True | True | True | True |
| HUMORUS1.HMI | 0 | 0 | 0 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| HUMORUS1.HMI | 1 | 1 | 0 | 73 | 0xA00A | 0xA000 | 0xA002 | 0xA004 | 0xA007 | True | True | True | True | True |
| HUMORUS2.HMI | 0 | 0 | 0 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| HUMORUS2.HMI | 1 | 1 | 0 | 145 | 0xA00A | 0xA000 | 0xA002 | 0xA004 | 0xA007 | True | True | True | True | True |
| LAISLAMI.HMI | 0 | 0 | 0 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 |  | True | True | True | False | True |
| LAISLAMI.HMI | 1 | 1 | 0 | 1103 | 0xA000 | 0xA00A | 0xA009 | 0xA002 |  | True | True | True | False | True |
| LAISLAMI.HMI | 2 | 2 | 1 | 1347 | 0xA000 | 0xA00A | 0xA009 | 0xA002 |  | True | True | True | False | True |
| LAISLAMI.HMI | 3 | 3 | 2 | 947 | 0xA000 | 0xA00A | 0xA009 | 0xA002 |  | True | True | True | False | True |
| LAISLAMI.HMI | 4 | 4 | 3 | 1170 | 0xA000 | 0xA00A | 0xA009 | 0xA002 |  | True | True | True | False | True |
| LAISLAMI.HMI | 5 | 5 | 4 | 265 | 0xA000 | 0xA00A | 0xA009 | 0xA002 |  | True | True | True | False | True |
| LAISLAMI.HMI | 6 | 6 | 9 | 2324 | 0xA000 | 0xA00A | 0xA009 | 0xA002 |  | True | True | True | False | True |
| LAISLAMI.HMI | 7 | 7 | 9 | 2544 | 0xA000 | 0xA00A | 0xA009 | 0xA002 |  | True | True | True | False | True |
| LAISLAMI.HMI | 8 | 8 | 9 | 3088 | 0xA000 | 0xA00A | 0xA009 | 0xA002 |  | True | True | True | False | True |
| LAISLAMI.HMI | 9 | 9 | 9 | 665 | 0xA000 | 0xA00A | 0xA009 | 0xA002 |  | True | True | True | False | True |
| PIANOGTR.HMI | 0 | 0 | 0 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| PIANOGTR.HMI | 1 | 1 | 0 | 2473 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| PIANOGTR.HMI | 2 | 2 | 4 | 1154 | 0xA00A | 0xA000 | 0xA004 | 0xA002 |  | True | True | True | True | True |
| PIANOGTR.HMI | 3 | 3 | 9 | 3249 | 0xA00A | 0xA005 | 0xA004 | 0xA002 |  | True | True | False | True | False |
| RAINDROP.HMI | 0 | 0 | 9 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| RAINDROP.HMI | 1 | 1 | 0 | 1425 | 0xA00A | 0xA000 | 0xA002 | 0xA004 |  | True | True | True | True | True |
| RAINDROP.HMI | 2 | 2 | 1 | 388 | 0xA00A | 0xA000 | 0xA002 | 0xA004 |  | True | True | True | True | True |
| TRAVELS1.HMI | 0 | 0 | 9 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| TRAVELS1.HMI | 1 | 1 | 0 | 1169 | 0xA00A | 0xA000 | 0xA004 | 0xA002 | 0xA007 | True | True | True | True | True |
| TRAVELS1.HMI | 2 | 2 | 9 | 969 | 0xA00A | 0xA005 | 0xA002 | 0xA004 | 0xA007 | True | True | False | True | False |
| XAD.HMI | 0 | 0 | 1 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| XAD.HMI | 1 | 1 | 0 | 405 | 0xA00A | 0xA000 | 0xA002 | 0xA004 |  | True | True | True | True | True |
| XAD.HMI | 2 | 2 | 1 | 493 | 0xA00A | 0xA000 | 0xA002 | 0xA004 |  | True | True | True | True | True |
| XAD.HMI | 3 | 3 | 2 | 405 | 0xA00A | 0xA000 | 0xA002 | 0xA004 |  | True | True | True | True | True |
| XCAREY.HMI | 0 | 0 | 2 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| XCAREY.HMI | 1 | 1 | 0 | 90 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| XCAREY.HMI | 2 | 2 | 1 | 51 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| XCAREY2.HMI | 0 | 0 | 0 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| XCAREY2.HMI | 1 | 1 | 0 | 65 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| XCAREY2.HMI | 2 | 2 | 1 | 65 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| XUSPENS1.HMI | 0 | 0 | 0 | 10 | 0xA000 | 0xA00A | 0xA009 | 0xA002 | 0xA007 | True | True | True | False | True |
| XUSPENS1.HMI | 1 | 1 | 0 | 825 | 0xA00A | 0xA000 | 0xA002 | 0xA004 |  | True | True | True | True | True |
| XUSPENS1.HMI | 2 | 2 | 1 | 706 | 0xA00A | 0xA000 | 0xA002 | 0xA004 |  | True | True | True | True | True |
| XUSPENS1.HMI | 3 | 3 | 2 | 370 | 0xA00A | 0xA000 | 0xA002 | 0xA004 |  | True | True | True | True | True |
| XUSPENS1.HMI | 4 | 4 | 9 | 1865 | 0xA00A | 0xA005 |  |  |  | False | False | False | False | False |
