### PR TITLE
GRIM: Fix Localizer leak on the Remastered path

### DIFF
--- a/engines/grim/localize.cpp
+++ b/engines/grim/localize.cpp
@@ -78,6 +78,7 @@ Localizer::Localizer() {
 
 	if (g_grim->isRemastered()) {
 		parseRemasteredData(Common::String(data));
+		delete[] data;
 		return;
 	}
 


### PR DESCRIPTION
`Localizer::Localizer()` reads the whole localization `.tab` file into a
`new char[]` buffer. The ordinary path frees it after the parse loop; the
`isRemastered()` early return does not.

Freeing it there is safe: `parseRemasteredData()` takes a
`const Common::String &`, which the call site builds by copying the buffer.

Tested with Grim Fandango Remastered (Windows/English) on macOS. Measured
with `leaks(1)`: both buffers stranded before this change, neither after.
The change is confined to the `isRemastered()` branch.
