### PR TITLE
GRIM: Report the size the Remastered text actually takes

### DIFF
--- a/engines/grim/remastered/lua_remastered.cpp
+++ b/engines/grim/remastered/lua_remastered.cpp
@@ -62,17 +62,14 @@ void Lua_Remastered::GetFontDimensions() {
 }
 
 void Lua_Remastered::GetTextObjectDimensions() {
+	// The second parameter repeats the coordinate space the text object was
+	// created with, which it already knows about, so it is ignored.
 	lua_Object textObj = lua_getparam(1);
-	lua_Object coordsObj = lua_getparam(2);
-	if (lua_isnumber(coordsObj)) {
-		int val = lua_getnumber(coordsObj);
-		warning("Stub function: GetTextObjectDimensions(%d)", val);
-	}
 
 	if (lua_isuserdata(textObj) && lua_tag(textObj) == MKTAG('T', 'E', 'X', 'T')) {
 		TextObject *textObject = gettextobject(textObj);
-		lua_pushnumber(textObject->getWidth()); // REMASTERED HACK
-		lua_pushnumber(textObject->getBitmapHeight()); // REMASTERED HACK
+		lua_pushnumber(textObject->getBitmapWidth());
+		lua_pushnumber(textObject->getBitmapHeight());
 		// If the line is rjustified getX does us no good
 		lua_pushnumber(textObject->getLineX(0));
 		lua_pushnumber(textObject->getY());


### PR DESCRIPTION
`GetTextObjectDimensions()` answered with `TextObject::getWidth()`, the width the script asked the text to wrap at, rather than the width the text ended up taking. The Remastered menu lays its bottom legend row out from that width, so "Select" and "Return to Game" were drawn on top of each other.

The second parameter repeats the coordinate space the text object was created with, which the text object already knows about, so it is ignored rather than warned about.

Tested by building and running `grim-remastered-win` (GOG 1.4.0 data, `--renderer=opengl`) before and after, and comparing the same frame of the in-game menu. I will attach the before/after screenshots to this PR.

This is one of a series of small independent fixes needed to get Grim Fandango Remastered working; the rest will follow separately.