### PR TITLE
ENGINES: use references instead of copying for loop variables

### DIFF
--- a/audio/softsynth/fluidsynth.cpp
+++ b/audio/softsynth/fluidsynth.cpp
@@ -312,7 +312,7 @@ Common::Path MidiDriver_FluidSynth::getSoundFontPath(bool *exists) {
 	// Finally look for it with SearchMan
 	Common::ArchiveMemberDetailsList files;
 	SearchMan.listMatchingMembers(files, path);
-	for (Common::ArchiveMemberDetails file : files) {
+	for (const auto &file : files) {
 		Common::FSDirectory* dir = dynamic_cast<Common::FSDirectory*>(SearchMan.getArchive(file.arcName));
 		if (!dir)
 			continue;

--- a/engines/ags/engine/ac/draw.cpp
+++ b/engines/ags/engine/ac/draw.cpp
@@ -609,8 +609,8 @@ void on_roomcamera_changed(Camera *cam) {
 	if (_G(drawstate).FullFrameRedraw || (_G(displayed_room) < 0))
 		return;
 	if (cam->HasChangedSize()) {
-		auto viewrefs = cam->GetLinkedViewports();
-		for (auto vr : viewrefs) {
+		const auto &viewrefs = cam->GetLinkedViewports();
+		for (const auto &vr : viewrefs) {
 			PViewport vp = vr.lock();
 			if (vp)
 				sync_roomview(vp.get());

--- a/engines/ags/engine/ac/game_state.cpp
+++ b/engines/ags/engine/ac/game_state.cpp
@@ -133,7 +133,7 @@ void GameState::UpdateViewports() {
 	}
 	if (vp_changed != SIZE_MAX)
 		detect_roomviewport_overlaps(vp_changed);
-	for (auto cam : _roomCameras) {
+	for (const auto &cam : _roomCameras) {
 		if (cam->HasChangedSize() || cam->HasChangedPosition()) {
 			on_roomcamera_changed(cam.get());
 			cam->ClearChangedFlags();

--- a/engines/ags/shared/util/ini_util.cpp
+++ b/engines/ags/shared/util/ini_util.cpp
@@ -87,7 +87,7 @@ String CfgFindKey(const ConfigTree &cfg, const String &sectn, const String &item
 	if (sec_it == cfg.end())
 		return "";
 	if (nocase) {
-		for (auto item_it : sec_it->_value) {
+		for (const auto &item_it : sec_it->_value) {
 			if (item_it._key.CompareNoCase(item) == 0)
 				return item_it._key;
 		}

--- a/engines/director/archive-save.cpp
+++ b/engines/director/archive-save.cpp
@@ -411,7 +411,7 @@ Common::Array<Resource *> RIFXArchive::rebuildResources(Movie *movie) {
 						res->children.push_back(child);
 					}
 
-					for (auto child : res->children) {
+					for (const auto &child : res->children) {
 						_keyData[child.tag][res->index].push_back(child.index);
 						_keyTableUsedCount += 1;
 						_keyTableEntryCount += 1;
@@ -420,7 +420,7 @@ Common::Array<Resource *> RIFXArchive::rebuildResources(Movie *movie) {
 					debugC(5, kDebugSaving, "RIFXArchive::rebuildResources(): new 'CASt' resource added");
 				} else {
 					// The castId is not new, overwrite the key data of the previous cast
-					for (auto child : res->children) {
+					for (const auto &child : res->children) {
 						// Remove the data of the previous (removed) 'CASt'
 						int8 count = _keyData[child.tag][res->index].size();
 						_keyData[child.tag][res->index].clear();
@@ -430,7 +430,7 @@ Common::Array<Resource *> RIFXArchive::rebuildResources(Movie *movie) {
 
 					res->children = jt._value->_children;
 
-					for (auto child : res->children) {
+					for (const auto &child : res->children) {
 						_keyData[child.tag][res->index].push_back(child.index);
 						_keyTableUsedCount += 1;
 						_keyTableEntryCount += 1;

--- a/engines/director/debugger.cpp
+++ b/engines/director/debugger.cpp
@@ -558,12 +558,12 @@ void Debugger::disasmAllCast(Cast *cast) {
 		if (cast->_lingoArchive->factoryContexts.empty()) {
 			debugPrintf("    [empty]\n");
 		} else {
-			for (auto it : cast->_lingoArchive->factoryContexts) {
+			for (const auto &it : cast->_lingoArchive->factoryContexts) {
 				debugPrintf("  %d:\n", it._key);
 				if (it._value->empty()) {
 					debugPrintf("    [empty]\n");
 				} else {
-					for (auto jt : *it._value) {
+					for (const auto &jt : *it._value) {
 						debugPrintf("    %s:\n", jt._key.c_str());
 						for (auto &kt : jt._value->_functionHandlers) {
 							debugPrintf("%s\n", g_lingo->formatFunctionBody(kt._value).c_str());

--- a/engines/director/debugger/debugtools.cpp
+++ b/engines/director/debugger/debugtools.cpp
@@ -57,7 +57,7 @@ const LingoDec::Handler *getHandler(const Cast *cast, CastMemberID id, const Com
 	// for the moment it's happening with Director version < 4
 	if (!cast->_lingodec)
 		return nullptr;
-	for (auto p : cast->_lingodec->scripts) {
+	for (const auto &p : cast->_lingodec->scripts) {
 		if (cast->getCastIdByScriptId(p.first) != id.member)
 			continue;
 

--- a/engines/gob/inter_v7.cpp
+++ b/engines/gob/inter_v7.cpp
@@ -903,7 +903,7 @@ void Inter_v7::o7_setActiveCD() {
 	SearchMan.listMatchingMembers(files, Common::Path(str0, '\\'));
 	Common::Path savedCDpath = _currentCDPath;
 
-	for (Common::ArchiveMemberDetails file : files) {
+	for (const auto &file : files) {
 		if (setCurrentCDPath(file.arcName)) {
 			debugC(5, kDebugFileIO, "o7_setActiveCD: %s -> %s", savedCDpath.toString().c_str(),  _currentCDPath.toString().c_str());
 			storeValue(1);


### PR DESCRIPTION
Use references in for-each loops instead of copying the loop variable for a minor performance improvement. The structs involved can by over 100 bytes large.

Could be extended further to also cover cases of `SharedPtr`.