### PR TITLE
SDL: Add IME composition support

### DIFF
--- a/backends/events/default/default-events.cpp
+++ b/backends/events/default/default-events.cpp
@@ -331,6 +331,10 @@ void DefaultEventManager::purgeKeyboardEvents() {
 			_modifierState = event.kbd.flags;
 			break;
 
+		case Common::EVENT_IME_COMPOSITION:
+			// A pending preedit belongs to the GUI text field that owned it.
+			break;
+
 		default:
 			filteredQueue.push(event);
 			break;

--- a/backends/events/sdl/sdl-common-events.cpp
+++ b/backends/events/sdl/sdl-common-events.cpp
@@ -39,37 +39,74 @@ SdlEventSource::~SdlEventSource() {
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 void SdlEventSource::acquireImeCompositionControl() {
-	if (_imeCompositionControlActive)
-		return;
-
+	// Synchronize the first controlled scope with the existing native text-input
+	// state. SDL text input is also used for non-IME text such as dead keys and
+	// non-English layouts, so an acquisition must not unconditionally stop it.
+	if (_imeCompositionControlStateStack.empty()) {
 #if SDL_VERSION_ATLEAST(3, 0, 0)
-	SDL_Window *window = _graphicsManager ? _graphicsManager->getWindow()->getSDLWindow() : nullptr;
-	_legacyTextInputEnabled = window && SDL_TextInputActive(window);
+		SDL_Window *window = _graphicsManager ? _graphicsManager->getWindow()->getSDLWindow() : nullptr;
+		_textInputEnabled = window && SDL_TextInputActive(window);
 #else
-	_legacyTextInputEnabled = SDL_IsTextInputActive() == SDL_TRUE;
+		_textInputEnabled = SDL_IsTextInputActive() == SDL_TRUE;
 #endif
-	_imeCompositionControlActive = true;
+	}
+
+	// Every nested owner starts with composition disabled. Preserve ordinary
+	// text input only when it was already active without composition. If the
+	// outer owner was composing, stopping text input below also cancels that
+	// unfinished native composition.
+	const ImeCompositionControlState previousState(_imeCompositionEnabled, _textInputEnabled);
+	const bool textInputEnabledWithoutComposition =
+		!previousState.compositionEnabled && previousState.textInputEnabled;
+	_imeCompositionControlStateStack.push(previousState);
 	_imeCompositionEnabled = false;
-	_textInputEnabled = false;
+	_textInputEnabled = textInputEnabledWithoutComposition;
 	applyNativeTextInputState();
 }
 
 void SdlEventSource::setImeCompositionEnabled(bool enable) {
-	if (!_imeCompositionControlActive)
+	// The feature state is meaningful only inside a controlled input scope.
+	// Enabling it does not acquire another scope.
+	if (_imeCompositionControlStateStack.empty())
 		return;
 
+	const ImeCompositionControlState &previousState = _imeCompositionControlStateStack.top();
+	const bool textInputEnabledWithoutComposition =
+		!previousState.compositionEnabled && previousState.textInputEnabled;
+
+	// SDL has no portable composition-only stop operation across the supported
+	// SDL 2 versions. When ordinary text input must remain active, stop and
+	// restart the native text-input session once so disabling composition also
+	// discards its unfinished native text.
+	if (!enable && _imeCompositionEnabled && textInputEnabledWithoutComposition) {
+		_imeCompositionEnabled = false;
+		_textInputEnabled = false;
+		applyNativeTextInputState();
+	}
+
 	_imeCompositionEnabled = enable;
-	_textInputEnabled = enable;
+	_textInputEnabled = enable || textInputEnabledWithoutComposition;
 	applyNativeTextInputState();
 }
 
 void SdlEventSource::releaseImeCompositionControl() {
-	if (!_imeCompositionControlActive)
+	if (_imeCompositionControlStateStack.empty())
 		return;
 
-	_imeCompositionEnabled = false;
-	_textInputEnabled = _legacyTextInputEnabled;
-	_imeCompositionControlActive = false;
+	const ImeCompositionControlState previousState = _imeCompositionControlStateStack.pop();
+
+	// Do not let an unfinished composition owned by the closing scope leak into
+	// an outer text-input session. Stop it before restoring an active session.
+	if (_imeCompositionEnabled && previousState.textInputEnabled) {
+		_imeCompositionEnabled = false;
+		_textInputEnabled = false;
+		applyNativeTextInputState();
+	}
+
+	// Restore both parts of the saved state. The outermost pop therefore returns
+	// SDL to the native text-input state observed by the first acquisition.
+	_imeCompositionEnabled = previousState.compositionEnabled;
+	_textInputEnabled = previousState.textInputEnabled;
 	applyNativeTextInputState();
 }
 

--- a/backends/events/sdl/sdl-common-events.cpp
+++ b/backends/events/sdl/sdl-common-events.cpp
@@ -37,6 +37,84 @@ SdlEventSource::~SdlEventSource() {
 	closeJoystick();
 }
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+void SdlEventSource::acquireImeCompositionControl() {
+	if (_imeCompositionControlActive)
+		return;
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_Window *window = _graphicsManager ? _graphicsManager->getWindow()->getSDLWindow() : nullptr;
+	_legacyTextInputEnabled = window && SDL_TextInputActive(window);
+#else
+	_legacyTextInputEnabled = SDL_IsTextInputActive() == SDL_TRUE;
+#endif
+	_imeCompositionControlActive = true;
+	_imeCompositionEnabled = false;
+	_textInputEnabled = false;
+	applyNativeTextInputState();
+}
+
+void SdlEventSource::setImeCompositionEnabled(bool enable) {
+	if (!_imeCompositionControlActive)
+		return;
+
+	_imeCompositionEnabled = enable;
+	_textInputEnabled = enable;
+	applyNativeTextInputState();
+}
+
+void SdlEventSource::releaseImeCompositionControl() {
+	if (!_imeCompositionControlActive)
+		return;
+
+	_imeCompositionEnabled = false;
+	_textInputEnabled = _legacyTextInputEnabled;
+	_imeCompositionControlActive = false;
+	applyNativeTextInputState();
+}
+
+void SdlEventSource::applyNativeTextInputState() {
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_Window *window = _graphicsManager ? _graphicsManager->getWindow()->getSDLWindow() : nullptr;
+	if (!window)
+		return;
+
+	if (_textInputEnabled) {
+		if (!SDL_TextInputActive(window) && !SDL_StartTextInput(window)) {
+			warning("Could not start SDL text input: %s", SDL_GetError());
+			_textInputEnabled = false;
+			_imeCompositionEnabled = false;
+		}
+	} else {
+		if (SDL_TextInputActive(window) && !SDL_StopTextInput(window))
+			warning("Could not stop SDL text input: %s", SDL_GetError());
+		SDL_FlushEvent(SDL_EVENT_TEXT_INPUT);
+		SDL_FlushEvent(SDL_EVENT_TEXT_EDITING);
+	}
+#else
+	if (_textInputEnabled) {
+		if (!SDL_IsTextInputActive()) {
+			SDL_StartTextInput();
+			if (!SDL_IsTextInputActive()) {
+				warning("Could not start SDL text input: %s", SDL_GetError());
+				_textInputEnabled = false;
+				_imeCompositionEnabled = false;
+			}
+		}
+	} else {
+		if (SDL_IsTextInputActive())
+			SDL_StopTextInput();
+		SDL_FlushEvent(SDL_TEXTINPUT);
+		SDL_FlushEvent(SDL_TEXTEDITING);
+#if SDL_VERSION_ATLEAST(2, 0, 22)
+		SDL_FlushEvent(SDL_TEXTEDITING_EXT);
+#endif
+	}
+#endif
+}
+
+#endif
+
 bool SdlEventSource::processMouseEvent(Common::Event &event, int x, int y, int relx, int rely) {
 	_mouseX = x;
 	_mouseY = y;

--- a/backends/events/sdl/sdl-common-events.cpp
+++ b/backends/events/sdl/sdl-common-events.cpp
@@ -74,19 +74,31 @@ void SdlEventSource::setImeCompositionEnabled(bool enable) {
 	const bool textInputEnabledWithoutComposition =
 		!previousState.compositionEnabled && previousState.textInputEnabled;
 
-	// SDL has no portable composition-only stop operation across the supported
-	// SDL 2 versions. When ordinary text input must remain active, stop and
-	// restart the native text-input session once so disabling composition also
-	// discards its unfinished native text.
-	if (!enable && _imeCompositionEnabled && textInputEnabledWithoutComposition) {
-		_imeCompositionEnabled = false;
-		_textInputEnabled = false;
-		applyNativeTextInputState();
-	}
+	if (!enable && _imeCompositionEnabled)
+		cancelImeComposition();
 
 	_imeCompositionEnabled = enable;
 	_textInputEnabled = enable || textInputEnabledWithoutComposition;
 	applyNativeTextInputState();
+}
+
+void SdlEventSource::cancelImeComposition() {
+	if (!_imeCompositionEnabled || !_textInputEnabled)
+		return;
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_Window *window = _graphicsManager ? _graphicsManager->getWindow()->getSDLWindow() : nullptr;
+	if (window && !SDL_ClearComposition(window))
+		warning("Could not clear SDL text composition: %s", SDL_GetError());
+#elif SDL_VERSION_ATLEAST(2, 0, 22)
+	SDL_ClearComposition();
+#else
+	// Older SDL 2 releases can only cancel composition by restarting text input.
+	_textInputEnabled = false;
+	applyNativeTextInputState();
+	_textInputEnabled = true;
+	applyNativeTextInputState();
+#endif
 }
 
 void SdlEventSource::releaseImeCompositionControl() {
@@ -96,12 +108,9 @@ void SdlEventSource::releaseImeCompositionControl() {
 	const ImeCompositionControlState previousState = _imeCompositionControlStateStack.pop();
 
 	// Do not let an unfinished composition owned by the closing scope leak into
-	// an outer text-input session. Stop it before restoring an active session.
-	if (_imeCompositionEnabled && previousState.textInputEnabled) {
-		_imeCompositionEnabled = false;
-		_textInputEnabled = false;
-		applyNativeTextInputState();
-	}
+	// an outer text-input session.
+	if (_imeCompositionEnabled)
+		cancelImeComposition();
 
 	// Restore both parts of the saved state. The outermost pop therefore returns
 	// SDL to the native text-input state observed by the first acquisition.

--- a/backends/events/sdl/sdl-common-events.cpp
+++ b/backends/events/sdl/sdl-common-events.cpp
@@ -25,7 +25,7 @@
 
 #include "backends/events/sdl/sdl-events.h"
 #include "backends/platform/sdl/sdl.h"
-#include "backends/graphics/graphics.h"
+#include "backends/graphics/sdl/sdl-graphics.h"
 #include "common/config-manager.h"
 #include "common/debug.h"
 #include "common/textconsole.h"
@@ -62,6 +62,29 @@ void SdlEventSource::acquireImeCompositionControl() {
 	_imeCompositionEnabled = false;
 	_textInputEnabled = textInputEnabledWithoutComposition;
 	applyNativeTextInputState();
+}
+
+void SdlEventSource::setImeCompositionArea(const Common::Rect &area) {
+	if (!_graphicsManager)
+		return;
+
+	const Common::Rect windowArea = _graphicsManager->convertOverlayToSdlWindow(area);
+	if (windowArea.isEmpty())
+		return;
+
+	SDL_Rect nativeArea;
+	nativeArea.x = windowArea.left;
+	nativeArea.y = windowArea.top;
+	nativeArea.w = windowArea.width();
+	nativeArea.h = windowArea.height();
+
+#if SDL_VERSION_ATLEAST(3, 0, 0)
+	SDL_Window *window = _graphicsManager->getWindow()->getSDLWindow();
+	if (!SDL_SetTextInputArea(window, &nativeArea, 0))
+		warning("Could not set SDL text input area: %s", SDL_GetError());
+#else
+	SDL_SetTextInputRect(&nativeArea);
+#endif
 }
 
 void SdlEventSource::setImeCompositionEnabled(bool enable) {

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -26,6 +26,7 @@
 #include "backends/graphics/sdl/sdl-graphics.h"
 
 #include "common/events.h"
+#include "common/stack.h"
 
 // Type names which changed between SDL 1.2 and SDL 2.
 #if !SDL_VERSION_ATLEAST(2, 0, 0)
@@ -63,19 +64,25 @@ public:
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	/**
-	 * Acquire explicit engine-side control of native IME composition.
+	 * Acquire explicit client-side control of native IME composition.
 	 *
-	 * This captures the current native text input state and starts with
-	 * composition disabled so the engine can continue using direct key events.
+	 * Control is nested because more than one client can need the controlled
+	 * text-input lifetime at the same time. For example, a game can hold control
+	 * for its lifetime while a GUI dialog acquires it temporarily. Each
+	 * acquisition saves the current composition and general text-input states,
+	 * then starts its scope with composition disabled. Each acquisition must be
+	 * paired with one call to @ref SdlEventSource::releaseImeCompositionControl().
 	 * Its IME-specific behavior is a no-op on systems without native IME support.
 	 */
 	void acquireImeCompositionControl();
 
 	/**
-	 * Release explicit engine-side control of IME composition.
+	 * Release explicit client-side control of IME composition.
 	 *
-	 * This ends the engine-side override and restores the native text input state
-	 * captured by @ref SdlEventSource::acquireImeCompositionControl().
+	 * This restores the composition and text-input states saved by the matching
+	 * acquisition. The native text-input state captured by the first acquisition
+	 * is restored only when the outermost scope releases control. Releasing
+	 * without an outstanding acquisition is ignored.
 	 */
 	void releaseImeCompositionControl();
 
@@ -83,7 +90,8 @@ public:
 	 * Enable or disable native IME composition processing after acquisition.
 	 *
 	 * This has no effect until @ref SdlEventSource::acquireImeCompositionControl()
-	 * has acquired explicit engine-side control.
+	 * has acquired explicit client-side control. This changes the current
+	 * scope's composition state; it does not acquire or release a scope.
 	 */
 	void setImeCompositionEnabled(bool enable);
 
@@ -98,12 +106,32 @@ protected:
 	bool _engineRunning;
 
 #if SDL_VERSION_ATLEAST(2, 0, 0)
+	/** Desired state of the SDL native text-input session. */
 	bool _textInputEnabled = false;
-	bool _legacyTextInputEnabled = false;
-	bool _imeCompositionControlActive = false;
+	struct ImeCompositionControlState {
+		ImeCompositionControlState(bool composition, bool textInput) :
+			compositionEnabled(composition), textInputEnabled(textInput) {
+		}
+
+		bool compositionEnabled;
+		bool textInputEnabled;
+	};
+	/**
+	 * Composition and general text-input state saved for each nested scope.
+	 *
+	 * A boolean or a reference count cannot restore whether an outer input
+	 * owner had composition enabled before a nested GUI took control. General
+	 * SDL text input must be tracked separately because it can already be active
+	 * for dead keys, non-English layouts, and other non-IME text entry. The stack
+	 * preserves both states. An empty stack means native SDL behavior is not
+	 * controlled. The first push captures the existing native text-input state,
+	 * and the last pop restores it.
+	 */
+	Common::Stack<ImeCompositionControlState> _imeCompositionControlStateStack;
+	/** Whether SDL text-editing events are converted to IME events. */
 	bool _imeCompositionEnabled = false;
 	/** Return whether committed SDL text input should enter the ScummVM event queue. */
-	bool shouldDispatchTextInput() const { return !_imeCompositionControlActive || _textInputEnabled; }
+	bool shouldDispatchTextInput() const { return _imeCompositionControlStateStack.empty() || _textInputEnabled; }
 	/** Apply the desired native SDL text input session state. */
 	void applyNativeTextInputState();
 #endif

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -61,11 +61,52 @@ public:
 	/** Sets whether a game is currently running */
 	void setEngineRunning(bool value);
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	/**
+	 * Acquire explicit engine-side control of native IME composition.
+	 *
+	 * This captures the current native text input state and starts with
+	 * composition disabled so the engine can continue using direct key events.
+	 * Its IME-specific behavior is a no-op on systems without native IME support.
+	 */
+	void acquireImeCompositionControl();
+
+	/**
+	 * Release explicit engine-side control of IME composition.
+	 *
+	 * This ends the engine-side override and restores the native text input state
+	 * captured by @ref SdlEventSource::acquireImeCompositionControl().
+	 */
+	void releaseImeCompositionControl();
+
+	/**
+	 * Enable or disable native IME composition processing after acquisition.
+	 *
+	 * This has no effect until @ref SdlEventSource::acquireImeCompositionControl()
+	 * has acquired explicit engine-side control.
+	 */
+	void setImeCompositionEnabled(bool enable);
+
+	/** Return whether native IME composition processing is enabled. */
+	bool isImeCompositionEnabled() const { return _imeCompositionEnabled; }
+#endif
+
 protected:
 	/** Scroll lock state - since SDL doesn't track it */
 	bool _scrollLock;
 
 	bool _engineRunning;
+
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	bool _textInputEnabled = false;
+	bool _legacyTextInputEnabled = false;
+	bool _imeCompositionControlActive = false;
+	bool _imeCompositionEnabled = false;
+	/** Return whether committed SDL text input should enter the ScummVM event queue. */
+	bool shouldDispatchTextInput() const { return !_imeCompositionControlActive || _textInputEnabled; }
+	/** Apply the desired native SDL text input session state. */
+	void applyNativeTextInputState();
+#endif
 
 	int _mouseX;
 	int _mouseY;

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -76,6 +76,9 @@ public:
 	 */
 	void acquireImeCompositionControl();
 
+	/** Cancel the native composition without disabling text input. */
+	void cancelImeComposition();
+
 	/**
 	 * Release explicit client-side control of IME composition.
 	 *

--- a/backends/events/sdl/sdl-events.h
+++ b/backends/events/sdl/sdl-events.h
@@ -76,6 +76,9 @@ public:
 	 */
 	void acquireImeCompositionControl();
 
+	/** Set the native IME candidate area from GUI overlay coordinates. */
+	void setImeCompositionArea(const Common::Rect &area);
+
 	/** Cancel the native composition without disabling text input. */
 	void cancelImeComposition();
 

--- a/backends/events/sdl/sdl2-events.cpp
+++ b/backends/events/sdl/sdl2-events.cpp
@@ -753,6 +753,9 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 		}
 
 	case SDL_TEXTINPUT: {
+		if (!shouldDispatchTextInput())
+			return false;
+
 		// When we get a TEXTINPUT event it means we got some user input for
 		// which no KEYDOWN exists. SDL 1.2 introduces a "fake" key down+up
 		// in such cases. We will do the same to mimic it's behavior.
@@ -772,6 +775,41 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 
 		return _queuedFakeKeyUp;
 		}
+
+	case SDL_TEXTEDITING:
+		if (!isImeCompositionEnabled())
+			return false;
+
+		event.type = Common::EVENT_IME_COMPOSITION;
+		event.imeComposition = Common::ImeComposition();
+		event.imeComposition.text = Common::U32String(ev.edit.text);
+		event.imeComposition.state = event.imeComposition.text.empty()
+			? Common::ImeComposition::kComplete
+			: Common::ImeComposition::kCompositing;
+		event.imeComposition.start = ev.edit.start;
+		event.imeComposition.length = ev.edit.length;
+		return true;
+
+#if SDL_VERSION_ATLEAST(2, 0, 22)
+	case SDL_TEXTEDITING_EXT:
+		if (!isImeCompositionEnabled()) {
+			SDL_free(ev.editExt.text);
+			ev.editExt.text = nullptr;
+			return false;
+		}
+
+		event.type = Common::EVENT_IME_COMPOSITION;
+		event.imeComposition = Common::ImeComposition();
+		event.imeComposition.text = Common::U32String(ev.editExt.text);
+		event.imeComposition.state = event.imeComposition.text.empty()
+			? Common::ImeComposition::kComplete
+			: Common::ImeComposition::kCompositing;
+		event.imeComposition.start = ev.editExt.start;
+		event.imeComposition.length = ev.editExt.length;
+		SDL_free(ev.editExt.text);
+		ev.editExt.text = nullptr;
+		return true;
+#endif
 
 	case SDL_WINDOWEVENT:
 		// We're only interested in events from the current display window
@@ -829,6 +867,12 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 			// Always allow the display to turn off if ScummVM is out of focus
 			event.type = Common::EVENT_FOCUS_LOST;
 			SDL_EnableScreenSaver();
+			if (isImeCompositionEnabled()) {
+				Common::Event imeCancellationEvent;
+				imeCancellationEvent.type = Common::EVENT_IME_COMPOSITION;
+				imeCancellationEvent.imeComposition = Common::ImeComposition(Common::ImeComposition::kCancelled);
+				g_system->getEventManager()->pushEvent(imeCancellationEvent);
+			}
 			return true;
 		}
 
@@ -1079,6 +1123,9 @@ SDL_Keycode SdlEventSource::obtainKeycode(const SDL_Keysym keySym) {
 }
 
 uint32 SdlEventSource::obtainUnicode(const SDL_KeyboardEvent &key) {
+	if (!shouldDispatchTextInput())
+		return 0;
+
 	SDL_Event events[2];
 
 #if defined(USE_IMGUI)

--- a/backends/events/sdl/sdl2-events.cpp
+++ b/backends/events/sdl/sdl2-events.cpp
@@ -756,6 +756,13 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 		if (!shouldDispatchTextInput())
 			return false;
 
+		if (isImeCompositionEnabled()) {
+			event.type = Common::EVENT_IME_COMPOSITION;
+			event.imeComposition = Common::ImeComposition(Common::ImeComposition::kComplete);
+			event.imeComposition.text = Common::U32String(ev.text.text);
+			return !event.imeComposition.text.empty();
+		}
+
 		// When we get a TEXTINPUT event it means we got some user input for
 		// which no KEYDOWN exists. SDL 1.2 introduces a "fake" key down+up
 		// in such cases. We will do the same to mimic it's behavior.
@@ -964,7 +971,7 @@ bool SdlEventSource::handleKeyDown(SDL_Event &ev, Common::Event &event) {
 		mod = SDL_Keymod(mod | KMOD_NUM);
 	}
 #endif
-	event.kbd.ascii = mapKey(sdlKeycode, mod, obtainUnicode(ev.key));
+	event.kbd.ascii = isImeCompositionEnabled() ? 0 : mapKey(sdlKeycode, mod, obtainUnicode(ev.key));
 
 	event.kbdRepeat = ev.key.repeat;
 
@@ -996,7 +1003,7 @@ bool SdlEventSource::handleKeyUp(SDL_Event &ev, Common::Event &event) {
 		mod = SDL_Keymod(mod | KMOD_NUM);
 	}
 #endif
-	event.kbd.ascii = mapKey(sdlKeycode, mod, 0);
+	event.kbd.ascii = isImeCompositionEnabled() ? 0 : mapKey(sdlKeycode, mod, 0);
 
 	return true;
 }

--- a/backends/events/sdl/sdl3-events.cpp
+++ b/backends/events/sdl/sdl3-events.cpp
@@ -614,6 +614,9 @@ void SdlEventSource::preprocessFingerMotion(SDL_Event *event) {
 }
 
 bool SdlEventSource::pollEvent(Common::Event &event) {
+	if (_textInputEnabled)
+		applyNativeTextInputState();
+
 	finishSimulatedMouseClicks();
 
 	// In case we still need to send a key up event for a key down from a
@@ -731,6 +734,9 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 		}
 
 	case SDL_EVENT_TEXT_INPUT: {
+		if (!shouldDispatchTextInput())
+			return false;
+
 		// When we get a TEXTINPUT event it means we got some user input for
 		// which no KEYDOWN exists. SDL 1.2 introduces a "fake" key down+up
 		// in such cases. We will do the same to mimic it's behavior.
@@ -761,6 +767,20 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 		event.type = Common::EVENT_QUIT;
 		return true;
 
+	case SDL_EVENT_TEXT_EDITING:
+		if (!isImeCompositionEnabled())
+			return false;
+
+		event.type = Common::EVENT_IME_COMPOSITION;
+		event.imeComposition = Common::ImeComposition();
+		event.imeComposition.text = Common::U32String(ev.edit.text);
+		event.imeComposition.state = event.imeComposition.text.empty()
+			? Common::ImeComposition::kComplete
+			: Common::ImeComposition::kCompositing;
+		event.imeComposition.start = ev.edit.start;
+		event.imeComposition.length = ev.edit.length;
+		return true;
+
 		case SDL_EVENT_WINDOW_EXPOSED:
 			if (_graphicsManager) {
 				_graphicsManager->notifyVideoExpose();
@@ -786,6 +806,12 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 			// Always allow the display to turn off if ScummVM is out of focus
 			event.type = Common::EVENT_FOCUS_LOST;
 			SDL_EnableScreenSaver();
+			if (isImeCompositionEnabled()) {
+				Common::Event imeCancellationEvent;
+				imeCancellationEvent.type = Common::EVENT_IME_COMPOSITION;
+				imeCancellationEvent.imeComposition = Common::ImeComposition(Common::ImeComposition::kCancelled);
+				g_system->getEventManager()->pushEvent(imeCancellationEvent);
+			}
 			return true;
 		}
 
@@ -1038,6 +1064,9 @@ bool SdlEventSource::isJoystickConnected() const {
 }
 
 uint32 SdlEventSource::obtainUnicode(const SDL_KeyboardEvent &key) {
+	if (!shouldDispatchTextInput())
+		return 0;
+
 	SDL_Event events[2];
 
 #if defined(USE_IMGUI)

--- a/backends/events/sdl/sdl3-events.cpp
+++ b/backends/events/sdl/sdl3-events.cpp
@@ -737,6 +737,13 @@ bool SdlEventSource::dispatchSDLEvent(SDL_Event &ev, Common::Event &event) {
 		if (!shouldDispatchTextInput())
 			return false;
 
+		if (isImeCompositionEnabled()) {
+			event.type = Common::EVENT_IME_COMPOSITION;
+			event.imeComposition = Common::ImeComposition(Common::ImeComposition::kComplete);
+			event.imeComposition.text = Common::U32String(ev.text.text);
+			return !event.imeComposition.text.empty();
+		}
+
 		// When we get a TEXTINPUT event it means we got some user input for
 		// which no KEYDOWN exists. SDL 1.2 introduces a "fake" key down+up
 		// in such cases. We will do the same to mimic it's behavior.
@@ -898,7 +905,7 @@ bool SdlEventSource::handleKeyDown(SDL_Event &ev, Common::Event &event) {
 		mod = SDL_Keymod(mod | KMOD_NUM);
 	}
 #endif
-	event.kbd.ascii = mapKey(sdlKeycode, mod, obtainUnicode(ev.key));
+	event.kbd.ascii = isImeCompositionEnabled() ? 0 : mapKey(sdlKeycode, mod, obtainUnicode(ev.key));
 
 	event.kbdRepeat = ev.key.repeat;
 
@@ -930,7 +937,7 @@ bool SdlEventSource::handleKeyUp(SDL_Event &ev, Common::Event &event) {
 		mod = SDL_Keymod(mod | KMOD_NUM);
 	}
 #endif
-	event.kbd.ascii = mapKey(sdlKeycode, mod, 0);
+	event.kbd.ascii = isImeCompositionEnabled() ? 0 : mapKey(sdlKeycode, mod, 0);
 
 	return true;
 }

--- a/backends/graphics/sdl/sdl-graphics.cpp
+++ b/backends/graphics/sdl/sdl-graphics.cpp
@@ -252,6 +252,32 @@ bool SdlGraphicsManager::lockMouse(bool lock) {
 	return _window->lockMouse(lock);
 }
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+Common::Rect SdlGraphicsManager::convertOverlayToSdlWindow(const Common::Rect &area) const {
+	if (area.isEmpty() || _overlayDrawRect.isEmpty() || getOverlayWidth() == 0 || getOverlayHeight() == 0 || !_window || !_window->getSDLWindow())
+		return Common::Rect();
+
+	const Common::Point corners[] = {
+		convertOverlayToWindow(area.left, area.top),
+		convertOverlayToWindow(area.right - 1, area.top),
+		convertOverlayToWindow(area.left, area.bottom - 1),
+		convertOverlayToWindow(area.right - 1, area.bottom - 1)
+	};
+	Common::Rect windowArea(corners[0].x, corners[0].y, corners[0].x, corners[0].y);
+	for (uint i = 1; i < ARRAYSIZE(corners); i++)
+		windowArea.extend(corners[i]);
+	windowArea.right += 1;
+	windowArea.bottom += 1;
+
+	const float dpiScale = _window->getSdlDpiScalingFactor();
+	const int16 left = static_cast<int16>(windowArea.left / dpiScale + 0.5f);
+	const int16 top = static_cast<int16>(windowArea.top / dpiScale + 0.5f);
+	const int width = MAX(1, static_cast<int>(windowArea.width() / dpiScale + 0.5f));
+	const int height = MAX(1, static_cast<int>(windowArea.height() / dpiScale + 0.5f));
+	return Common::Rect(left, top, left + width, top + height);
+}
+#endif
+
 bool SdlGraphicsManager::notifyMousePosition(Common::Point &mouse) {
 	bool showCursor = false;
 	// Currently on macOS we need to scale the events for HiDPI screen, but on

--- a/backends/graphics/sdl/sdl-graphics.h
+++ b/backends/graphics/sdl/sdl-graphics.h
@@ -94,6 +94,11 @@ public:
 	bool showMouse(bool visible) override;
 	bool lockMouse(bool lock) override;
 
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	/** Convert a GUI overlay rectangle to SDL window coordinates. */
+	Common::Rect convertOverlayToSdlWindow(const Common::Rect &area) const;
+#endif
+
 	virtual bool saveScreenshot(const Common::Path &filename) const { return false; }
 	void saveScreenshot() override;
 

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -226,12 +226,22 @@ protected:
 	 * overlay-to-window).
 	 */
 	Common::Point convertVirtualToWindow(const int x, const int y) const {
-		const int targetX = _activeArea.drawRect.left;
-		const int targetY = _activeArea.drawRect.top;
-		const int targetWidth = _activeArea.drawRect.width();
-		const int targetHeight = _activeArea.drawRect.height();
-		const int sourceWidth = _activeArea.width;
-		const int sourceHeight = _activeArea.height;
+		return convertVirtualToWindow(x, y, _activeArea.drawRect, _activeArea.width, _activeArea.height);
+	}
+
+	/**
+	 * Converts the given point from overlay coordinates to window coordinates,
+	 * regardless of which virtual screen is currently active.
+	 */
+	Common::Point convertOverlayToWindow(const int x, const int y) const {
+		return convertVirtualToWindow(x, y, _overlayDrawRect, getOverlayWidth(), getOverlayHeight());
+	}
+
+	Common::Point convertVirtualToWindow(const int x, const int y, const Common::Rect &drawRect, const int sourceWidth, const int sourceHeight) const {
+		const int targetX = drawRect.left;
+		const int targetY = drawRect.top;
+		const int targetWidth = drawRect.width();
+		const int targetHeight = drawRect.height();
 
 		if (sourceWidth == 0 || sourceHeight == 0) {
 			error("convertVirtualToWindow called without a valid draw rect");

--- a/backends/graphics/windowed.h
+++ b/backends/graphics/windowed.h
@@ -245,16 +245,16 @@ protected:
 			windowY = targetY + (y * targetHeight + sourceHeight / 2) / sourceHeight;
 			break;
 		case Common::kRotation90:
-			windowX = targetX + ((y - (sourceHeight - 1)) * targetWidth + sourceHeight / 2) / sourceHeight;
+			windowX = targetX + (((sourceHeight - 1) - y) * targetWidth + sourceHeight / 2) / sourceHeight;
 			windowY = targetY + (x * targetHeight + sourceWidth / 2) / sourceWidth;
 			break;
 		case Common::kRotation180:
-			windowX = targetX + ((x - (sourceWidth - 1)) * targetWidth + sourceWidth / 2) / sourceWidth;
-			windowY = targetY + ((y - (sourceHeight - 1)) * targetHeight + sourceHeight / 2) / sourceHeight;
+			windowX = targetX + (((sourceWidth - 1) - x) * targetWidth + sourceWidth / 2) / sourceWidth;
+			windowY = targetY + (((sourceHeight - 1) - y) * targetHeight + sourceHeight / 2) / sourceHeight;
 			break;
 		case Common::kRotation270:
 			windowX = targetX + (y * targetWidth + sourceHeight / 2) / sourceHeight;
-			windowY = targetY + ((x - (sourceWidth - 1)) * targetHeight + sourceWidth / 2) / sourceWidth;
+			windowY = targetY + (((sourceWidth - 1) - x) * targetHeight + sourceWidth / 2) / sourceWidth;
 			break;
 		}
 

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -205,6 +205,7 @@ bool OSystem_SDL::hasFeature(Feature f) {
 #endif
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	if (f == kFeatureClipboardSupport) return true;
+	if (f == kFeatureImeComposition) return true;
 	if (f == kFeatureCpuSSE41) return SDL_HasSSE41();
 #endif
 #if SDL_VERSION_ATLEAST(2, 0, 4)
@@ -249,6 +250,12 @@ bool OSystem_SDL::hasFeature(Feature f) {
 
 void OSystem_SDL::setFeatureState(Feature f, bool enable) {
 	switch (f) {
+	case kFeatureImeComposition:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		if (_eventSource)
+			_eventSource->setImeCompositionEnabled(enable);
+#endif
+		break;
 	case kFeatureTouchpadMode:
 		ConfMan.setBool("touchpad_mouse_mode", enable);
 		break;
@@ -263,6 +270,12 @@ void OSystem_SDL::setFeatureState(Feature f, bool enable) {
 
 bool OSystem_SDL::getFeatureState(Feature f) {
 	switch (f) {
+	case kFeatureImeComposition:
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+		return _eventSource && _eventSource->isImeCompositionEnabled();
+#else
+		return false;
+#endif
 	case kFeatureTouchpadMode:
 		return ConfMan.getBool("touchpad_mouse_mode");
 		break;
@@ -273,6 +286,20 @@ bool OSystem_SDL::getFeatureState(Feature f) {
 		return ModularGraphicsBackend::getFeatureState(f);
 		break;
 	}
+}
+
+void OSystem_SDL::acquireImeCompositionControl() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_eventSource)
+		_eventSource->acquireImeCompositionControl();
+#endif
+}
+
+void OSystem_SDL::releaseImeCompositionControl() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_eventSource)
+		_eventSource->releaseImeCompositionControl();
+#endif
 }
 
 void OSystem_SDL::initBackend() {
@@ -606,6 +633,7 @@ void OSystem_SDL::engineDone() {
 	// Reset presence status
 	_presence->updateStatus("", "");
 #endif
+	releaseImeCompositionControl();
 	_eventSource->setEngineRunning(false);
 }
 

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -295,6 +295,13 @@ void OSystem_SDL::acquireImeCompositionControl() {
 #endif
 }
 
+void OSystem_SDL::cancelImeComposition() {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_eventSource)
+		_eventSource->cancelImeComposition();
+#endif
+}
+
 void OSystem_SDL::releaseImeCompositionControl() {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	if (_eventSource)

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -295,6 +295,13 @@ void OSystem_SDL::acquireImeCompositionControl() {
 #endif
 }
 
+void OSystem_SDL::setImeCompositionArea(const Common::Rect &area) {
+#if SDL_VERSION_ATLEAST(2, 0, 0)
+	if (_eventSource)
+		_eventSource->setImeCompositionArea(area);
+#endif
+}
+
 void OSystem_SDL::cancelImeComposition() {
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	if (_eventSource)

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -659,12 +659,16 @@ void OSystem_SDL::initSDL() {
 	// Check if SDL has not been initialized
 	if (!_initedSDL) {
 		// ScummVM renders the transient composition text in its own editable
-		// widgets. Request editing events before SDL initializes the video
-		// backend, since SDL3 otherwise lets the native IME consume them.
+		// widgets. Candidate lists are the OS-provided popups of conversion
+		// choices, such as Hanja and symbols, which ScummVM does not render.
+		// Configure both responsibilities before SDL initializes video.
 #if SDL_VERSION_ATLEAST(3, 2, 0)
 		SDL_SetHintWithPriority(SDL_HINT_IME_IMPLEMENTED_UI, "composition", SDL_HINT_OVERRIDE);
 #elif SDL_VERSION_ATLEAST(2, 0, 0)
 		SDL_SetHintWithPriority(SDL_HINT_IME_INTERNAL_EDITING, "0", SDL_HINT_OVERRIDE);
+#ifdef SDL_HINT_IME_SHOW_UI
+		SDL_SetHintWithPriority(SDL_HINT_IME_SHOW_UI, "1", SDL_HINT_OVERRIDE);
+#endif
 #endif
 
 		// We always initialize the video subsystem because we will need it to

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -595,6 +595,10 @@ void OSystem_SDL::detectAntiAliasingSupport() {
 #endif // defined(USE_OPENGL_GAME) || defined(USE_OPENGL_SHADERS)
 
 void OSystem_SDL::engineInit() {
+	// GUI composition control applies only while a GUI text field owns input.
+	// An engine must acquire and enable its own scope after it starts.
+	releaseImeCompositionControl();
+
 #if SDL_VERSION_ATLEAST(2, 0, 0)
 	if (_graphicsManager) {
 		dynamic_cast<SdlGraphicsManager *>(_graphicsManager)->unlockWindowSize();

--- a/backends/platform/sdl/sdl.cpp
+++ b/backends/platform/sdl/sdl.cpp
@@ -640,6 +640,15 @@ void OSystem_SDL::engineDone() {
 void OSystem_SDL::initSDL() {
 	// Check if SDL has not been initialized
 	if (!_initedSDL) {
+		// ScummVM renders the transient composition text in its own editable
+		// widgets. Request editing events before SDL initializes the video
+		// backend, since SDL3 otherwise lets the native IME consume them.
+#if SDL_VERSION_ATLEAST(3, 2, 0)
+		SDL_SetHintWithPriority(SDL_HINT_IME_IMPLEMENTED_UI, "composition", SDL_HINT_OVERRIDE);
+#elif SDL_VERSION_ATLEAST(2, 0, 0)
+		SDL_SetHintWithPriority(SDL_HINT_IME_INTERNAL_EDITING, "0", SDL_HINT_OVERRIDE);
+#endif
+
 		// We always initialize the video subsystem because we will need it to
 		// be initialized before the graphics managers to retrieve the desktop
 		// resolution, for example. WebOS also requires this initialization

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -58,6 +58,8 @@ public:
 	bool hasFeature(Feature f) override;
 	void setFeatureState(Feature f, bool enable) override;
 	bool getFeatureState(Feature f) override;
+	void acquireImeCompositionControl() override;
+	void releaseImeCompositionControl() override;
 
 	// Override functions from ModularBackend and OSystem
 	void initBackend() override;

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -59,6 +59,7 @@ public:
 	void setFeatureState(Feature f, bool enable) override;
 	bool getFeatureState(Feature f) override;
 	void acquireImeCompositionControl() override;
+	void cancelImeComposition() override;
 	void releaseImeCompositionControl() override;
 
 	// Override functions from ModularBackend and OSystem

--- a/backends/platform/sdl/sdl.h
+++ b/backends/platform/sdl/sdl.h
@@ -59,6 +59,7 @@ public:
 	void setFeatureState(Feature f, bool enable) override;
 	bool getFeatureState(Feature f) override;
 	void acquireImeCompositionControl() override;
+	void setImeCompositionArea(const Common::Rect &area) override;
 	void cancelImeComposition() override;
 	void releaseImeCompositionControl() override;
 

--- a/common/events.h
+++ b/common/events.h
@@ -118,9 +118,6 @@ enum EventType {
 	EVENT_FOCUS_GAINED = 36,
 	EVENT_FOCUS_LOST = 37,
 
-	/** An input method editor changed its in-progress composition. */
-	EVENT_IME_COMPOSITION = 38,
-
 	/**
 	 * Hotspot display, driven by a hold-to-show key. Bound as a keymapper
 	 * start/end pair (see Keymapper::convertStartToEnd), so SHOW is sent while
@@ -128,6 +125,9 @@ enum EventType {
 	 */
 	EVENT_HOTSPOTS_SHOW = 38,
 	EVENT_HOTSPOTS_HIDE = 39,
+
+	/** An input method editor changed its in-progress composition. */
+	EVENT_IME_COMPOSITION = 40,
 
 	/**
 	 * We reserve some event ids for custom events.

--- a/common/events.h
+++ b/common/events.h
@@ -27,6 +27,7 @@
 #include "common/queue.h"
 #include "common/rect.h"
 #include "common/noncopyable.h"
+#include "common/ustr.h"
 
 #include "common/list.h"
 #include "common/singleton.h"
@@ -116,6 +117,9 @@ enum EventType {
 	/** ScummVM has gained or lost focus. */
 	EVENT_FOCUS_GAINED = 36,
 	EVENT_FOCUS_LOST = 37,
+
+	/** An input method editor changed its in-progress composition. */
+	EVENT_IME_COMPOSITION = 38,
 
 	/**
 	 * Hotspot display, driven by a hold-to-show key. Bound as a keymapper
@@ -212,6 +216,52 @@ enum MouseButton {
 typedef uint32 CustomEventType;
 
 /**
+ * Data supplied with an @ref EVENT_IME_COMPOSITION event.
+ *
+ * The state distinguishes an in-progress update, normal completion, and
+ * cancellation. Start and length describe the selected range inside an
+ * in-progress composition, or are negative when the backend does not provide
+ * that range.
+ *
+ * Committed text is not stored in this structure. It is delivered separately
+ * to engines through @ref EVENT_KEYDOWN.
+ */
+struct ImeComposition {
+	enum State {
+		/** The native input method is updating uncommitted text. */
+		kCompositing,
+		/**
+		 * The native composition ended normally.
+		 * Committed text is delivered separately to engines through @ref EVENT_KEYDOWN.
+		 */
+		kComplete,
+		/** The native composition was cancelled (e.g. lost focus) */
+		kCancelled
+	};
+
+	/** Whether the composition is being updated, completed, or cancelled. */
+	State state;
+	/**
+	 * The current uncommitted composition.
+	 * The string is valid only while @ref state is @ref kCompositing.
+	 */
+	U32String text;
+	/**
+	 * The start of the selected range inside the composition,
+	 * or negative when the backend does not provide that range.
+	 */
+	int32 start;
+	/**
+	 * The length of the selected range inside the composition,
+	 * or negative when the backend does not provide that range.
+	 */
+	int32 length;
+
+	explicit ImeComposition(State compositionState = kComplete) : state(compositionState), start(-1), length(-1) {
+	}
+};
+
+/**
  * Data structure for an event. A pointer to an instance of Event
  * can be passed to pollEvent.
  */
@@ -257,6 +307,9 @@ struct Event {
 	 * EVENT_JOYBUTTON_DOWN and EVENT_JOYBUTTON_UP).
 	 */
 	JoystickState joystick;
+
+	/** IME composition data; only valid for @ref EVENT_IME_COMPOSITION events. */
+	ImeComposition imeComposition;
 
 	Event() : type(EVENT_INVALID), kbdRepeat(false), customType(0) {
 	}

--- a/common/events.h
+++ b/common/events.h
@@ -126,7 +126,7 @@ enum EventType {
 	EVENT_HOTSPOTS_SHOW = 38,
 	EVENT_HOTSPOTS_HIDE = 39,
 
-	/** An input method editor changed its in-progress composition. */
+	/** An input method editor changed, completed, or cancelled a composition. */
 	EVENT_IME_COMPOSITION = 40,
 
 	/**
@@ -218,22 +218,17 @@ typedef uint32 CustomEventType;
 /**
  * Data supplied with an @ref EVENT_IME_COMPOSITION event.
  *
- * The state distinguishes an in-progress update, normal completion, and
+ * The state distinguishes an in-progress update, text commitment, and
  * cancellation. Start and length describe the selected range inside an
  * in-progress composition, or are negative when the backend does not provide
- * that range.
- *
- * Committed text is not stored in this structure. It is delivered separately
- * to engines through @ref EVENT_KEYDOWN.
+ * that range. A completed composition carries the entire committed string in
+ * @ref text instead of reducing it to a single @ref EVENT_KEYDOWN.
  */
 struct ImeComposition {
 	enum State {
 		/** The native input method is updating uncommitted text. */
 		kCompositing,
-		/**
-		 * The native composition ended normally.
-		 * Committed text is delivered separately to engines through @ref EVENT_KEYDOWN.
-		 */
+		/** The native composition ended normally, optionally committing @ref text. */
 		kComplete,
 		/** The native composition was cancelled (e.g. lost focus) */
 		kCancelled
@@ -242,8 +237,9 @@ struct ImeComposition {
 	/** Whether the composition is being updated, completed, or cancelled. */
 	State state;
 	/**
-	 * The current uncommitted composition.
-	 * The string is valid only while @ref state is @ref kCompositing.
+	 * The current uncommitted composition or the complete committed string.
+	 * The string is empty for cancellation and can be empty for completion
+	 * events that only signal the end of a preedit.
 	 */
 	U32String text;
 	/**

--- a/common/recorderfile.cpp
+++ b/common/recorderfile.cpp
@@ -407,6 +407,11 @@ void PlaybackFile::readEvent(RecorderEvent& event) {
 			event.kbd.ascii = _tmpPlaybackFile.readUint16BE();
 			event.kbd.flags = _tmpPlaybackFile.readByte();
 			break;
+		case EVENT_IME_COMPOSITION:
+			// Recorder format 1 stores unknown events as timestamp-only records.
+			// FIXME: Serialize the transient payload after a later format adds sized event payloads.
+			event.time = _tmpPlaybackFile.readUint32BE();
+			break;
 		case EVENT_MOUSEMOVE:
 		case EVENT_LBUTTONDOWN:
 		case EVENT_LBUTTONUP:
@@ -599,6 +604,11 @@ void PlaybackFile::writeEvent(const RecorderEvent &event) {
 			_tmpRecordFile.writeSint32BE(event.kbd.keycode);
 			_tmpRecordFile.writeUint16BE(event.kbd.ascii);
 			_tmpRecordFile.writeByte(event.kbd.flags);
+			break;
+		case EVENT_IME_COMPOSITION:
+			// Recorder format 1 stores unknown events as timestamp-only records.
+			// FIXME: Serialize the transient payload after a later format adds sized event payloads.
+			_tmpRecordFile.writeUint32BE(event.time);
 			break;
 		case EVENT_MOUSEMOVE:
 		case EVENT_LBUTTONDOWN:

--- a/common/system.h
+++ b/common/system.h
@@ -684,22 +684,27 @@ public:
 	virtual bool getFeatureState(Feature f) { return false; }
 
 	/**
-	 * Acquire explicit engine-side control of native IME composition.
+	 * Acquire explicit client-side control of native IME composition.
 	 *
 	 * This opt-in is separate from the enabled state of
 	 * @ref OSystem::kFeatureImeComposition. Control starts with composition disabled,
 	 * after which @ref OSystem::setFeatureState() can enable or disable it for
-	 * the current input owner. This is a no-op on unsupported backends.
+	 * the current input owner. Calls may be nested; each acquisition saves the
+	 * current controlled composition and general text-input states and must be
+	 * paired with one call to @ref OSystem::releaseImeCompositionControl(). This
+	 * is a no-op on unsupported backends.
 	 */
 	virtual void acquireImeCompositionControl() {}
 
 	/**
-	 * Release explicit engine-side control of native IME composition.
+	 * Release explicit client-side control of native IME composition.
 	 *
-	 * This restores the native text input state captured by
-	 * @ref OSystem::acquireImeCompositionControl(). Backends may call this
-	 * automatically when the engine finishes. This is a no-op when control was
-	 * not acquired or the backend does not support native IME composition.
+	 * This restores the composition and general text-input states saved by the
+	 * matching acquisition. The native text-input state captured by the first
+	 * acquisition is restored only after the outermost control scope ends.
+	 * Backends may call this automatically when the engine finishes. This is a
+	 * no-op when control was not acquired or the backend does not support native
+	 * IME composition.
 	 */
 	virtual void releaseImeCompositionControl() {}
 

--- a/common/system.h
+++ b/common/system.h
@@ -456,6 +456,23 @@ public:
 		kFeatureVirtualKeyboard,
 
 		/**
+		 * Control native text input and IME composition processing.
+		 *
+		 * IME composition support is required for CJK languages,
+		 * as its characters cannot be entered directly from a keyboard.
+		 *
+		 * Client code must call @ref OSystem::acquireImeCompositionControl()
+		 * before changing this feature state.
+		 * It should enable the feature only while an editable text field owns keyboard input.
+		 * A supporting backend can then emit @ref Common::EVENT_IME_COMPOSITION
+		 * for composition updates, completion, and cancellation.
+		 * Disabling the feature restores direct key-event processing and cancels
+		 * native composition owned by the backend.
+		 * Its IME-specific behavior is a no-op on systems without native IME support.
+		 */
+		kFeatureImeComposition,
+
+		/**
 		 * Backends supporting this feature allow specifying a custom palette
 		 * for the cursor. The custom palette is used if the feature state
 		 * is set to true by the client code using setFeatureState().
@@ -665,6 +682,26 @@ public:
 	 * For example, test whether fullscreen mode is active or not.
 	 */
 	virtual bool getFeatureState(Feature f) { return false; }
+
+	/**
+	 * Acquire explicit engine-side control of native IME composition.
+	 *
+	 * This opt-in is separate from the enabled state of
+	 * @ref OSystem::kFeatureImeComposition. Control starts with composition disabled,
+	 * after which @ref OSystem::setFeatureState() can enable or disable it for
+	 * the current input owner. This is a no-op on unsupported backends.
+	 */
+	virtual void acquireImeCompositionControl() {}
+
+	/**
+	 * Release explicit engine-side control of native IME composition.
+	 *
+	 * This restores the native text input state captured by
+	 * @ref OSystem::acquireImeCompositionControl(). Backends may call this
+	 * automatically when the engine finishes. This is a no-op when control was
+	 * not acquired or the backend does not support native IME composition.
+	 */
+	virtual void releaseImeCompositionControl() {}
 
 	/** @} */
 

--- a/common/system.h
+++ b/common/system.h
@@ -697,6 +697,16 @@ public:
 	virtual void acquireImeCompositionControl() {}
 
 	/**
+	 * Cancel the native composition without disabling text input.
+	 *
+	 * The active input owner should call this before discarding its local
+	 * preedit state because of a caret move or another editing operation.
+	 * This is a no-op when controlled composition is not enabled or the backend
+	 * does not support native IME composition.
+	 */
+	virtual void cancelImeComposition() {}
+
+	/**
 	 * Release explicit client-side control of native IME composition.
 	 *
 	 * This restores the composition and general text-input states saved by the

--- a/common/system.h
+++ b/common/system.h
@@ -697,6 +697,19 @@ public:
 	virtual void acquireImeCompositionControl() {}
 
 	/**
+	 * Set the native IME candidate area for a GUI overlay text caret.
+	 *
+	 * A native candidate list is the platform popup that presents possible
+	 * conversions for the current composition, such as Hanja and symbols.
+	 * The rectangle is expressed in overlay coordinates. A supporting backend
+	 * converts it to native window coordinates before forwarding it to the input
+	 * method. This should be called before enabling
+	 * @ref OSystem::kFeatureImeComposition and whenever the GUI caret moves.
+	 * This is a no-op on unsupported backends.
+	 */
+	virtual void setImeCompositionArea(const Common::Rect &area) {}
+
+	/**
 	 * Cancel the native composition without disabling text input.
 	 *
 	 * The active input owner should call this before discarding its local

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -101,6 +101,8 @@ GuiManager::GuiManager() : CommandSender(nullptr), _redrawStatus(kRedrawDisabled
 }
 
 GuiManager::~GuiManager() {
+	if (_imeCompositionControlActive)
+		_system->releaseImeCompositionControl();
 	delete _theme;
 	delete _wm;
 }
@@ -787,6 +789,11 @@ void GuiManager::restoreState() {
 }
 
 void GuiManager::openDialog(Dialog *dialog) {
+	if (_dialogStack.empty() && !_tooltip && !_imeCompositionControlActive) {
+		_system->acquireImeCompositionControl();
+		_imeCompositionControlActive = true;
+	}
+
 	if (!_dialogStack.empty())
 		_dialogStack.top()->lostFocus();
 
@@ -842,6 +849,11 @@ void GuiManager::closeTopDialog() {
 		// We need to reset it to nullptr here, else getTopDialog keeps
 		// returning us as top dialog and we never leave the tooltip event loop
 		_tooltip = nullptr;
+	}
+
+	if (!_tooltip && _dialogStack.empty() && _imeCompositionControlActive) {
+		_system->releaseImeCompositionControl();
+		_imeCompositionControlActive = false;
 	}
 }
 

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -190,6 +190,7 @@ protected:
 	bool		_useRTL;
 
 	bool		_displayTopDialogOnly;
+	bool		_imeCompositionControlActive = false;
 
 	Common::Mutex _iconsMutex;
 	Common::SearchSet _iconsSet;

--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -78,7 +78,7 @@ void EditableWidget::drawWidget() {
 void EditableWidget::reflowLayout() {
 	Widget::reflowLayout();
 
-	_editScrollOffset = g_gui.getStringWidth(_editString, _font) - getEditRect().width();
+	_editScrollOffset = g_gui.getStringWidth(getDisplayedEditString(), _font) - getEditRect().width();
 	if (_editScrollOffset < 0) {
 		_editScrollOffset = 0;
 		_drawAlign = _align;
@@ -90,6 +90,7 @@ void EditableWidget::reflowLayout() {
 void EditableWidget::setEditString(const Common::U32String &str) {
 	// TODO: We probably should filter the input string here,
 	// e.g. using tryInsertChar.
+	clearImeComposition();
 	_editString = str;
 	clearSelection();
 	setCaretPos(caretVisualPos(str.size()));
@@ -105,6 +106,103 @@ bool EditableWidget::tryInsertChar(Common::u32char_type_t c, int pos) {
 		return false;
 	_editString.insertChar(c, pos);
 	return true;
+}
+
+Common::U32String EditableWidget::getDisplayedEditString() const {
+	if (!hasImeComposition())
+		return _editString;
+
+	int baseBegin;
+	int baseEnd;
+	getImeCompositionBaseRange(baseBegin, baseEnd);
+	Common::U32String displayedText = _editString.substr(0, baseBegin);
+	displayedText += _imeComposition.text;
+	displayedText += _editString.substr(baseEnd);
+	return displayedText;
+}
+
+int EditableWidget::getDisplayedCaretPos() const {
+	if (!hasImeComposition())
+		return _caretPos;
+
+	int baseBegin;
+	int baseEnd;
+	getImeCompositionBaseRange(baseBegin, baseEnd);
+	const Common::U32String displayedText = getDisplayedEditString();
+	const int logicalPos = MAX(0, MIN(baseBegin + _imeComposition.start, static_cast<int>(displayedText.size())));
+	return static_cast<int>(Common::convertBiDiU32String(displayedText + " ").getVisualPosition(logicalPos));
+}
+
+void EditableWidget::getDisplayedSelection(int &selectionBegin, int &selectionEnd) const {
+	if (!hasImeComposition()) {
+		selectionBegin = _selCaretPos;
+		selectionEnd = _selCaretPos + _selOffset;
+	} else {
+		int baseBegin;
+		int baseEnd;
+		getImeCompositionBaseRange(baseBegin, baseEnd);
+		const Common::U32String displayedText = getDisplayedEditString();
+		const int logicalBegin = MAX(0, MIN(baseBegin + _imeComposition.start,
+											static_cast<int>(displayedText.size())));
+		const int logicalEnd = MAX(logicalBegin, MIN(logicalBegin + _imeComposition.length,
+											static_cast<int>(displayedText.size())));
+		const Common::UnicodeBiDiText bidi(displayedText + " ");
+		selectionBegin = static_cast<int>(bidi.getVisualPosition(logicalBegin));
+		selectionEnd = static_cast<int>(bidi.getVisualPosition(logicalEnd));
+	}
+
+	if (selectionBegin > selectionEnd)
+		SWAP(selectionBegin, selectionEnd);
+
+	const int displayedLength = static_cast<int>(getDisplayedEditString().size());
+	selectionBegin = MAX(0, MIN(selectionBegin, displayedLength));
+	selectionEnd = MAX(0, MIN(selectionEnd, displayedLength));
+}
+
+bool EditableWidget::hasImeComposition() const {
+	return _imeComposition.state == Common::ImeComposition::kCompositing && !_imeComposition.text.empty();
+}
+
+void EditableWidget::getImeCompositionBaseRange(int &baseBegin, int &baseEnd) const {
+	baseBegin = caretLogicalPos();
+	baseEnd = baseBegin;
+	if (_selCaretPos < 0 || _selOffset == 0)
+		return;
+
+	int selectionBegin = _selCaretPos;
+	int selectionEnd = _selCaretPos + _selOffset;
+	if (selectionBegin > selectionEnd)
+		SWAP(selectionBegin, selectionEnd);
+
+	const Common::UnicodeBiDiText bidi(_editString + " ");
+	const int logicalBegin = static_cast<int>(bidi.getLogicalPosition(selectionBegin));
+	const int logicalEnd = static_cast<int>(bidi.getLogicalPosition(selectionEnd));
+	baseBegin = MAX(0, MIN(MIN(logicalBegin, logicalEnd), static_cast<int>(_editString.size())));
+	baseEnd = MAX(baseBegin, MIN(MAX(logicalBegin, logicalEnd), static_cast<int>(_editString.size())));
+}
+
+bool EditableWidget::clearImeComposition() {
+	if (!hasImeComposition())
+		return false;
+
+	_imeComposition = Common::ImeComposition();
+	return true;
+}
+
+void EditableWidget::handleImeComposition(const Common::ImeComposition &composition) {
+	if (composition.state != Common::ImeComposition::kCompositing || composition.text.empty()) {
+		clearImeComposition();
+		return;
+	}
+
+	const int compositionLength = static_cast<int>(composition.text.size());
+	_imeComposition = composition;
+	if (_imeComposition.start < 0)
+		_imeComposition.start = compositionLength;
+	_imeComposition.start = MAX(0, MIN(_imeComposition.start, compositionLength));
+	if (_imeComposition.length < 0)
+		_imeComposition.length = 0;
+	_imeComposition.length = MIN(_imeComposition.length, compositionLength - _imeComposition.start);
 }
 
 int EditableWidget::caretVisualPos(int logicalPos) const {
@@ -126,6 +224,8 @@ void EditableWidget::handleTickle() {
 void EditableWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 	if (!isEnabled())
 		return;
+	if (clearImeComposition())
+		markAsDirty();
 
 	_isDragging = true;
 	// Select all text incase of double press
@@ -219,10 +319,21 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 
 	if (!isEnabled())
 		return false;
+	const bool imeCompositionActive = hasImeComposition();
+	if (imeCompositionActive && state.keycode != Common::KEYCODE_INVALID) {
+		// The native IME owns key interpretation until it completes or cancels
+		// the composition. Raw key events must not modify the committed text.
+		_shiftPressed = state.hasFlags(Common::KBD_SHIFT);
+		return true;
+	}
+	// SDL text input without a matching physical key uses KEYCODE_INVALID.
+	// Such an event commits the composition and is inserted below.
 
 	// First remove caret
 	if (_caretVisible)
 		drawCaret(true);
+	if (imeCompositionActive && clearImeComposition())
+		dirty = true;
 
 	_shiftPressed = state.hasFlags(Common::KBD_SHIFT);
 
@@ -433,30 +544,48 @@ void EditableWidget::handleOtherEvent(const Common::Event &evt) {
 		drawCaret(true);
 
 	switch (evt.type) {
+	case Common::EVENT_IME_COMPOSITION:
+		handleImeComposition(evt.imeComposition);
+		dirty = true;
+		forcecaret = true;
+		break;
+	case Common::EVENT_FOCUS_LOST:
+		dirty = clearImeComposition();
+		break;
 	case Common::EVENT_CUSTOM_ENGINE_ACTION_START:
 		switch (evt.customType) {
 		case kActionHome:
+			if (clearImeComposition())
+				dirty = true;
 			moveCaretToStart(false);
 			forcecaret = true;
 			dirty = true;
 			break;
 		case kActionShiftHome:
+			if (clearImeComposition())
+				dirty = true;
 			moveCaretToStart(true);
 			forcecaret = true;
 			dirty = true;
 			break;
 		case kActionEnd:
+			if (clearImeComposition())
+				dirty = true;
 			moveCaretToEnd(false);
 			forcecaret = true;
 			dirty = true;
 			break;
 		case kActionShiftEnd:
+			if (clearImeComposition())
+				dirty = true;
 			moveCaretToEnd(true);
 			forcecaret = true;
 			dirty = true;
 			break;
 		case kActionCut:
 			if (!getEditString().empty() && _selOffset != 0) {
+				if (clearImeComposition())
+					dirty = true;
 				int selBegin = _selCaretPos;
 				int selEnd = _selCaretPos + _selOffset;
 				if (selBegin > selEnd)
@@ -485,6 +614,8 @@ void EditableWidget::handleOtherEvent(const Common::Event &evt) {
 
 		case kActionPaste:
 			if (g_system->hasTextInClipboard()) {
+				if (clearImeComposition())
+					dirty = true;
 				Common::U32String text = g_system->getTextFromClipboard();
 				if (_selOffset != 0) {
 					int selBegin = _selCaretPos;
@@ -521,14 +652,20 @@ void EditableWidget::handleOtherEvent(const Common::Event &evt) {
 }
 
 int EditableWidget::getCaretOffset() const {
-	Common::UnicodeBiDiText utxt(_editString);
-	Common::U32String substr(utxt.visual.begin(), utxt.visual.begin() + _caretPos);
+	const Common::U32String displayedText = getDisplayedEditString();
+	const Common::UnicodeBiDiText utxt(displayedText);
+	const int caretPos = getDisplayedCaretPos();
+	Common::U32String substr(utxt.visual.begin(), utxt.visual.begin() + caretPos);
 	return g_gui.getStringWidth(substr, _font) - _editScrollOffset;
 }
 
 int EditableWidget::getSelectionCarretOffset() const {
-	Common::UnicodeBiDiText utxt(_editString);
-	Common::U32String substr(utxt.visual.begin(), utxt.visual.begin() + _selCaretPos);
+	const Common::U32String displayedText = getDisplayedEditString();
+	const Common::UnicodeBiDiText utxt(displayedText);
+	int selectionBegin;
+	int selectionEnd;
+	getDisplayedSelection(selectionBegin, selectionEnd);
+	Common::U32String substr(utxt.visual.begin(), utxt.visual.begin() + selectionBegin);
 	return g_gui.getStringWidth(substr, _font) - _editScrollOffset;
 }
 
@@ -553,8 +690,11 @@ int EditableWidget::getSelectionCarretOffset() const {
 	int x = editRect.left;
 	int y = editRect.top;
 
+	const Common::U32String displayedText = getDisplayedEditString();
+	const int caretPos = getDisplayedCaretPos();
+
 	if (_align == Graphics::kTextAlignRight) {
-		int strVisibleWidth = g_gui.getStringWidth(_editString, _font) - _editScrollOffset;
+		int strVisibleWidth = g_gui.getStringWidth(displayedText, _font) - _editScrollOffset;
 		if (strVisibleWidth > editRect.width()) {
 			_drawAlign = Graphics::kTextAlignLeft;
 			strVisibleWidth = editRect.width();
@@ -582,13 +722,13 @@ int EditableWidget::getSelectionCarretOffset() const {
 		Common::U32String character;
 		int width;
 
-		if ((uint)_caretPos < _editString.size()) {
-			Common::UnicodeBiDiText utxt(_editString);
-			const Common::u32char_type_t chr = utxt.visual[_caretPos];
+		if ((uint)caretPos < displayedText.size()) {
+			Common::UnicodeBiDiText utxt(displayedText);
+			const Common::u32char_type_t chr = utxt.visual[caretPos];
 			width = g_gui.getCharWidth(chr, _font);
 			character = Common::U32String(chr);
 
-			const uint32 last = (_caretPos > 0) ?  utxt.visual[_caretPos - 1] : 0;
+			const uint32 last = (caretPos > 0) ?  utxt.visual[caretPos - 1] : 0;
 			x += g_gui.getKerningOffset(last, chr, _font);
 		} else {
 			// We draw a fake space here to assure that removing the caret
@@ -643,7 +783,7 @@ bool EditableWidget::adjustOffset() {
 		_editScrollOffset -= (editWidth - caretpos);
 		return true;
 	} else if (_editScrollOffset > 0) {
-		const int strWidth = g_gui.getStringWidth(_editString, _font);
+		const int strWidth = g_gui.getStringWidth(getDisplayedEditString(), _font);
 		if (strWidth - _editScrollOffset < editWidth) {
 			// scroll right
 			_editScrollOffset = (strWidth - editWidth);

--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -90,7 +90,7 @@ void EditableWidget::reflowLayout() {
 void EditableWidget::setEditString(const Common::U32String &str) {
 	// TODO: We probably should filter the input string here,
 	// e.g. using tryInsertChar.
-	clearImeComposition();
+	cancelImeComposition();
 	_editString = str;
 	clearSelection();
 	setCaretPos(caretVisualPos(str.size()));
@@ -189,7 +189,39 @@ bool EditableWidget::clearImeComposition() {
 	return true;
 }
 
+bool EditableWidget::cancelImeComposition() {
+	g_system->cancelImeComposition();
+	return clearImeComposition();
+}
+
+bool EditableWidget::commitImeComposition(const Common::U32String &text) {
+	int baseBegin;
+	int baseEnd;
+	getImeCompositionBaseRange(baseBegin, baseEnd);
+
+	Common::U32String acceptedText;
+	for (uint32 i = 0; i < text.size(); i++) {
+		if (isCharAllowed(text[i]))
+			acceptedText.insertChar(text[i], acceptedText.size());
+	}
+
+	clearImeComposition();
+	if (acceptedText.empty())
+		return false;
+
+	_editString.replace(baseBegin, baseEnd - baseBegin, acceptedText);
+	clearSelection();
+	setCaretPos(caretVisualPos(baseBegin + static_cast<int>(acceptedText.size())));
+	sendCommand(_cmd, 0);
+	return true;
+}
+
 void EditableWidget::handleImeComposition(const Common::ImeComposition &composition) {
+	if (composition.state == Common::ImeComposition::kComplete) {
+		commitImeComposition(composition.text);
+		return;
+	}
+
 	if (composition.state != Common::ImeComposition::kCompositing || composition.text.empty()) {
 		clearImeComposition();
 		return;
@@ -224,7 +256,7 @@ void EditableWidget::handleTickle() {
 void EditableWidget::handleMouseDown(int x, int y, int button, int clickCount) {
 	if (!isEnabled())
 		return;
-	if (clearImeComposition())
+	if (cancelImeComposition())
 		markAsDirty();
 
 	_isDragging = true;
@@ -319,21 +351,16 @@ bool EditableWidget::handleKeyDown(Common::KeyState state) {
 
 	if (!isEnabled())
 		return false;
-	const bool imeCompositionActive = hasImeComposition();
-	if (imeCompositionActive && state.keycode != Common::KEYCODE_INVALID) {
+	if (hasImeComposition()) {
 		// The native IME owns key interpretation until it completes or cancels
 		// the composition. Raw key events must not modify the committed text.
 		_shiftPressed = state.hasFlags(Common::KBD_SHIFT);
 		return true;
 	}
-	// SDL text input without a matching physical key uses KEYCODE_INVALID.
-	// Such an event commits the composition and is inserted below.
 
 	// First remove caret
 	if (_caretVisible)
 		drawCaret(true);
-	if (imeCompositionActive && clearImeComposition())
-		dirty = true;
 
 	_shiftPressed = state.hasFlags(Common::KBD_SHIFT);
 
@@ -555,28 +582,28 @@ void EditableWidget::handleOtherEvent(const Common::Event &evt) {
 	case Common::EVENT_CUSTOM_ENGINE_ACTION_START:
 		switch (evt.customType) {
 		case kActionHome:
-			if (clearImeComposition())
+			if (cancelImeComposition())
 				dirty = true;
 			moveCaretToStart(false);
 			forcecaret = true;
 			dirty = true;
 			break;
 		case kActionShiftHome:
-			if (clearImeComposition())
+			if (cancelImeComposition())
 				dirty = true;
 			moveCaretToStart(true);
 			forcecaret = true;
 			dirty = true;
 			break;
 		case kActionEnd:
-			if (clearImeComposition())
+			if (cancelImeComposition())
 				dirty = true;
 			moveCaretToEnd(false);
 			forcecaret = true;
 			dirty = true;
 			break;
 		case kActionShiftEnd:
-			if (clearImeComposition())
+			if (cancelImeComposition())
 				dirty = true;
 			moveCaretToEnd(true);
 			forcecaret = true;
@@ -584,7 +611,7 @@ void EditableWidget::handleOtherEvent(const Common::Event &evt) {
 			break;
 		case kActionCut:
 			if (!getEditString().empty() && _selOffset != 0) {
-				if (clearImeComposition())
+				if (cancelImeComposition())
 					dirty = true;
 				int selBegin = _selCaretPos;
 				int selEnd = _selCaretPos + _selOffset;
@@ -614,7 +641,7 @@ void EditableWidget::handleOtherEvent(const Common::Event &evt) {
 
 		case kActionPaste:
 			if (g_system->hasTextInClipboard()) {
-				if (clearImeComposition())
+				if (cancelImeComposition())
 					dirty = true;
 				Common::U32String text = g_system->getTextFromClipboard();
 				if (_selOffset != 0) {

--- a/gui/widgets/editable.cpp
+++ b/gui/widgets/editable.cpp
@@ -72,6 +72,7 @@ EditableWidget::~EditableWidget() {
 void EditableWidget::drawWidget() {
 	if (_caretVisible) {
 		drawCaret(false, true);
+		updateImeCompositionArea();
 	}
 }
 
@@ -696,10 +697,10 @@ int EditableWidget::getSelectionCarretOffset() const {
 	return g_gui.getStringWidth(substr, _font) - _editScrollOffset;
 }
 
-  void EditableWidget::drawCaret(bool erase, bool useRelativeCoordinates) {
-	// Only draw if item is visible
+Common::Rect EditableWidget::getCaretRect(bool useRelativeCoordinates) {
+	// Only calculate the caret area if the widget is visible.
 	if (!isVisible() || !_boss->isVisible())
-		return;
+		return Common::Rect();
 
 	Common::Rect editRect = getEditRect();
 
@@ -718,7 +719,6 @@ int EditableWidget::getSelectionCarretOffset() const {
 	int y = editRect.top;
 
 	const Common::U32String displayedText = getDisplayedEditString();
-	const int caretPos = getDisplayedCaretPos();
 
 	if (_align == Graphics::kTextAlignRight) {
 		int strVisibleWidth = g_gui.getStringWidth(displayedText, _font) - _editScrollOffset;
@@ -735,7 +735,7 @@ int EditableWidget::getSelectionCarretOffset() const {
 	x += caretOffset;
 
 	if (y < 0 || y + editRect.height() > _h)
-		return;
+		return Common::Rect();
 
 	if (g_gui.useRTL())
 		x += g_system->getOverlayWidth() - _w - xOff;
@@ -743,7 +743,31 @@ int EditableWidget::getSelectionCarretOffset() const {
 		x += xOff;
 	y += yOff;
 
-	g_gui.theme()->drawCaret(Common::Rect(x, y, x + 1, y + editRect.height()), erase);
+	return Common::Rect(x, y, x + 1, y + editRect.height());
+}
+
+void EditableWidget::updateImeCompositionArea() {
+	const Common::Rect caretRect = getCaretRect();
+	if (!caretRect.isEmpty())
+		g_system->setImeCompositionArea(caretRect);
+}
+
+void EditableWidget::drawCaret(bool erase, bool useRelativeCoordinates) {
+	const Common::Rect caretRect = getCaretRect(useRelativeCoordinates);
+	if (caretRect.isEmpty())
+		return;
+
+	const Common::Rect editRect = getEditRect();
+	const Common::U32String displayedText = getDisplayedEditString();
+	const int caretPos = getDisplayedCaretPos();
+	const int caretOffset = getCaretOffset();
+	int x = caretRect.left;
+	const int y = caretRect.top;
+
+	if (!erase && !useRelativeCoordinates)
+		g_system->setImeCompositionArea(caretRect);
+
+	g_gui.theme()->drawCaret(caretRect, erase);
 
 	if (erase) {
 		Common::U32String character;

--- a/gui/widgets/editable.h
+++ b/gui/widgets/editable.h
@@ -41,6 +41,7 @@ namespace GUI {
 class EditableWidget : public Widget, public CommandSender {
 protected:
 	Common::U32String _editString;
+	Common::ImeComposition _imeComposition;
 
 	uint32		_cmd;
 
@@ -114,6 +115,21 @@ protected:
 
 	virtual bool isCharAllowed(Common::u32char_type_t c) const;
 	bool tryInsertChar(Common::u32char_type_t c, int pos);
+
+	/** Return the committed text with the current uncommitted composition inserted. */
+	Common::U32String getDisplayedEditString() const;
+	/** Return the caret position in the visual order of getDisplayedEditString(). */
+	int getDisplayedCaretPos() const;
+	/** Return the visual selection range used to draw the editable text. */
+	void getDisplayedSelection(int &selectionBegin, int &selectionEnd) const;
+	/** Return whether an uncommitted composition is currently displayed. */
+	bool hasImeComposition() const;
+	/** Return the logical range in the committed text replaced by the composition. */
+	void getImeCompositionBaseRange(int &baseBegin, int &baseEnd) const;
+	/** Clear the uncommitted composition and return whether one was active. */
+	bool clearImeComposition();
+	/** Update the uncommitted composition from a native IME event. */
+	void handleImeComposition(const Common::ImeComposition &composition);
 
 	int caretVisualPos(int logicalPos) const;
 	int caretLogicalPos() const;

--- a/gui/widgets/editable.h
+++ b/gui/widgets/editable.h
@@ -105,6 +105,8 @@ protected:
 	virtual Common::Rect getEditRect() const = 0;
 	virtual int getCaretOffset() const;
 	virtual int getSelectionCarretOffset() const;
+	Common::Rect getCaretRect(bool useRelativeCoordinates = false);
+	void updateImeCompositionArea();
 	void drawCaret(bool erase, bool useRelativeCoordinates = false);
 	bool adjustOffset();
 	void makeCaretVisible();

--- a/gui/widgets/editable.h
+++ b/gui/widgets/editable.h
@@ -128,6 +128,10 @@ protected:
 	void getImeCompositionBaseRange(int &baseBegin, int &baseEnd) const;
 	/** Clear the uncommitted composition and return whether one was active. */
 	bool clearImeComposition();
+	/** Cancel the native composition and clear its uncommitted text. */
+	bool cancelImeComposition();
+	/** Replace the composition range with committed text. */
+	bool commitImeComposition(const Common::U32String &text);
 	/** Update the uncommitted composition from a native IME event. */
 	void handleImeComposition(const Common::ImeComposition &composition);
 

--- a/gui/widgets/edittext.cpp
+++ b/gui/widgets/edittext.cpp
@@ -82,15 +82,13 @@ void EditTextWidget::drawWidget() {
 	int x = -_editScrollOffset;
 	int y = drawRect.top;
 
-	int selBegin = _selCaretPos;
-	int selEnd = _selOffset + _selCaretPos;
-	if (selBegin > selEnd)
-		SWAP(selBegin, selEnd);
-	selBegin = MAX(selBegin, 0);
-	selEnd = MAX(selEnd, 0);
+	const Common::U32String displayedText = getDisplayedEditString();
+	int selBegin;
+	int selEnd;
+	getDisplayedSelection(selBegin, selEnd);
 	
 	if (!g_gui.useRTL()) {
-		Common::UnicodeBiDiText utxt(_editString);
+		Common::UnicodeBiDiText utxt(displayedText);
 		Common::U32String left = Common::U32String(utxt.visual.c_str(), utxt.visual.c_str() + selBegin);
 		Common::U32String selected = Common::U32String(utxt.visual.c_str() + selBegin, selEnd - selBegin);
 		Common::U32String right = Common::U32String(utxt.visual.c_str() + selEnd);
@@ -115,10 +113,8 @@ void EditTextWidget::drawWidget() {
 		}
 	} else {
 		// The above method does not render RTL languages correctly, so fallback to default method
-		// There are only two possible cases, either the whole string has been selected
-		// or nothing has been selected.
-		_inversion = _selOffset ? ThemeEngine::kTextInversionFocus : ThemeEngine::kTextInversionNone;
-		g_gui.theme()->drawText(drawRect, _editString, _state, _drawAlign, _inversion, 
+		_inversion = selBegin != selEnd ? ThemeEngine::kTextInversionFocus : ThemeEngine::kTextInversionNone;
+		g_gui.theme()->drawText(drawRect, displayedText, _state, _drawAlign, _inversion,
 		                        -_editScrollOffset, false, _font, ThemeEngine::kFontColorNormal, true, 
 		                        _textDrawableArea);
 	}
@@ -145,15 +141,18 @@ Common::Rect EditTextWidget::getEditRect() const {
 
 void EditTextWidget::receivedFocusWidget() {
 	g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
+	g_system->setFeatureState(OSystem::kFeatureImeComposition, true);
 }
 
 void EditTextWidget::lostFocusWidget() {
 	// If we lose focus, 'commit' the user changes and clear selection
 	_backupString = _editString;
 	drawCaret(true);
+	clearImeComposition();
 	clearSelection();
 
 	g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, false);
+	g_system->setFeatureState(OSystem::kFeatureImeComposition, false);
 }
 
 void EditTextWidget::startEditMode() {

--- a/gui/widgets/edittext.cpp
+++ b/gui/widgets/edittext.cpp
@@ -141,6 +141,7 @@ Common::Rect EditTextWidget::getEditRect() const {
 
 void EditTextWidget::receivedFocusWidget() {
 	g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
+	updateImeCompositionArea();
 	g_system->setFeatureState(OSystem::kFeatureImeComposition, true);
 }
 

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -22,6 +22,7 @@
 #include "common/system.h"
 #include "common/frac.h"
 #include "common/tokenizer.h"
+#include "common/unicode-bidi.h"
 
 #include "gui/widgets/list.h"
 #include "gui/widgets/scrollbar.h"
@@ -278,8 +279,10 @@ void ListWidget::selectItemRange(int from, int to) {
 }
 
 void ListWidget::setList(const Common::U32StringArray &list) {
-	if (_editMode && _caretVisible)
+	const bool wasEditing = _editMode;
+	if (wasEditing && _caretVisible)
 		drawCaret(true);
+	clearImeComposition();
 
 	// Copy everything
 	copyListData(list);
@@ -301,6 +304,8 @@ void ListWidget::setList(const Common::U32StringArray &list) {
 	_lastSelectionStartItem = -1;
 	_editMode = false;
 	g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, false);
+	if (wasEditing)
+		g_system->setFeatureState(OSystem::kFeatureImeComposition, false);
 	scrollBarRecalc();
 }
 
@@ -834,6 +839,7 @@ void ListWidget::receivedFocusWidget() {
 }
 
 void ListWidget::lostFocusWidget() {
+	const bool wasEditing = _editMode;
 	_inversion = ThemeEngine::kTextInversion;
 	_isMouseDown = _isDragging = false;
 	_dragStartY = _dragLastY = 0;
@@ -841,7 +847,10 @@ void ListWidget::lostFocusWidget() {
 	// If we lose focus, we simply forget the user changes
 	_editMode = false;
 	g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, false);
+	if (wasEditing)
+		g_system->setFeatureState(OSystem::kFeatureImeComposition, false);
 	drawCaret(true);
+	clearImeComposition();
 	markAsDirty();
 }
 
@@ -918,7 +927,7 @@ void ListWidget::drawWidget() {
 		ThemeEngine::FontColor color = ThemeEngine::kFontColorFormatting;
 
 		if (_selectedItem == pos && _editMode) {
-			buffer = _editString;
+			buffer = getDisplayedEditString();
 			color = _editColor;
 			adjustOffset();
 		} else {
@@ -978,7 +987,19 @@ Common::Rect ListWidget::getEditRect() const {
 }
 
 int ListWidget::getCaretOffset() const {
-	Common::U32String substr(_editString.begin(), _editString.begin() + _caretPos);
+	// Preserve the original non-composition path exactly. In particular, list
+	// entries may contain GUI formatting that is stripped after selecting the
+	// committed substring.
+	if (!hasImeComposition()) {
+		Common::U32String substr(_editString.begin(), _editString.begin() + _caretPos);
+		Common::U32String stripped = stripGUIformatting(substr);
+		return g_gui.getStringWidth(stripped, _font) - _editScrollOffset;
+	}
+
+	const Common::U32String displayedText = getDisplayedEditString();
+	const Common::UnicodeBiDiText bidi(displayedText);
+	const int caretPos = getDisplayedCaretPos();
+	Common::U32String substr(bidi.visual.begin(), bidi.visual.begin() + caretPos);
 	Common::U32String stripped = stripGUIformatting(substr);
 	return g_gui.getStringWidth(stripped, _font) - _editScrollOffset;
 }
@@ -1024,6 +1045,7 @@ void ListWidget::startEditMode() {
 		_editColor = ThemeEngine::kFontColorNormal;
 		markAsDirty();
 		g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
+		g_system->setFeatureState(OSystem::kFeatureImeComposition, true);
 		sendCommand(kListItemEditModeStartedCmd, _selectedItem);
 	}
 }
@@ -1033,8 +1055,10 @@ void ListWidget::endEditMode() {
 		return;
 	// send a message that editing finished with a return/enter key press
 	_editMode = false;
+	clearImeComposition();
 	_list[_selectedItem] = _editString;
 	g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, false);
+	g_system->setFeatureState(OSystem::kFeatureImeComposition, false);
 	sendCommand(kListItemActivatedCmd, _selectedItem);
 }
 
@@ -1042,7 +1066,9 @@ void ListWidget::abortEditMode() {
 	// undo any changes made
 	assert(_selectedItem >= 0);
 	_editMode = false;
+	clearImeComposition();
 	g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, false);
+	g_system->setFeatureState(OSystem::kFeatureImeComposition, false);
 }
 
 void ListWidget::reflowLayout() {

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -282,7 +282,7 @@ void ListWidget::setList(const Common::U32StringArray &list) {
 	const bool wasEditing = _editMode;
 	if (wasEditing && _caretVisible)
 		drawCaret(true);
-	clearImeComposition();
+	cancelImeComposition();
 
 	// Copy everything
 	copyListData(list);

--- a/gui/widgets/list.cpp
+++ b/gui/widgets/list.cpp
@@ -1045,6 +1045,7 @@ void ListWidget::startEditMode() {
 		_editColor = ThemeEngine::kFontColorNormal;
 		markAsDirty();
 		g_system->setFeatureState(OSystem::kFeatureVirtualKeyboard, true);
+		updateImeCompositionArea();
 		g_system->setFeatureState(OSystem::kFeatureImeComposition, true);
 		sendCommand(kListItemEditModeStartedCmd, _selectedItem);
 	}


### PR DESCRIPTION
<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

ATTENTION TO AI USERS:

EVERY WORD of your code, comments, commit log messages, PR description, must be re-read by a human and checked for sanity, correctness and common sense. At any sight of AI slop, including lengthy LLM-oriented explanations, your PR will be closed.

On top of that, we created AI-specific guidelines https://github.com/scummvm/scummvm/blob/master/AI-GUIDELINES.md

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not, please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

We require linear history, so no merge commits are allowed.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->

## PR Summary

Implements `Common::EVENT_IME_COMPOSITION` through the SDL backend and adds support for IME composition to ScummVM GUI text fields.

This allows clients to display transient IME preedit text and receive the complete committed string, which may contain multiple Unicode code points. 

Without IME support, writing CJK text is hard or impossible. This PR enables it.

- Adds `Common::EVENT_IME_COMPOSITION` for IME preedit updates, text commitment, and cancellation.
  - While an IME updates uncommitted text, ScummVM emits `Common::ImeComposition::kCompositing`.
    - `ImeComposition::text` contains the current preedit string.
    - `ImeComposition::start` and `ImeComposition::length` describe the selected range within that preedit string when provided by the backend.
  - When SDL commits text, ScummVM emits `Common::ImeComposition::kComplete`.
    - For `kComplete`, `ImeComposition::text` contains the complete committed string instead of reducing it to the first code point of a synthetic key event.
    - An empty `kComplete` event may only indicate that the current preedit has ended.
  - When composition is cancelled, including when the ScummVM window loses focus, ScummVM emits `Common::ImeComposition::kCancelled`.
- Supports IME composition in ScummVM GUI text fields.
  - Preedit text (in the process of composition) is kept separate from the committed edit string (end of composition). 
  - The GUI displays the current preedit text, caret, and selection.
  - A completed composition replaces the active selection or composition range with the complete committed string.
  - A cancelled composition clears the displayed preedit without modifying committed text.
- Adds explicit native composition cancellation.
  - GUI operations that invalidate the current preedit, such as moving the caret or replacing the edit string, cancel the corresponding native composition instead of only clearing the GUI state.
  - SDL 2.0.22 and later and SDL3 use `SDL_ClearComposition()`.
  - Older SDL2 versions fall back to restarting the text-input session.

## Details

IME means Input Method Editor. It manages complex text input and composition, particularly for languages such as Chinese, Japanese, and Korean.

SDL exposes the native composition and committed-text events used by this implementation:

- SDL2:
  - `SDL_TEXTEDITING`
  - `SDL_TEXTEDITING_EXT`
  - `SDL_TEXTINPUT`
- SDL3:
  - `SDL_EVENT_TEXT_EDITING`
  - `SDL_EVENT_TEXT_INPUT`

SDL text-input events may commit more than one Unicode code point at a time. While controlled IME composition is enabled, ScummVM delivers the complete `SDL_TEXTINPUT` string through `Common::EVENT_IME_COMPOSITION` with `Common::ImeComposition::kComplete`.

Raw key events are still emitted so clients retain keycodes, modifiers, and repeat state for editing commands. Their text payload is suppressed while IME composition is enabled, making the `kComplete` composition event the single source of committed text.

IME composition remains opt-in:

- A client (e.g., engine or subengine) first acquires explicit composition control.
- It enables `OSystem::kFeatureImeComposition` only while an editable text field owns text input.
- Disabling the feature or releasing composition control cancels unfinished native composition and restores the previously active text-input state.
- Clients that do not opt in retain ScummVM's existing SDL text-input and key-event behavior.
- Composition control may be nested, allowing an engine and a temporarily opened GUI dialog to preserve and restore their respective text-input states.

The ScummVM GUI is included as the first consumer of this event contract. Individual engines may opt in when they have an editable field that can display and consume composition events.

### Screenshot

#### AS-IS

https://github.com/user-attachments/assets/0d0b200e-34da-4f30-aef5-7ebe5135d3ed

#### TO-BE


https://github.com/user-attachments/assets/3cac0502-6ac0-4691-8796-55e7cb18c60f



<img width="254" height="445" alt="image" src="https://github.com/user-attachments/assets/c5ca685f-ef76-4e3e-b13b-1505174c9bdc" />

<img width="286" height="462" alt="image" src="https://github.com/user-attachments/assets/209b0022-c310-43a1-bf8e-ccc4e9b00941" />




## Known limitations & Future Work

### Omission of events on EventRecorder

EventRecorder format 1 stores `Common::EVENT_IME_COMPOSITION` as a timestamp-only record, since storing proper state may break the existing files. This means the format cannot preserve IME input, preventing proper reproduction during playback.

This PR intentionally leaves the recorder format unchanged. 
- Adding the composition payload requires a backward-compatible format bump.
- It may be handled in a follow-up PR, after the compatibility policy on the EventRecorder format is provided.

