### PR TITLE
GLK: Fix operator precedence bug in the Level 9 detector

### DIFF
--- a/engines/glk/level9/detection.cpp
+++ b/engines/glk/level9/detection.cpp
@@ -800,7 +800,7 @@ bool Level9MetaEngine::detectGames(const Common::FSList &fslist, DetectedGames &
 		// Check if it's a valid Level 9 game
 		byte *startFile = &data[0];
 		Scanner scanner;
-		int offset = scanner.scanner(&data[0], fileSize) < 0;
+		int offset = scanner.scanner(&data[0], fileSize);
 		if (offset < 0)
 			continue;
 


### PR DESCRIPTION
`<` binds tighter than `=`, so `offset` received the comparison result (0 or 1)
instead of the scan offset:

```c
int offset = scanner.scanner(&data[0], fileSize) < 0;
if (offset < 0)
    continue;
```

Two effects: the guard can never fire, so files the scanner rejected still reach
`gln_gameid_identify_game()`; and `startData = startFile + offset` is computed
from byte 0 or 1 rather than the located offset.

Found when a directory containing Dungeon Master's `DMSAVE.DAT` (a 48K save
file) was detected as a Level 9 game and failed with "Unable to locate valid
Level 9 game in file: DMSAVE.DAT!". The DM game in the same directory detects
and plays normally once Level 9 stops claiming it.

Can only remove false positives: a file that legitimately scans as a Level 9
game returns a non-negative offset and is unaffected.
