### PR TITLE
GRIM: Fix crash rendering EMI text ending in a space

### DIFF
--- a/engines/grim/font.cpp
+++ b/engines/grim/font.cpp
@@ -300,11 +300,13 @@ int BitmapFont::getKernedStringLength(const Common::String &text) const {
 
 int BitmapFont::getBitmapStringLength(const Common::String &text) const {
 	int result = 0;
-	const uint size = text.size();
-	for (uint32 i = 0; i < size; ) {
+	int startColumn = 0;
+	for (uint32 i = 0; i < text.size(); ) {
 		const uint32 ch = getNextChar(text, i);
-		result += getCharStartingCol(ch);
-		result += (i >= size) ? getCharBitmapWidth(ch) : getCharKernedWidth(ch);
+		const int charExtent = startColumn + getCharStartingCol(ch) + getCharBitmapWidth(ch);
+		if (charExtent > result)
+			result = charExtent;
+		startColumn += getCharKernedWidth(ch);
 	}
 	return result;
 }
@@ -397,14 +399,23 @@ void BitmapFont::render(Graphics::Surface &buf, const Common::String &currentLin
 		int32 charBitmapWidth = getCharBitmapWidth(ch);
 		int32 charBitmapPitch = getCharBitmapPitch(ch);
 		int32 charBitmapHeight = getCharBitmapHeight(ch);
-		int8 fontRow = getCharStartingLine(ch) + getBaseOffsetY();
-		int8 fontCol = getCharStartingCol(ch);
+		int32 fontRow = getCharStartingLine(ch) + getBaseOffsetY();
+		int32 fontCol = getCharStartingCol(ch);
+
+		if (startColumn + fontCol + charBitmapWidth > buf.w ||
+		    fontRow + charBitmapHeight > buf.h || startColumn + fontCol < 0 || fontRow < 0) {
+			warning("BitmapFont::render: glyph 0x%x extends outside the %dx%d surface "
+			        "for string \"%s\"; clipping. This is a font metrics bug.",
+			        ch, buf.w, buf.h, currentLine.c_str());
+		}
 
 		for (int line = 0; line < charBitmapHeight; line++) {
 			int lineOffset = (fontRow + line);
 			int columnOffset = startColumn + fontCol;
 			int fontOffset = (charBitmapPitch * line);
 			for (int bitmapCol = 0; bitmapCol < charBitmapWidth; bitmapCol++, columnOffset++, fontOffset++) {
+				if (lineOffset < 0 || lineOffset >= buf.h || columnOffset < 0 || columnOffset >= buf.w)
+					continue;
 				byte pixel = getCharData(ch)[fontOffset];
 				if (pixel == 0x80) {
 					buf.setPixel(columnOffset, lineOffset, blackColor);


### PR DESCRIPTION
Talking to Otis and Carla on Melee Island crashed with an assertion in Surface::setPixel(): a glyph was drawn past the right edge of the text surface.

getBitmapStringLength() sizes the surface using the last character's bitmap width. When the string ends in a space, that width is zero, so the surface is too narrow for the character before it and render() draws out of bounds.

Size the surface from the widest glyph's right edge instead of the last one. Also widen fontRow/fontCol to int32, and clip (with a warning) any glyph that still lands outside the surface.

Companion to 2b4ce79ea50.

Assisted-by: Kiro:claude-sonnet-4-5


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

ATTENTION TO AI USERS:

EVERY WORD of your code, comments, commit log messages, PR description, must be re-read by a human and checked for sanity, correctness and common sense. At any sight of AI slop, including lengthy LLM-oriented explanations, your PR will be closed.

On top of that, we created AI-specific guidelines https://github.com/scummvm/scummvm/blob/master/AI-GUIDELINES.md

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not, please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

We require linear history, so no merge commits are allowed.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
