### PR TITLE
GRIM: Fix Remastered TTF text rendering far too large

### DIFF
--- a/engines/grim/font.h
+++ b/engines/grim/font.h
@@ -50,6 +50,13 @@ public:
 	virtual bool is8Bit() const = 0;
 	const Common::String &getFilename() const { return _filename; }
 
+	/**
+	 * True if this font's metrics are measured against the 1920x1080 the
+	 * Remastered HD assets are authored at, rather than the 640x480 the game
+	 * lays its text out in.
+	 */
+	virtual bool needsGameSpaceScale() const { return false; }
+
 	// for Korean Translate
 	int32 getWCharKernedWidth(byte hi, byte lo) const { return getCharKernedWidth(hi) + getCharKernedWidth(lo); }
 	bool isKoreanChar(const byte hi, const byte lo) const { return (hi >= 0xB0 && hi <= 0xC8 && lo >= 0xA1 && lo <= 0xFE); }
@@ -145,6 +152,9 @@ public:
 	int getKernedStringLength(const Common::String &text) const override;
 	void render(Graphics::Surface &buf, const Common::String &currentLine, const Graphics::PixelFormat &pixelFormat, uint32 blackColor, uint32 color, uint32 colorKey) const override;
 	bool is8Bit() const override { return false; }
+
+	// ResourceLoader takes the Remastered fonts, and only those, out of FontsHD.
+	bool needsGameSpaceScale() const override { return _filename.hasPrefix("FontsHD/"); }
 
 	void saveState(SaveGame *state) const;
 	void restoreState(SaveGame *state);

--- a/engines/grim/gfx_base.h
+++ b/engines/grim/gfx_base.h
@@ -88,6 +88,10 @@ public:
 	virtual uint getScreenWidth() { return _screenWidth; }
 	virtual uint getScreenHeight() { return _screenHeight; }
 
+	/** Scale from the 1920x1080 the HD assets are authored at to the 640x480 the game lays out in. */
+	static float getGlobalToGameScaleW() { return (float)_gameWidth / _globalWidth; }
+	static float getGlobalToGameScaleH() { return (float)_gameHeight / _globalHeight; }
+
 	virtual void setupCameraFrustum(float fov, float nclip, float fclip) = 0;
 	virtual void positionCamera(const Math::Vector3d &pos, const Math::Vector3d &interest, float roll) = 0;
 	virtual void positionCamera(const Math::Vector3d &pos, const Math::Matrix4 &rot) = 0;

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -1480,8 +1480,8 @@ void GfxOpenGL::drawTextObject(const TextObject *text) {
 
 		int numLines = text->getNumLines();
 		for (int i = 0; i < numLines; ++i) {
-			float width = f->getKernedStringLength(text->getLines()[i]);
-			float height = f->getKernedHeight();
+			float width = text->getLineWidth(i);
+			float height = text->getLineHeight();
 			float x = text->getLineX(i);
 
 			float y = text->getLineY(i);

--- a/engines/grim/textobject.cpp
+++ b/engines/grim/textobject.cpp
@@ -139,12 +139,30 @@ void TextObject::setDefaults(const TextObjectDefaults *defaults) {
 	_justify = defaults->getJustify();
 }
 
+bool TextObject::scaleFontMetrics() const {
+	return _coords == 0 && _font->needsGameSpaceScale();
+}
+
+int TextObject::getLineHeight() const {
+	int height = _font->getKernedHeight();
+	if (scaleFontMetrics())
+		height = (int)(height * GfxBase::getGlobalToGameScaleH());
+	return height;
+}
+
+int TextObject::getLineWidth(int line) const {
+	int width = _font->getKernedStringLength(_lines[line]);
+	if (scaleFontMetrics())
+		width = (int)(width * GfxBase::getGlobalToGameScaleW());
+	return width;
+}
+
 int TextObject::getBitmapWidth() const {
 	return _maxLineWidth;
 }
 
 int TextObject::getBitmapHeight() const {
-	return _numberLines * _font->getKernedHeight();
+	return _numberLines * getLineHeight();
 }
 
 int TextObject::getTextCharPosition(int pos) {
@@ -210,6 +228,9 @@ void TextObject::setupTextReal(S msg, Common::String (*convert)(const S &s)) {
 		maxWidth = _x;
 	}
 
+	if (scaleFontMetrics())
+		maxWidth = (int)(maxWidth / GfxBase::getGlobalToGameScaleW());
+
 	// We break the message to lines not longer than maxWidth
 	S currLine;
 	_numberLines = 1;
@@ -271,9 +292,9 @@ void TextObject::setupTextReal(S msg, Common::String (*convert)(const S &s)) {
 	// coordinate of the bottom of the text block (instead of the top). It means
 	// that every extra line pushes the previous lines up, instead of being
 	// printed further down the screen.
-	const int SCREEN_TOP_MARGIN = _font->getKernedHeight();
+	const int SCREEN_TOP_MARGIN = getLineHeight();
 	if (_isSpeech) {
-		_y -= _numberLines * _font->getKernedHeight();
+		_y -= _numberLines * getLineHeight();
 		if (_y < SCREEN_TOP_MARGIN) {
 			_y = SCREEN_TOP_MARGIN;
 		}
@@ -305,7 +326,7 @@ void TextObject::setupTextReal(S msg, Common::String (*convert)(const S &s)) {
 			currentLineConvert = Common::convertBiDiString(currentLineConvert, Common::kWindows1255);
 
 		_lines[j] = currentLineConvert;
-		int width = _font->getKernedStringLength(currentLineConvert);
+		int width = getLineWidth(j);
 		if (width > _maxLineWidth)
 			_maxLineWidth = width;
 		for (int count = 0; count < cutLen; count++)
@@ -343,7 +364,7 @@ int TextObject::getLineX(int line) const {
 	if (line >= _numberLines)
 		return 0;
 	if (_justify == CENTER)
-		x = _x - (_font->getKernedStringLength(_lines[line]) / 2);
+		x = _x - (getLineWidth(line) / 2);
 	else if (_justify == RJUSTIFY)
 		x = _x - getBitmapWidth();
 
@@ -374,7 +395,7 @@ int TextObject::getLineY(int line) const {
 
 	if (y < 0)
 		y = 0;
-	y += _font->getKernedHeight() * line;
+	y += getLineHeight() * line;
 
 	return y;
 }

--- a/engines/grim/textobject.h
+++ b/engines/grim/textobject.h
@@ -96,6 +96,8 @@ public:
 	int getBitmapHeight() const;
 	int getTextCharPosition(int pos);
 
+	int getLineWidth(int line) const;
+	int getLineHeight() const;
 	int getLineX(int line) const;
 	int getLineY(int line) const;
 
@@ -151,6 +153,8 @@ protected:
 private:
 	template <typename S>
 	void setupTextReal(S msg, Common::String (*convert)(const S &s));
+
+	bool scaleFontMetrics() const;
 };
 
 } // end of namespace Grim


### PR DESCRIPTION
The HD fonts are rasterized at sizes authored for 1920x1080, so their metrics are in that space, but `TextObject` lays the text out and `drawTextObject()` sizes it as if the metrics came from the 640x480 bitmap fonts of the classic game. Wrapping and centring broke down and the glyphs were drawn about twice their size, stretched, since the two scale factors differ on a 16:9 screen.

Give `Font` a `needsGameSpaceScale()` query, true for the fonts the resource loader takes out of `FontsHD`, and convert their metrics wherever the layout measures them against its own coordinates. The font cannot convert them on its own: the menus draw with the same fonts but are positioned in the HD space, and need the metrics left as they are — `Lua_Remastered::GetFontDimensions()` hands them straight to the menu scripts.

Tested by building and running `grim-remastered-win` (GOG 1.4.0 data, `--renderer=opengl`) before and after. On a frame-matched pair of the same line, upstream lays it out at 420x46 in a 640x480 space, which the coords-0 draw scale (x2.5, x1.875) turns into 1050x86 px on a 1600x900 screen; with the fix it is 140x20, drawn 350x37, which is the authored 420x46 at the correct 0.833 global factor. I will attach the before/after screenshots.

Also verified that the menus, which are positioned in the HD space, are unchanged — removing the coordinate-space condition shrinks the whole menu to a third, which is what the condition is there to prevent.

This is one of a series of small independent fixes needed to get Grim Fandango Remastered working; the rest will follow separately.