### PR TITLE
GRIM: Fix commentary lookups in the Remastered version

### DIFF
--- a/engines/grim/remastered/commentary.cpp
+++ b/engines/grim/remastered/commentary.cpp
@@ -126,7 +126,10 @@ void Commentary::loadCommentary() {
 			c->addLine(id, str, start, end);
 		}
 
-		_comments.setVal(name, c);
+		// The scripts don't necessarily use the same case as the definition file.
+		Common::String key = name;
+		key.toLowercase();
+		_comments.setVal(key, c);
 	}
 }
 

--- a/engines/grim/remastered/commentary.h
+++ b/engines/grim/remastered/commentary.h
@@ -30,7 +30,6 @@ namespace Grim {
 class Comment;
 
 class Commentary {
-	// TODO: Case sensitivity
 	Common::HashMap<Common::String, Comment*> _comments;
 	Comment *_currentCommentary;
 	Comment *findCommentary(const Common::String &name);


### PR DESCRIPTION
One of a series of fixes I am breaking out of my work on getting Grim Fandango
Remastered running.

`loadCommentary()` stored the comments keyed by the name as it is spelled in
commentary_def.txt, while `findCommentary()` and `hasHeardCommentary()` lowercase
the name they are given before looking it up. As a result no commentary was ever
found, no matter how it was spelled by the caller.

The engine already notices: `setCurrentCommentary()` warns "could not find
commentary" on every call, which is what put me onto this. The definition file
spells the entries in mixed case, e.g. Year1Alley, so the lookup could never match.
