### PR TITLE
AGS: Move include for wchar.h before scummsys.h in ALFONT

### DIFF
--- a/engines/ags/lib/alfont/alfont.cpp
+++ b/engines/ags/lib/alfont/alfont.cpp
@@ -24,25 +24,15 @@
 #define FORBIDDEN_SYMBOL_EXCEPTION_strcpy
 #define FORBIDDEN_SYMBOL_EXCEPTION_strcat
 
-// Following are pulled in for wchar.h header on XCode iOS-7
-#define FORBIDDEN_SYMBOL_EXCEPTION_FILE
-#define FORBIDDEN_SYMBOL_EXCEPTION_fgetwc
-#define FORBIDDEN_SYMBOL_EXCEPTION_fgetws
-#define FORBIDDEN_SYMBOL_EXCEPTION_asctime
-#define FORBIDDEN_SYMBOL_EXCEPTION_clock
-#define FORBIDDEN_SYMBOL_EXCEPTION_ctime
-#define FORBIDDEN_SYMBOL_EXCEPTION_difftime
-#define FORBIDDEN_SYMBOL_EXCEPTION_getdate
-#define FORBIDDEN_SYMBOL_EXCEPTION_gmtime
-#define FORBIDDEN_SYMBOL_EXCEPTION_localtime
-#define FORBIDDEN_SYMBOL_EXCEPTION_mktime
-#define FORBIDDEN_SYMBOL_EXCEPTION_time
+// <wchar.h> is included here directly, because it's required for wcslen() on some platforms.
+// It is included before scummsys.h, to avoid clutter with symbol exceptions for forbidden symbols
+// that are pulled due this inclusion in some toolchains (eg. XCode iOS-7, MinGW-w64)
+#include <wchar.h>
 
 #include "common/scummsys.h"
 
 #ifdef USE_FREETYPE2
 
-#include <wchar.h>
 #include "ags/lib/alfont/alfont.h"
 #include "ags/lib/allegro/color.h"
 #include "ags/lib/allegro/draw.h"


### PR DESCRIPTION
This is done to avoid symbol exception clutter

New updates in msys2/mingw64 (header io.h) would now otherwise require additional symbol exceptions for mkdir(), chdir() and getcwd() because those get pulled too with the <wchar.h> inclusion. Moving the file before scummsys.h removes the need for maintaining the symbol exceptions specific to this inclusion.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

ATTENTION TO AI USERS:

EVERY WORD of your code, comments, commit log messages, PR description, must be re-read by a human and checked for sanity, correctness and common sense. At any sight of AI slop, including lengthy LLM-oriented explanations, your PR will be closed.

On top of that, we created AI-specific guidelines https://github.com/scummvm/scummvm/blob/master/AI-GUIDELINES.md

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not, please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

We require linear history, so no merge commits are allowed.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
