### PR TITLE
GRIM: Fix the debug channel checks

### DIFF
--- a/engines/grim/debug.cpp
+++ b/engines/grim/debug.cpp
@@ -33,7 +33,7 @@ bool Debug::isChannelEnabled(DebugChannel chan) {
 }
 
 void Debug::debug(DebugChannel channel, const char *s, ...) {
-	if (isChannelEnabled(channel | Debug::Info)) {
+	if (isChannelEnabled(channel) || isChannelEnabled(Debug::Info)) {
 		va_list args;
 		va_start(args, s);
 		Common::String buf = Common::String::vformat(s, args);
@@ -44,7 +44,7 @@ void Debug::debug(DebugChannel channel, const char *s, ...) {
 }
 
 void Debug::warning(DebugChannel channel, const char *s, ...) {
-	if (isChannelEnabled(channel | Debug::Warning)) {
+	if (isChannelEnabled(channel) || isChannelEnabled(Debug::Warning)) {
 		va_list args;
 		va_start(args, s);
 		Common::String buf = Common::String::vformat(s, args);
@@ -55,7 +55,7 @@ void Debug::warning(DebugChannel channel, const char *s, ...) {
 }
 
 void Debug::error(DebugChannel channel, const char *s, ...) {
-	if (isChannelEnabled(channel | Debug::Error)) {
+	if (isChannelEnabled(channel) || isChannelEnabled(Debug::Error)) {
 		va_list args;
 		va_start(args, s);
 		Common::String buf = Common::String::vformat(s, args);


### PR DESCRIPTION
`Debug::debug()`, `Debug::warning()` and `Debug::error()` OR the channel they are
given with `Info`, `Warning` or `Error` before the lookup. `isDebugChannelEnabled()`
matches a single channel, so the combined value never matches a registered channel
and none of these messages are printed, whatever `--debugflags` is passed. Only
`--debuglevel=11`, which skips the channel check entirely, produced any output from
these helpers.

Tested with Grim Fandango Remastered: `--debugflags=engine,materials` now produces
output where it previously produced none.
