### PR TITLE
PHOENIXVR: Use simpleBlitFrom() for rendering cursors with alpha transparency

### DIFF
--- a/engines/phoenixvr/phoenixvr.cpp
+++ b/engines/phoenixvr/phoenixvr.cpp
@@ -1270,11 +1270,11 @@ Graphics::ManagedSurface *PhoenixVREngine::loadSurface(const Common::String &pat
 	if (dec->hasPalette())
 		s->setPalette(dec->getPalette().data(), 0, dec->getPalette().size());
 	// TODO: Skip conversion for surfaces with palettes?
-	if (version() == 1) {
+	if (s->format.aBits() == 0) {
 		s->convertToInPlace(_pixelFormat);
 		s->setTransparentColor(s->format.RGBToColor(0, 0, 0));
-	} else {
-		s->convertToInPlace(Graphics::BlendBlit::getSupportedPixelFormat());
+	} else if (_pixelFormat.aBits() >= s->format.aBits()) {
+		s->convertToInPlace(_pixelFormat);
 	}
 	return s;
 }
@@ -1538,6 +1538,7 @@ void PhoenixVREngine::renderLensflare() {
 		const int dstX = static_cast<int>(sourceX + (_screenCenter.x - sourceX) * lens.scale);
 		const int dstY = static_cast<int>(sourceY + (_screenCenter.y - sourceY) * lens.scale);
 
+		// TODO: Could ManagedSurface routines be used here?
 		for (int y = 0; y != src.h; ++y) {
 			const int screenY = dstY + y;
 			if (screenY < 0 || screenY >= _screen->h)
@@ -1902,8 +1903,8 @@ void PhoenixVREngine::tick(float dt) {
 	if (!cursor)
 		cursor = loadCursor(anyMatched ? _defaultCursor[1] : _defaultCursor[0]);
 	if (cursor) {
-		if (cursor->surface->format.aBits() != 0)
-			_screen->blendBlitFrom(*cursor->surface, _mousePos - cursor->offset);
+		if (!cursor->surface->hasTransparentColor())
+			_screen->simpleBlitFrom(*cursor->surface, _mousePos - cursor->offset, Graphics::FLIP_NONE, true);
 		else
 			_screen->simpleBlitFrom(*cursor->surface, _mousePos - cursor->offset);
 	}
@@ -1926,8 +1927,7 @@ Common::Error PhoenixVREngine::run() {
 		formats.push_back(_rgb565);
 		initGraphics(640, 480, formats);
 	} else {
-		_pixelFormat = Graphics::BlendBlit::getSupportedPixelFormat();
-		initGraphics(640, 480, &_pixelFormat);
+		initGraphics(640, 480, nullptr);
 	}
 
 	_pixelFormat = g_system->getScreenFormat();

--- a/graphics/blit/blit-alpha.cpp
+++ b/graphics/blit/blit-alpha.cpp
@@ -64,7 +64,7 @@ static inline void alphaBlitLogic(byte *dst, const byte *src, const byte *mask, 
 						const int srcInc, const int dstInc, const int maskInc,
 						const uint32 key, const byte flip, const byte aMod) {
 	const uint32 alphaMask = srcFmt.ARGBToColor(255, 0, 0, 0);
-	const bool convert = hasMap ? false : ((SrcSize != DstSize) ? true : srcFmt == dstFmt);
+	const bool convert = hasMap ? false : ((SrcSize != DstSize) ? true : srcFmt != dstFmt);
 
 	for (uint y = 0; y < h; ++y) {
 		for (uint x = 0; x < w; ++x) {


### PR DESCRIPTION
This also revealed a bug in common code that is also fixed as part of this PR.