### PR TITLE
TITANIC: Drop the unreachable second diff >= 0 branch in LiftbotScript

### DIFF
--- a/engines/titanic/true_talk/liftbot_script.cpp
+++ b/engines/titanic/true_talk/liftbot_script.cpp
@@ -712,9 +712,6 @@ int LiftbotScript::sentence1(const TTsentence *sentence) {
 		selectResponse(210138);
 		applyResponse();
 		return 1;
-	} else if (diff >= 0) {
-		addResponse1(diff, true, newId);
-		return 1;
 	} else {
 		return 0;
 	}


### PR DESCRIPTION
In `LiftbotScript::sentence1` the chain tests `diff >= 0` twice, once near the top and once four branches later. Reaching the second one means `diff != -98` and every earlier test failed, so `diff >= 0` is already known to be false there. The body is also byte for byte the same as the earlier branch, which is what makes me read it as a leftover rather than a condition someone meant to write differently.

Deleting it is the reading that matches the duplicate body. If a different test was meant there, say so and I will change it instead.
