### PR TITLE
TETRAEDGE: Do not string format an awry float for debug print

### DIFF
--- a/engines/tetraedge/game/scene_lights_xml_parser.cpp
+++ b/engines/tetraedge/game/scene_lights_xml_parser.cpp
@@ -95,7 +95,8 @@ bool SceneLightsXmlParser::parserCallback_Attenuation(ParserNode *node) {
 	float l = parseDouble(node, "linear");
 	float q = parseDouble(node, "quadratic");
 	if (c < 0 || l < 0 || q < 0)
-		warning("Loaded invalid lighting attenuation vals %f %f %f", c, l, q);
+		warning("Loaded invalid lighting attenuation vals %s %s %s", node->values["constant"].c_str(), node->values["linear"].c_str(), node->values["quadratic"].c_str());
+
 	_lights->back()->setConstAtten(c);
 	_lights->back()->setLinearAtten(l);
 	_lights->back()->setQuadraticAtten(q);
@@ -105,7 +106,7 @@ bool SceneLightsXmlParser::parserCallback_Attenuation(ParserNode *node) {
 bool SceneLightsXmlParser::parserCallback_Cutoff(ParserNode *node) {
 	float cutoff = parseDouble(node);
 	if (cutoff < 0.0f || (cutoff > 90.0f && cutoff != 180.0f))
-		warning("Loaded invalid lighting cutoff value %f", cutoff);
+		warning("Loaded invalid lighting cutoff value %s", node->values["value"].c_str());
 	_lights->back()->setCutoff((cutoff * M_PI) / 180.0);
 	return true;
 }
@@ -114,8 +115,8 @@ bool SceneLightsXmlParser::parserCallback_Exponent(ParserNode *node) {
 	float expon = parseDouble(node);
 	if (expon < 0.0f || expon > 128.0f) {
 		// Print debug but don't bother warning - the value is not used anyway.
-		debug("Loaded invalid lighting exponent value %f, default to 1.0", expon);
-		expon = 1.0;
+		debug("Loaded invalid lighting exponent value %s, default to 1.0", node->values["value"].c_str());
+		expon = 1.0f;
 	}
 	_lights->back()->setExponent(expon);
 	return true;

--- a/engines/tetraedge/te/te_light.cpp
+++ b/engines/tetraedge/te/te_light.cpp
@@ -90,7 +90,7 @@ Common::String TeLight::dump() const {
 
 void TeLight::correctAttenuation() {
 	if (!_constAtten && !_linearAtten && !_quadraticAtten)
-		_constAtten = 1.0;
+		_constAtten = 1.0f;
 }
 
 /*static*/


### PR DESCRIPTION
Fixes #15077

Trying to debug print an awry, really big float value for light exponent caused freeze on Android for Syberia. Instead we print the string value as it was before being parsed to double. The bug occured in SceneLightsXmlParser::parserCallback_Exponent(), but this commit also changes SceneLightsXmlParser::parserCallback_Cutoff() and SceneLightsXmlParser::parserCallback_Attenuation() accordingly for consistency.


<!---
Thank you for contributing to ScummVM. Please read the following carefully before submitting your Pull Request.

ATTENTION TO AI USERS:

EVERY WORD of your code, comments, commit log messages, PR description, must be re-read by a human and checked for sanity, correctness and common sense. At any sight of AI slop, including lengthy LLM-oriented explanations, your PR will be closed.

On top of that, we created AI-specific guidelines https://github.com/scummvm/scummvm/blob/master/AI-GUIDELINES.md

Make sure your individual commits follow the guidelines found in the ScummVM Wiki: https://wiki.scummvm.org/index.php?title=Commit_Guidelines. If they're not, please edit them before submitting the Pull Request.

Proper documentation must also be included for common code and changes impacting user facing elements.

We require linear history, so no merge commits are allowed.

Commits and Pull Requests should use the following template:

```
SUBSYSTEM: Short (50 chars or less) summary of changes

More detailed explanatory text, if necessary.  Wrap it to about 72
characters or so.  In some contexts, the first line is treated as the
subject of an email and the rest of the text as the body.  The blank
line separating the summary from the body is critical (unless you omit
the body entirely); tools like rebase can get confused if you run the
two together.

Write your commit message in the present tense: "Fix bug" and not "Fixed
bug."  This convention matches up with commit messages generated by
commands like git merge and git revert.

Further paragraphs come after blank lines.

- Bullet points are okay, too

- Typically a hyphen or asterisk is used for the bullet, preceded by a
 single space, with blank lines in between, but conventions vary here

- Use a hanging indent
```
--->
