### PR TITLE
BACKENDS: Don't abort on mouse events when display is disabled

### DIFF
--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -278,7 +278,15 @@ protected:
 		const int targetHeight = _activeArea.height;
 
 		if (sourceWidth == 0 || sourceHeight == 0) {
-			error("convertWindowToVirtual called without a valid draw rect");
+			// No draw rect. This is headless operation (--disable-display),
+			// which keeps using this graphics manager but never sizes a window,
+			// so there is no window space to map from. Erroring out here makes
+			// --disable-display unusable for the thing it exists for, since the
+			// first replayed mouse event of an Event Recorder playback aborts
+			// the run. Clamp into the virtual area instead, which is what the
+			// caller wants when there is nothing to scale by.
+			return Common::Point(CLIP<int>(x, 0, MAX(0, targetWidth - 1)),
+								 CLIP<int>(y, 0, MAX(0, targetHeight - 1)));
 		}
 
 		x = CLIP<int>(x, sourceX, sourceMaxX);


### PR DESCRIPTION
`--disable-display` is honoured inside `SurfaceSdlGraphicsManager`
(`_displayDisabled`), so the windowed graphics manager stays in use but never
sizes a window and `_activeArea.drawRect` stays empty.

`WindowedGraphicsManager::convertWindowToVirtual()` treats an empty draw rect as
a programming error:

```cpp
if (sourceWidth == 0 || sourceHeight == 0) {
	error("convertWindowToVirtual called without a valid draw rect");
}
```

It is reached from the ordinary mouse paths (`sdl-graphics.cpp:305` and `:325`,
`warpMouseInWindow`, and the equivalents in the android/ios backends), so the
first mouse event that arrives while the display is disabled aborts the process.

That collides with the feature `--disable-display` exists for. Event Recorder
playback replays mouse events, so a headless playback run dies on its first one
and the option cannot be used for automated replay at all.

### Fix

With no draw rect there is no scaling to apply, so clamp into the virtual area
and return that — the identity the caller wants in this case — instead of
erroring.

### Note for reviewers

I am not sure this is where you would prefer the fix. The alternative I can see
is to give `_activeArea` the game resolution when the display is disabled, so
the conversion is a genuine identity rather than a special case inside the
converter, and the `error()` keeps its value as a real assertion for the windowed
path. Happy to redo it that way, or any other way you prefer — I went with the
minimal change because it is the one I have actually exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
