### PR TITLE
COMMON: Fix VS compiler warnings in core

### DIFF
--- a/graphics/blit/blit-alpha.cpp
+++ b/graphics/blit/blit-alpha.cpp
@@ -151,9 +151,9 @@ static inline bool alphaBlitHelper(byte *dst, const byte *src, const byte *mask,
 	if (flipy && flipx)
 		dstDelta = -dstDelta;
 	else if (flipy)
-		dstDelta = -((dstPitch * 2) - dstDelta);
+		dstDelta = -(static_cast<int>(dstPitch * 2) - dstDelta);
 	else if (flipx)
-		dstDelta =   (dstPitch * 2) - dstDelta;
+		dstDelta = static_cast<int>(dstPitch * 2) - dstDelta;
 
 	if (aMod == 0)
 		return true;
@@ -209,9 +209,9 @@ static inline bool alphaBlitMapHelper(byte *dst, const byte *src, const byte *ma
 	if (flipy && flipx)
 		dstDelta = -dstDelta;
 	else if (flipy)
-		dstDelta = -((dstPitch * 2) - dstDelta);
+		dstDelta = -(static_cast<int>(dstPitch * 2) - dstDelta);
 	else if (flipx)
-		dstDelta =   (dstPitch * 2) - dstDelta;
+		dstDelta = static_cast<int>(dstPitch * 2) - dstDelta;
 
 	// TODO: optimized cases for dstDelta of 0
 	if (dstFmt.bytesPerPixel == 2) {

--- a/image/jpeg.cpp
+++ b/image/jpeg.cpp
@@ -243,6 +243,12 @@ J_COLOR_SPACE fromScummvmPixelFormat(const Graphics::PixelFormat &format) {
 } // End of anonymous namespace
 #endif
 
+
+#if defined(_MSC_VER)
+#pragma warning(push)
+#pragma warning(disable : 4611) // warning C4611: interaction between '_setjmp' and C++ object destruction is non-portable
+#endif
+
 bool JPEGDecoder::loadStream(Common::SeekableReadStream &stream) {
 #ifdef USE_JPEG
 	// Reset member variables from previous decodings
@@ -383,5 +389,9 @@ bool JPEGDecoder::loadStream(Common::SeekableReadStream &stream) {
 	return false;
 #endif
 }
+
+#if defined(_MSC_VER)
+#pragma warning(pop)
+#endif
 
 } // End of Graphics namespace


### PR DESCRIPTION
Fixes more VS compiler warnings

Disables a warning about using setjmp in JPEGDecoder (there are no objects in the function scope with non-trivial destructors so this is safe).

Fixes negate of an unsigned integer.