### PR TITLE
GUI: Fix locked icon pack files on Windows

### DIFF
--- a/gui/downloadpacksdialog.cpp
+++ b/gui/downloadpacksdialog.cpp
@@ -323,12 +323,16 @@ void DownloadPacksDialog::handleCommand(CommandSender *sender, uint32 cmd, uint3
 		break;
 	case kDownloadEndedCmd:
 		setState(kDownloadComplete);
+		if (_packsglob && !strcmp(_packsglob, "gui-icons*.dat"))
+			g_gui.initIconsSet();
 		break;
 	case kListDownloadFinishedCmd:
 		setState(kDownloadStateListDownloaded);
 		calculateList();
 		break;
 	case kDownloadProceedCmd:
+		if (_packsglob && !strcmp(_packsglob, "gui-icons*.dat"))
+			g_gui.clearIconsSet();
 		setState(kDownloadStateDownloading);
 		g_state->proceedDownload();
 		break;
@@ -409,6 +413,8 @@ void DownloadPacksDialog::calculateList() {
 	for (auto ic = iconFiles.begin(); ic != iconFiles.end(); ++ic) {
 		Common::String fname = (*ic)->getName();
 		Common::SeekableReadStream *str = (*ic)->createReadStream();
+		if (!str)
+			continue;
 		uint32 size = str->size();
 		delete str;
 
@@ -453,6 +459,8 @@ void DownloadPacksDialog::clearCache() {
 	for (auto ic = iconFiles.begin(); ic != iconFiles.end(); ++ic) {
 		Common::String fname = (*ic)->getName();
 		Common::SeekableReadStream *str = (*ic)->createReadStream();
+		if (!str)
+			continue;
 		uint32 size = str->size();
 		delete str;
 
@@ -467,16 +475,20 @@ void DownloadPacksDialog::clearCache() {
 		// Cancel all downloads
 		g_state->session.abortRequest();
 
+		if (_packsglob && !strcmp(_packsglob, "gui-icons*.dat"))
+			g_gui.clearIconsSet();
+
 		// Build list of previously downloaded icon files
 		for (auto ic = iconFiles.begin(); ic != iconFiles.end(); ++ic) {
 			Common::String fname = (*ic)->getName();
 			Common::FSNode fs(iconsPath.join(fname));
 			Common::WriteStream *str = fs.createWriteStream();
-
-			// Overwrite previously downloaded pack files with dummy data
-			str->writeByte(0);
-			str->finalize();
-			delete str;
+			if (str) {
+				// Overwrite previously downloaded pack files with dummy data
+				str->writeByte(0);
+				str->finalize();
+				delete str;
+			}
 		}
 		g_state->fileHash.clear();
 

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -119,6 +119,13 @@ void GuiManager::initIconsSet() {
 #endif
 }
 
+void GuiManager::clearIconsSet() {
+	Common::StackLock lock(_iconsMutex);
+
+	_iconsSet.clear();
+	_iconsSetChanged = true;
+}
+
 void GuiManager::computeScaleFactor() {
 	const Common::Rect safeArea = g_system->getSafeOverlayArea();
 	const uint16 w = safeArea.width();

--- a/gui/gui-manager.h
+++ b/gui/gui-manager.h
@@ -152,6 +152,7 @@ public:
 	void redrawFull();
 
 	void initIconsSet();
+	void clearIconsSet();
 
 	void displayTopDialogOnly(bool mode);
 


### PR DESCRIPTION
Fixes bug #16835.

On Windows, clearing the icon cache or overwriting icon packs fails with
"Couldn't save file" warnings and leaves orphaned .dat.tmp files. This
occurs because g_gui._iconsSet holds open ZipArchive read streams to the
.dat files, causing MoveFileEx to fail with access denied.

- Add GuiManager::clearIconsSet() to release file handles before cache clear
  and downloads under _iconsMutex lock.
- Call clearIconsSet() in DownloadPacksDialog::clearCache() and
  kDownloadProceedCmd.
- Re-initialize icons via g_gui.initIconsSet() on kDownloadEndedCmd.
- Add defensive null checks for stream pointers.

