### PR TITLE
KYRA: move HaleStorm sound driver to audio/mac

### DIFF
--- a/audio/mac/halestorm.cpp
+++ b/audio/mac/halestorm.cpp
@@ -19,7 +19,7 @@
  *
  */
 
-#include "kyra/sound/drivers/halestorm.h"
+#include "audio/mac/halestorm.h"
 
 #include "audio/audiostream.h"
 #include "audio/mixer.h"
@@ -35,7 +35,7 @@
 
 #define ASC_DEVICE_RATE		22254
 
-namespace Kyra {
+namespace Audio {
 
 class HSLowLevelDriver;
 class HSAudioStream : public Audio::AudioStream {
@@ -757,7 +757,7 @@ bool HSMidiParser::loadTracks(HSSong &song) {
 	return true;
 }
 
-uint32 vlqRead(const uint8 *&s) {
+static uint32 vlqRead(const uint8 *&s) {
 	uint32 res = 0;
 	do {
 		res = (res << 7) | (*s & 0x7f);
@@ -2624,7 +2624,7 @@ const uint16 HSSoundSystem::_noteFreq[58] = {
 	0x02d4, 0x02d4
 };
 
-uint32 copySndHeader(const uint8 *&src, uint8 *&dst) {
+static uint32 copySndHeader(const uint8 *&src, uint8 *&dst) {
 	uint16 type = src ? READ_BE_UINT16(src) : 0;
 	uint32 len = 0;
 	if (type == 1 || type == 2) {
@@ -2826,4 +2826,4 @@ void HalestormDriver::setSoundEffectVolume(int volume) {
 	_hs->setSoundEffectVolume(volume);
 }
 
-} // End of namespace Kyra
+} // End of namespace Audio

--- a/audio/mac/halestorm.h
+++ b/audio/mac/halestorm.h
@@ -19,20 +19,18 @@
  *
  */
 
-#ifndef KYRA_SOUND_HALESTORM_H
-#define KYRA_SOUND_HALESTORM_H
+#ifndef AUDIO_MAC_HALESTORM_H
+#define AUDIO_MAC_HALESTORM_H
 
 #include "common/scummsys.h"
-
-namespace Audio {
-	class Mixer;
-}
 
 namespace Common {
 	class SeekableReadStream;
 }
 
-namespace Kyra {
+namespace Audio {
+
+class Mixer;
 
 class HSSoundSystem;
 
@@ -93,6 +91,6 @@ private:
 	HSSoundSystem *_hs;
 };
 
-} // End of namespace Kyra
+} // End of namespace Audio
 
 #endif

--- a/audio/module.mk
+++ b/audio/module.mk
@@ -51,6 +51,7 @@ MODULE_OBJS := \
 	decoders/wma.o \
 	decoders/xa.o \
 	decoders/xan_dpcm.o \
+	mac/halestorm.o \
 	mods/universaltracker.o \
 	mods/infogrames.o \
 	mods/maxtrax.o \

--- a/engines/kyra/module.mk
+++ b/engines/kyra/module.mk
@@ -72,7 +72,6 @@ MODULE_OBJS := \
 	sound/sound_lok.o \
 	sound/drivers/adlib.o \
 	sound/drivers/audstream.o \
-	sound/drivers/halestorm.o \
 	sound/drivers/pcspeaker_v2.o \
 	text/text.o \
 	text/text_lok.o \

--- a/engines/kyra/sound/sound_intern.h
+++ b/engines/kyra/sound/sound_intern.h
@@ -39,6 +39,7 @@ class TownsPC98_AudioDriver;
 namespace Audio {
 class PCSpeakerStream;
 class MaxTrax;
+class HalestormDriver;
 } // End of namespace Audio
 
 namespace Common {
@@ -355,7 +356,6 @@ protected:
 };
 
 class SoundMacRes;
-class HalestormDriver;
 class SoundMac : public Sound {
 public:
 	SoundMac(KyraEngine_v1 *vm, Audio::Mixer *mixer);
@@ -382,7 +382,7 @@ private:
 	void setQuality(bool hi);
 
 	SoundMacRes *_res;
-	HalestormDriver *_driver;
+	Audio::HalestormDriver *_driver;
 	const int _talkieFlag;
 	bool _ready;
 

--- a/engines/kyra/sound/sound_mac_lok.cpp
+++ b/engines/kyra/sound/sound_mac_lok.cpp
@@ -23,14 +23,13 @@
 #include "kyra/resource/resource.h"
 #include "kyra/sound/sound_intern.h"
 #include "kyra/sound/sound_mac_res.h"
-#include "kyra/sound/drivers/halestorm.h"
 
 #include "common/config-manager.h"
 #include "common/macresman.h"
 #include "common/compression/stuffit.h"
 
 #include "audio/mixer.h"
-
+#include "audio/mac/halestorm.h"
 
 #define HS_16BITOUTPUT		false
 
@@ -143,9 +142,9 @@ bool SoundMac::init(bool hiQuality) {
 	if (!(_res && _res->init()))
 		return false;
 
-	_driver = new HalestormDriver(_res, _mixer);
+	_driver = new Audio::HalestormDriver(_res, _mixer);
 
-	if (!(_driver && _driver->init(hiQuality, (hiQuality && _talkieFlag) ? HalestormDriver::kSimple : HalestormDriver::kNone, 1 + _talkieFlag, HS_16BITOUTPUT)))
+	if (!(_driver && _driver->init(hiQuality, (hiQuality && _talkieFlag) ? Audio::HalestormDriver::kSimple : Audio::HalestormDriver::kNone, 1 + _talkieFlag, HS_16BITOUTPUT)))
 		return false;
 
 	setQuality(hiQuality);
@@ -183,10 +182,10 @@ void SoundMac::playTrack(uint8 track) {
 		beginFadeOut();
 		return;
 	} else if (_currentResourceSet == kMusicFinale && track == 2) {
-		_driver->doCommand(HalestormDriver::kSongPlayLoop, 0x12c);
+		_driver->doCommand(Audio::HalestormDriver::kSongPlayLoop, 0x12c);
 		return;
 	} else if (_currentResourceSet == kMusicFinale && track == 4) {
-		_driver->doCommand(HalestormDriver::kSongPlayLoop, 0x12d);
+		_driver->doCommand(Audio::HalestormDriver::kSongPlayLoop, 0x12d);
 		return;
 	} else {
 		track -= 11;
@@ -194,12 +193,12 @@ void SoundMac::playTrack(uint8 track) {
 		loop = _musicLoopTable[track];
 	}
 
-	_driver->doCommand(loop ? HalestormDriver::kSongPlayLoop : HalestormDriver::kSongPlayOnce, _resIDMusic[track]);
+	_driver->doCommand(loop ? Audio::HalestormDriver::kSongPlayLoop : Audio::HalestormDriver::kSongPlayOnce, _resIDMusic[track]);
 }
 
 void SoundMac::haltTrack() {
 	if (_ready)
-		_driver->doCommand(HalestormDriver::kSongAbort);
+		_driver->doCommand(Audio::HalestormDriver::kSongAbort);
 }
 
 void SoundMac::playSoundEffect(uint16 track, uint8) {
@@ -217,7 +216,7 @@ void SoundMac::playSoundEffect(uint16 track, uint8) {
 }
 
 bool SoundMac::isPlaying() const {
-	return _ready && _driver->doCommand(HalestormDriver::kSongIsPlaying);
+	return _ready && _driver->doCommand(Audio::HalestormDriver::kSongIsPlaying);
 }
 
 void SoundMac::beginFadeOut() {
@@ -227,11 +226,11 @@ void SoundMac::beginFadeOut() {
 	if (!isPlaying())
 		return;
 
-	_driver->doCommand(HalestormDriver::kSongFadeOut, 30);
-	while (_driver->doCommand(HalestormDriver::kSongFadeGetState) >= 16)
+	_driver->doCommand(Audio::HalestormDriver::kSongFadeOut, 30);
+	while (_driver->doCommand(Audio::HalestormDriver::kSongFadeGetState) >= 16)
 		_vm->delay(8);
-	_driver->doCommand(HalestormDriver::kSongAbort);
-	_driver->doCommand(HalestormDriver::kSongFadeReset, 256);
+	_driver->doCommand(Audio::HalestormDriver::kSongAbort);
+	_driver->doCommand(Audio::HalestormDriver::kSongFadeReset, 256);
 }
 
 void SoundMac::updateVolumeSettings() {
@@ -268,7 +267,7 @@ void SoundMac::setQuality(bool hi) {
 	if (!(_driver && _res))
 		return;
 
-	_driver->doCommand(HalestormDriver::kSongAbort);
+	_driver->doCommand(Audio::HalestormDriver::kSongAbort);
 	_driver->stopAllSoundEffects();
 	_driver->releaseSamples();
 
@@ -276,10 +275,10 @@ void SoundMac::setQuality(bool hi) {
 
 	if (hi) {
 		_driver->changeSystemVoices(7 - _talkieFlag, 4, 1 + _talkieFlag);
-		_driver->doCommand(HalestormDriver::kSetRateAndIntrplMode, 3 + (_talkieFlag << 1));
+		_driver->doCommand(Audio::HalestormDriver::kSetRateAndIntrplMode, 3 + (_talkieFlag << 1));
 	} else {
 		_driver->changeSystemVoices(4, 3 + _talkieFlag, 1 + _talkieFlag);
-		_driver->doCommand(HalestormDriver::kSetRateAndIntrplMode, 2 + _talkieFlag);
+		_driver->doCommand(Audio::HalestormDriver::kSetRateAndIntrplMode, 2 + _talkieFlag);
 	}
 
 	_driver->registerSamples(resIDs[_talkieFlag], true);

--- a/engines/kyra/sound/sound_mac_res.h
+++ b/engines/kyra/sound/sound_mac_res.h
@@ -26,7 +26,7 @@
 #include "common/str.h"
 #include "common/mutex.h"
 
-#include "kyra/sound/drivers/halestorm.h"
+#include "audio/mac/halestorm.h"
 
 namespace Common {
 	class Archive;
@@ -38,7 +38,7 @@ namespace Kyra {
 
 class KyraEngine_v1;
 
-class SoundMacRes final : public HalestormLoader {
+class SoundMacRes final : public Audio::HalestormLoader {
 public:
 	SoundMacRes(KyraEngine_v1 *vm);
 	~SoundMacRes() override;


### PR DESCRIPTION
KYRA: move HaleStorm sound driver to audio/mac

The HaleStorm music player for Mac is used in more games
than just KYRA engine - move it to a shared location so it can
be pulled into other engines as needed.