### PR TITLE
GUI: Fix event recorder build without ImGui

### DIFF
--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -194,10 +194,6 @@ public:
 
 private:
 
-	// Not guarded by USE_IMGUI: the definition is unconditional and already
-	// returns false when ImGui is absent, and four of the five call sites are
-	// unguarded too. Guarding only the declaration breaks --enable-eventrecorder
-	// in every build without ImGui.
 	bool isImGuiRecorderEnabled() const;
 
 	bool pollEvent(Common::Event &ev) override;

--- a/gui/EventRecorder.h
+++ b/gui/EventRecorder.h
@@ -194,9 +194,11 @@ public:
 
 private:
 
-#ifdef USE_IMGUI
+	// Not guarded by USE_IMGUI: the definition is unconditional and already
+	// returns false when ImGui is absent, and four of the five call sites are
+	// unguarded too. Guarding only the declaration breaks --enable-eventrecorder
+	// in every build without ImGui.
 	bool isImGuiRecorderEnabled() const;
-#endif
 
 	bool pollEvent(Common::Event &ev) override;
 	bool notifyEvent(const Common::Event &event) override;


### PR DESCRIPTION
`EventRecorder::isImGuiRecorderEnabled()` has its declaration wrapped in
`#ifdef USE_IMGUI`, but its definition is not wrapped, and neither are four of
its five call sites. The definition already handles the no-ImGui case itself:

```cpp
bool EventRecorder::isImGuiRecorderEnabled() const {
#ifdef USE_IMGUI
	return debugChannelSet(-1, kDebugImGui);
#else
	return false;
#endif
}
```

So the guard on the declaration is the only thing that varies, and building
with `--enable-eventrecorder` while ImGui is off fails.

### Reproduction

On master (8f65a3b7):

```
./configure --enable-eventrecorder --disable-all-engines --enable-engine=nancy
make gui/EventRecorder.o
```

`configure` reports `Checking for ImGui... no` and leaves `USE_IMGUI` undefined,
then the build fails:

```
gui/EventRecorder.cpp:432:7: error: use of undeclared identifier 'isImGuiRecorderEnabled'
gui/EventRecorder.cpp:609:6: error: use of undeclared identifier 'isImGuiRecorderEnabled'
gui/EventRecorder.cpp:739:6: error: use of undeclared identifier 'isImGuiRecorderEnabled'
gui/EventRecorder.cpp:759:6: error: use of undeclared identifier 'isImGuiRecorderEnabled'
gui/EventRecorder.cpp:862:21: error: out-of-line definition of 'isImGuiRecorderEnabled'
    does not match any declaration in 'GUI::EventRecorder'
```

ImGui is off unless an enabled engine pulls it in, so this affects every SDL
build that does not opt into it.

### Fix

Drop the guard from the declaration so it matches the definition. Same
configuration afterwards builds the file with no errors. Builds with ImGui
enabled are unaffected: the declaration simply becomes unconditional, and the
definition it matches was already unconditional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
