### PR TITLE
GRIM: Only warn when a video cannot be loaded at all

### DIFF
--- a/engines/grim/movie/codecs/smush_decoder.cpp
+++ b/engines/grim/movie/codecs/smush_decoder.cpp
@@ -256,7 +256,6 @@ bool SmushDecoder::loadStream(Common::SeekableReadStream *stream) {
 
 	// Load the video
 	if (!readHeader()) {
-		warning("Failure loading SMUSH-file");
 		return false;
 	}
 

--- a/engines/grim/movie/smush.cpp
+++ b/engines/grim/movie/smush.cpp
@@ -70,9 +70,9 @@ bool SmushPlayer::loadFile(const Common::String &filename) {
 		success = _theoraDecoder->loadFile(theoraFilename);
 		_videoDecoder = _theoraDecoder;
 		_currentVideoIsTheora = true;
-#else
-		success = false;
 #endif
+		if (!success)
+			warning("Could not load the video %s", filename.c_str());
 	} else {
 		_videoDecoder = _smushDecoder;
 		_currentVideoIsTheora = false;


### PR DESCRIPTION
One of a series of fixes I am breaking out of my work on getting Grim Fandango
Remastered running.

`SmushPlayer::loadFile()` tries the SMUSH decoder first and falls back to the
Theora video the Remastered version ships, but `loadStream()` warned on every
failed attempt, so each Remastered cutscene logged a failure it then recovered
from. Warn in `loadFile()` instead, once neither decoder could open the video.

The `#else success = false;` it replaces was dead: `success` is already false to
reach that block.

Checked in game: the three videos played during startup still load through the
Theora fallback, and none of them warn now.
