### PR TITLE
GRIM: Fix the model-view matrix of the shader renderer

### DIFF
--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -489,7 +489,10 @@ Math::Matrix4 GfxOpenGLS::getModelView() {
 		Math::Matrix4 modelView = invertZ * viewMatrix * camPos;
 		return modelView;
 	} else {
-		return _mvpMatrix;
+		// _viewMatrix is kept transposed, ready to be fed to the shaders.
+		Math::Matrix4 modelView = _viewMatrix;
+		modelView.transpose();
+		return modelView;
 	}
 }
 


### PR DESCRIPTION
`getModelView()` returned `_mvpMatrix` for Grim, but that member is only ever
assigned by the Escape from Monkey Island overload of `positionCamera()`, so for
Grim it kept the identity matrix its default constructor leaves behind. The Grim
overload leaves the model-view in `_viewMatrix`, transposed for the shaders, so
this hands a transposed copy of that back.

`Lua_V1::WorldToScreen()` and `Set::setupCamera()` read this matrix. The Remastered
mouse support unprojects the cursor with `getProjection() * getModelView()`, which
is what led me here.

Verified on Grim by printing `getModelView()` under `--renderer=opengl_shaders` and
`--renderer=opengl` for the same set and camera: they now agree to float rounding,
where before the shader renderer returned the identity.
