### PR TITLE
ALL: use float math functions on floats

### DIFF
--- a/audio/adlib_ms.cpp
+++ b/audio/adlib_ms.cpp
@@ -1655,7 +1655,7 @@ uint16 MidiDriver_ADLIB_Multisource::calculateFrequency(uint8 channel, uint8 sou
 		// Note that the resulting value is double the actual frequency because
 		// of the use of block 0 (which halves the frequency). This allows for
 		// slightly higher precision in the pitch bend calculation.
-		oplFrequency = round(noteFrequency * _oplFrequencyConversionFactor);
+		oplFrequency = roundf(noteFrequency * _oplFrequencyConversionFactor);
 		block = 0;
 	}
 
@@ -1779,7 +1779,7 @@ uint8 MidiDriver_ADLIB_Multisource::calculateUnscaledVolume(uint8 channel, uint8
 		// 40 log(velocity * volume * expression / 127 ^ 3)
 		// Note that velocity is not specified in detail in the MIDI standards;
 		// we use the same volume curve as channel volume and expression.
-		float volumeDb = 40 * log10((velocity * _controlData[source][channel].volume * _controlData[source][channel].expression) / 2048383.0f);
+		float volumeDb = 40 * log10f((velocity * _controlData[source][channel].volume * _controlData[source][channel].expression) / 2048383.0f);
 		// Convert to OPL volume (every unit is 0.75 dB attenuation). The
 		// operator volume is an additional (negative) volume adjustment to balance
 		// the instruments.

--- a/audio/decoders/qdm2.cpp
+++ b/audio/decoders/qdm2.cpp
@@ -881,7 +881,7 @@ void QDM2Stream::softclipTableInit(void) {
 	float delta = 1.0 / -dfl;
 
 	for (i = 0; i < ARRAYSIZE(_softclipTable); i++)
-		_softclipTable[i] = SOFTCLIP_THRESHOLD - ((int)(sin((float)i * delta) * dfl) & 0x0000FFFF);
+		_softclipTable[i] = SOFTCLIP_THRESHOLD - ((int)(sinf((float)i * delta) * dfl) & 0x0000FFFF);
 }
 
 // random generated table

--- a/audio/decoders/wma.cpp
+++ b/audio/decoders/wma.cpp
@@ -425,7 +425,7 @@ void WMACodec::initNoise() {
 	_noiseIndex = 0;
 
 	uint  seed = 1;
-	float norm = (1.0 / (float)(1LL << 31)) * sqrt(3.0f) * _noiseMult;
+	float norm = (1.0f / (float)(1LL << 31)) * sqrtf(3.0f) * _noiseMult;
 
 	for (int i = 0; i < kNoiseTabSize; i++) {
 		seed = seed * 314159 + 1;
@@ -532,7 +532,7 @@ void WMACodec::initLSPToCurve() {
 		int   m = (1 << kLSPPowBits) + i;
 		float a = (float) m * (0.5 / (1 << kLSPPowBits));
 
-		a = pow(a, -0.25f);
+		a = powf(a, -0.25f);
 
 		_lspPowMTable1[i] = 2 * a - b;
 		_lspPowMTable2[i] = b - a;
@@ -1003,7 +1003,7 @@ float WMACodec::getNormalizedMDCTLength() const {
 
 	float mdctNorm = 1.0 / (float) n4;
 	if (_version == 1)
-		mdctNorm *= sqrt((float) n4);
+		mdctNorm *= sqrtf((float) n4);
 
 	return mdctNorm;
 }
@@ -1072,7 +1072,7 @@ void WMACodec::calculateMDCTCoefficients(int bSize, bool *hasChannel,
 				if (k >= 0 && _highBandCoded[i][k]) {
 					// Use noise with specified power
 
-					float mult1 = sqrt(expPower[k] / expPower[lastHighBand]);
+					float mult1 = sqrtf(expPower[k] / expPower[lastHighBand]);
 
 					mult1 *= pow(10, _highBandValues[i][k] * 0.05);
 					mult1 /= _maxExponent[i] * _noiseMult;

--- a/audio/effects/hmi/interfaces/mono_delay.cpp
+++ b/audio/effects/hmi/interfaces/mono_delay.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+
 #include "audio/effects/hmi/interfaces/mono_delay.h"
 
 namespace Audio {
@@ -62,7 +63,7 @@ int HMIMonoDelay::initEffect(HMIPreset *preset, HMIEffectNode *base) {
 
 int HMIMonoDelay::getMinDuration(HMIEffectNode *base, uint32 *out) {
 	HMIMonoDelayNode *n = (HMIMonoDelayNode *)base;
-	*out = (uint32)(log(kHmiMillis) / log(n->feedback) * n->delayTime);
+	*out = (uint32)(log(kHmiMillis) / logf(n->feedback) * n->delayTime);
 	return 0;
 }
 

--- a/audio/effects/hmi/interfaces/mono_delay.cpp
+++ b/audio/effects/hmi/interfaces/mono_delay.cpp
@@ -19,7 +19,6 @@
  *
  */
 
-
 #include "audio/effects/hmi/interfaces/mono_delay.h"
 
 namespace Audio {

--- a/audio/effects/hmi/interfaces/stereo_delay.cpp
+++ b/audio/effects/hmi/interfaces/stereo_delay.cpp
@@ -19,6 +19,7 @@
  *
  */
 
+
 #include "audio/effects/hmi/interfaces/stereo_delay.h"
 
 namespace Audio {
@@ -76,7 +77,7 @@ int HMIStereoDelay::getMinDuration(HMIEffectNode *base, uint32 *out) {
 	HMIStereoDelayNode *n = (HMIStereoDelayNode *)base;
 
 	double delay = n->delayTimeL > n->delayTimeR ? n->delayTimeL : n->delayTimeR;
-	*out = (uint32)(log(kHmiMillis) / log(n->feedback) * delay);
+	*out = (uint32)(log(kHmiMillis) / logf(n->feedback) * delay);
 	return 0;
 }
 

--- a/audio/effects/hmi/interfaces/stereo_delay.cpp
+++ b/audio/effects/hmi/interfaces/stereo_delay.cpp
@@ -19,7 +19,6 @@
  *
  */
 
-
 #include "audio/effects/hmi/interfaces/stereo_delay.h"
 
 namespace Audio {

--- a/audio/mods/paula.cpp
+++ b/audio/mods/paula.cpp
@@ -296,7 +296,7 @@ float Paula::filterCalculateA0(int rate, int cutoff) {
 	/* Compensate for the bilinear transformation. This allows us to specify the
 	 * stop frequency more exactly, but the filter becomes less steep further
 	 * from stopband. */
-	omega = tan(omega / 2) * 2;
+	omega = tanf(omega / 2) * 2;
 	return 1 / (1 + 1 / omega);
 }
 

--- a/backends/keymapper/virtual-mouse.cpp
+++ b/backends/keymapper/virtual-mouse.cpp
@@ -187,7 +187,7 @@ void VirtualMouse::handleAxisMotion(int16 axisPositionX, int16 axisPositionY) {
 	float analogY  = (float)_inputAxisPositionY;
 	float deadZone = (float)ConfMan.getInt("joystick_deadzone") * 1000.0f;
 
-	float magnitude = sqrt(analogX * analogX + analogY * analogY);
+	float magnitude = sqrtf(analogX * analogX + analogY * analogY);
 
 	if (magnitude >= deadZone) {
 		float scalingFactor = 1.0f / magnitude * (magnitude - deadZone) / (JOYAXIS_MAX - deadZone);

--- a/engines/access/martian/martian_duct.cpp
+++ b/engines/access/martian/martian_duct.cpp
@@ -158,8 +158,8 @@ void MartianDuct::updateMatrix() {
 	// The original does a full fixed-point matrix calculation here, but
 	// half the values are always 1 or 0 so it's much simpler than that.
 	float moveAngleRad = (float)(_moveAngle / 256.0f) * 2.0f * M_PI;
-	float cosVal = cos(moveAngleRad);
-	float sinVal = sin(moveAngleRad);
+	float cosVal = cosf(moveAngleRad);
+	float sinVal = sinf(moveAngleRad);
 
 	// 3D rotation through Y axis.  We never rotate through the others.
 	_matrix[0][0] = cosVal;
@@ -669,8 +669,8 @@ Point3 MartianDuct::divmul1(const Point3 &pt1, const Point3 &pt2) {
 	Point3 out;
 	out.z = 2;
 	float tmp = (2.0f - pt1.z) / (pt2.z - pt1.z);
-	out.x = (int)round((pt2.x - pt1.x) * tmp + pt1.x);
-	out.y = (int)round((pt2.y - pt1.y) * tmp + pt1.y);
+	out.x = (int)roundf((pt2.x - pt1.x) * tmp + pt1.x);
+	out.y = (int)roundf((pt2.y - pt1.y) * tmp + pt1.y);
 	return out;
 }
 
@@ -678,9 +678,9 @@ Point3 MartianDuct::divmul2(const Point3 &pt1, const Point3 &pt2) {
 	// called for kDuctFlagXLessThanNegZ
 	Point3 out;
 	float tmp = (pt1.z + pt1.x * 2.0f) / ((pt1.x - pt2.x) * 2 - pt2.z + pt1.z);
-	out.z = (int)round((pt2.z - pt1.z) * tmp + pt1.z);
+	out.z = (int)roundf((pt2.z - pt1.z) * tmp + pt1.z);
 	out.x = -(out.z / 2);
-	out.y = (int)round((pt2.y - pt1.y) * tmp + pt1.y);
+	out.y = (int)roundf((pt2.y - pt1.y) * tmp + pt1.y);
 	return out;
 }
 
@@ -688,9 +688,9 @@ Point3 MartianDuct::divmul3(const Point3 &pt1, const Point3 &pt2) {
 	// called for kDuctFlagZLessThanY
 	Point3 out;
 	float tmp = (pt1.z - pt1.y * 2.0f) / ((pt2.y - pt1.y) * 2 - pt2.z + pt1.z);
-	out.y = (int)round((pt2.z - pt1.z) * tmp + pt1.z);
+	out.y = (int)roundf((pt2.z - pt1.z) * tmp + pt1.z);
 	out.z = out.y;
-	out.x = (int)round((pt2.x - pt1.x) * tmp + pt1.x);
+	out.x = (int)roundf((pt2.x - pt1.x) * tmp + pt1.x);
 	return out;
 }
 
@@ -698,9 +698,9 @@ Point3 MartianDuct::divmul4(const Point3 &pt1, const Point3 &pt2) {
 	// called for kDuctFlagZLessThanX
 	Point3 out;
 	float tmp = (pt1.z - pt1.x * 2.0f) / ((pt2.x - pt1.x) * 2 - pt2.z + pt1.z);
-	out.z = (int)round((pt2.z - pt1.z) * tmp + pt1.z);
+	out.z = (int)roundf((pt2.z - pt1.z) * tmp + pt1.z);
 	out.x = out.z / 2;
-	out.y = (int)round((pt2.y - pt1.y) * tmp + pt1.y);
+	out.y = (int)roundf((pt2.y - pt1.y) * tmp + pt1.y);
 	return out;
 }
 
@@ -708,9 +708,9 @@ Point3 MartianDuct::divmul5(const Point3 &pt1, const Point3 &pt2) {
 	// called for kDuctFlagYLessThanNegZ
 	Point3 out;
 	float tmp = (pt1.z + pt1.y * 2.0f) / ((pt1.y - pt2.y) * 2 - pt2.z + pt1.z);
-	out.z = (int)round((pt2.z - pt1.z) * tmp + pt1.z);
+	out.z = (int)roundf((pt2.z - pt1.z) * tmp + pt1.z);
 	out.y = -(out.z / 2);
-	out.x = (int)round((pt2.x - pt1.x) * tmp + pt1.x);
+	out.x = (int)roundf((pt2.x - pt1.x) * tmp + pt1.x);
 	return out;
 }
 

--- a/engines/agi/graphics.cpp
+++ b/engines/agi/graphics.cpp
@@ -1417,7 +1417,7 @@ void GfxMgr::initPaletteCLUT(uint8 *destPalette, const uint16 *paletteCLUTData, 
 		for (uint componentNr = 0; componentNr < 3; componentNr++) { // RGB component
 			byte component = (paletteCLUTData[colorNr * 3 + componentNr] >> 8);
 			// Adjust gamma (1.8 to 2.2)
-			component = (byte)(255 * pow(component / 255.0f, 0.8181f));
+			component = (byte)(255 * powf(component / 255.0f, 0.8181f));
 			destPalette[colorNr * 3 + componentNr] = component;
 		}
 	}

--- a/engines/ags/engine/ac/display.cpp
+++ b/engines/ags/engine/ac/display.cpp
@@ -438,7 +438,7 @@ int CalcLipsyncFrameDuration(int text_len, int fps) {
 
 int GetTextDisplayTime(const char *text, int canberel) {
 	int uselen = 0;
-	auto fpstimer = ::lround(get_game_fps());
+	auto fpstimer = lroundf(get_game_fps());
 
 	// if it's background speech, make it stay relative to game speed
 	if ((canberel == 1) && (_GP(play).bgspeech_game_speed == 1))

--- a/engines/ags/engine/ac/global_game.cpp
+++ b/engines/ags/engine/ac/global_game.cpp
@@ -382,7 +382,7 @@ void SetGameSpeed(int newspd) {
 }
 
 int GetGameSpeed() {
-	return ::lround(get_game_fps()) - _GP(play).game_speed_modifier;
+	return lroundf(get_game_fps()) - _GP(play).game_speed_modifier;
 }
 
 int SetGameOption(int opt, int newval) {

--- a/engines/ags/engine/ac/math.cpp
+++ b/engines/ags/engine/ac/math.cpp
@@ -34,11 +34,11 @@ namespace AGS3 {
 int FloatToInt(float value, int roundDirection) {
 	switch (roundDirection) {
 	case eRoundDown:
-		return static_cast<int>(floor(value));
+		return static_cast<int>(floorf(value));
 	case eRoundUp:
-		return static_cast<int>(ceil(value));
+		return static_cast<int>(ceilf(value));
 	case eRoundNearest:
-		return static_cast<int>(round(value));
+		return static_cast<int>(roundf(value));
 	default:
 		quit("!FloatToInt: invalid round direction");
 	}
@@ -54,59 +54,59 @@ float StringToFloat(const char *theString) {
 }
 
 float Math_Cos(float value) {
-	return cos(value);
+	return cosf(value);
 }
 
 float Math_Sin(float value) {
-	return sin(value);
+	return sinf(value);
 }
 
 float Math_Tan(float value) {
-	return tan(value);
+	return tanf(value);
 }
 
 float Math_ArcCos(float value) {
-	return acos(value);
+	return acosf(value);
 }
 
 float Math_ArcSin(float value) {
-	return asin(value);
+	return asinf(value);
 }
 
 float Math_ArcTan(float value) {
-	return atan(value);
+	return atanf(value);
 }
 
 float Math_ArcTan2(float yval, float xval) {
-	return atan2(yval, xval);
+	return atan2f(yval, xval);
 }
 
 float Math_Log(float value) {
-	return log(value);
+	return logf(value);
 }
 
 float Math_Log10(float value) {
-	return ::log10(value);
+	return log10f(value);
 }
 
 float Math_Exp(float value) {
-	return exp(value);
+	return expf(value);
 }
 
 float Math_Cosh(float value) {
-	return cosh(value);
+	return coshf(value);
 }
 
 float Math_Sinh(float value) {
-	return sinh(value);
+	return sinhf(value);
 }
 
 float Math_Tanh(float value) {
-	return tanh(value);
+	return tanhf(value);
 }
 
 float Math_RaiseToPower(float base, float exp) {
-	return ::pow(base, exp);
+	return powf(base, exp);
 }
 
 float Math_DegreesToRadians(float value) {
@@ -125,7 +125,7 @@ float Math_Sqrt(float value) {
 	if (value < 0.0)
 		error("!Sqrt: cannot perform square root of negative number");
 
-	return ::sqrt(value);
+	return sqrtf(value);
 }
 
 int __Rand(int upto) {

--- a/engines/ags/engine/ac/move_list.cpp
+++ b/engines/ags/engine/ac/move_list.cpp
@@ -33,13 +33,13 @@ float MoveList::GetStepLength() const {
 	assert(numstage > 0);
 	float permove_x = fixtof(xpermove[onstage]);
 	float permove_y = fixtof(ypermove[onstage]);
-	return sqrt(permove_x * permove_x + permove_y * permove_y);
+	return sqrtf(permove_x * permove_x + permove_y * permove_y);
 }
 
 float MoveList::GetPixelUnitFraction() const {
 	assert(numstage > 0);
 	float distance = GetStepLength() * onpart;
-	return distance - floor(distance);
+	return distance - floorf(distance);
 }
 
 void MoveList::SetPixelUnitFraction(float frac) {

--- a/engines/ags/engine/ac/route_finder_jps.cpp
+++ b/engines/ags/engine/ac/route_finder_jps.cpp
@@ -470,7 +470,7 @@ Navigation::NavResult Navigation::Navigate(int sx, int sy, int ex, int ey, std::
 			UnpackSquare(pneig[ni], nx, ny);
 			float edx = (float)(nx - ex);
 			float edy = (float)(ny - ey);
-			sort[ni].cost = sqrt(edx * edx + edy * edy);
+			sort[ni].cost = sqrtf(edx * edx + edy * edy);
 			sort[ni].index = pneig[ni];
 		}
 
@@ -508,12 +508,12 @@ Navigation::NavResult Navigation::Navigate(int sx, int sy, int ex, int ey, std::
 			float dx = (float)(nx - x);
 			float dy = (float)(ny - y);
 			// FIXME: can do better here
-			float cost = sqrt(dx * dx + dy * dy);
+			float cost = sqrtf(dx * dx + dy * dy);
 			float ecost = dist + cost;
 
 			float edx = (float)(nx - ex);
 			float edy = (float)(ny - ey);
-			float heur = sqrt(edx * edx + edy * edy);
+			float heur = sqrtf(edx * edx + edy * edy);
 
 			if (ecost < ndist) {
 				ecost *= DIST_SCALE_PACK;

--- a/engines/ags/engine/main/update.cpp
+++ b/engines/ags/engine/main/update.cpp
@@ -304,7 +304,7 @@ void update_speech_and_messages() {
 		if (!_GP(play).speech_in_post_state && (_GP(play).fast_forward == 0) && (_GP(play).messagetime < 1)) {
 			_GP(play).speech_in_post_state = true;
 			if (_GP(play).speech_display_post_time_ms > 0) {
-				_GP(play).messagetime = ::lround(_GP(play).speech_display_post_time_ms * get_game_fps() / 1000.0f);
+				_GP(play).messagetime = lroundf(_GP(play).speech_display_post_time_ms * get_game_fps() / 1000.0f);
 			}
 		}
 

--- a/engines/ags/engine/media/audio/audio.cpp
+++ b/engines/ags/engine/media/audio/audio.cpp
@@ -833,7 +833,7 @@ void update_audio_system_on_game_loop() {
 					// we want to crossfade, and we know how far through
 					// the tune we are
 					int takesSteps = calculate_max_volume() / _GP(game).options[OPT_CROSSFADEMUSIC];
-					int takesMs = ::lround(takesSteps * 1000.0f / get_game_fps());
+					int takesMs = lroundf(takesSteps * 1000.0f / get_game_fps());
 					if (curpos >= muslen - takesMs)
 						play_next_queued();
 				}

--- a/engines/ags/lib/allegro/color.cpp
+++ b/engines/ags/lib/allegro/color.cpp
@@ -529,7 +529,7 @@ void hsv_to_rgb(float h, float s, float v, int *r, int *g, int *b) {
 	if (s == 0.0f) { /* ok since we don't divide by s, and faster */
 		*r = *g = *b = v + 0.5f;
 	} else {
-		h = fmod(h, 360.0f) / 60.0f;
+		h = fmodf(h, 360.0f) / 60.0f;
 		if (h < 0.0f)
 			h += 6.0f;
 

--- a/engines/ags/plugins/ags_pal_render/ags_pal_render.cpp
+++ b/engines/ags/plugins/ags_pal_render/ags_pal_render.cpp
@@ -375,7 +375,7 @@ void AGSPalRender::LensInitialize(ScriptMethodParams &params) {
 			int lx, ly;
 			int xsq = x * x;
 			if ((xsq + ysq) < (radsq)) {
-				float shift = zoom / sqrt((float)(zoomsq - (xsq + ysq - radsq)));
+				float shift = zoom / sqrtf((float)(zoomsq - (xsq + ysq - radsq)));
 				lx = (int)(x * shift - x);
 				ly = (int)(y * shift - y);
 			} else {

--- a/engines/ags/plugins/ags_snow_rain/weather.cpp
+++ b/engines/ags/plugins/ags_snow_rain/weather.cpp
@@ -317,8 +317,8 @@ void Weather::SetTransparency(int min_value, int max_value) {
 	if (min_value > max_value)
 		min_value = max_value;
 
-	_mMinAlpha = 255 - floor((float)max_value * 2.55f + 0.5f);
-	_mMaxAlpha = 255 - floor((float)min_value * 2.55f + 0.5f);
+	_mMinAlpha = 255 - floorf((float)max_value * 2.55f + 0.5f);
+	_mMaxAlpha = 255 - floorf((float)min_value * 2.55f + 0.5f);
 	_mDeltaAlpha = _mMaxAlpha - _mMinAlpha;
 
 	if (_mDeltaAlpha == 0)

--- a/engines/ags/plugins/ags_waves/draw.cpp
+++ b/engines/ags/plugins/ags_waves/draw.cpp
@@ -228,8 +228,8 @@ void AGSWaves::DrawCylinder(ScriptMethodParams &params) {
 			float r = width;
 
 			float omega = width / 2;
-			float z0 = f - sqrt(r * r - omega * omega);
-			float zc = (2 * z0 + sqrt(4 * z0 * z0 - 4 * (pcx * pcx / (f * f) + 1) * (z0 * z0 - r * r))) / (2 * (pcx * pcx / (f * f) + 1));
+			float z0 = f - sqrtf(r * r - omega * omega);
+			float zc = (2 * z0 + sqrtf(4 * z0 * z0 - 4 * (pcx * pcx / (f * f) + 1) * (z0 * z0 - r * r))) / (2 * (pcx * pcx / (f * f) + 1));
 
 			float finalpointx = pcx * zc / f;
 			float finalpointy = pcy * zc / f;
@@ -286,14 +286,14 @@ void AGSWaves::DrawForceField(ScriptMethodParams &params) {
 
 			float jx = uvx;
 			float jy = uvy + b_time[id] * 3.14;
-			float jz = sin(b_time[id]);
+			float jz = sinf(b_time[id]);
 			float jyy = uvy + b_time[id];
-			float jzz = cos(b_time[id] + 3.0);
+			float jzz = cosf(b_time[id] + 3.0f);
 
 			float af = ABS(noiseField(jx, jy, jz) - noiseField(jx, jyy, jzz));
-			float newR = 0.5 - pow(af, float(0.2)) / 2.0;
+			float newR = 0.5f - powf(af, 0.2f) / 2.0f;
 			float newG = 0.0;
-			float newB = 0.4 - pow(af, float(0.4));
+			float newB = 0.4f - powf(af, 0.4f);
 
 			int Rd = int(newR * 255.0);
 			int Gd = int(newG * 255.0);
@@ -1138,11 +1138,11 @@ int AGSWaves::SetColorRGBA(int r, int g, int b, int a) {
 }
 
 float AGSWaves::noiseField(float tx, float ty, float tz) {
-	float px = floor(tx);
+	float px = floorf(tx);
 	float fx = fracts(tx);
-	float py = floor(ty);
+	float py = floorf(ty);
 	float fy = fracts(ty);
-	float pz = floor(tz);
+	float pz = floorf(tz);
 	float fz = fracts(tz);
 	fx = fx * fx * (3.0 - 2.0 * fx);
 	fy = fy * fy * (3.0 - 2.0 * fy);
@@ -1161,7 +1161,7 @@ int AGSWaves::ConvertColorToGrayScale(int color) {
 	int b = getBcolor(color);
 
 	float d = float((r * r + g * g + b * b) / 3);
-	int gr = int(sqrt(d));
+	int gr = int(sqrtf(d));
 
 	return ((gr << 16) | (gr << 8) | (gr << 0) | (255 << 24));
 }

--- a/engines/ags/plugins/ags_waves/weather.cpp
+++ b/engines/ags/plugins/ags_waves/weather.cpp
@@ -258,8 +258,8 @@ void AGSWaves::WindUpdate(ScriptMethodParams &params) {
 				if (particles[h].angleLay > 12.0) {
 					particles[h].angleLay = 0.0;
 					particles[h].angle += particles[h].anglespeed;
-					int Y = particles[h].y + int((sin(particles[h].angle) * particles[h].radius));
-					int X = particles[h].x + int((cos(particles[h].angle) * particles[h].radius));
+					int Y = particles[h].y + int((sinf(particles[h].angle) * particles[h].radius));
+					int X = particles[h].x + int((cosf(particles[h].angle) * particles[h].radius));
 					particles[h].x = X;
 					particles[h].y = Y;
 				}
@@ -477,8 +477,8 @@ void AGSWaves::WindUpdate(ScriptMethodParams &params) {
 					if (particles2[h].angleLay > 12.0) {
 						particles2[h].angleLay = 0.0;
 						particles2[h].angle += particles2[h].anglespeed;
-						int Y = particles2[h].y + int((sin(particles2[h].angle) * particles2[h].radius));
-						int X = particles2[h].x + int((cos(particles2[h].angle) * particles2[h].radius));
+						int Y = particles2[h].y + int((sinf(particles2[h].angle) * particles2[h].radius));
+						int X = particles2[h].x + int((cosf(particles2[h].angle) * particles2[h].radius));
 						particles2[h].x = X;
 						particles2[h].y = Y;
 					}

--- a/engines/ags/shared/gui/gui_inv.cpp
+++ b/engines/ags/shared/gui/gui_inv.cpp
@@ -118,8 +118,8 @@ void GUIInvWindow::CalculateNumCells() {
 		ColCount = _width / data_to_game_coord(ItemWidth);
 		RowCount = _height / data_to_game_coord(ItemHeight);
 	} else {
-		ColCount = floor((float)_width / (float)data_to_game_coord(ItemWidth) + 0.5f);
-		RowCount = floor((float)_height / (float)data_to_game_coord(ItemHeight) + 0.5f);
+		ColCount = floorf((float)_width / (float)data_to_game_coord(ItemWidth) + 0.5f);
+		RowCount = floorf((float)_height / (float)data_to_game_coord(ItemHeight) + 0.5f);
 	}
 }
 

--- a/engines/asylum/puzzles/pipes.cpp
+++ b/engines/asylum/puzzles/pipes.cpp
@@ -346,7 +346,7 @@ void PuzzlePipes::updateScreen() {
 
 	uint32 filled = 0;
 	for (uint32 i = 0; i < 4; ++i) {
-		if (fabs(_levelValues[i] - _previousLevels[i]) > 0.005)
+		if (fabsf(_levelValues[i] - _previousLevels[i]) > 0.005)
 			_previousLevels[i] += _levelValues[i] > _previousLevels[i] ? 0.01f : -0.01f;
 		else
 			++filled;

--- a/engines/bagel/hodjnpodj/beacon/beacon.cpp
+++ b/engines/bagel/hodjnpodj/beacon/beacon.cpp
@@ -380,8 +380,8 @@ void CMainWindow::DrawBeams(CDC *pDC) {
 		radians = degrees * (float)0.017453292;
 		rads = (degrees + 0.5F) * (float)0.017453292;
 
-		x = (float)cos(rads);
-		y = (float)sin(rads);
+		x = cosf(rads);
+		y = sinf(rads);
 
 		StartPt.x = Center.x + (int)(x * radius);
 		StartPt.y = Center.y + (int)(y * radius);
@@ -407,8 +407,8 @@ void CMainWindow::DrawBeams(CDC *pDC) {
 		delete pMyBrush;
 		pMyBrush = nullptr;
 
-		x = (float)cos(radians);
-		y = (float)sin(radians);
+		x = cosf(radians);
+		y = sinf(radians);
 
 		EndPt.x = Center.x + (int)(x * radius);
 		EndPt.y = Center.y + (int)(y * radius);
@@ -967,8 +967,8 @@ void CMainWindow::CheckUnderBeam() {
 	while (degrees < endAngle) {
 		radians = degrees * (float)0.017453292;                     // Convert to radians
 
-		x = (float)cos(radians);
-		y = (float)sin(radians);
+		x = cosf(radians);
+		y = sinf(radians);
 
 		End.x = Start.x + (int)(x * radius);
 		End.y = Start.y + (int)(y * radius);

--- a/engines/bladerunner/actor.cpp
+++ b/engines/bladerunner/actor.cpp
@@ -1048,7 +1048,7 @@ void Actor::resetScreenRectangleAndBbox() {
 float Actor::distanceFromView(View *view) const{
 	float xDist = _position.x - view->_cameraPosition.x;
 	float zDist = _position.z + view->_cameraPosition.y; // y<->z is intentional, not a bug
-	return sqrt(xDist * xDist + zDist * zDist);
+	return sqrtf(xDist * xDist + zDist * zDist);
 }
 
 bool Actor::isWalking() const {

--- a/engines/bladerunner/fog.cpp
+++ b/engines/bladerunner/fog.cpp
@@ -140,7 +140,7 @@ void FogSphere::calculateCoeficient(Vector3 position, Vector3 viewPosition, floa
 	float d = b * b - c;
 
 	if (d >= 0.0f) { // there is an interstection between ray and the sphere
-		float sqrt_d = sqrt(d);
+		float sqrt_d = sqrtf(d);
 
 		Vector3 intersection1 = rayOrigin + (-b - sqrt_d) * rayDirection;
 		Vector3 intersection2 = rayOrigin + (-b + sqrt_d) * rayDirection;
@@ -169,9 +169,9 @@ void FogCone::read(Common::ReadStream *stream, int frameCount) {
 	_frameCount = frameCount;
 	int size = readCommon(stream);
 	float coneAngle = stream->readFloatLE();
-	float tan_coneAngle = tan(coneAngle);
+	float tan_coneAngle = tanf(coneAngle);
 
-	_cos_coneAngle = cos(coneAngle);
+	_cos_coneAngle = cosf(coneAngle);
 	_tan_coneAngle_sq = tan_coneAngle * tan_coneAngle;
 
 	readAnimationData(stream, size - 52);
@@ -196,16 +196,16 @@ void FogCone::calculateCoeficient(Vector3 position, Vector3 viewPosition, float 
 			planeNormal = -1.0f * planeNormal;
 		}
 
-		float cosTheta = sqrt(1.0f - Vector3::dot(planeNormal, v) * Vector3::dot(planeNormal, v));
+		float cosTheta = sqrtf(1.0f - Vector3::dot(planeNormal, v) * Vector3::dot(planeNormal, v));
 
 		if (cosTheta > _cos_coneAngle) {
 			Vector3 u = Vector3::cross(v, planeNormal).normalize();
 			Vector3 w = Vector3::cross(u, v).normalize();
 
-			float tanTheta = sqrt(1.0f - cosTheta * cosTheta) / cosTheta;
+			float tanTheta = sqrtf(1.0f - cosTheta * cosTheta) / cosTheta;
 
 			Vector3 temp1 = tanTheta * w;
-			Vector3 temp2 = sqrt(_tan_coneAngle_sq - tanTheta * tanTheta) * u;
+			Vector3 temp2 = sqrtf(_tan_coneAngle_sq - tanTheta * tanTheta) * u;
 
 			Vector3 delta1 = v + temp1 - temp2;
 			Vector3 delta2 = v + temp1 + temp2;

--- a/engines/bladerunner/light.cpp
+++ b/engines/bladerunner/light.cpp
@@ -228,8 +228,8 @@ float Light1::calculate(Vector3 start, Vector3 end) const {
 		v40 = calculateFalloutCoefficient(start, end, _falloffStart, _falloffEnd);
 	}
 
-	float v41 = atan2(sqrt(start.x * start.x + start.y * start.y), -start.z);
-	float v42 = atan2(sqrt(end.x * end.x + end.y * end.y), -end.z);
+	float v41 = atan2f(sqrtf(start.x * start.x + start.y * start.y), -start.z);
+	float v42 = atan2f(sqrtf(end.x * end.x + end.y * end.y), -end.z);
 
 	float v43;
 	if ((_angleStart >= v41 && _angleStart >= v42) || (_angleEnd <= v41 && _angleEnd <= v42)) {
@@ -252,7 +252,7 @@ void Light1::calculateColor(Color *outColor, Vector3 position) const {
 	outColor->b = 0.0f;
 
 	if (positionT.z < 0.0f) {
-		float v12 = attenuation(_angleStart, _angleEnd, atan2(sqrt(positionT.x * positionT.x + positionT.y * positionT.y), -positionT.z));
+		float v12 = attenuation(_angleStart, _angleEnd, atan2f(sqrtf(positionT.x * positionT.x + positionT.y * positionT.y), -positionT.z));
 		float v13 = attenuation(_falloffStart, _falloffEnd, positionT.length());
 
 		outColor->r = v12 * v13 * _color.r;
@@ -270,10 +270,10 @@ float Light2::calculate(Vector3 start, Vector3 end) const {
 		v54 = calculateFalloutCoefficient(start, end, _falloffStart, _falloffEnd);
 	}
 
-	float v55 = atan2(fabs(start.x), -start.z);
-	float v58 = atan2(fabs(start.y), -start.z);
-	float v57 = atan2(fabs(end.x), -end.z);
-	float v56 = atan2(fabs(end.y), -end.z);
+	float v55 = atan2f(fabsf(start.x), -start.z);
+	float v58 = atan2f(fabsf(start.y), -start.z);
+	float v57 = atan2f(fabsf(end.x), -end.z);
+	float v56 = atan2f(fabsf(end.y), -end.z);
 
 	float v59;
 	if ((_angleStart >= v55 && _angleStart >= v57 && _angleStart >= v58 && _angleStart >= v56) || (_angleEnd <= v55 && _angleEnd <= v57 && _angleEnd <= v58 && _angleEnd <= v56)) {
@@ -296,8 +296,8 @@ void Light2::calculateColor(Color *outColor, Vector3 position) const {
 	outColor->b = 0.0f;
 
 	if (positionT.z < 0.0f) {
-		float v11 = attenuation(_angleStart, _angleEnd, atan2(fabs(positionT.y), -positionT.z));
-		float v12 = attenuation(_angleStart, _angleEnd, atan2(fabs(positionT.x), -positionT.z));
+		float v11 = attenuation(_angleStart, _angleEnd, atan2f(fabsf(positionT.y), -positionT.z));
+		float v12 = attenuation(_angleStart, _angleEnd, atan2f(fabsf(positionT.x), -positionT.z));
 		float v13 = attenuation(_falloffStart, _falloffEnd, positionT.length());
 
 		outColor->r = v11 * v12 * v13 * _color.r;
@@ -314,7 +314,7 @@ void Light3::calculateColor(Color *outColor, Vector3 position) const {
 	outColor->b = 0.0f;
 
 	if (positionT.z < 0.0f) {
-		float v12 = attenuation(_angleStart, _angleEnd, sqrt(positionT.x * positionT.x + positionT.y * positionT.y));
+		float v12 = attenuation(_angleStart, _angleEnd, sqrtf(positionT.x * positionT.x + positionT.y * positionT.y));
 		float v13 = attenuation(_falloffStart, _falloffEnd, positionT.length());
 
 		outColor->r = v12 * v13 * _color.r;
@@ -331,8 +331,8 @@ void Light4::calculateColor(Color *outColor, Vector3 position) const {
 	outColor->b = 0.0f;
 
 	if (positionT.z < 0.0f) {
-		float v11 = attenuation(_angleStart, _angleEnd, fabs(positionT.y));
-		float v12 = attenuation(_angleStart, _angleEnd, fabs(positionT.x));
+		float v11 = attenuation(_angleStart, _angleEnd, fabsf(positionT.y));
+		float v12 = attenuation(_angleStart, _angleEnd, fabsf(positionT.x));
 		float v13 = attenuation(_falloffStart, _falloffEnd, positionT.length());
 
 		outColor->r = v11 * v12 * v13 * _color.r;

--- a/engines/bladerunner/matrix.cpp
+++ b/engines/bladerunner/matrix.cpp
@@ -79,8 +79,8 @@ Matrix4x3::Matrix4x3(
 }
 
 Matrix4x3 rotationMatrixX(float angle) {
-	float ca = cos(angle);
-	float sa = sin(angle);
+	float ca = cosf(angle);
+	float sa = sinf(angle);
 
 	return Matrix4x3( 1.0f, 0.0f, 0.0f, 0.0f,
 	                  0.0f,   ca,   sa, 0.0f,

--- a/engines/bladerunner/mouse.cpp
+++ b/engines/bladerunner/mouse.cpp
@@ -657,7 +657,7 @@ Vector3 Mouse::getXYZ(int x, int y) const {
 	int screenRight = BladeRunnerEngine::kOriginalGameWidth  - x;
 	int screenDown  = BladeRunnerEngine::kOriginalGameHeight - y;
 
-	float zcoef = 1.0f / tan(_vm->_view->_fovX / 2.0f);
+	float zcoef = 1.0f / tanf(_vm->_view->_fovX / 2.0f);
 
 	// Division of float by int is float, so no precision is lost here
 	float x3d = (2.0f / BladeRunnerEngine::kOriginalGameWidth  * screenRight - 1.0f);

--- a/engines/bladerunner/obstacles.cpp
+++ b/engines/bladerunner/obstacles.cpp
@@ -363,9 +363,9 @@ int Obstacles::findEmptyPolygon() const {
 
 float Obstacles::getLength(float x0, float z0, float x1, float z1) {
 	if (x0 == x1) {
-		return fabs(z1 - z0);
+		return fabsf(z1 - z0);
 	}
-	return fabs(x1 - x0);
+	return fabsf(x1 - x0);
 }
 
 #if DISABLE_PATHFINDING

--- a/engines/bladerunner/scene_objects.cpp
+++ b/engines/bladerunner/scene_objects.cpp
@@ -209,7 +209,7 @@ bool SceneObjects::addSceneObject(int sceneObjectId, SceneObjectType sceneObject
 
 	float centerZ = (_sceneObjects[index].boundingBox.getZ0() + _sceneObjects[index].boundingBox.getZ1()) / 2.0f;
 
-	float distanceToCamera = fabs(-centerZ - _view->_cameraPosition.y); // y<->z is intentional, not a bug
+	float distanceToCamera = fabsf(-centerZ - _view->_cameraPosition.y); // y<->z is intentional, not a bug
 	_sceneObjects[index].distanceToCamera = distanceToCamera;
 
 	// insert according to distance from camera

--- a/engines/bladerunner/script/ai/dektora.cpp
+++ b/engines/bladerunner/script/ai/dektora.cpp
@@ -1531,7 +1531,7 @@ double AIScriptDektora::comp_distance(int actorId, float x1, float y1, float z1)
 
 	Actor_Query_XYZ(actorId, &x, &y, &z);
 
-	return sqrt((z1 - z) * (z1 - z) + (x1 - x) * (x1 - x) + (y1 - y) * (y1 - y));
+	return sqrtf((z1 - z) * (z1 - z) + (x1 - x) * (x1 - x) + (y1 - y) * (y1 - y));
 }
 
 void AIScriptDektora::checkCombat() {

--- a/engines/bladerunner/script/ai/generic_walker_a.cpp
+++ b/engines/bladerunner/script/ai/generic_walker_a.cpp
@@ -424,7 +424,7 @@ void AIScriptGenericWalkerA::movingStart() {
 	deltaX = walkerX - mccoyX;
 	deltaZ = walkerZ - mccoyZ;
 
-	float dist = sqrt(deltaX * deltaX + deltaZ * deltaZ);
+	float dist = sqrtf(deltaX * deltaX + deltaZ * deltaZ);
 	if (dist == 0.0f) {
 		deltaZ = 0.0f;
 		deltaX = 0.0f;

--- a/engines/bladerunner/script/ai/generic_walker_b.cpp
+++ b/engines/bladerunner/script/ai/generic_walker_b.cpp
@@ -375,7 +375,7 @@ void AIScriptGenericWalkerB::movingStart() {
 	deltaX = walkerX - mccoyX;
 	deltaZ = walkerZ - mccoyZ;
 
-	float dist = sqrt(deltaX * deltaX + deltaZ * deltaZ);
+	float dist = sqrtf(deltaX * deltaX + deltaZ * deltaZ);
 	if (dist == 0.0f) {
 		deltaZ = 0.0f;
 		deltaX = 0.0f;

--- a/engines/bladerunner/script/ai/generic_walker_c.cpp
+++ b/engines/bladerunner/script/ai/generic_walker_c.cpp
@@ -376,7 +376,7 @@ void AIScriptGenericWalkerC::movingStart() {
 	deltaX = walkerX - mccoyX;
 	deltaZ = walkerZ - mccoyZ;
 
-	float dist = sqrt(deltaX * deltaX + deltaZ * deltaZ);
+	float dist = sqrtf(deltaX * deltaX + deltaZ * deltaZ);
 	if (dist == 0.0f) {
 		deltaZ = 0.0f;
 		deltaX = 0.0f;

--- a/engines/bladerunner/script/ai/leon.cpp
+++ b/engines/bladerunner/script/ai/leon.cpp
@@ -516,7 +516,7 @@ void AIScriptLeon::FledCombat() {}
 float AIScriptLeon::distanceTo(int actorId, float x, float y, float z) {
 	float actorX, actorY, actorZ;
 	Actor_Query_XYZ(actorId, &actorX, &actorY, &actorZ);
-	return sqrt(static_cast<float>((z - actorZ) * (z - actorZ) + (y - actorY) * (y - actorY) + (x - actorX) * (x - actorX)));
+	return sqrtf(static_cast<float>((z - actorZ) * (z - actorZ) + (y - actorY) * (y - actorY) + (x - actorX) * (x - actorX)));
 }
 
 } // End of namespace BladeRunner

--- a/engines/bladerunner/script/ai/maggie.cpp
+++ b/engines/bladerunner/script/ai/maggie.cpp
@@ -1145,7 +1145,7 @@ int AIScriptMaggie::randomWaypointMA02() {
 float AIScriptMaggie::distanceToActor(int actorId, float x, float y, float z) {
 	float actorX, actorY, actorZ;
 	Actor_Query_XYZ(actorId, &actorX, &actorY, &actorZ);
-	return sqrt(static_cast<float>((z - actorZ) * (z - actorZ) + (y - actorY) * (y - actorY) + (x - actorX) * (x - actorX)));
+	return sqrtf(static_cast<float>((z - actorZ) * (z - actorZ) + (y - actorY) * (y - actorY) + (x - actorX) * (x - actorX)));
 }
 
 } // End of namespace BladeRunner

--- a/engines/bladerunner/script/ai/steele.cpp
+++ b/engines/bladerunner/script/ai/steele.cpp
@@ -581,7 +581,7 @@ double AIScriptSteele::comp_distance(int actorId, float a5, float a6, int a1, fl
 	float actorY;
 
 	Actor_Query_XYZ(actorId, &actorX, &actorY, &actorZ);
-	return sqrt((a4 - actorZ) * (a4 - actorZ) + (a2 - actorX) * (a2 - actorX) + (a3 - actorY) * (a3 - actorY));
+	return sqrtf((a4 - actorZ) * (a4 - actorZ) + (a2 - actorX) * (a2 - actorX) + (a3 - actorY) * (a3 - actorY));
 }
 
 bool AIScriptSteele::GoalChanged(int currentGoalNumber, int newGoalNumber) {

--- a/engines/bladerunner/script/scene/nr03.cpp
+++ b/engines/bladerunner/script/scene/nr03.cpp
@@ -441,7 +441,7 @@ void SceneScriptNR03::rotateActorOnTable(int frame) {
 	int facing;
 	float angle, invertedAngle;
 
-	angle = cos((frame - 70) * (M_PI / 40.0f)) * M_PI_2;
+	angle = cosf((frame - 70) * (M_PI / 40.0f)) * M_PI_2;
 	invertedAngle = M_PI - angle;
 	if (!Game_Flag_Query(kFlagNR03toNR05)
 	 &&  Actor_Query_Goal_Number(kActorGuzza) != kGoalGuzzaSitAtNR03
@@ -450,8 +450,8 @@ void SceneScriptNR03::rotateActorOnTable(int frame) {
 		invertedAngle = invertedAngle + M_PI;
 	}
 
-	float c = cos(invertedAngle);
-	float s = sin(invertedAngle);
+	float c = cosf(invertedAngle);
+	float s = sinf(invertedAngle);
 	float x = 36.49f * s - -60.21f * c + -265.49f;
 	float z = -60.21f * s + 36.49f * c + -408.79f;
 

--- a/engines/bladerunner/script/scene/nr05.cpp
+++ b/engines/bladerunner/script/scene/nr05.cpp
@@ -231,8 +231,8 @@ void SceneScriptNR05::rotateActorOnTable(int frame) {
 		angle = angle + M_PI;
 		invertedAngle = invertedAngle + M_PI;
 	}
-	float c = cos(invertedAngle);
-	float s = sin(invertedAngle);
+	float c = cosf(invertedAngle);
+	float s = sinf(invertedAngle);
 	float x = 6.0f * s - 80.0f * c + -450.0f;
 	float z = 80.0f * s + 6.0f * c + -531.0f;
 

--- a/engines/bladerunner/script/script.cpp
+++ b/engines/bladerunner/script/script.cpp
@@ -429,7 +429,7 @@ int ScriptBase::Actor_Query_Inch_Distance_From_Waypoint(int actorId, int waypoin
 	float distX = actorX - waypointX;
 	float distZ = actorZ - waypointZ;
 
-	return sqrt(distX * distX + distZ * distZ);
+	return sqrtf(distX * distX + distZ * distZ);
 }
 
 bool ScriptBase::Actor_Query_In_Between_Two_Actors(int actorId, int otherActor1Id, int otherActor2Id) {

--- a/engines/bladerunner/shape.cpp
+++ b/engines/bladerunner/shape.cpp
@@ -124,18 +124,18 @@ void Shape::drawFilledTriangleAux(Graphics::Surface &surface, const int &dst_x, 
 
 		if (triangleV2.y == triangleV3.y) {
 			if (vTmp1.x < vTmp2.x) {
-				leftEndPoint = ceil(vTmp1.x);
+				leftEndPoint = ceilf(vTmp1.x);
 				rightEndPoint = int(vTmp2.x);
 			} else {
-				leftEndPoint = ceil(vTmp2.x);
+				leftEndPoint = ceilf(vTmp2.x);
 				rightEndPoint = int(vTmp1.x);
 			}
 		} else {
 			if (vTmp1.y < vTmp2.y) {
-				leftEndPoint = ceil(vTmp1.y);
+				leftEndPoint = ceilf(vTmp1.y);
 				rightEndPoint = int(vTmp2.y);
 			} else {
-				leftEndPoint = ceil(vTmp2.y);
+				leftEndPoint = ceilf(vTmp2.y);
 				rightEndPoint = int(vTmp1.y);
 			}
 		}
@@ -143,9 +143,9 @@ void Shape::drawFilledTriangleAux(Graphics::Surface &surface, const int &dst_x, 
 		void *dstPtr;
 		for (int xPos = leftEndPoint; xPos <= rightEndPoint; ++xPos) {
 			if (triangleV2.y == triangleV3.y) {
-				dstPtr = surface.getBasePtr(CLIP(dst_x + xPos, 0, surface.w - 1), CLIP(dst_y + (int)ceil(vTmp1.y), 0, surface.h - 1));
+				dstPtr = surface.getBasePtr(CLIP(dst_x + xPos, 0, surface.w - 1), CLIP(dst_y + (int)ceilf(vTmp1.y), 0, surface.h - 1));
 			} else {
-				dstPtr = surface.getBasePtr(CLIP(dst_x + (int)ceil(vTmp1.x), 0, surface.w - 1), CLIP(dst_y + xPos, 0, surface.h - 1));
+				dstPtr = surface.getBasePtr(CLIP(dst_x + (int)ceilf(vTmp1.x), 0, surface.w - 1), CLIP(dst_y + xPos, 0, surface.h - 1));
 			}
 			drawPixel(surface, dstPtr, colorRGB);
 		}

--- a/engines/bladerunner/slice_renderer.cpp
+++ b/engines/bladerunner/slice_renderer.cpp
@@ -118,9 +118,9 @@ Matrix3x2 SliceRenderer::calculateFacingRotationMatrix() {
 	assert(_sliceFramePtr);
 
 	Vector3 viewPos = _view->_sliceViewMatrix * _position;
-	float dir = atan2(viewPos.x, viewPos.z) + _facing;
-	float s = sin(dir);
-	float c = cos(dir);
+	float dir = atan2f(viewPos.x, viewPos.z) + _facing;
+	float s = sinf(dir);
+	float c = cosf(dir);
 
 	Matrix3x2 mRotation(c, -s, 0.0f,
 	                    s,  c, 0.0f);
@@ -321,7 +321,7 @@ void SliceLineIterator::setup(
 	_stepZ     = (endScreenZ - startScreenZ) / size;
 
 	_stepSlice     = (endSlice - startSlice) / size;
-	_currentSlice  = startSlice - (startScreenY - floor(startScreenY) - 1.0f) * _stepSlice;
+	_currentSlice  = startSlice - (startScreenY - floorf(startScreenY) - 1.0f) * _stepSlice;
 
 	_currentX = startScreenX;
 	_stepX    = (endScreenX - startScreenX) / size;
@@ -435,7 +435,7 @@ void SliceRenderer::drawInWorld(int animationId, int animationFrame, Vector3 pos
 				&coeficientShadow,
 				&colorShadow);
 
-		int transparency = 32.0f * sqrt(setEffectColor.r * setEffectColor.r + setEffectColor.g * setEffectColor.g + setEffectColor.b * setEffectColor.b);
+		int transparency = 32.0f * sqrtf(setEffectColor.r * setEffectColor.r + setEffectColor.g * setEffectColor.g + setEffectColor.b * setEffectColor.b);
 
 		drawShadowInWorld(transparency, surface, zbuffer);
 	}
@@ -489,11 +489,11 @@ void SliceRenderer::drawOnScreen(int animationId, int animationFrame, int screen
 	loadFrame(animationId, animationFrame);
 
 	float frameHeight = _frameSliceHeight * _frameSliceCount;
-	float frameSize = sqrt(_frameScale.x * 255.0f * _frameScale.x * 255.0f + _frameScale.y * 255.0f * _frameScale.y * 255.0f);
+	float frameSize = sqrtf(_frameScale.x * 255.0f * _frameScale.x * 255.0f + _frameScale.y * 255.0f * _frameScale.y * 255.0f);
 	float size = scale / MAX(frameSize, frameHeight);
 
-	float s = sin(_facing);
-	float c = cos(_facing);
+	float s = sinf(_facing);
+	float c = cosf(_facing);
 
 	Matrix3x2 mRotation(c, -s, 0.0f,
 	                    s,  c, 0.0f);
@@ -612,8 +612,8 @@ void SliceRenderer::drawShadowInWorld(int transparency, Graphics::Surface &surfa
 		0.0f, 1.0f, 0.0f, _position.y,
 		0.0f, 0.0f, 1.0f, _position.z);
 
-	float s = sin(_facing);
-	float c = cos(_facing);
+	float s = sinf(_facing);
+	float c = cosf(_facing);
 
 	Matrix4x3 mRotation(
 		   c,   -s, 0.0f, 0.0f,

--- a/engines/bladerunner/view.cpp
+++ b/engines/bladerunner/view.cpp
@@ -51,7 +51,7 @@ void View::setFovX(float fovX) {
 
 	_viewportPosition.x = 320.0f;
 	_viewportPosition.y = 240.0f;
-	_viewportPosition.z = 320.0f / tan(_fovX / 2.0f);
+	_viewportPosition.z = 320.0f / tanf(_fovX / 2.0f);
 }
 
 void View::calculateSliceViewMatrix() {

--- a/engines/chewy/detail.cpp
+++ b/engines/chewy/detail.cpp
@@ -566,10 +566,10 @@ void Detail::calc_zoom_kor(int16 *kx, int16 *ky, int16 xzoom, int16 yzoom) {
 	float tmpy = (float)(((float)*ky / 100.0) * ((float)yzoom));
 
 	float tmpx1 = tmpx - (int16)tmpx;
-	if (fabs(tmpx1) > 0.5)
+	if (fabsf(tmpx1) > 0.5f)
 		++tmpx;
 	float tmpy1 = tmpy - (int16)tmpy;
-	if (fabs(tmpy1) > 0.5)
+	if (fabsf(tmpy1) > 0.5f)
 		++tmpy;
 	*kx += (int16)tmpx;
 	*ky += (int16)tmpy;

--- a/engines/crab/TMX/TMXMap.cpp
+++ b/engines/crab/TMX/TMXMap.cpp
@@ -96,8 +96,8 @@ void TMXMap::load(const Common::Path &path, const Common::String &filename) {
 			_w = _tileRows * _tileSize.x;
 			_h = _tileCols * _tileSize.y;
 
-			_pathRows = (int)ceil((float)_w / (float)_pathSize.x + .5f); // Adding .5 before casting in order to round up (SZ)
-			_pathCols = (int)ceil((float)_h / (float)_pathSize.y + .5f);
+			_pathRows = (int)ceilf((float)_w / (float)_pathSize.x + .5f); // Adding .5 before casting in order to round up (SZ)
+			_pathCols = (int)ceilf((float)_h / (float)_pathSize.y + .5f);
 
 			g_engine->_imageManager->_tileset.load(path, node);
 

--- a/engines/dgds/head.cpp
+++ b/engines/dgds/head.cpp
@@ -208,7 +208,7 @@ void CDSTTMInterpreter::handleOperation(TTMEnviro &env_, TTMSeq &seq, uint16 op,
 	case 0x1020: { // SET DELAY:	    i:int   [0..n]
 		// TODO: Probably should do this accounting (as well as timeCut and dialogs)
 		// 		 in game frames, not millis.
-		int16 delayMillis = (int16)round(ivals[0] * MS_PER_FRAME);
+		int16 delayMillis = (int16)roundf(ivals[0] * MS_PER_FRAME);
 		env._cdsDelay = delayMillis;
 		break;
 	}

--- a/engines/dgds/ttm.cpp
+++ b/engines/dgds/ttm.cpp
@@ -759,7 +759,7 @@ void TTMInterpreter::handleOperation(TTMEnviro &env, TTMSeq &seq, uint16 op, byt
 	case 0x1020: { // SET DELAY:	    i:int   [0..n]
 		// TODO: Probably should do this accounting (as well as timeCut and dialogs)
 		// 		 in game frames, not millis.
-		int delayMillis = (int)round(ivals[0] * MS_PER_FRAME);
+		int delayMillis = (int)roundf(ivals[0] * MS_PER_FRAME);
 		_vm->adsInterpreter()->setScriptDelay(delayMillis);
 		break;
 	}

--- a/engines/drascula/graphics.cpp
+++ b/engines/drascula/graphics.cpp
@@ -490,14 +490,14 @@ void DrasculaEngine::screenSaver() {
 			count = 0;
 
 		for (int i = 0; i < 320; i++) {
-			tempLine[i] = (int)(sin(coeff2) * 16);
+			tempLine[i] = (int)(sinf(coeff2) * 16);
 			coeff2 += 0.02f;
 			tempLine[i] = checkWrapY(tempLine[i]);
 		}
 
 		coeff2 = coeff;
 		for (int i = 0; i < 200; i++) {
-			tempRow[i] = (int)(sin(coeff2) * 16);
+			tempRow[i] = (int)(sinf(coeff2) * 16);
 			coeff2 += 0.02f;
 			tempRow[i] = checkWrapX(tempRow[i]);
 		}

--- a/engines/freescape/area.cpp
+++ b/engines/freescape/area.cpp
@@ -296,7 +296,7 @@ static bool aabbIntersectsViewVolume(const Math::AABB &aabb, const Math::Vector3
 		return false;
 
 	// Match updateProjectionMatrix's horizontal FOV.
-	const float horizontalScale = tan(Math::deg2rad(fov) / 2.0f);
+	const float horizontalScale = tanf(Math::deg2rad(fov) / 2.0f);
 	const float verticalScale = horizontalScale / aspectRatio;
 	const Math::Vector3d planes[] = {
 		front * horizontalScale + right, front * horizontalScale - right,

--- a/engines/freescape/freescape.cpp
+++ b/engines/freescape/freescape.cpp
@@ -504,9 +504,9 @@ Math::Vector3d FreescapeEngine::directionToVector(float pitch, float heading, bo
 		float radHeading = Math::deg2rad(heading);
 		float radPitch = Math::deg2rad(pitch);
 
-		v.setValue(0, cos(radPitch) * cos(radHeading));
-		v.setValue(1, sin(radPitch));
-		v.setValue(2, cos(radPitch) * sin(radHeading));
+		v.setValue(0, cosf(radPitch) * cosf(radHeading));
+		v.setValue(1, sinf(radPitch));
+		v.setValue(2, cosf(radPitch) * sinf(radHeading));
 	}
 	v.normalize();
 	return v;

--- a/engines/freescape/gfx_opengl.cpp
+++ b/engines/freescape/gfx_opengl.cpp
@@ -440,8 +440,8 @@ void OpenGLRenderer::drawCelestialBody(Math::Vector3d position, float radius, by
 
 	for (int i = 0; i <= triangleAmount; i++) {
 		copyToVertexArray(i + 1,
-		                  Math::Vector3d(position.x(), position.y() + (radius * cos(i *  twicePi / triangleAmount)),
-		                                 position.z() + (adj * radius * sin(i * twicePi / triangleAmount)))
+		                  Math::Vector3d(position.x(), position.y() + (radius * cosf(i *  twicePi / triangleAmount)),
+		                                 position.z() + (adj * radius * sinf(i * twicePi / triangleAmount)))
 		                 );
 	}
 
@@ -458,8 +458,8 @@ void OpenGLRenderer::drawCelestialBody(Math::Vector3d position, float radius, by
 
 		for (int i = 0; i <= triangleAmount; i++) {
 			copyToVertexArray(i + 1,
-			                  Math::Vector3d(position.x(), position.y() + (radius * cos(i *  twicePi / triangleAmount)),
-			                                 position.z() + (adj * radius * sin(i * twicePi / triangleAmount)))
+			                  Math::Vector3d(position.x(), position.y() + (radius * cosf(i *  twicePi / triangleAmount)),
+			                                 position.z() + (adj * radius * sinf(i * twicePi / triangleAmount)))
 			                 );
 		}
 
@@ -520,8 +520,8 @@ void OpenGLRenderer::renderPlayerShootBall(byte color, const Common::Point &posi
 	copyToVertexArray(0, Math::Vector3d(ballX, ballY, 0));
 
 	for (int i = 0; i <= triangleAmount; i++) {
-		float x = ballX + (radius * cos(i * twicePi / triangleAmount));
-		float y = ballY + (radius * sin(i * twicePi / triangleAmount));
+		float x = ballX + (radius * cosf(i * twicePi / triangleAmount));
+		float y = ballY + (radius * sinf(i * twicePi / triangleAmount));
 		copyToVertexArray(i + 1, Math::Vector3d(x, y, 0));
 	}
 

--- a/engines/freescape/gfx_opengl_shaders.cpp
+++ b/engines/freescape/gfx_opengl_shaders.cpp
@@ -420,8 +420,8 @@ void OpenGLShaderRenderer::renderPlayerShootBall(byte color, const Common::Point
 	copyToVertexArray(0, Math::Vector3d(remap(ballX, _screenW), remap(ballY, _screenH), 0));
 
 	for (int i = 0; i <= triangleAmount; i++) {
-		float x = remap(ballX + (radius * cos(i * twicePi / triangleAmount)), _screenW);
-		float y = remap(ballY + (radius * sin(i * twicePi / triangleAmount)), _screenH);
+		float x = remap(ballX + (radius * cosf(i * twicePi / triangleAmount)), _screenW);
+		float y = remap(ballY + (radius * sinf(i * twicePi / triangleAmount)), _screenH);
 		copyToVertexArray(i + 1, Math::Vector3d(x, y, 0));
 	}
 

--- a/engines/freescape/gfx_tinygl.cpp
+++ b/engines/freescape/gfx_tinygl.cpp
@@ -285,8 +285,8 @@ void TinyGLRenderer::renderPlayerShootBall(byte color, const Common::Point &posi
 	copyToVertexArray(0, Math::Vector3d(ballX, ballY, 0));
 
 	for (int i = 0; i <= triangleAmount; i++) {
-		float x = ballX + (radius * cos(i * twicePi / triangleAmount));
-		float y = ballY + (radius * sin(i * twicePi / triangleAmount));
+		float x = ballX + (radius * cosf(i * twicePi / triangleAmount));
+		float y = ballY + (radius * sinf(i * twicePi / triangleAmount));
 		copyToVertexArray(i + 1, Math::Vector3d(x, y, 0));
 	}
 
@@ -488,8 +488,8 @@ void TinyGLRenderer::drawCelestialBody(Math::Vector3d position, float radius, by
 
 	for (int i = 0; i <= triangleAmount; i++) {
 		copyToVertexArray(i + 1,
-		                  Math::Vector3d(position.x(), position.y() + (radius * cos(i *  twicePi / triangleAmount)),
-		                                 position.z() + (adj * radius * sin(i * twicePi / triangleAmount)))
+		                  Math::Vector3d(position.x(), position.y() + (radius * cosf(i *  twicePi / triangleAmount)),
+		                                 position.z() + (adj * radius * sinf(i * twicePi / triangleAmount)))
 		                 );
 	}
 

--- a/engines/freescape/movement.cpp
+++ b/engines/freescape/movement.cpp
@@ -231,10 +231,10 @@ void FreescapeEngine::activate() {
 
 	float fovHorizontalRad = (float)(75.0f * M_PI / 180.0f);
 	float aspectRatio = 1.6f;
-	float fovVerticalRad = 2.0f * atan(tan(fovHorizontalRad / 2.0f) / aspectRatio);
+	float fovVerticalRad = 2.0f * atanf(tanf(fovHorizontalRad / 2.0f) / aspectRatio);
 
-	float angleOffsetX = atan(ndcX * tan(fovHorizontalRad / 2.0f)) * 180.0f / M_PI;
-	float angleOffsetY = atan(ndcY * tan(fovVerticalRad / 2.0f)) * 180.0f / M_PI;
+	float angleOffsetX = atanf(ndcX * tanf(fovHorizontalRad / 2.0f)) * 180.0f / M_PI;
+	float angleOffsetY = atanf(ndcY * tanf(fovVerticalRad / 2.0f)) * 180.0f / M_PI;
 
 	Math::Vector3d direction = directionToVector(_pitch + angleOffsetY, _yaw - angleOffsetX, false);
 	Math::Ray ray(_position, direction);
@@ -332,8 +332,8 @@ void FreescapeEngine::shoot() {
 	float fovVerticalRad = 2.0f * atan(tan(fovHorizontalRad / 2.0f) / aspectRatio);
 
 	// Convert NDC to angle offset
-	float angleOffsetX = atan(ndcX * tan(fovHorizontalRad / 2.0f)) * 180.0f / M_PI;
-	float angleOffsetY = atan(ndcY * tan(fovVerticalRad / 2.0f)) * 180.0f / M_PI;
+	float angleOffsetX = atanf(ndcX * tanf(fovHorizontalRad / 2.0f)) * 180.0f / M_PI;
+	float angleOffsetY = atanf(ndcY * tanf(fovVerticalRad / 2.0f)) * 180.0f / M_PI;
 
 	Math::Vector3d direction = directionToVector(_pitch + angleOffsetY, _yaw - angleOffsetX, false);
 	Math::Ray ray(_position, direction);
@@ -519,14 +519,14 @@ void FreescapeEngine::updatePlayerMovementClassic(float deltaTime) {
 		stepFront = _cameraFront * (float(_playerSteps[_playerStepIndex]) / 2 / _cameraFront.length());
 		stepRight = _cameraRight * (float(_playerSteps[_playerStepIndex]) / 2 / _cameraRight.length());
 
-		stepFront.x() = floor(stepFront.x()) + 0.5;
-		stepFront.z() = floor(stepFront.z()) + 0.5;
+		stepFront.x() = floorf(stepFront.x()) + 0.5f;
+		stepFront.z() = floorf(stepFront.z()) + 0.5f;
 	} else {
 		stepFront = _cameraFront * (float(_playerSteps[_playerStepIndex]) / _cameraFront.length());
 		stepRight = _cameraRight * (float(_playerSteps[_playerStepIndex]) / _cameraRight.length());
 
-		stepFront.x() = ceil(stepFront.x());
-		stepFront.z() = ceil(stepFront.z());
+		stepFront.x() = ceilf(stepFront.x());
+		stepFront.z() = ceilf(stepFront.z());
 	}
 
 	float positionY = _position.y();

--- a/engines/griffon/logic.cpp
+++ b/engines/griffon/logic.cpp
@@ -561,7 +561,7 @@ void GriffonEngine::updateNPCs() {
 						ydif = _player.py - npy;
 
 						if (ABS(xdif) < 24 && ABS(ydif) < 24) {
-							float dist = sqrt(xdif * xdif + ydif * ydif);
+							float dist = sqrtf(xdif * xdif + ydif * ydif);
 
 							if ((dist) < 24) {
 								if (config.effects) {
@@ -667,7 +667,7 @@ void GriffonEngine::updateNPCs() {
 								ydif = _player.py - npy;
 
 								if (ABS(xdif) < 48 && ABS(ydif) < 48) {
-									float dist = sqrt(xdif * xdif + ydif * ydif);
+									float dist = sqrtf(xdif * xdif + ydif * ydif);
 
 									if ((dist) < 36) {
 										if (config.effects) {
@@ -847,7 +847,7 @@ void GriffonEngine::updateNPCs() {
 						ydif = _player.py - npy;
 
 						if (ABS(xdif) < 24 && ABS(ydif) < 24) {
-							float dist = sqrt(xdif * xdif + ydif * ydif);
+							float dist = sqrtf(xdif * xdif + ydif * ydif);
 
 							if ((dist) < 24) {
 								if (config.effects) {
@@ -1694,7 +1694,7 @@ void GriffonEngine::updateSpells() {
 						float ay = _spellInfo[i].fireballs[ff][1];
 						float bx = _player.px + 4;
 						float by = _player.py + 4;
-						float d = sqrt((bx - ax) * (bx - ax) + (by - ay) * (by - ay));
+						float d = sqrtf((bx - ax) * (bx - ax) + (by - ay) * (by - ay));
 
 						float tx = (bx - ax) / d;
 						float ty = (by - ay) / d;
@@ -2100,7 +2100,7 @@ void GriffonEngine::updateSpellsUnder() {
 					int xdif = _spellInfo[i].enemyx - _npcInfo[f].x;
 					int ydif = _spellInfo[i].enemyy - _npcInfo[f].y;
 
-					float dist = sqrt((float)(xdif * xdif + ydif * ydif));
+					float dist = sqrtf((float)(xdif * xdif + ydif * ydif));
 
 					if (dist > 20)
 						dist = 20;

--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -909,7 +909,7 @@ void Actor::walkForward() {
 			// EMI: some sectors are significantly higher/lower than others.
 			if (currSector && g_grim->getGameType() == GType_MONKEY4) {
 				float planeDist = currSector->distanceToPoint(_pos);
-				if (fabs(planeDist) < 1.f)
+				if (fabsf(planeDist) < 1.f)
 					_pos -= planeDist * currSector->getNormal();
 			}
 

--- a/engines/grim/emi/emi.cpp
+++ b/engines/grim/emi/emi.cpp
@@ -312,7 +312,7 @@ bool EMIEngine::compareActor(const Actor *x, const Actor *y) {
 		xp = xp * camRot.getRotation();
 		yp = yp * camRot.getRotation();
 
-		if (fabs(xp.z() - yp.z()) < 0.001f) {
+		if (fabsf(xp.z() - yp.z()) < 0.001f) {
 			return x->getId() < y->getId();
 		} else {
 			return xp.z() > yp.z();

--- a/engines/grim/emi/modelemi.cpp
+++ b/engines/grim/emi/modelemi.cpp
@@ -357,7 +357,7 @@ void EMIModel::updateLighting(const Math::Matrix4 &modelToWorld) {
 					dir.normalize();
 
 					if (distSq > l->_falloffNear * l->_falloffNear) {
-						float dist = sqrt(distSq);
+						float dist = sqrtf(distSq);
 						float attn = 1.0f - (dist - l->_falloffNear) / (l->_falloffFar - l->_falloffNear);
 						shade *= attn;
 					}

--- a/engines/grim/emi/sound/track.cpp
+++ b/engines/grim/emi/sound/track.cpp
@@ -96,8 +96,8 @@ void SoundTrack::updatePosition() {
 	Math::Vector3d relPos = (_pos - setup->_pos);
 	Math::Vector3d p(relPos);
 	p = p * worldRot.getRotation();
-	float angle = atan2(p.x(), p.z());
-	float pan = sin(angle);
+	float angle = atan2f(p.x(), p.z());
+	float pan = sinf(angle);
 	_balance = (int)(pan * 127.0f);
 
 	if (_handle) {

--- a/engines/grim/gfx_base.cpp
+++ b/engines/grim/gfx_base.cpp
@@ -136,10 +136,10 @@ Math::Matrix4 GfxBase::makeLookMatrix(const Math::Vector3d& pos, const Math::Vec
 }
 
 Math::Matrix4 GfxBase::makeProjMatrix(float fov, float nclip, float fclip) {
-	float right = nclip * tan(fov / 2 * ((float)M_PI / 180));
+	float right = nclip * tanf(fov / 2 * ((float)M_PI / 180));
 	float left = -right;
-	float top = right * 0.75;
-	float bottom = -right * 0.75;
+	float top = right * 0.75f;
+	float bottom = -right * 0.75f;
 
 	Math::Matrix4 proj;
 	proj(0,0) = (2.0f * nclip) / (right - left);

--- a/engines/grim/gfx_opengl.cpp
+++ b/engines/grim/gfx_opengl.cpp
@@ -198,7 +198,7 @@ void GfxOpenGL::setupCameraFrustum(float fov, float nclip, float fclip) {
 	glMatrixMode(GL_PROJECTION);
 	glLoadIdentity();
 
-	float right = nclip * tan(fov / 2 * ((float)M_PI / 180));
+	float right = nclip * tanf(fov / 2 * ((float)M_PI / 180));
 	glFrustum(-right, right, -right * 0.75, right * 0.75, nclip, fclip);
 
 	glMatrixMode(GL_MODELVIEW);

--- a/engines/grim/gfx_opengl_shaders.cpp
+++ b/engines/grim/gfx_opengl_shaders.cpp
@@ -430,8 +430,8 @@ void GfxOpenGLS::setupCameraFrustum(float fov, float nclip, float fclip) {
 
 	_fov = fov; _nclip = nclip; _fclip = fclip;
 
-	float right = nclip * tan(fov / 2 * ((float)M_PI / 180));
-	float top = right * 0.75;
+	float right = nclip * tanf(fov / 2 * ((float)M_PI / 180));
+	float top = right * 0.75f;
 
 	_projMatrix = makeFrustumMatrix(-right, right, -top, top, nclip, fclip);
 }

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -114,7 +114,7 @@ void GfxTinyGL::setupCameraFrustum(float fov, float nclip, float fclip) {
 	tglMatrixMode(TGL_PROJECTION);
 	tglLoadIdentity();
 
-	float right = nclip * tan(fov / 2 * ((float)M_PI / 180));
+	float right = nclip * tanf(fov / 2 * ((float)M_PI / 180));
 	tglFrustumf(-right, right, -right * 0.75f, right * 0.75f, nclip, fclip);
 
 	tglMatrixMode(TGL_MODELVIEW);

--- a/engines/grim/lua/lmathlib.cpp
+++ b/engines/grim/lua/lmathlib.cpp
@@ -25,55 +25,55 @@ static void math_abs() {
 }
 
 static void math_sin() {
-	lua_pushnumber(sin(TORAD(luaL_check_number(1))));
+	lua_pushnumber(sinf(TORAD(luaL_check_number(1))));
 }
 
 static void math_cos() {
-	lua_pushnumber(cos(TORAD(luaL_check_number(1))));
+	lua_pushnumber(cosf(TORAD(luaL_check_number(1))));
 }
 
 static void math_tan() {
-	lua_pushnumber(tan(TORAD(luaL_check_number(1))));
+	lua_pushnumber(tanf(TORAD(luaL_check_number(1))));
 }
 
 static void math_asin() {
-	lua_pushnumber(FROMRAD(asin(luaL_check_number(1))));
+	lua_pushnumber(FROMRAD(asinf(luaL_check_number(1))));
 }
 
 static void math_acos() {
-	lua_pushnumber(FROMRAD(acos(luaL_check_number(1))));
+	lua_pushnumber(FROMRAD(acosf(luaL_check_number(1))));
 }
 
 static void math_atan() {
-	lua_pushnumber(FROMRAD(atan(luaL_check_number(1))));
+	lua_pushnumber(FROMRAD(atanf(luaL_check_number(1))));
 }
 
 static void math_ceil() {
-	lua_pushnumber(ceil(luaL_check_number(1)));
+	lua_pushnumber(ceilf(luaL_check_number(1)));
 }
 
 static void math_floor() {
-	lua_pushnumber(floor(luaL_check_number(1)));
+	lua_pushnumber(floorf(luaL_check_number(1)));
 }
 
 static void math_mod() {
-	lua_pushnumber(fmod(luaL_check_number(1), luaL_check_number(2)));
+	lua_pushnumber(fmodf(luaL_check_number(1), luaL_check_number(2)));
 }
 
 static void math_sqrt() {
-	lua_pushnumber(sqrt(luaL_check_number(1)));
+	lua_pushnumber(sqrtf(luaL_check_number(1)));
 }
 
 static void math_pow() {
-	lua_pushnumber(pow(luaL_check_number(1), luaL_check_number(2)));
+	lua_pushnumber(powf(luaL_check_number(1), luaL_check_number(2)));
 }
 
 static void math_deg() {
-	lua_pushnumber(luaL_check_number(1) * (180.0 / (float)M_PI));
+	lua_pushnumber(luaL_check_number(1) * (180.0f / (float)M_PI));
 }
 
 static void math_rad() {
-	lua_pushnumber(luaL_check_number(1) * ((float)M_PI / 180.0));
+	lua_pushnumber(luaL_check_number(1) * ((float)M_PI / 180.0f));
 }
 
 static void math_min() {

--- a/engines/grim/lua_v1.cpp
+++ b/engines/grim/lua_v1.cpp
@@ -275,7 +275,7 @@ void Lua_V1::GetAngleBetweenVectors() {
 	vec2.normalize();
 
 	float dot = vec1.dotProduct(vec2);
-	float angle = 90.0f - (180.0f * asin(dot)) / (float)M_PI;
+	float angle = 90.0f - (180.0f * asinf(dot)) / (float)M_PI;
 	if (angle < 0)
 		angle = -angle;
 	lua_pushnumber(angle);

--- a/engines/grim/sector.cpp
+++ b/engines/grim/sector.cpp
@@ -317,7 +317,7 @@ float Sector::distanceToPoint(const Math::Vector3d &point) const {
 	// dist is positive if it is above the plain, negative if it is
 	// below and 0 if it is on the plane.
 	float dist = (a * point.x() + b * point.y() + c * point.z() + d);
-	dist /= sqrt(a * a + b * b + c * c);
+	dist /= sqrtf(a * a + b * b + c * c);
 	return dist;
 }
 
@@ -408,14 +408,14 @@ Common::List<Math::Line3d> Sector::getBridgesTo(Sector *sector) const {
 			//
 			// The value of at least 0.1 was chosen to fix a path finding issue
 			// in set pac when guybrush tried to reach the pile of rocks.
-			if (fabs(getProjectionToPlane((*it).begin()).y() - sector->getProjectionToPlane((*it).begin()).y()) > 0.1f ||
-			    fabs(getProjectionToPlane((*it).end()).y() - sector->getProjectionToPlane((*it).end()).y()) > 0.1f) {
+			if (fabsf(getProjectionToPlane((*it).begin()).y() - sector->getProjectionToPlane((*it).begin()).y()) > 0.1f ||
+			    fabsf(getProjectionToPlane((*it).end()).y() - sector->getProjectionToPlane((*it).end()).y()) > 0.1f) {
 				it = bridges.erase(it);
 				continue;
 			}
 		} else {
-			if (fabs(getProjectionToPlane((*it).begin()).z() - sector->getProjectionToPlane((*it).begin()).z()) > 0.01f ||
-			    fabs(getProjectionToPlane((*it).end()).z() - sector->getProjectionToPlane((*it).end()).z()) > 0.01f) {
+			if (fabsf(getProjectionToPlane((*it).begin()).z() - sector->getProjectionToPlane((*it).begin()).z()) > 0.01f ||
+			    fabsf(getProjectionToPlane((*it).end()).z() - sector->getProjectionToPlane((*it).end()).z()) > 0.01f) {
 				it = bridges.erase(it);
 				continue;
 			}

--- a/engines/grim/set.cpp
+++ b/engines/grim/set.cpp
@@ -1049,15 +1049,15 @@ void Set::calculateSoundPosition(const Math::Vector3d &pos, int minVol, int maxV
 	Math::Vector3d right;
 	cameraVector.normalize();
 	float roll = -_currSetup->_roll * (float)M_PI / 180.f;
-	float cosr = cos(roll);
+	float cosr = cosf(roll);
 	// Rotate the up vector by roll.
-	up = up * cosr + Math::Vector3d::crossProduct(cameraVector, up) * sin(roll) +
+	up = up * cosr + Math::Vector3d::crossProduct(cameraVector, up) * sinf(roll) +
 	     cameraVector * Math::Vector3d::dotProduct(cameraVector, up) * (1 - cosr);
 	right = Math::Vector3d::crossProduct(cameraVector, up);
 	right.normalize();
-	angle = atan2(Math::Vector3d::dotProduct(vector, right), Math::Vector3d::dotProduct(vector, cameraVector));
+	angle = atan2f(Math::Vector3d::dotProduct(vector, right), Math::Vector3d::dotProduct(vector, cameraVector));
 
-	float pan = sin(angle);
+	float pan = sinf(angle);
 	balance = (int)((pan + 1.f) / 2.f * 127.f + 0.5f);
 }
 

--- a/engines/illusions/bbdou/bbdou_bubble.cpp
+++ b/engines/illusions/bbdou/bbdou_bubble.cpp
@@ -270,8 +270,8 @@ void BbdouBubble::calcBubbleTrail(Common::Point &sourcePt, Common::Point &destPt
 		angleIncr -= angleStep;
 
 		Common::Point newPoint(
-			centerX + _vm->getRandom(8) - 2 + (int)(cos(currentAngle) * radius),
-			centerY + _vm->getRandom(8) - 2 - (int)(sin(currentAngle) * radius));
+			centerX + _vm->getRandom(8) - 2 + (int)(cosf(currentAngle) * radius),
+			centerY + _vm->getRandom(8) - 2 - (int)(sinf(currentAngle) * radius));
 
 		Control *trailControl = _vm->_dict->getObjectControl(_trailObjectIds[i]);
 

--- a/engines/illusions/fixedpoint.cpp
+++ b/engines/illusions/fixedpoint.cpp
@@ -52,21 +52,21 @@ FixedPoint16 fixedDistance(FixedPoint16 x1, FixedPoint16 y1, FixedPoint16 x2, Fi
 	float xd = fixedToFloat(x1) - fixedToFloat(x2);
 	float yd = fixedToFloat(y1) - fixedToFloat(y2);
 	if (xd != 0.0f || yd != 0.0f)
-		return floatToFixed(sqrt(xd * xd + yd * yd));
+		return floatToFixed(sqrtf(xd * xd + yd * yd));
 	return 0;
 }
 
 FixedPoint16 fixedAtan(FixedPoint16 value) {
 	//return floatToFixed(atan2(1.0, fixedToFloat(value)));
-	return floatToFixed(atan(fixedToFloat(value)));
+	return floatToFixed(atanf(fixedToFloat(value)));
 }
 
 FixedPoint16 fixedCos(FixedPoint16 value) {
-	return floatToFixed(cos(fixedToFloat(value)));
+	return floatToFixed(cosf(fixedToFloat(value)));
 }
 
 FixedPoint16 fixedSin(FixedPoint16 value) {
-	return floatToFixed(sin(fixedToFloat(value)));
+	return floatToFixed(sinf(fixedToFloat(value)));
 }
 
 } // End of namespace Illusions

--- a/engines/lastexpress/sound/driver.cpp
+++ b/engines/lastexpress/sound/driver.cpp
@@ -38,7 +38,7 @@ void SoundManager::soundDriverInit() {
 
 	// The following is a way to adapt the amount of buffers to the current device capabilities.
 	// Re-adapted from my own code found within the Digital iMUSE subsystem from the SCUMM engine.
-	_maxQueuedStreams = (uint32)ceil((_mixer->getOutputBufSize() / 1470) / ((float)_mixer->getOutputRate() / 44100));
+	_maxQueuedStreams = (uint32)ceilf((_mixer->getOutputBufSize() / 1470) / ((float)_mixer->getOutputRate() / 44100));
 
 	if (_mixer->getOutputRate() % 44100) {
 		_maxQueuedStreams++;

--- a/engines/mohawk/myst_stacks/myst.cpp
+++ b/engines/mohawk/myst_stacks/myst.cpp
@@ -3280,8 +3280,8 @@ Common::Point Myst::towerRotationMapComputeCoords(uint16 angle) {
 
 	// Polar to rect coords
 	float radians = Math::deg2rad<uint16,float>(angle);
-	end.x = (int16)(_towerRotationCenter.x + cos(radians) * 310.0f);
-	end.y = (int16)(_towerRotationCenter.y + sin(radians) * 310.0f);
+	end.x = (int16)(_towerRotationCenter.x + cosf(radians) * 310.0f);
+	end.y = (int16)(_towerRotationCenter.y + sinf(radians) * 310.0f);
 
 	return end;
 }

--- a/engines/mohawk/riven_graphics.cpp
+++ b/engines/mohawk/riven_graphics.cpp
@@ -983,8 +983,8 @@ void FliesEffect::updateFlyPosition(uint index) {
 	if (fly.directionAngleRadZ < 0.0F) {
 		fly.directionAngleRadZ = fly.directionAngleRadZ + 2.0F * M_PI;
 	}
-	fly.posXFloat += cos(fly.directionAngleRad) * fly.speed;
-	fly.posYFloat += sin(fly.directionAngleRad) * fly.speed;
+	fly.posXFloat += cosf(fly.directionAngleRad) * fly.speed;
+	fly.posYFloat += sinf(fly.directionAngleRad) * fly.speed;
 	fly.posX = fly.posXFloat;
 	fly.posY = fly.posYFloat;
 	selectAlphaMap(
@@ -993,7 +993,7 @@ void FliesEffect::updateFlyPosition(uint index) {
 			&fly.alphaMap,
 			&fly.width,
 			&fly.height);
-	fly.posZFloat += cos(fly.directionAngleRadZ) * (fly.speed / 2.0F);
+	fly.posZFloat += cosf(fly.directionAngleRadZ) * (fly.speed / 2.0F);
 	fly.posZ = fly.posZFloat;
 	if (_parameters->canBlur && fly.speed > _parameters->blurSpeedTreshold) {
 		fly.hasBlur = true;

--- a/engines/myst3/movie.cpp
+++ b/engines/myst3/movie.cpp
@@ -575,8 +575,8 @@ ProjectorMovie::ProjectorMovie(Myst3Engine *vm, uint16 id, Graphics::Surface *ba
 	_enabled = true;
 
 	for (uint i = 0; i < kBlurIterations; i++) {
-		_blurTableX[i] = (uint8)(sin(2 * (float)M_PI * i / (float)kBlurIterations) * 256.0);
-		_blurTableY[i] = (uint8)(cos(2 * (float)M_PI * i / (float)kBlurIterations) * 256.0);
+		_blurTableX[i] = (uint8)(sinf(2 * (float)M_PI * i / (float)kBlurIterations) * 256.0);
+		_blurTableY[i] = (uint8)(cosf(2 * (float)M_PI * i / (float)kBlurIterations) * 256.0);
 	}
 }
 

--- a/engines/myst3/myst3.cpp
+++ b/engines/myst3/myst3.cpp
@@ -1727,8 +1727,8 @@ void Myst3Engine::animateDirectionChange(float targetPitch, float targetHeading,
 	if (scriptTicks) {
 		numTicks = scriptTicks;
 	} else {
-		numTicks = sqrt(pitchDistance * pitchDistance + headingDistance * headingDistance)
-				* 30.0f / _state->getCameraMoveSpeed();
+		numTicks = sqrtf(pitchDistance * pitchDistance + headingDistance * headingDistance)
+		           * 30.0f / _state->getCameraMoveSpeed();
 
 		if (numTicks > 0.0f)
 			numTicks += 10.0f;

--- a/engines/myst3/scene.cpp
+++ b/engines/myst3/scene.cpp
@@ -118,9 +118,9 @@ Math::Vector3d Scene::directionToVector(float pitch, float heading) {
 	float radHeading = Math::deg2rad(heading);
 	float radPitch = Math::deg2rad(pitch);
 
-	v.setValue(0, cos(radPitch) * cos(radHeading));
-	v.setValue(1, sin(radPitch));
-	v.setValue(2, cos(radPitch) * sin(radHeading));
+	v.setValue(0, cosf(radPitch) * cosf(radHeading));
+	v.setValue(1, sinf(radPitch));
+	v.setValue(2, cosf(radPitch) * sinf(radHeading));
 
 	return v;
 }

--- a/engines/myst3/script.cpp
+++ b/engines/myst3/script.cpp
@@ -912,8 +912,8 @@ void Script::polarToRectSimple(Context &c, const Opcode &cmd) {
 
 	int32 angleDeg = _vm->_state->getVar(cmd.args[5]);
 	float angleRad = 2 * (float)M_PI / cmd.args[6] * angleDeg;
-	float angleSin = sin(angleRad);
-	float angleCos = cos(angleRad);
+	float angleSin = sinf(angleRad);
+	float angleCos = cosf(angleRad);
 
 	int32 offsetX = cmd.args[2];
 	int32 offsetY = cmd.args[3];
@@ -936,8 +936,8 @@ void Script::polarToRect(Context &c, const Opcode &cmd) {
 
 	int32 angleDeg = _vm->_state->getVar(cmd.args[8]);
 	float angleRad = 2 * (float)M_PI / cmd.args[9] * angleDeg;
-	float angleSin = sin(angleRad);
-	float angleCos = cos(angleRad);
+	float angleSin = sinf(angleRad);
+	float angleCos = cosf(angleRad);
 
 	float radiusX;
 	float radiusY;
@@ -1689,9 +1689,9 @@ void Script::leverDrag(Context &c, const Opcode &cmd) {
 			float pitch, heading;
 			_vm->_cursor->getDirection(pitch, heading);
 
-			float amplitude = sqrt(Math::square(maxPosX - minPosX) + Math::square(maxPosY - minPosY));
-			float distanceToMin = sqrt(Math::square(pitch - minPosX) + Math::square(heading - minPosY));
-			float distanceToMax = sqrt(Math::square(pitch - maxPosX) + Math::square(heading - maxPosY));
+			float amplitude = sqrtf(Math::square(maxPosX - minPosX) + Math::square(maxPosY - minPosY));
+			float distanceToMin = sqrtf(Math::square(pitch - minPosX) + Math::square(heading - minPosY));
+			float distanceToMax = sqrtf(Math::square(pitch - maxPosX) + Math::square(heading - maxPosY));
 
 			ratioPosition = distanceToMax < amplitude ? distanceToMin / amplitude : 0.0;
 		} else {
@@ -1783,7 +1783,7 @@ void Script::leverDragPositions(Context &c, const Opcode &cmd) {
 			float posHeading = cmd.args[2 + i * 3 + 1] * 0.1;
 
 			// Distance between the mouse and the lever
-			float distance = sqrt(Math::square(pitch - posPitch) + Math::square(heading - posHeading));
+			float distance = sqrtf(Math::square(pitch - posPitch) + Math::square(heading - posHeading));
 
 			if (distance < minDistance) {
 				minDistance = distance;
@@ -1901,7 +1901,7 @@ void Script::runScriptWhileDragging(Context &c, const Opcode &cmd) {
 			mouse = _vm->_scene->scalePoint(mouse);
 			int16 distanceX = mouse.x - leverWidth / 2 - _vm->_state->getVar(cmd.args[0]);
 			int16 distanceY = mouse.y - leverHeight / 2 - _vm->_state->getVar(cmd.args[1]);
-			float distance = sqrt((float) distanceX * distanceX + distanceY * distanceY);
+			float distance = sqrtf((float) distanceX * distanceX + distanceY * distanceY);
 
 			uint16 bestPosition = lastLeverPosition;
 			if (distance > maxDistance) {
@@ -1920,7 +1920,7 @@ void Script::runScriptWhileDragging(Context &c, const Opcode &cmd) {
 					mouse = _vm->_scene->scalePoint(mouse);
 					distanceX = mouse.x - leverWidth / 2 - _vm->_state->getVar(cmd.args[0]);
 					distanceY = mouse.y - leverHeight / 2 - _vm->_state->getVar(cmd.args[1]);
-					distance = sqrt((float) distanceX * distanceX + distanceY * distanceY);
+					distance = sqrtf((float) distanceX * distanceX + distanceY * distanceY);
 
 					if (distance < minDistance) {
 						minDistance = distance;

--- a/engines/nancy/action/puzzle/arcadepuzzle.cpp
+++ b/engines/nancy/action/puzzle/arcadepuzzle.cpp
@@ -233,10 +233,10 @@ void ArcadePuzzle::buildAngleTable() {
 	while (left <= halfW) {
 		// Rotate unit vector (1,0) by curAngleDeg
 		float angleRad = curAngleDeg * (float)M_PI / 180.0f;
-		float dx = (float)cos(angleRad);
-		float dy = (float)sin(angleRad);
+		float dx = (float)cosf(angleRad);
+		float dy = (float)sinf(angleRad);
 		// Normalize (already unit length from cos/sin, but in case of precision)
-		float len = (float)sqrt(dx * dx + dy * dy);
+		float len = (float)sqrtf(dx * dx + dy * dy);
 		if (len > 0.0f) { dx /= len; dy /= len; }
 
 		// sub-entry 0: direct
@@ -256,7 +256,7 @@ void ArcadePuzzle::buildAngleTable() {
 		float rdx  = 2.0f * dot * mirrorNx - dx;    // = -dx
 		float rdy  = 2.0f * dot * mirrorNy - dy;    // = dy
 		// Normalize
-		float rlen = (float)sqrt(rdx * rdx + rdy * rdy);
+		float rlen = (float)sqrtf(rdx * rdx + rdy * rdy);
 		if (rlen > 0.0f) { rdx /= rlen; rdy /= rlen; }
 
 		_angleTable[left * 6 + 3] = rdx;
@@ -1070,7 +1070,7 @@ void ArcadePuzzle::applyCollision() {
 			_ballSpin = _angleTable[hitPos * 6 + 5];
 		}
 
-		const float len = (float)sqrt(_ballDX * _ballDX + _ballDY * _ballDY);
+		const float len = sqrtf(_ballDX * _ballDX + _ballDY * _ballDY);
 		if (len > 0.0f) {
 			_ballDX /= len;
 			_ballDY /= len;
@@ -1093,7 +1093,7 @@ void ArcadePuzzle::applyCollision() {
 		float dot = dx * n[0] + dy * n[1];
 		_ballDX = 2.0f * dot * n[0] - dx;
 		_ballDY = 2.0f * dot * n[1] - dy;
-		float len = (float)sqrt(_ballDX * _ballDX + _ballDY * _ballDY);
+		float len = sqrtf(_ballDX * _ballDX + _ballDY * _ballDY);
 		if (len > 0.0f) { _ballDX /= len; _ballDY /= len; }
 		g_nancy->_sound->playSound(_sounds[0]); // wall bounce sound (same as paddle)
 		break;
@@ -1106,7 +1106,7 @@ void ArcadePuzzle::applyCollision() {
 		float dot = dx * n[0] + dy * n[1];
 		_ballDX = 2.0f * dot * n[0] - dx;
 		_ballDY = 2.0f * dot * n[1] - dy;
-		float len = (float)sqrt(_ballDX * _ballDX + _ballDY * _ballDY);
+		float len = sqrtf(_ballDX * _ballDX + _ballDY * _ballDY);
 		if (len > 0.0f) { _ballDX /= len; _ballDY /= len; }
 		playBrickHitSound();
 		break;

--- a/engines/nancy/action/puzzle/raycastpuzzle.cpp
+++ b/engines/nancy/action/puzzle/raycastpuzzle.cpp
@@ -960,7 +960,7 @@ bool RaycastDeferredLoader::loadInner() {
 		uint center = selectedBounds.left + (selectedBounds.width() >> 1);
 		for (uint i = 0; i < _owner._wallCastColumnAngles.size(); ++i) {
 			int32 &angle = _owner._wallCastColumnAngles[i];
-			angle = (int32)(atan(((float)i - (float)center) / (float)_owner._fov) * _owner._rotationSingleStep);
+			angle = (int32)(atanf(((float)i - (float)center) / (float)_owner._fov) * _owner._rotationSingleStep);
 			clampRotation(angle);
 		}
 

--- a/engines/pegasus/neighborhood/mars/robotship.cpp
+++ b/engines/pegasus/neighborhood/mars/robotship.cpp
@@ -258,7 +258,7 @@ void RobotShip::makeVelocityVector(CoordType x1, CoordType y1, CoordType x2, Coo
 	CoordType length = g_vm->getRandomNumber(kVelocityVectorSlop - 1) + kVelocityVectorLength;
 	vector.x = x2 - x1;
 	vector.y = y2 - y1;
-	float oldLength = sqrt((float)(vector.x * vector.x + vector.y * vector.y));
+	float oldLength = sqrtf((float)(vector.x * vector.x + vector.y * vector.y));
 	vector.x = (int)(vector.x * length / oldLength);
 	vector.y = (int)(vector.y * length / oldLength);
 }

--- a/engines/pegasus/neighborhood/norad/delta/globegame.cpp
+++ b/engines/pegasus/neighborhood/norad/delta/globegame.cpp
@@ -1185,27 +1185,27 @@ void GlobeGame::globePointToLatLong(const GlobeGame::Point3D &pt, int16 latOrigi
 
 	// Rotate around z axis latOrigin degrees to bring equator parallel with XZ plane
 	float theta = degreesToRadians(latOrigin);
-	float s = sin(theta);
-	float c = cos(theta);
+	float s = sinf(theta);
+	float c = cosf(theta);
 	float x = scratch.x * c - scratch.y * s;
 	float y = scratch.y * c + scratch.x * s;
 	scratch.x = x;
 	scratch.y = y;
 
 	// Calculate latitude
-	latitude = (int16)radiansToDegrees(asin(scratch.y / kGlobeRadius));
+	latitude = (int16)radiansToDegrees(asinf(scratch.y / kGlobeRadius));
 
 	// Rotate around y axis longOrigin degrees to bring longitude 0 to positive X axis
 	theta = degreesToRadians(longOrigin);
-	s = sin(theta);
-	c = cos(theta);
+	s = sinf(theta);
+	c = cosf(theta);
 	x = scratch.x * c - scratch.z * s;
 	float z = scratch.z * c + scratch.x * s;
 	scratch.x = x;
 	scratch.z = z;
 
 	// Calculate longitude
-	longitude = (int16)radiansToDegrees(acos(scratch.x / sqrt(scratch.x * scratch.x + scratch.z * scratch.z)));
+	longitude = (int16)radiansToDegrees(acosf(scratch.x / sqrtf(scratch.x * scratch.x + scratch.z * scratch.z)));
 
 	if (scratch.z < 0)
 		longitude = -longitude;
@@ -1238,7 +1238,7 @@ bool GlobeGame::lineHitsGlobe(const GlobeGame::Line3D &line, GlobeGame::Point3D 
 
 	if (t >= 0.0f) {
 		// Return smaller root, which corresponds to closest intersection point.
-		t = (-b - sqrt(t)) / (2 * a);
+		t = (-b - sqrtf(t)) / (2 * a);
 		pt.x = i * t + line.pt1.x;
 		pt.y = j * t + line.pt1.y;
 		pt.z = k * t + line.pt1.z;

--- a/engines/pelrock/graphics.cpp
+++ b/engines/pelrock/graphics.cpp
@@ -343,7 +343,7 @@ void GraphicsManager::calculateScalingMasks() {
 		float position = step;
 		int counter = 1;
 		while (position < kAlfredFrameHeight) {
-			int idx = static_cast<int>(round(position));
+			int idx = static_cast<int>(roundf(position));
 			if (idx < kAlfredFrameHeight) {
 				row[idx] = counter;
 				counter++;

--- a/engines/qdengine/minigames/adv/RunTime.cpp
+++ b/engines/qdengine/minigames/adv/RunTime.cpp
@@ -657,8 +657,8 @@ void MinigameManager::gameWin() {
 	if (_currentGameIndex._gameNum == 0)
 		return;
 
-	int gameTime = round(getTime());
-	_eventManager->addScore(round(_timeManager->leftTime() * _timeManager->timeCost()));
+	int gameTime = roundf(getTime());
+	_eventManager->addScore(roundf(_timeManager->leftTime() * _timeManager->timeCost()));
 
 	_currentGameInfo->_game._lastTime = gameTime;
 	_currentGameInfo->_game._lastScore = _eventManager->score();
@@ -767,7 +767,7 @@ mgVect2f MinigameManager::world2game(const mgVect3f& pos) const {
 
 mgVect3f MinigameManager::world2game(qdMinigameObjectInterface *obj) const {
 	mgVect2i scr = obj->screen_R();
-	return mgVect3f(scr.x, scr.y, round(getDepth(obj)));
+	return mgVect3f(scr.x, scr.y, roundf(getDepth(obj)));
 }
 
 mgVect2f MinigameManager::getSize(qdMinigameObjectInterface *obj) const {
@@ -858,7 +858,7 @@ float MinigameManager::rnd(float min, float max) const {
 }
 
 int MinigameManager::rnd(int min, int max) const {
-	return min + round(_engine->fabs_rnd(max - min));
+	return min + roundf(_engine->fabs_rnd(max - min));
 }
 
 int MinigameManager::rnd(const Std::vector<float> &prob) const {
@@ -1006,13 +1006,13 @@ void MinigameManager::GameInfoIndex::read(Common::ReadStream &in) {
 }
 
 int MinigameManager::getParameter(const char* name, const int& defValue) {
-	return round(getParameter(name, (float)defValue));
+	return roundf(getParameter(name, (float)defValue));
 }
 
 bool MinigameManager::getParameter(const char* name, int& out, bool obligatory) {
 	float retValue = out;
 	if (getParameter(name, retValue, obligatory)) {
-		out = round(retValue);
+		out = roundf(retValue);
 		return true;
 	}
 	return false;
@@ -1150,11 +1150,11 @@ float TimeManager::leftTime() const {
 }
 
 void TimeManager::quant(float dt) {
-	int seconds = round(_runtime->getTime());
+	int seconds = roundf(_runtime->getTime());
 	if (seconds != _lastEventTime) {
 		_lastEventTime = seconds;
 		_runtime->textManager().updateTime(seconds);
-		int amountSeconds = round(leftTime());
+		int amountSeconds = roundf(leftTime());
 		if (_gameTime < 0.f || amountSeconds > 10)
 			if (seconds % 60 == 0)
 				_runtime->signal(EVENT_TIME_60_SECOND_TICK);

--- a/engines/qdengine/minigames/adv/m_puzzle.cpp
+++ b/engines/qdengine/minigames/adv/m_puzzle.cpp
@@ -86,8 +86,8 @@ Puzzle::Puzzle(MinigameManager *runtime) {
 		return;
 
 	if (_runtime->getParameter("rotate_period", _rotateTimePeriod, false)) {
-		assert(sqr(sqrt((float)_gameSize)) == _gameSize);
-		if (sqr(sqrt((float)_gameSize)) != _gameSize)
+		assert(sqr(sqrtf((float)_gameSize)) == _gameSize);
+		if (sqr(sqrtf((float)_gameSize)) != _gameSize)
 			return;
 	} else
 		_rotateTimePeriod = 86400; // сутки
@@ -281,7 +281,7 @@ void Puzzle::quant(float dt) {
 	if (_inField < (int)_nodes.size() && _runtime->getTime() > _nextObjTime &&
 			((int)_stack.size() < _stackSize - 1 || ((int)_stack.size() < _stackSize && _pickedItem == -1))) { // нужно добавить в инвентори фишку
 		// ищем случайный не выставленный фрагмент
-		int freeIdx = round(_runtime->rnd(0.f, _nodes.size() - 1));
+		int freeIdx = roundf(_runtime->rnd(0.f, _nodes.size() - 1));
 		Nodes::iterator it = _nodes.begin();
 		for (;;) {
 			if (++it == _nodes.end())
@@ -452,7 +452,7 @@ const mgVect3f &Puzzle::position(int num) const {
 	assert(num >= 0 && num < (int)_positions.size());
 	// Если глобальный поворот ненулевой, пересчитываем индекс
 	if (_globalAngle > 0) {
-		int size = sqrt((float)_gameSize);
+		int size = sqrtf((float)_gameSize);
 		int y = num / size;
 		int x = num - y * size;
 		--size;

--- a/engines/qdengine/minigames/adv/m_triangles.cpp
+++ b/engines/qdengine/minigames/adv/m_triangles.cpp
@@ -561,7 +561,7 @@ int MinigameTriangle::rowByNum(int num) const {
 
 	switch (_gameType) {
 	case TRIANGLE:
-		return floor(sqrt((float)num));
+		return floorf(sqrtf((float)num));
 	case RECTANGLE:
 		return num / _fieldWidth;
 	default:

--- a/engines/qdengine/qdcore/qd_animation.cpp
+++ b/engines/qdengine/qdcore/qd_animation.cpp
@@ -160,7 +160,7 @@ void qdAnimation::redraw(int x, int y, int z, int mode) const {
 void qdAnimation::redraw(int x, int y, int z, float scale, int mode) const {
 	debugC(2, kDebugGraphics, "qdAnimation::redraw([%d, %d, %d], scale: %f, mode: %d), name: '%s'", x, y, z, scale, mode, transCyrillic(_parent ? _parent->name() : name()));
 
-	if (fabs(scale - 1.0f) < 0.01f) {
+	if (fabsf(scale - 1.0f) < 0.01f) {
 		redraw(x, y, z, mode);
 		return;
 	}
@@ -208,7 +208,7 @@ void qdAnimation::redraw_rot(int x, int y, int z, float angle, int mode) const {
 void qdAnimation::redraw_rot(int x, int y, int z, float angle, const Vect2f &scale, int mode) const {
 	debugC(2, kDebugGraphics, "qdAnimation::redraw_rot([%d, %d, %d], angle: %f, scale: [%f, %f], mode: %d), name: '%s'", x, y, z, angle, scale.x, scale.y, mode, transCyrillic(_parent ? _parent->name() : name()));
 
-	if (fabs(scale.x - 1.0f) < 0.01f && fabs(scale.y - 1.0f) < 0.01f) {
+	if (fabsf(scale.x - 1.0f) < 0.01f && fabsf(scale.y - 1.0f) < 0.01f) {
 		redraw_rot(x, y, z, angle, mode);
 		return;
 	}
@@ -221,7 +221,7 @@ void qdAnimation::redraw_rot(int x, int y, int z, float angle, const Vect2f &sca
 
 	if (tileAnimation()) {
 		tileAnimation()->drawFrame(Vect2i(x, y), get_cur_frame_number(), angle, scale, mode);
-	} else if (fabs(scale.x - scale.y) >= 0.01f) {
+	} else if (fabsf(scale.x - scale.y) >= 0.01f) {
 		if (const qdAnimationFrame *p = get_cur_frame())
 			p->redraw_rot(x, y, z, angle, scale, mode);
 	} else {
@@ -260,7 +260,7 @@ void qdAnimation::draw_mask(int x, int y, int z, uint32 mask_color, int mask_alp
 }
 
 void qdAnimation::draw_mask(int x, int y, int z, uint32 mask_color, int mask_alpha, float scale, int mode) const {
-	if (fabs(scale - 1.0f) < 0.01f) {
+	if (fabsf(scale - 1.0f) < 0.01f) {
 		draw_mask(x, y, z, mask_color, mask_alpha, mode);
 		return;
 	}
@@ -304,7 +304,7 @@ void qdAnimation::draw_mask_rot(int x, int y, int z, float angle, uint32 mask_co
 }
 
 void qdAnimation::draw_mask_rot(int x, int y, int z, float angle, uint32 mask_color, int mask_alpha, const Vect2f &scale, int mode) const {
-	if (fabs(scale.x - 1.0f) < 0.01f && fabs(scale.y - 1.0f) < 0.01f) {
+	if (fabsf(scale.x - 1.0f) < 0.01f && fabsf(scale.y - 1.0f) < 0.01f) {
 		draw_mask_rot(x, y, z, angle, mask_color, mask_alpha, mode);
 		return;
 	}
@@ -317,7 +317,7 @@ void qdAnimation::draw_mask_rot(int x, int y, int z, float angle, uint32 mask_co
 
 	if (tileAnimation()) {
 		tileAnimation()->drawMask_rot(Vect2i(x, y), get_cur_frame_number(), mask_color, mask_alpha, angle, scale, mode);
-	} else if (fabs(scale.x - scale.y) >= 0.01f) {
+	} else if (fabsf(scale.x - scale.y) >= 0.01f) {
 		if (const qdAnimationFrame *p = get_cur_frame())
 			p->draw_mask_rot(x, y, z, angle, mask_color, mask_alpha, scale, mode);
 	} else {
@@ -1117,7 +1117,7 @@ void qdAnimation::clear_frames() {
 }
 
 bool qdAnimation::add_scale(float value) {
-	if (fabs(value - 1.0f) <= 0.01f || value <= 0.01f) return false;
+	if (fabsf(value - 1.0f) <= 0.01f || value <= 0.01f) return false;
 
 	Std::vector<float>::const_iterator it = Common::find(_scales.begin(), _scales.end(), value);
 	if (it != _scales.end()) return false;
@@ -1151,7 +1151,7 @@ int qdAnimation::get_scale_index(float &scale_value) const {
 	const Std::vector<float> &scales_vect = (check_flag(QD_ANIMATION_FLAG_REFERENCE) && _parent) ? _parent->_scales : _scales;
 
 	for (uint i = 0; i < scales_vect.size(); i++) {
-		if (fabs(scale_value - scl) > fabs(scale_value - scales_vect[i])) {
+		if (fabsf(scale_value - scl) > fabsf(scale_value - scales_vect[i])) {
 			scl = scales_vect[i];
 			index = i;
 		}

--- a/engines/qdengine/qdcore/qd_animation_set.cpp
+++ b/engines/qdengine/qdcore/qd_animation_set.cpp
@@ -107,7 +107,7 @@ int qdAnimationSet::get_angle_index(float direction_angle, int dir_count) {
 	if (direction_angle < 0.0f)
 		direction_angle += 2.0f * M_PI;
 
-	int index = round(direction_angle * float(dir_count) / (2.0f * M_PI));
+	int index = roundf(direction_angle * float(dir_count) / (2.0f * M_PI));
 	if (index >= dir_count) index -= dir_count;
 	if (index < 0) index += dir_count;
 
@@ -225,7 +225,7 @@ bool qdAnimationSet::save_script(Common::WriteStream &fh, int indent) const {
 
 	fh.writeString(Common::String::format(" size=\"%d\"", size()));
 
-	if (fabs(_start_angle) > FLT_EPS) {
+	if (fabsf(_start_angle) > FLT_EPS) {
 		fh.writeString(Common::String::format(" start_angle=\"%f\"", _start_angle));
 	}
 

--- a/engines/qdengine/qdcore/qd_animation_set_preview.cpp
+++ b/engines/qdengine/qdcore/qd_animation_set_preview.cpp
@@ -172,22 +172,22 @@ void qdAnimationSetPreview::set_screen(Vect2s offs, Vect2s size) {
 void qdAnimationSetPreview::redraw_grid() {
 	float size = 0;
 	Vect2f p = _camera->scr2plane(_screen_offset);
-	if (fabs(p.x) > size) size = fabs(p.x);
-	if (fabs(p.y) > size) size = fabs(p.y);
+	if (fabsf(p.x) > size) size = fabsf(p.x);
+	if (fabsf(p.y) > size) size = fabsf(p.y);
 	p = _camera->scr2plane(_screen_offset + _screen_size);
-	if (fabs(p.x) > size) size = fabs(p.x);
-	if (fabs(p.y) > size) size = fabs(p.y);
+	if (fabsf(p.x) > size) size = fabsf(p.x);
+	if (fabsf(p.y) > size) size = fabsf(p.y);
 	p = _camera->scr2plane(Vect2s(_screen_offset.x + _screen_size.x, _screen_offset.y));
-	if (fabs(p.x) > size) size = fabs(p.x);
-	if (fabs(p.y) > size) size = fabs(p.y);
+	if (fabsf(p.x) > size) size = fabsf(p.x);
+	if (fabsf(p.y) > size) size = fabsf(p.y);
 	p = _camera->scr2plane(Vect2s(_screen_offset.x, _screen_offset.y + _screen_size.y));
-	if (fabs(p.x) > size) size = fabs(p.x);
-	if (fabs(p.y) > size) size = fabs(p.y);
+	if (fabsf(p.x) > size) size = fabsf(p.x);
+	if (fabsf(p.y) > size) size = fabsf(p.y);
 
-	int sz = round(size) + _cell_size;
+	int sz = roundf(size) + _cell_size;
 	sz -= sz % _cell_size;
 	for (int i = -sz; i <= sz; i += _cell_size) {
-		int dx = round(_cell_offset);
+		int dx = roundf(_cell_offset);
 
 		Vect3f v00 = _camera->global2camera_coord(Vect3f(i + dx, -sz, 0));
 		Vect3f v10 = _camera->global2camera_coord(Vect3f(i + dx, sz, 0));

--- a/engines/qdengine/qdcore/qd_camera.cpp
+++ b/engines/qdengine/qdcore/qd_camera.cpp
@@ -152,13 +152,13 @@ void qdCamera::clear_grid() {
 	}
 }
 float qdCamera::get_scale(const Vect3f &glCoord) const {
-	if ((_focus < 5000.0f) || (fabs(_scale_pow - 1) > 0.001)) {
+	if ((_focus < 5000.0f) || (fabsf(_scale_pow - 1) > 0.001)) {
 		Vect3f cameraCoord = global2camera_coord(glCoord);
 		float buf = cameraCoord.z + _scale_z_offset;
 		// Если координата отрицательна, то масштабирование происходит по линейному
 		// закону. Иначе по общему (степенному) закону.
 		if (buf > 0)
-			buf = exp(_scale_pow * log(buf));
+			buf = expf(_scale_pow * logf(buf));
 
 		float scale = (_focus / (buf + _focus));
 		if (scale < 0)
@@ -208,8 +208,8 @@ const Vect3f qdCamera::rscr2camera_coord(const Vect2s &rScrPoint, float z) const
 }
 
 const Vect2s qdCamera::camera_coord2rscr(const Vect3f &coord) const {
-	int16 sx = round(coord.x * _focus / (coord.z + _focus));
-	int16 sy = round(coord.y * _focus / (coord.z + _focus));
+	int16 sx = roundf(coord.x * _focus / (coord.z + _focus));
+	int16 sy = roundf(coord.y * _focus / (coord.z + _focus));
 	return Vect2s(sx, sy);
 }
 
@@ -311,15 +311,15 @@ const Vect2s qdCamera::plane2rscr(const Vect3f &plnPoint) const {
 
 	if (res.z < (SMALL_VALUE - _focus)) return Vect2s(0, 0);
 
-	int sx0 = round(res.x * _focus / (res.z + _focus));
-	int sy0 = round(res.y * _focus / (res.z + _focus));
+	int sx0 = roundf(res.x * _focus / (res.z + _focus));
+	int sy0 = roundf(res.y * _focus / (res.z + _focus));
 
 	return Vect2s(sx0, sy0);
 }
 
 const sGridCell *qdCamera::get_cell(float X, float Y) const {
-	int x = round(X - _gridCenter.x);
-	int y = round(Y - _gridCenter.y);
+	int x = roundf(X - _gridCenter.x);
+	int y = roundf(Y - _gridCenter.y);
 
 	const int XSP = _cellSX * _GSX;
 	const int YSP = _cellSY * _GSY;
@@ -335,8 +335,8 @@ const sGridCell *qdCamera::get_cell(float X, float Y) const {
 }
 
 const Vect2s qdCamera::get_cell_index(float X, float Y, bool grid_crop) const {
-	int x = round(X - _gridCenter.x);
-	int y = round(Y - _gridCenter.y);
+	int x = roundf(X - _gridCenter.x);
+	int y = roundf(Y - _gridCenter.y);
 
 	const int XSP = _cellSX * _GSX;
 	const int YSP = _cellSY * _GSY;
@@ -1462,13 +1462,13 @@ bool qdCamera::set_grid_line_attributes(const Vect2s &start_pos, const Vect2s &e
 	dr.normalize(d);
 
 	if (abs(dx) > abs(dy)) {
-		int i = round(float(dx) / dr.x);
+		int i = roundf(float(dx) / dr.x);
 		do {
 			set_grid_attributes(Vect2s(r.xi(), r.yi()), size, attr);
 			r += dr;
 		} while (--i >= 0);
 	} else {
-		int i = round(float(dy) / dr.y);
+		int i = roundf(float(dy) / dr.y);
 		do {
 			set_grid_attributes(Vect2s(r.xi(), r.yi()), size, attr);
 			r += dr;
@@ -1495,13 +1495,13 @@ bool qdCamera::drop_grid_line_attributes(const Vect2s &start_pos, const Vect2s &
 	dr.normalize(d);
 
 	if (abs(dx) > abs(dy)) {
-		int i = round(float(dx) / dr.x);
+		int i = roundf(float(dx) / dr.x);
 		do {
 			drop_grid_attributes(Vect2s(r.xi(), r.yi()), size, attr);
 			r += dr;
 		} while (--i >= 0);
 	} else {
-		int i = round(float(dy) / dr.y);
+		int i = roundf(float(dy) / dr.y);
 		do {
 			drop_grid_attributes(Vect2s(r.xi(), r.yi()), size, attr);
 			r += dr;
@@ -1526,14 +1526,14 @@ bool qdCamera::check_grid_line_attributes(const Vect2s &start_pos, const Vect2s 
 	dr.normalize(d);
 
 	if (abs(dx) > abs(dy)) {
-		int i = round(float(dx) / dr.x);
+		int i = roundf(float(dx) / dr.x);
 		do {
 			if (check_grid_attributes(Vect2s(r.xi(), r.yi()), size, attr))
 				return true;
 			r += dr;
 		} while (--i >= 0);
 	} else {
-		int i = round(float(dy) / dr.y);
+		int i = roundf(float(dy) / dr.y);
 		do {
 			if (check_grid_attributes(Vect2s(r.xi(), r.yi()), size, attr))
 				return true;

--- a/engines/qdengine/qdcore/qd_d3dutils.cpp
+++ b/engines/qdengine/qdcore/qd_d3dutils.cpp
@@ -62,7 +62,7 @@ CrossProduct(const Vect3f &v1, const Vect3f &v2) {
 //угол между векторами лежащими в плоскости ХОУ
 //иначе ее применять НЕЛЬЗЯ
 float VectorAngle(const Vect3f &v1, const Vect3f &v2) {
-	return float(atan2(v2.y, v2.x) - atan2(v1.y, v1.x));
+	return float(atan2f(v2.y, v2.x) - atan2f(v1.y, v1.x));
 }
 
 }//vector_helpers
@@ -210,8 +210,8 @@ ViewMatrix(const Vect3f &from,
 
 MATRIX3D
 RotateXMatrix(const float rads) {
-	float cosine = (float) cos(rads);
-	float sine = (float) sin(rads);
+	float cosine = cosf(rads);
+	float sine = sinf(rads);
 	MATRIX3D ret = IdentityMatrix();
 	ret(1, 1) = cosine;
 	ret(2, 2) = -cosine;
@@ -229,8 +229,8 @@ RotateXMatrix(const float rads) {
 
 MATRIX3D
 RotateYMatrix(const float rads) {
-	float const cosine  = (float) cos(rads);
-	float const sine    = (float) sin(rads);
+	float const cosine  = cosf(rads);
+	float const sine    = sinf(rads);
 
 	MATRIX3D ret = IdentityMatrix();
 	ret(0, 0) = cosine;
@@ -251,8 +251,8 @@ RotateYMatrix(const float rads) {
 
 MATRIX3D
 RotateZMatrix(const float rads) {
-	float const cosine = (float) cos(rads);
-	float const sine = (float) sin(rads);
+	float const cosine = cosf(rads);
+	float const sine = sinf(rads);
 	MATRIX3D ret = IdentityMatrix();
 	ret(0, 0) = cosine;
 	ret(1, 1) = -cosine;
@@ -513,7 +513,7 @@ ludcmp(MATRIX3D &a, int *indx, float *d) {
 				sum -= a(i, k) * a(k, j);
 			}
 			a(i, j) = sum;
-			if ((dum = vv[i] * (float)fabs(sum)) >= big) {
+			if ((dum = vv[i] * fabsf(sum)) >= big) {
 				big = dum;
 				imax = i;
 			}

--- a/engines/qdengine/qdcore/qd_game_dispatcher.cpp
+++ b/engines/qdengine/qdcore/qd_game_dispatcher.cpp
@@ -805,7 +805,7 @@ void qdGameDispatcher::redraw_scene(bool draw_interface) {
 
 			grDispatcher::instance()->rectangleAlpha(0, 0,
 					g_engine->_screenW, g_engine->_screenH,
-			        0, round(phase * 255.f));
+			        0, roundf(phase * 255.f));
 		}
 	}
 }
@@ -1645,7 +1645,7 @@ bool qdGameDispatcher::check_condition(qdCondition *cnd) {
 
 			float angle = obj->calc_direction_angle(obj1->R());
 
-			if (fabs(angle - obj->direction_angle()) < M_PI / 2.0f) return true;
+			if (fabsf(angle - obj->direction_angle()) < M_PI / 2.0f) return true;
 		}
 		return false;
 	case qdCondition::CONDITION_KEYPRESS: {

--- a/engines/qdengine/qdcore/qd_game_object.cpp
+++ b/engines/qdengine/qdcore/qd_game_object.cpp
@@ -140,8 +140,8 @@ bool qdGameObject::update_screen_pos() {
 			}
 
 			if (_parallax_offset.x || _parallax_offset.y) {
-				_screen_r.x += round(float(_parallax_offset.x) * cp->scrolling_phase_x());
-				_screen_r.y += round(float(_parallax_offset.y) * cp->scrolling_phase_y());
+				_screen_r.x += roundf(float(_parallax_offset.x) * cp->scrolling_phase_x());
+				_screen_r.y += roundf(float(_parallax_offset.y) * cp->scrolling_phase_y());
 			}
 		} else
 			return false;

--- a/engines/qdengine/qdcore/qd_game_object_animated.cpp
+++ b/engines/qdengine/qdcore/qd_game_object_animated.cpp
@@ -763,8 +763,8 @@ void qdGameObjectAnimated::debug_redraw() const {
 	} else {
 		Vect2f scale(_current_transform.scale());
 
-		ssz.x = round(float(ssz.x) * scale.x);
-		ssz.y = round(float(ssz.y) * scale.y);
+		ssz.x = roundf(float(ssz.x) * scale.x);
+		ssz.y = roundf(float(ssz.y) * scale.y);
 
 		float sn = sinf(-_current_transform.angle());
 		float cs = cosf(-_current_transform.angle());
@@ -774,44 +774,44 @@ void qdGameObjectAnimated::debug_redraw() const {
 		v0 = Vect2i(-ssz.x / 2, -ssz.y / 2);
 		v1 = Vect2i(-ssz.x / 2, +ssz.y / 2);
 
-		p0.x = screen_pos().x + round(float(v0.x) * cs + float(v0.y) * sn);
-		p0.y = screen_pos().y + round(float(-v0.x) * sn + float(v0.y) * cs);
+		p0.x = screen_pos().x + roundf(float(v0.x) * cs + float(v0.y) * sn);
+		p0.y = screen_pos().y + roundf(float(-v0.x) * sn + float(v0.y) * cs);
 
-		p1.x = screen_pos().x + round(float(v1.x) * cs + float(v1.y) * sn);
-		p1.y = screen_pos().y + round(float(-v1.x) * sn + float(v1.y) * cs);
+		p1.x = screen_pos().x + roundf(float(v1.x) * cs + float(v1.y) * sn);
+		p1.y = screen_pos().y + roundf(float(-v1.x) * sn + float(v1.y) * cs);
 
 		grDispatcher::instance()->line(p0.x, p0.y, p1.x, p1.y, 0x000000FF);
 
 		v0 = Vect2i(-ssz.x / 2, +ssz.y / 2);
 		v1 = Vect2i(+ssz.x / 2, +ssz.y / 2);
 
-		p0.x = screen_pos().x + round(float(v0.x) * cs + float(v0.y) * sn);
-		p0.y = screen_pos().y + round(float(-v0.x) * sn + float(v0.y) * cs);
+		p0.x = screen_pos().x + roundf(float(v0.x) * cs + float(v0.y) * sn);
+		p0.y = screen_pos().y + roundf(float(-v0.x) * sn + float(v0.y) * cs);
 
-		p1.x = screen_pos().x + round(float(v1.x) * cs + float(v1.y) * sn);
-		p1.y = screen_pos().y + round(float(-v1.x) * sn + float(v1.y) * cs);
+		p1.x = screen_pos().x + roundf(float(v1.x) * cs + float(v1.y) * sn);
+		p1.y = screen_pos().y + roundf(float(-v1.x) * sn + float(v1.y) * cs);
 
 		grDispatcher::instance()->line(p0.x, p0.y, p1.x, p1.y, 0x000000FF);
 
 		v0 = Vect2i(+ssz.x / 2, +ssz.y / 2);
 		v1 = Vect2i(+ssz.x / 2, -ssz.y / 2);
 
-		p0.x = screen_pos().x + round(float(v0.x) * cs + float(v0.y) * sn);
-		p0.y = screen_pos().y + round(float(-v0.x) * sn + float(v0.y) * cs);
+		p0.x = screen_pos().x + roundf(float(v0.x) * cs + float(v0.y) * sn);
+		p0.y = screen_pos().y + roundf(float(-v0.x) * sn + float(v0.y) * cs);
 
-		p1.x = screen_pos().x + round(float(v1.x) * cs + float(v1.y) * sn);
-		p1.y = screen_pos().y + round(float(-v1.x) * sn + float(v1.y) * cs);
+		p1.x = screen_pos().x + roundf(float(v1.x) * cs + float(v1.y) * sn);
+		p1.y = screen_pos().y + roundf(float(-v1.x) * sn + float(v1.y) * cs);
 
 		grDispatcher::instance()->line(p0.x, p0.y, p1.x, p1.y, 0x000000FF);
 
 		v0 = Vect2i(+ssz.x / 2, -ssz.y / 2);
 		v1 = Vect2i(-ssz.x / 2, -ssz.y / 2);
 
-		p0.x = screen_pos().x + round(float(v0.x) * cs + float(v0.y) * sn);
-		p0.y = screen_pos().y + round(float(-v0.x) * sn + float(v0.y) * cs);
+		p0.x = screen_pos().x + roundf(float(v0.x) * cs + float(v0.y) * sn);
+		p0.y = screen_pos().y + roundf(float(-v0.x) * sn + float(v0.y) * cs);
 
-		p1.x = screen_pos().x + round(float(v1.x) * cs + float(v1.y) * sn);
-		p1.y = screen_pos().y + round(float(-v1.x) * sn + float(v1.y) * cs);
+		p1.x = screen_pos().x + roundf(float(v1.x) * cs + float(v1.y) * sn);
+		p1.y = screen_pos().y + roundf(float(-v1.x) * sn + float(v1.y) * cs);
 
 		grDispatcher::instance()->line(p0.x, p0.y, p1.x, p1.y, 0x000000FF);
 	}
@@ -846,8 +846,8 @@ bool qdGameObjectAnimated::hit(int x, int y) const {
 				float cs = cosf(_current_transform.angle());
 				float sn = sinf(_current_transform.angle());
 
-				int xx = round(1.f / _current_transform.scale().x * (float(x) * cs + float(y) * sn));
-				int yy = round(1.f / _current_transform.scale().y * (float(-x) * sn + float(y) * cs));
+				int xx = roundf(1.f / _current_transform.scale().x * (float(x) * cs + float(y) * sn));
+				int yy = roundf(1.f / _current_transform.scale().y * (float(-x) * sn + float(y) * cs));
 
 				return _animation.hit(xx, yy);
 			} else
@@ -1197,13 +1197,13 @@ bool qdGameObjectAnimated::update_screen_pos() {
 			if (delta.x || delta.y) {
 				Vect2f scale(_current_transform.scale());
 
-				delta.x = round(float(delta.x) * scale.x);
-				delta.y = round(float(delta.y) * scale.y);
+				delta.x = roundf(float(delta.x) * scale.x);
+				delta.y = roundf(float(delta.y) * scale.y);
 
 				float angle = _current_transform.angle();
 
-				r.x += round(float(delta.x) * cosf(angle) - float(delta.y) * sinf(angle));
-				r.y += round(float(delta.x) * sinf(angle) + float(delta.y) * cosf(angle));
+				r.x += roundf(float(delta.x) * cosf(angle) - float(delta.y) * sinf(angle));
+				r.y += roundf(float(delta.x) * sinf(angle) + float(delta.y) * cosf(angle));
 			}
 
 			set_screen_R(r);
@@ -1510,8 +1510,8 @@ grScreenRegion qdGameObjectAnimated::screen_region() const {
 				float sn = sinf(_current_transform.angle());
 				float cs = cosf(_current_transform.angle());
 
-				int sx = round(fabs(cs) * float(size.x) * scale.x + fabs(sn) * float(size.y) * scale.y) + 2;
-				int sy = round(fabs(sn) * float(size.x) * scale.x + fabs(cs) * float(size.y) * scale.y) + 2;
+				int sx = roundf(fabsf(cs) * float(size.x) * scale.x + fabsf(sn) * float(size.y) * scale.y) + 2;
+				int sy = roundf(fabsf(sn) * float(size.x) * scale.x + fabsf(cs) * float(size.y) * scale.y) + 2;
 
 				reg = grScreenRegion(0, 0, sx, sy);
 				reg.move(r.x, r.y);

--- a/engines/qdengine/qdcore/qd_game_object_mouse.cpp
+++ b/engines/qdengine/qdcore/qd_game_object_mouse.cpp
@@ -270,7 +270,7 @@ void qdGameObjectMouse::quant(float dt) {
 			if (_screen_pos_offset.norm2() >= sqr(p->rnd_move_radius()) || (_screen_pos_offset_delta.x <= FLT_EPS && _screen_pos_offset_delta.y <= FLT_EPS)) {
 				float angle = qd_fabs_rnd(M_PI * 2.0f);
 
-				Vect2f r(p->rnd_move_radius() * cos(angle), p->rnd_move_radius() * sin(angle));
+				Vect2f r(p->rnd_move_radius() * cosf(angle), p->rnd_move_radius() * sinf(angle));
 				_screen_pos_offset_delta = r - _screen_pos_offset;
 				_screen_pos_offset_delta.normalize(p->rnd_move_speed());
 			}

--- a/engines/qdengine/qdcore/qd_game_object_moving.cpp
+++ b/engines/qdengine/qdcore/qd_game_object_moving.cpp
@@ -617,7 +617,7 @@ float qdGameObjectMoving::calc_direction_angle(const Vect3f &target) const {
 
 	float angle = dr.psi() + qdCamera::current_camera()->get_z_angle() * M_PI / 180.0f;
 
-	if (fabs(angle) >= M_PI * 2.0f) angle = fmodf(angle, M_PI * 2.0f);
+	if (fabsf(angle) >= M_PI * 2.0f) angle = fmodf(angle, M_PI * 2.0f);
 	if (angle < 0.0f) angle += M_PI * 2.0f;
 
 	return angle;
@@ -625,7 +625,7 @@ float qdGameObjectMoving::calc_direction_angle(const Vect3f &target) const {
 
 float qdGameObjectMoving::animate_rotation(float dt) {
 	// Второе значение - на сколько повернуться за квант
-	float work_dt = fabs(_rotation_angle / rotation_angle_per_quant());
+	float work_dt = fabsf(_rotation_angle / rotation_angle_per_quant());
 	if (work_dt <= FLT_EPS) return dt;   // Поворачиваться не нужно
 	// Считаем на сколько можем повернуться и сколько после этого останется квантов
 	if (work_dt > dt) {
@@ -809,8 +809,8 @@ Vect3f qdGameObjectMoving::get_future_r(float dt, bool &end_movement, bool real_
 
 			float dist = sp * time;
 			float angle = _direction_angle + qdCamera::current_camera()->get_z_angle() * M_PI / 180.0f;
-			r.x += dist * cos(angle);
-			r.y += dist * sin(angle);
+			r.x += dist * cosf(angle);
+			r.y += dist * sinf(angle);
 
 			set_grid_zone_attributes(sGridCell::CELL_SELECTED);
 
@@ -1044,7 +1044,7 @@ bool qdGameObjectMoving::is_path_walkable(int x1, int y1, int x2, int y2) const 
 	dr.normalize(0.2f);
 
 	if (abs(x2 - x1) > abs(y2 - y1)) {
-		int dx = round(float(x2 - x1) / dr.x);
+		int dx = roundf(float(x2 - x1) / dr.x);
 		do {
 			if (!is_walkable(Vect2s(r.xi(), r.yi())))
 				return false;
@@ -1052,7 +1052,7 @@ bool qdGameObjectMoving::is_path_walkable(int x1, int y1, int x2, int y2) const 
 			r += dr;
 		} while (--dx >= 0);
 	} else {
-		int dy = round(float(y2 - y1) / dr.y);
+		int dy = roundf(float(y2 - y1) / dr.y);
 		do {
 			if (!is_walkable(Vect2s(r.xi(), r.yi())))
 				return false;
@@ -1095,8 +1095,8 @@ bool qdGameObjectMoving::update_screen_pos() {
 
 			if (offs.x || offs.y) {
 				float scale = calc_scale();
-				offs.x = round(float(offs.x) * scale);
-				offs.y = round(float(offs.y) * scale);
+				offs.x = roundf(float(offs.x) * scale);
+				offs.y = roundf(float(offs.y) * scale);
 
 				set_screen_R(get_screen_R() + offs);
 			}
@@ -1111,7 +1111,7 @@ bool qdGameObjectMoving::update_screen_pos() {
 Vect2s qdGameObjectMoving::screen_size() const {
 	float scale = calc_scale();
 
-	return Vect2s(round(static_cast<float>(get_animation()->size_x()) * scale), round(static_cast<float>(get_animation()->size_y()) * scale));
+	return Vect2s(roundf(static_cast<float>(get_animation()->size_x()) * scale), roundf(static_cast<float>(get_animation()->size_y()) * scale));
 }
 
 float qdGameObjectMoving::radius() const {
@@ -1205,7 +1205,7 @@ bool qdGameObjectMoving::is_in_position(const Vect3f pos) const {
 
 bool qdGameObjectMoving::is_in_position(const Vect3f pos, float angle) const {
 	if (!is_in_position(pos)) return false;
-	if (fabs(_direction_angle - angle) <= 0.01f) return true;
+	if (fabsf(_direction_angle - angle) <= 0.01f) return true;
 
 	return false;
 }
@@ -1236,7 +1236,7 @@ bool qdGameObjectMoving::is_moving2position(const Vect3f pos) const {
 bool qdGameObjectMoving::is_moving2position(const Vect3f pos, float angle) const {
 	if (!is_moving2position(pos)) return false;
 
-	if (fabs(angle - _target_angle) <= 0.01f)
+	if (fabsf(angle - _target_angle) <= 0.01f)
 		return true;
 
 	return false;
@@ -1286,9 +1286,9 @@ Vect2s qdGameObjectMoving::walk_grid_size(const Vect3f &r) const {
 
 	if (qdCamera::current_camera() && qdCamera::current_camera()->need_perspective_correction()) {
 		float scale = calc_scale(r);
-		size.x = round(float(size.x) * scale);
+		size.x = roundf(float(size.x) * scale);
 		if (size.x < 1) size.x = 1;
-		size.y = round(float(size.y) * scale);
+		size.y = roundf(float(size.y) * scale);
 		if (size.y < 1) size.y = 1;
 	}
 
@@ -1301,9 +1301,9 @@ Vect2s qdGameObjectMoving::walk_grid_size(const Vect2s &r) const {
 	if (qdCamera::current_camera() && qdCamera::current_camera()->need_perspective_correction()) {
 		Vect3f rr = qdCamera::current_camera()->get_cell_coords(r.x, r.y);
 		float scale = calc_scale(rr);
-		size.x = round(float(size.x) * scale);
+		size.x = roundf(float(size.x) * scale);
 		if (size.x < 1) size.x = 1;
-		size.y = round(float(size.y) * scale);
+		size.y = roundf(float(size.y) * scale);
 		if (size.y < 1) size.y = 1;
 	}
 
@@ -2151,8 +2151,8 @@ bool qdGameObjectMoving::avoid_collision(const qdGameObjectMoving *p) {
 	float dist = (radius() + p->radius()) * 0.7f;
 
 	Vect3f r(R());
-	r.x += dist * cos(direction);
-	r.y += dist * sin(direction);
+	r.x += dist * cosf(direction);
+	r.y += dist * sinf(direction);
 
 	if (move(r, true)) return true;
 
@@ -2484,7 +2484,7 @@ void qdGameObjectMoving::finalize_path(const Vect3f &from, const Vect3f &to, con
 				d.x = 0;
 		}
 
-		if (fabs(d.x) <= FLT_EPS && fabs(d.y) <= FLT_EPS)
+		if (fabsf(d.x) <= FLT_EPS && fabsf(d.y) <= FLT_EPS)
 			break;
 
 		++it;
@@ -2495,25 +2495,25 @@ void qdGameObjectMoving::finalize_path(const Vect3f &from, const Vect3f &to, con
 bool qdGameObjectMoving::adjust_position(Vect3f &pos) const {
 	switch (movement_type()) {
 	case qdGameObjectStateWalk::MOVEMENT_LEFT:
-		if (pos.x <= R().x && fabs(R().y - pos.y) <= bound().y / 2.0f) {
+		if (pos.x <= R().x && fabsf(R().y - pos.y) <= bound().y / 2.0f) {
 			pos.y = R().y;
 			return true;
 		}
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_UP:
-		if (pos.y >= R().y && fabs(R().x - pos.x) <= bound().x / 2.0f) {
+		if (pos.y >= R().y && fabsf(R().x - pos.x) <= bound().x / 2.0f) {
 			pos.x = R().x;
 			return true;
 		}
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_RIGHT:
-		if (pos.x >= R().x && fabs(R().y - pos.y) <= bound().y / 2.0f) {
+		if (pos.x >= R().x && fabsf(R().y - pos.y) <= bound().y / 2.0f) {
 			pos.y = R().y;
 			return true;
 		}
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_DOWN:
-		if (pos.y <= R().y && fabs(R().x - pos.x) <= bound().x / 2.0f) {
+		if (pos.y <= R().y && fabsf(R().x - pos.x) <= bound().x / 2.0f) {
 			pos.x = R().x;
 			return true;
 		}
@@ -2527,13 +2527,13 @@ bool qdGameObjectMoving::adjust_position(Vect3f &pos) const {
 	case qdGameObjectStateWalk::MOVEMENT_DOWN_LEFT:
 		return adjust_position(pos, M_PI / 4.0f * 5.0f);
 	case qdGameObjectStateWalk::MOVEMENT_HORIZONTAL:
-		if (fabs(R().y - pos.y) <= bound().y / 2.0f) {
+		if (fabsf(R().y - pos.y) <= bound().y / 2.0f) {
 			pos.y = R().y;
 			return true;
 		}
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_VERTICAL:
-		if (fabs(R().x - pos.x) <= bound().x / 2.0f) {
+		if (fabsf(R().x - pos.x) <= bound().x / 2.0f) {
 			pos.x = R().x;
 			return true;
 		}
@@ -2546,15 +2546,15 @@ bool qdGameObjectMoving::adjust_position(Vect3f &pos) const {
 }
 
 bool qdGameObjectMoving::adjust_position(Vect3f &pos, float dir_angle) const {
-	float d = -pos.x * sin(dir_angle) + pos.y * cos(dir_angle);
+	float d = -pos.x * sinf(dir_angle) + pos.y * cosf(dir_angle);
 
-	if (fabs(d) <= radius()) {
+	if (fabsf(d) <= radius()) {
 		float angle = calc_direction_angle(pos);
 		float delta_angle = getDeltaAngle(angle, dir_angle);
-		if (fabs(delta_angle) <= M_PI / 2.0f) {
-			float d1 = sqrt(pos.x * pos.x + pos.y * pos.y - d * d);
-			pos.x = d1 * cos(dir_angle);
-			pos.y = d1 * sin(dir_angle);
+		if (fabsf(delta_angle) <= M_PI / 2.0f) {
+			float d1 = sqrtf(pos.x * pos.x + pos.y * pos.y - d * d);
+			pos.x = d1 * cosf(dir_angle);
+			pos.y = d1 * sinf(dir_angle);
 			return true;
 		}
 	}
@@ -2567,36 +2567,36 @@ bool qdGameObjectMoving::is_direction_allowed(float angle) const {
 
 	switch (movement_type()) {
 	case qdGameObjectStateWalk::MOVEMENT_LEFT:
-		if (fabs(angle - M_PI) <= 0.01f) return true;
+		if (fabsf(angle - M_PI) <= 0.01f) return true;
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_UP:
-		if (fabs(angle - M_PI / 2.0f) <= 0.01f) return true;
+		if (fabsf(angle - M_PI / 2.0f) <= 0.01f) return true;
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_RIGHT:
-		if (fabs(angle) <= 0.01f) return true;
+		if (fabsf(angle) <= 0.01f) return true;
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_DOWN:
-		if (fabs(angle - M_PI / 2.0f * 3.0f) <= 0.01f) return true;
+		if (fabsf(angle - M_PI / 2.0f * 3.0f) <= 0.01f) return true;
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_UP_LEFT:
-		if (fabs(angle - M_PI / 4.0f * 3.0f) <= 0.01f) return true;
+		if (fabsf(angle - M_PI / 4.0f * 3.0f) <= 0.01f) return true;
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_UP_RIGHT:
-		if (fabs(angle - M_PI / 4.0f * 1.0f) <= 0.01f) return true;
+		if (fabsf(angle - M_PI / 4.0f * 1.0f) <= 0.01f) return true;
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_DOWN_RIGHT:
-		if (fabs(angle - M_PI / 4.0f * 7.0f) <= 0.01f) return true;
+		if (fabsf(angle - M_PI / 4.0f * 7.0f) <= 0.01f) return true;
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_DOWN_LEFT:
-		if (fabs(angle - M_PI / 4.0f * 5.0f) <= 0.01f) return true;
+		if (fabsf(angle - M_PI / 4.0f * 5.0f) <= 0.01f) return true;
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_HORIZONTAL:
-		if (fabs(angle) <= 0.01f) return true;
-		if (fabs(angle - M_PI) <= 0.01f) return true;
+		if (fabsf(angle) <= 0.01f) return true;
+		if (fabsf(angle - M_PI) <= 0.01f) return true;
 		break;
 	case qdGameObjectStateWalk::MOVEMENT_VERTICAL:
-		if (fabs(angle - M_PI / 2.0f) <= 0.01f) return true;
-		if (fabs(angle - M_PI / 2.0f * 3.0f) <= 0.01f) return true;
+		if (fabsf(angle - M_PI / 2.0f) <= 0.01f) return true;
+		if (fabsf(angle - M_PI / 2.0f * 3.0f) <= 0.01f) return true;
 		break;
 	default:
 		return true;
@@ -2738,8 +2738,8 @@ bool qdGameObjectMoving::move_from_personage_path() {
 			float dir = 2.0f * M_PI / float(num_angles) * float(j);
 
 			Vect3f r(R());
-			r.x += dist * cos(dir);
-			r.y += dist * sin(dir);
+			r.x += dist * cosf(dir);
+			r.y += dist * sinf(dir);
 
 			if (!check_grid_zone_attributes(Vect2f(r.x, r.y), sGridCell::CELL_PERSONAGE_PATH)) {
 				if (move(r, true))

--- a/engines/qdengine/qdcore/qd_game_object_state.cpp
+++ b/engines/qdengine/qdcore/qd_game_object_state.cpp
@@ -40,8 +40,8 @@
 namespace QDEngine {
 
 bool qdScreenTransform::operator == (const qdScreenTransform &trans) const {
-	return fabs(_angle - trans._angle) < FLT_EPS &&
-	       fabs(_scale.x - trans._scale.x) < FLT_EPS && fabs(_scale.y - trans._scale.y) < FLT_EPS;
+	return fabsf(_angle - trans._angle) < FLT_EPS &&
+	       fabsf(_scale.x - trans._scale.x) < FLT_EPS && fabsf(_scale.y - trans._scale.y) < FLT_EPS;
 }
 
 bool qdScreenTransform::change(float dt, const qdScreenTransform &target_trans, const qdScreenTransform &speed) {
@@ -477,7 +477,7 @@ bool qdGameObjectState::save_script_body(Common::WriteStream &fh, int indent) co
 		fh.writeString(Common::String::format(" rnd_move=\"%f %f\"", _rnd_move_radius, _rnd_move_speed));
 	}
 
-	if (fabs(_fade_time - 0.1f) > FLT_EPS) {
+	if (fabsf(_fade_time - 0.1f) > FLT_EPS) {
 		fh.writeString(Common::String::format(" fade_time=\"%f\"", _fade_time));
 	}
 
@@ -1005,18 +1005,18 @@ float qdGameObjectStateWalk::adjust_direction_angle(float angle) const {
 		angle = M_PI / 4.0f * 5.0f;
 		break;
 	case MOVEMENT_HORIZONTAL:
-		angle = (fabs(getDeltaAngle(0.0f, angle)) < fabs(getDeltaAngle(M_PI, angle))) ? 0.0f : M_PI;
+		angle = (fabsf(getDeltaAngle(0.0f, angle)) < fabsf(getDeltaAngle(M_PI, angle))) ? 0.0f : M_PI;
 		break;
 	case MOVEMENT_VERTICAL:
-		angle = (fabs(getDeltaAngle(M_PI / 2.0f, angle)) < fabs(getDeltaAngle(M_PI / 2.0f * 3.0f, angle))) ? M_PI / 2.0f : M_PI / 2.0f * 3.0f;
+		angle = (fabsf(getDeltaAngle(M_PI / 2.0f, angle)) < fabsf(getDeltaAngle(M_PI / 2.0f * 3.0f, angle))) ? M_PI / 2.0f : M_PI / 2.0f * 3.0f;
 		break;
 	case MOVEMENT_FOUR_DIRS: {
-		float dist0 = fabs(getDeltaAngle(0.0f, angle));
+		float dist0 = fabsf(getDeltaAngle(0.0f, angle));
 		float angle0 = 0.0f;
 
 		for (int i = 1; i < 4; i++) {
 			float angle1 = float(i) * M_PI / 2.0f;
-			float dist1 = fabs(getDeltaAngle(angle1, angle));
+			float dist1 = fabsf(getDeltaAngle(angle1, angle));
 			if (dist1 < dist0) {
 				dist0 = dist1;
 				angle0 = angle1;
@@ -1027,12 +1027,12 @@ float qdGameObjectStateWalk::adjust_direction_angle(float angle) const {
 	}
 	break;
 	case MOVEMENT_EIGHT_DIRS: {
-		float dist0 = fabs(getDeltaAngle(0.0f, angle));
+		float dist0 = fabsf(getDeltaAngle(0.0f, angle));
 		float angle0 = 0.0f;
 
 		for (int i = 1; i < 8; i++) {
 			float angle1 = float(i) * M_PI / 4.0f;
-			float dist1 = fabs(getDeltaAngle(angle1, angle));
+			float dist1 = fabsf(getDeltaAngle(angle1, angle));
 			if (dist1 < dist0) {
 				dist0 = dist1;
 				angle0 = angle1;

--- a/engines/qdengine/qdcore/qd_game_scene.cpp
+++ b/engines/qdengine/qdcore/qd_game_scene.cpp
@@ -1524,14 +1524,14 @@ void qdGameScene::collision_quant() {
 			float angle = _selected_object->calc_direction_angle((*it)->R());
 
 			if (dr.norm() < dist) {
-				if (fabs(getDeltaAngle(angle, _selected_object->direction_angle())) < M_PI / 2.0f) {
+				if (fabsf(getDeltaAngle(angle, _selected_object->direction_angle())) < M_PI / 2.0f) {
 					if ((*it)->has_control_type(qdGameObjectMoving::CONTROL_COLLISION))
 						(*it)->set_movement_impulse(_selected_object->direction_angle());
 				}
 			}
 
 			if (dr.norm() < dist) {
-				if (fabs(getDeltaAngle(angle, _selected_object->direction_angle())) < M_PI / 2.0f) {
+				if (fabsf(getDeltaAngle(angle, _selected_object->direction_angle())) < M_PI / 2.0f) {
 					if ((*it)->has_control_type(qdGameObjectMoving::CONTROL_AVOID_COLLISION))
 						(*it)->avoid_collision(_selected_object);
 				}

--- a/engines/qdengine/qdcore/qd_interface_screen.cpp
+++ b/engines/qdengine/qdcore/qd_interface_screen.cpp
@@ -115,8 +115,8 @@ bool qdInterfaceScreen::quant(float dt) {
 		if (_autohide_phase > 1.0f)
 			_autohide_phase = 1.0f;
 
-		int x = round(float(_autohide_offset.x) * _autohide_phase);
-		int y = round(float(_autohide_offset.y) * _autohide_phase);
+		int x = roundf(float(_autohide_offset.x) * _autohide_phase);
+		int y = roundf(float(_autohide_offset.y) * _autohide_phase);
 
 		g_engine->set_screen_offset(Vect2i(x, y));
 	} else {

--- a/engines/qdengine/qdcore/qd_interface_slider.cpp
+++ b/engines/qdengine/qdcore/qd_interface_slider.cpp
@@ -117,7 +117,7 @@ bool qdInterfaceSlider::keyboard_handler(Common::KeyCode vkey) {
 }
 
 int qdInterfaceSlider::option_value() const {
-	return round(_phase * 255.0f);
+	return roundf(_phase * 255.0f);
 }
 
 bool qdInterfaceSlider::set_option_value(int value) {

--- a/engines/qdengine/qdcore/qd_interface_text_window.cpp
+++ b/engines/qdengine/qdcore/qd_interface_text_window.cpp
@@ -453,15 +453,15 @@ bool qdInterfaceTextWindow::quant(float dt) {
 		if (_text_set) {
 			debugC(2, kDebugText,"** qdInterfaceTextWindow::quant(): text_set, id: %d", _text_set->ID());
 
-			if (fabs(_scrolling_position) > FLT_EPS) {
+			if (fabsf(_scrolling_position) > FLT_EPS) {
 				float delta = _scrolling_speed * dt;
-				if (fabs(_scrolling_position) > delta)
+				if (fabsf(_scrolling_position) > delta)
 					_scrolling_position += (_scrolling_position > 0) ? -delta : delta;
 				else
 					_scrolling_position = 0;
 
 				Vect2i pos = _text_set->screen_pos();
-				pos.y = _text_set_position + round(_scrolling_position);
+				pos.y = _text_set_position + roundf(_scrolling_position);
 				_text_set->set_screen_pos(pos);
 			}
 

--- a/engines/qdengine/qdcore/qd_sprite.cpp
+++ b/engines/qdengine/qdcore/qd_sprite.cpp
@@ -587,8 +587,8 @@ void qdSprite::redraw_rot(int x, int y, int z, float angle, int mode) const {
 		delta.y = -delta.y;
 
 	if (delta.x || delta.y) {
-		xx += round(float(delta.x) * cosf(angle) - float(delta.y) * sinf(angle));
-		yy += round(float(delta.x) * sinf(angle) + float(delta.y) * cosf(angle));
+		xx += roundf(float(delta.x) * cosf(angle) - float(delta.y) * sinf(angle));
+		yy += roundf(float(delta.x) * sinf(angle) + float(delta.y) * cosf(angle));
 	}
 
 	xx -= _picture_size.x / 2;
@@ -614,16 +614,16 @@ void qdSprite::redraw_rot(int x, int y, int z, float angle, const Vect2f &scale,
 	if (mode & GR_FLIP_VERTICAL)
 		delta.y = -delta.y;
 
-	delta.x = round(float(delta.x) * scale.x);
-	delta.y = round(float(delta.y) * scale.y);
+	delta.x = roundf(float(delta.x) * scale.x);
+	delta.y = roundf(float(delta.y) * scale.y);
 
 	if (delta.x || delta.y) {
-		xx += round(float(delta.x) * cosf(angle) - float(delta.y) * sinf(angle));
-		yy += round(float(delta.x) * sinf(angle) + float(delta.y) * cosf(angle));
+		xx += roundf(float(delta.x) * cosf(angle) - float(delta.y) * sinf(angle));
+		yy += roundf(float(delta.x) * sinf(angle) + float(delta.y) * cosf(angle));
 	}
 
-	xx -= round(float(_picture_size.x / 2) * scale.x);
-	yy -= round(float(_picture_size.y / 2) * scale.y);
+	xx -= roundf(float(_picture_size.x / 2) * scale.x);
+	yy -= roundf(float(_picture_size.y / 2) * scale.y);
 
 	if (!is_compressed()) {
 		if (!_data) return;
@@ -635,18 +635,18 @@ void qdSprite::redraw_rot(int x, int y, int z, float angle, const Vect2f &scale,
 void qdSprite::redraw(int x, int y, int z, float scale, int mode) const {
 	debugC(3, kDebugGraphics, "qdSprite::redraw([%d, %d, %d], scale: %f, mode: %d)", x, y, z, scale, mode);
 
-	int xx = x - round(float(size_x()) * scale) / 2;
-	int yy = y - round(float(size_y()) * scale) / 2;
+	int xx = x - roundf(float(size_x()) * scale) / 2;
+	int yy = y - roundf(float(size_y()) * scale) / 2;
 
 	if (mode & GR_FLIP_HORIZONTAL)
-		xx += round(float(_size.x - _picture_offset.x - _picture_size.x) * scale);
+		xx += roundf(float(_size.x - _picture_offset.x - _picture_size.x) * scale);
 	else
-		xx += round(float(_picture_offset.x) * scale);
+		xx += roundf(float(_picture_offset.x) * scale);
 
 	if (mode & GR_FLIP_VERTICAL)
-		yy += round(float(_size.y - _picture_offset.y - _picture_size.y) * scale);
+		yy += roundf(float(_size.y - _picture_offset.y - _picture_size.y) * scale);
 	else
-		yy += round(float(_picture_offset.y) * scale);
+		yy += roundf(float(_picture_offset.y) * scale);
 
 #ifdef _GR_ENABLE_ZBUFFER
 	if (!is_compressed()) {
@@ -694,18 +694,18 @@ void qdSprite::draw_mask(int x, int y, int z, uint32 mask_color, int mask_alpha,
 }
 
 void qdSprite::draw_mask(int x, int y, int z, uint32 mask_color, int mask_alpha, float scale, int mode) const {
-	int xx = x - round(float(size_x()) * scale) / 2;
-	int yy = y - round(float(size_y()) * scale) / 2;
+	int xx = x - roundf(float(size_x()) * scale) / 2;
+	int yy = y - roundf(float(size_y()) * scale) / 2;
 
 	if (mode & GR_FLIP_HORIZONTAL)
-		xx += round(float(_size.x - _picture_offset.x - _picture_size.x) * scale);
+		xx += roundf(float(_size.x - _picture_offset.x - _picture_size.x) * scale);
 	else
-		xx += round(float(_picture_offset.x) * scale);
+		xx += roundf(float(_picture_offset.x) * scale);
 
 	if (mode & GR_FLIP_VERTICAL)
-		yy += round(float(_size.y - _picture_offset.y - _picture_size.y) * scale);
+		yy += roundf(float(_size.y - _picture_offset.y - _picture_size.y) * scale);
 	else
-		yy += round(float(_picture_offset.y) * scale);
+		yy += roundf(float(_picture_offset.y) * scale);
 
 	if (!is_compressed()) {
 		if (!_data) return;
@@ -729,8 +729,8 @@ void qdSprite::draw_mask_rot(int x, int y, int z, float angle, uint32 mask_color
 		delta.y = -delta.y;
 
 	if (delta.x || delta.y) {
-		xx += round(float(delta.x) * cosf(angle) - float(delta.y) * sinf(angle));
-		yy += round(float(delta.x) * sinf(angle) + float(delta.y) * cosf(angle));
+		xx += roundf(float(delta.x) * cosf(angle) - float(delta.y) * sinf(angle));
+		yy += roundf(float(delta.x) * sinf(angle) + float(delta.y) * cosf(angle));
 	}
 
 	xx -= _picture_size.x / 2;
@@ -754,16 +754,16 @@ void qdSprite::draw_mask_rot(int x, int y, int z, float angle, uint32 mask_color
 	if (mode & GR_FLIP_VERTICAL)
 		delta.y = -delta.y;
 
-	delta.x = round(float(delta.x) * scale.x);
-	delta.y = round(float(delta.y) * scale.y);
+	delta.x = roundf(float(delta.x) * scale.x);
+	delta.y = roundf(float(delta.y) * scale.y);
 
 	if (delta.x || delta.y) {
-		xx += round(float(delta.x) * cosf(angle) - float(delta.y) * sinf(angle));
-		yy += round(float(delta.x) * sinf(angle) + float(delta.y) * cosf(angle));
+		xx += roundf(float(delta.x) * cosf(angle) - float(delta.y) * sinf(angle));
+		yy += roundf(float(delta.x) * sinf(angle) + float(delta.y) * cosf(angle));
 	}
 
-	xx -= round(float(_picture_size.x / 2) * scale.x);
-	yy -= round(float(_picture_size.y / 2) * scale.y);
+	xx -= roundf(float(_picture_size.x / 2) * scale.x);
+	yy -= roundf(float(_picture_size.y / 2) * scale.y);
 
 	if (!is_compressed()) {
 		if (!_data) return;
@@ -798,18 +798,18 @@ void qdSprite::draw_contour(int x, int y, uint32 color, int mode) const {
 }
 
 void qdSprite::draw_contour(int x, int y, uint32 color, float scale, int mode) const {
-	int xx = x - round(float(size_x()) * scale) / 2;
-	int yy = y - round(float(size_y()) * scale) / 2;
+	int xx = x - roundf(float(size_x()) * scale) / 2;
+	int yy = y - roundf(float(size_y()) * scale) / 2;
 
 	if (mode & GR_FLIP_HORIZONTAL)
-		xx += round(float(_size.x - _picture_offset.x - _picture_size.x) * scale);
+		xx += roundf(float(_size.x - _picture_offset.x - _picture_size.x) * scale);
 	else
-		xx += round(float(_picture_offset.x) * scale);
+		xx += roundf(float(_picture_offset.x) * scale);
 
 	if (mode & GR_FLIP_VERTICAL)
-		yy += round(float(_size.y - _picture_offset.y - _picture_size.y) * scale);
+		yy += roundf(float(_size.y - _picture_offset.y - _picture_size.y) * scale);
 	else
-		yy += round(float(_picture_offset.y) * scale);
+		yy += roundf(float(_picture_offset.y) * scale);
 
 	if (!is_compressed()) {
 		if (check_flag(ALPHA_FLAG))
@@ -876,8 +876,8 @@ bool qdSprite::hit(int x, int y) const {
 }
 
 bool qdSprite::hit(int x, int y, float scale) const {
-	x = round(float(x) / scale);
-	y = round(float(y) / scale);
+	x = roundf(float(x) / scale);
+	y = roundf(float(y) / scale);
 
 	return hit(x, y);
 }
@@ -1306,8 +1306,8 @@ bool qdSprite::scale(float coeff_x, float coeff_y) {
 
 	undo_crop();
 
-	int sx = round(float(_picture_size.x) * coeff_x);
-	int sy = round(float(_picture_size.y) * coeff_y);
+	int sx = roundf(float(_picture_size.x) * coeff_x);
+	int sy = roundf(float(_picture_size.y) * coeff_y);
 
 	byte *src_data = _data;
 
@@ -1361,11 +1361,11 @@ bool qdSprite::scale(float coeff_x, float coeff_y) {
 	_picture_size.x = sx;
 	_picture_size.y = sy;
 
-	_size.x = round(float(_size.x) * coeff_x);
-	_size.y = round(float(_size.y) * coeff_y);
+	_size.x = roundf(float(_size.x) * coeff_x);
+	_size.y = roundf(float(_size.y) * coeff_y);
 
-	_picture_offset.x = round(float(_picture_offset.x) * coeff_x);
-	_picture_offset.y = round(float(_picture_offset.y) * coeff_y);
+	_picture_offset.x = roundf(float(_picture_offset.x) * coeff_x);
+	_picture_offset.y = roundf(float(_picture_offset.y) * coeff_y);
 
 	crop();
 
@@ -1387,17 +1387,17 @@ grScreenRegion qdSprite::screen_region(int mode, float scale) const {
 	int x, y;
 
 	if (mode & GR_FLIP_HORIZONTAL)
-		x = round(float(_size.x / 2 - _picture_offset.x - _picture_size.x / 2) * scale);
+		x = roundf(float(_size.x / 2 - _picture_offset.x - _picture_size.x / 2) * scale);
 	else
-		x = round(float(_picture_offset.x + _picture_size.x / 2 - _size.x / 2) * scale);
+		x = roundf(float(_picture_offset.x + _picture_size.x / 2 - _size.x / 2) * scale);
 
 	if (mode & GR_FLIP_VERTICAL)
-		y = round(float(_size.y / 2 - _picture_offset.y - _picture_size.y / 2) * scale);
+		y = roundf(float(_size.y / 2 - _picture_offset.y - _picture_size.y / 2) * scale);
 	else
-		y = round(float(_picture_offset.y + _picture_size.y / 2 - _size.y / 2) * scale);
+		y = roundf(float(_picture_offset.y + _picture_size.y / 2 - _size.y / 2) * scale);
 
-	int sx = round(float(_picture_size.x) * scale) + 4;
-	int sy = round(float(_picture_size.y) * scale) + 4;
+	int sx = roundf(float(_picture_size.x) * scale) + 4;
+	int sy = roundf(float(_picture_size.y) * scale) + 4;
 
 	return grScreenRegion(x, y, sx, sy);
 }

--- a/engines/qdengine/qdcore/util/AIAStar_API.cpp
+++ b/engines/qdengine/qdcore/util/AIAStar_API.cpp
@@ -40,7 +40,7 @@ int qdHeuristic::getH(int x, int y) {
 	y -= _target.y;
 
 	if (g_engine->_gameVersion <= 20041201) {
-		return sqrt(static_cast<float>(x * x + y * y));
+		return sqrtf(static_cast<float>(x * x + y * y));
 	} else {
 		// Достаточно будет эвристики без квадратного корня, который медленный
 		return static_cast<float>(x * x + y * y);

--- a/engines/qdengine/system/graphics/gr_draw_sprite.cpp
+++ b/engines/qdengine/system/graphics/gr_draw_sprite.cpp
@@ -33,8 +33,8 @@ void grDispatcher::putSpr_a(int x, int y, int sx, int sy, const byte *p, int mod
 
 	int i, j, sx_dest, sy_dest;
 
-	sx_dest = round(float(sx) * scale);
-	sy_dest = round(float(sy) * scale);
+	sx_dest = roundf(float(sx) * scale);
+	sy_dest = roundf(float(sy) * scale);
 
 	if (!sx_dest || !sy_dest) return;
 
@@ -101,8 +101,8 @@ void grDispatcher::putSpr_a(int x, int y, int sx, int sy, const byte *p, int mod
 void grDispatcher::putSpr(int x, int y, int sx, int sy, const byte *p, int mode, int spriteFormat, float scale) {
 	debugC(4, kDebugGraphics, "grDispatcher::putSpr([%d, %d], [%d, %d], mode: %d, format: %d, scale: %f)", x, y, sx, sy, mode, spriteFormat, scale);
 
-	int sx_dest = round(float(sx) * scale);
-	int sy_dest = round(float(sy) * scale);
+	int sx_dest = roundf(float(sx) * scale);
+	int sy_dest = roundf(float(sy) * scale);
 
 	if (!sx_dest || !sy_dest) return;
 
@@ -248,8 +248,8 @@ void grDispatcher::putSpr_rot(const Vect2i &pos, const Vect2i &size, const byte 
 	float sn = sinf(angle);
 	float cs = cosf(angle);
 
-	int sx = round(fabs(cs) * float(size.x) + fabs(sn) * float(size.y)) + 2;
-	int sy = round(fabs(sn) * float(size.x) + fabs(cs) * float(size.y)) + 2;
+	int sx = round(fabsf(cs) * float(size.x) + fabsf(sn) * float(size.y)) + 2;
+	int sy = round(fabsf(sn) * float(size.x) + fabsf(cs) * float(size.y)) + 2;
 
 	int x0 = xc - sx / 2;
 	int y0 = yc - sy / 2;
@@ -257,8 +257,8 @@ void grDispatcher::putSpr_rot(const Vect2i &pos, const Vect2i &size, const byte 
 	int dx = 0;
 	int dy = 0;
 
-	if (!((int)(round(R2G(angle))) % 90)) {
-		int angle_num = round(cycleAngle(angle) / (M_PI / 2.f));
+	if (!((int)(roundf(R2G(angle))) % 90)) {
+		int angle_num = roundf(cycleAngle(angle) / (M_PI / 2.f));
 		switch (angle_num) {
 		case 1:
 			dy = -2;
@@ -276,8 +276,8 @@ void grDispatcher::putSpr_rot(const Vect2i &pos, const Vect2i &size, const byte 
 	if (!clip_rectangle(x0, y0, sx, sy))
 		return;
 
-	int sin_a = round(sn * float(1 << F_PREC));
-	int cos_a = round(cs * float(1 << F_PREC));
+	int sin_a = roundf(sn * float(1 << F_PREC));
+	int cos_a = roundf(cs * float(1 << F_PREC));
 
 	if (has_alpha) {
 		for (int y = 0; y <= sy; y++) {
@@ -355,14 +355,14 @@ void grDispatcher::putSpr_rot(const Vect2i &pos, const Vect2i &size, const byte 
 
 	const int F_PREC = 16;
 
-	int xc = pos.x + round(float(size.x) * scale.x / 2.f);
-	int yc = pos.y + round(float(size.y) * scale.y / 2.f);
+	int xc = pos.x + roundf(float(size.x) * scale.x / 2.f);
+	int yc = pos.y + roundf(float(size.y) * scale.y / 2.f);
 
 	float sn = sinf(angle);
 	float cs = cosf(angle);
 
-	int sx = round(fabs(cs) * float(size.x) * scale.x + fabs(sn) * float(size.y) * scale.y) + 2;
-	int sy = round(fabs(sn) * float(size.x) * scale.x + fabs(cs) * float(size.y) * scale.y) + 2;
+	int sx = roundf(fabsf(cs) * float(size.x) * scale.x + fabsf(sn) * float(size.y) * scale.y) + 2;
+	int sy = roundf(fabsf(sn) * float(size.x) * scale.x + fabsf(cs) * float(size.y) * scale.y) + 2;
 
 	int x0 = xc - sx / 2;
 	int y0 = yc - sy / 2;
@@ -370,8 +370,8 @@ void grDispatcher::putSpr_rot(const Vect2i &pos, const Vect2i &size, const byte 
 	if (!clip_rectangle(x0, y0, sx, sy))
 		return;
 
-	int sin_a = round(sinf(angle) * float(1 << F_PREC));
-	int cos_a = round(cosf(angle) * float(1 << F_PREC));
+	int sin_a = roundf(sinf(angle) * float(1 << F_PREC));
+	int cos_a = roundf(cosf(angle) * float(1 << F_PREC));
 
 	Vect2i iscale = Vect2i(scale.x * float(1 << F_PREC), scale.y * float(1 << F_PREC));
 	Vect2i scaled_size = Vect2i(iscale.x * size.x, iscale.y * size.y);
@@ -457,8 +457,8 @@ void grDispatcher::putSprMask_rot(const Vect2i &pos, const Vect2i &size, const b
 	float sn = sinf(angle);
 	float cs = cosf(angle);
 
-	int sx = round(fabs(cs) * float(size.x) + fabs(sn) * float(size.y)) + 2;
-	int sy = round(fabs(sn) * float(size.x) + fabs(cs) * float(size.y)) + 2;
+	int sx = round(fabsf(cs) * float(size.x) + fabsf(sn) * float(size.y)) + 2;
+	int sy = round(fabsf(sn) * float(size.x) + fabsf(cs) * float(size.y)) + 2;
 
 	int x0 = xc - sx / 2;
 	int y0 = yc - sy / 2;
@@ -466,8 +466,8 @@ void grDispatcher::putSprMask_rot(const Vect2i &pos, const Vect2i &size, const b
 	if (!clip_rectangle(x0, y0, sx, sy))
 		return;
 
-	int sin_a = round(sn * float(1 << F_PREC));
-	int cos_a = round(cs * float(1 << F_PREC));
+	int sin_a = roundf(sn * float(1 << F_PREC));
+	int cos_a = roundf(cs * float(1 << F_PREC));
 
 	if (has_alpha) {
 		byte mr, mg, mb;
@@ -576,14 +576,14 @@ void grDispatcher::putSprMask_rot(const Vect2i &pos, const Vect2i &size, const b
 
 	debugC(4, kDebugGraphics, "grDispatcher::putSprMask_rot([%d, %d], [%d, %d], alpha: %d, mask: %d, mask_alpha: %d, mode: %d, angle: %f, scale: [%f, %f])", pos.x, pos.y, size.x, size.y, has_alpha, mask_color, mask_alpha, mode, angle, scale.x, scale.y);
 
-	int xc = pos.x + round(float(size.x) * scale.x / 2.f);
-	int yc = pos.y + round(float(size.y) * scale.y / 2.f);
+	int xc = pos.x + roundf(float(size.x) * scale.x / 2.f);
+	int yc = pos.y + roundf(float(size.y) * scale.y / 2.f);
 
 	float sn = sinf(angle);
 	float cs = cosf(angle);
 
-	int sx = round(fabs(cs) * float(size.x) * scale.x + fabs(sn) * float(size.y) * scale.y) + 2;
-	int sy = round(fabs(sn) * float(size.x) * scale.x + fabs(cs) * float(size.y) * scale.y) + 2;
+	int sx = round(fabsf(cs) * float(size.x) * scale.x + fabsf(sn) * float(size.y) * scale.y) + 2;
+	int sy = round(fabsf(sn) * float(size.x) * scale.x + fabsf(cs) * float(size.y) * scale.y) + 2;
 
 	int x0 = xc - sx / 2;
 	int y0 = yc - sy / 2;
@@ -591,8 +591,8 @@ void grDispatcher::putSprMask_rot(const Vect2i &pos, const Vect2i &size, const b
 	if (!clip_rectangle(x0, y0, sx, sy))
 		return;
 
-	int sin_a = round(sinf(angle) * float(1 << F_PREC));
-	int cos_a = round(cosf(angle) * float(1 << F_PREC));
+	int sin_a = roundf(sinf(angle) * float(1 << F_PREC));
+	int cos_a = roundf(cosf(angle) * float(1 << F_PREC));
 
 	Vect2i iscale = Vect2i(scale.x * float(1 << F_PREC), scale.y * float(1 << F_PREC));
 	Vect2i scaled_size = Vect2i(iscale.x * size.x, iscale.y * size.y);
@@ -904,8 +904,8 @@ void grDispatcher::drawSprContour(int x, int y, int sx, int sy, const byte *p, i
 void grDispatcher::drawSprContour(int x, int y, int sx, int sy, const byte *p, int contour_color, int mode, float scale) {
 	debugC(4, kDebugGraphics, "grDispatcher::drawSprContour([%d, %d], [%d, %d], contour: %d, mode: %d, scale: %f)", x, y, sx, sy, contour_color, mode, scale);
 
-	int sx_dest = round(float(sx) * scale);
-	int sy_dest = round(float(sy) * scale);
+	int sx_dest = roundf(float(sx) * scale);
+	int sy_dest = roundf(float(sy) * scale);
 
 	if (!sx_dest || !sy_dest) return;
 
@@ -987,8 +987,8 @@ void grDispatcher::drawSprContour(int x, int y, int sx, int sy, const byte *p, i
 void grDispatcher::drawSprContour_a(int x, int y, int sx, int sy, const byte *p, int contour_color, int mode, float scale) {
 	debugC(4, kDebugGraphics, "grDispatcher::drawSprContour_a([%d, %d], [%d, %d], contour: %d, mode: %d, scale: %f)", x, y, sx, sy, contour_color, mode, scale);
 
-	int sx_dest = round(float(sx) * scale);
-	int sy_dest = round(float(sy) * scale);
+	int sx_dest = roundf(float(sx) * scale);
+	int sy_dest = roundf(float(sy) * scale);
 
 	if (!sx_dest || !sy_dest) return;
 
@@ -1206,8 +1206,8 @@ void grDispatcher::putSprMask(int x, int y, int sx, int sy, const byte *p, uint3
 void grDispatcher::putSprMask(int x, int y, int sx, int sy, const byte *p, uint32 mask_color, int mask_alpha, int mode, float scale) {
 	debugC(4, kDebugGraphics, "grDispatcher::putSprMask([%d, %d], [%d, %d], mask: %d, alpha: %d, mode: %d, scale: %f)", x, y, sx, sy, mask_color, mask_alpha, mode, scale);
 
-	int sx_dest = round(float(sx) * scale);
-	int sy_dest = round(float(sy) * scale);
+	int sx_dest = roundf(float(sx) * scale);
+	int sy_dest = roundf(float(sy) * scale);
 
 	if (!sx_dest || !sy_dest) return;
 
@@ -1355,8 +1355,8 @@ void grDispatcher::putSprMask_a(int x, int y, int sx, int sy, const byte *p, uin
 
 	int i, j, sx_dest, sy_dest;
 
-	sx_dest = round(float(sx) * scale);
-	sy_dest = round(float(sy) * scale);
+	sx_dest = roundf(float(sx) * scale);
+	sy_dest = roundf(float(sy) * scale);
 
 	if (!sx_dest || !sy_dest) return;
 

--- a/engines/qdengine/system/graphics/gr_draw_sprite_rle.cpp
+++ b/engines/qdengine/system/graphics/gr_draw_sprite_rle.cpp
@@ -176,8 +176,8 @@ void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class RLEBuffe
 void grDispatcher::putSpr_rle(int x, int y, int sx, int sy, const class RLEBuffer *p, int mode, float scale, bool alpha_flag) {
 	debugC(4, kDebugGraphics, "grDispatcher::putSpr_rle([%d, %d], [%d, %d], mode: %d, scale: %f, alpha: %d", x, y, sx, sy, mode, scale, alpha_flag);
 
-	int sx_dest = round(float(sx) * scale);
-	int sy_dest = round(float(sy) * scale);
+	int sx_dest = roundf(float(sx) * scale);
+	int sy_dest = roundf(float(sy) * scale);
 
 	if (sx_dest <= 0 || sy_dest <= 0) return;
 
@@ -448,8 +448,8 @@ void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const RLEBuffer 
 void grDispatcher::putSprMask_rle(int x, int y, int sx, int sy, const RLEBuffer *p, uint32 mask_color, int mask_alpha, int mode, float scale, bool alpha_flag) {
 	debugC(4, kDebugGraphics, "grDispatcher::putSprMask_rle([%d, %d], [%d, %d], mask: %d, alpha: %d, mode: %d, scale: %f, alpha_flag: %d)", x, y, sx, sy, mask_color, mask_alpha, mode, scale, alpha_flag);
 
-	int sx_dest = round(float(sx) * scale);
-	int sy_dest = round(float(sy) * scale);
+	int sx_dest = roundf(float(sx) * scale);
+	int sy_dest = roundf(float(sy) * scale);
 
 	if (sx_dest <= 0 || sy_dest <= 0) return;
 
@@ -796,8 +796,8 @@ void grDispatcher::drawSprContour(int x, int y, int sx, int sy, const class RLEB
 void grDispatcher::drawSprContour(int x, int y, int sx, int sy, const class RLEBuffer *p, int contour_color, int mode, float scale, bool alpha_flag) {
 	debugC(4, kDebugGraphics, "grDispatcher::drawSprContour([%d, %d], [%d, %d], contour_color: %d, mode: %d, scale: %f, alpha_flag: %d)", x, y, sx, sy, contour_color, mode, scale, alpha_flag);
 
-	int sx_dest = round(float(sx) * scale);
-	int sy_dest = round(float(sy) * scale);
+	int sx_dest = roundf(float(sx) * scale);
+	int sy_dest = roundf(float(sy) * scale);
 
 	if (!sx_dest || !sy_dest) return;
 

--- a/engines/qdengine/system/graphics/gr_tile_animation.cpp
+++ b/engines/qdengine/system/graphics/gr_tile_animation.cpp
@@ -413,8 +413,8 @@ void grTileAnimation::drawFrame_scale(const Vect2i &position, int frame_index, f
 		else
 			frameSize =_scaleArray[closest_scale]._frameSize;
 
-		int x = position.x - round(float(frameSize.x) * scale) / 2;
-		int y = position.y - round(float(frameSize.y) * scale) / 2;
+		int x = position.x - roundf(float(frameSize.x) * scale) / 2;
+		int y = position.y - roundf(float(frameSize.y) * scale) / 2;
 
 		grDispatcher::instance()->putSpr_a(x, y, frameSize.x, frameSize.y, data, mode, scale);
 	} else {
@@ -568,7 +568,7 @@ int grTileAnimation::find_closest_scale(float *scale) const {
 	float temp = 1.0;
 
 	for (uint i = 0; i < _scaleArray.size(); i++) {
-		if (fabs(*scale - _scaleArray[i]._scale) < fabs(*scale - temp)) {
+		if (fabsf(*scale - _scaleArray[i]._scale) < fabsf(*scale - temp)) {
 			idx = i;
 			temp = _scaleArray[i]._scale;
 		}

--- a/engines/sci/engine/kmath.cpp
+++ b/engines/sci/engine/kmath.cpp
@@ -88,7 +88,7 @@ reg_t kAbs(EngineState *s, int argc, reg_t *argv) {
 }
 
 reg_t kSqrt(EngineState *s, int argc, reg_t *argv) {
-	return make_reg(0, (int16) sqrt((float) ABS(argv[0].toSint16())));
+	return make_reg(0, (int16)sqrtf((float) ABS(argv[0].toSint16())));
 }
 
 uint16 kGetAngle_SCI0(int16 x1, int16 y1, int16 x2, int16 y2) {
@@ -207,7 +207,7 @@ reg_t kGetDistance(EngineState *s, int argc, reg_t *argv) {
 	int angle = (argc > 5) ? argv[5].toSint16() : 0;
 	int xrel = (int)(((float) argv[1].toSint16() - xdiff) / cos(angle * M_PI / 180.0)); // This works because cos(0)==1
 	int yrel = argv[0].toSint16() - ydiff;
-	return make_reg(0, (int16)sqrt((float) xrel*xrel + yrel*yrel));
+	return make_reg(0, (int16)sqrtf((float) xrel*xrel + yrel*yrel));
 }
 
 reg_t kTimesSin(EngineState *s, int argc, reg_t *argv) {

--- a/engines/sci/engine/kmovement.cpp
+++ b/engines/sci/engine/kmovement.cpp
@@ -141,7 +141,7 @@ reg_t kSetJump(EngineState *s, int argc, reg_t *argv) {
 
 		// FIXME: This choice of vy makes t roughly (2+sqrt(2))/gy * sqrt(dy);
 		// so if gy==3, then t is roughly sqrt(dy)...
-		vy = (int)sqrt((float)gy * ABS(2 * dy)) + 1;
+		vy = (int)sqrtf((float)gy * ABS(2 * dy)) + 1;
 	} else {
 		// As stated above, the vertical direction is correlated to the horizontal by the
 		// (non-zero) factor c.

--- a/engines/sci/engine/kpathing.cpp
+++ b/engines/sci/engine/kpathing.cpp
@@ -778,7 +778,7 @@ static int find_free_point(FloatPoint f, Polygon *polygon, Common::Point *ret) {
 		return PF_OK;
 	}
 
-	p = Common::Point((int)floor(f.x), (int)floor(f.y));
+	p = Common::Point((int)floorf(f.x), (int)floorf(f.y));
 
 	// Try (x, y), (x + 1, y), (x , y + 1) and (x + 1, y + 1)
 	if (contained(p, polygon) == CONT_INSIDE) {
@@ -1368,7 +1368,7 @@ static void AStar(PathfindingState *s) {
 
 	openSet.push_front(s->vertex_start);
 	s->vertex_start->costG = 0;
-	s->vertex_start->costF = (uint32)sqrt((float)s->vertex_start->v.sqrDist(s->vertex_end->v));
+	s->vertex_start->costF = (uint32)sqrtf((float)s->vertex_start->v.sqrDist(s->vertex_end->v));
 
 	while (!openSet.empty()) {
 		// Find vertex in open set with lowest F cost
@@ -1407,7 +1407,7 @@ static void AStar(PathfindingState *s) {
 			if (!openSet.contains(vertex))
 				openSet.push_front(vertex);
 
-			new_dist = vertex_min->costG + (uint32)sqrt((float)vertex_min->v.sqrDist(vertex->v));
+			new_dist = vertex_min->costG + (uint32)sqrtf((float)vertex_min->v.sqrDist(vertex->v));
 
 			// When travelling to a vertex on the screen edge, we
 			// add a penalty score to make this path less appealing.
@@ -1441,7 +1441,7 @@ static void AStar(PathfindingState *s) {
 
 			if (new_dist < vertex->costG) {
 				vertex->costG = new_dist;
-				vertex->costF = vertex->costG + (uint32)sqrt((float)vertex->v.sqrDist(s->vertex_end->v));
+				vertex->costF = vertex->costG + (uint32)sqrtf((float)vertex->v.sqrDist(s->vertex_end->v));
 				vertex->path_prev = vertex_min;
 			}
 		}

--- a/engines/sci/graphics/palette16.cpp
+++ b/engines/sci/graphics/palette16.cpp
@@ -480,7 +480,7 @@ void GfxPalette::setOnScreen(bool update) {
 }
 
 static byte convertMacGammaToSCIGamma(int comp) {
-	return (byte)sqrt(comp * 255.0f);
+	return (byte)sqrtf(comp * 255.0f);
 }
 
 void GfxPalette::copySysPaletteToScreen(bool update) {

--- a/engines/scumm/he/basketball/collision/bball_collision.cpp
+++ b/engines/scumm/he/basketball/collision/bball_collision.cpp
@@ -263,7 +263,7 @@ static void trackCollisionObject(const ICollisionObject &sourceObject, const ICo
 		// is less than or equal to the distance between the source object and the last
 		// target object, then the current target object is stored along side the last
 		// target object. Otherwise, the current object replaces the last object.
-		if ((fabs(pastDist - currentDist) < COLLISION_EPSILON) ||
+		if ((fabsf(pastDist - currentDist) < COLLISION_EPSILON) ||
 			(!sourceObject.isCollisionHandled(targetObject)) ||
 			(!sourceObject.isCollisionHandled(**objectIt))) {
 			break;

--- a/engines/scumm/he/basketball/collision/bball_collision_cylinder.cpp
+++ b/engines/scumm/he/basketball/collision/bball_collision_cylinder.cpp
@@ -90,7 +90,7 @@ float CCollisionCylinder::getObjectDistance(const CCollisionSphere &targetObject
 	if (zDistance < 0)
 		zDistance = 0;
 
-	float totalDistance = sqrt((xyDistance * xyDistance) + (zDistance * zDistance));
+	float totalDistance = sqrtf((xyDistance * xyDistance) + (zDistance * zDistance));
 	return (totalDistance);
 }
 
@@ -109,7 +109,7 @@ float CCollisionCylinder::getObjectDistance(const CCollisionBox &targetObject) c
 	if (zDistance < 0)
 		zDistance = 0;
 
-	float totalDistance = sqrt((xyDistance * xyDistance) + (zDistance * zDistance));
+	float totalDistance = sqrtf((xyDistance * xyDistance) + (zDistance * zDistance));
 	return (totalDistance);
 }
 
@@ -128,7 +128,7 @@ float CCollisionCylinder::getObjectDistance(const CCollisionCylinder &targetObje
 	if (zDistance < 0)
 		zDistance = 0;
 
-	float totalDistance = sqrt((xyDistance * xyDistance) + (zDistance * zDistance));
+	float totalDistance = sqrtf((xyDistance * xyDistance) + (zDistance * zDistance));
 	return (totalDistance);
 }
 
@@ -455,9 +455,9 @@ bool CCollisionCylinder::circleOutOfObject(const CCollisionBox &targetObject, U3
 													&xIntercept);
 		} else {
 			if (revDirection == kClockwise) {
-				xIntercept.x = sqrt(xInterceptSquared) + _revCenterPt.x;
+				xIntercept.x = sqrtf(xInterceptSquared) + _revCenterPt.x;
 			} else {
-				xIntercept.x = -sqrt(xInterceptSquared) + _revCenterPt.x;
+				xIntercept.x = -sqrtf(xInterceptSquared) + _revCenterPt.x;
 			}
 		}
 	} else if (distance->y > 0) {
@@ -472,9 +472,9 @@ bool CCollisionCylinder::circleOutOfObject(const CCollisionBox &targetObject, U3
 													&xIntercept);
 		} else {
 			if (revDirection == kClockwise) {
-				xIntercept.x = -sqrt(xInterceptSquared) + _revCenterPt.x;
+				xIntercept.x = -sqrtf(xInterceptSquared) + _revCenterPt.x;
 			} else {
-				xIntercept.x = sqrt(xInterceptSquared) + _revCenterPt.x;
+				xIntercept.x = sqrtf(xInterceptSquared) + _revCenterPt.x;
 			}
 		}
 	} else {
@@ -505,9 +505,9 @@ bool CCollisionCylinder::circleOutOfObject(const CCollisionBox &targetObject, U3
 													&yIntercept);
 		} else {
 			if (revDirection == kClockwise) {
-				yIntercept.y = -sqrt(yInterceptSquared) + _revCenterPt.y;
+				yIntercept.y = -sqrtf(yInterceptSquared) + _revCenterPt.y;
 			} else {
-				yIntercept.y = sqrt(yInterceptSquared) + _revCenterPt.y;
+				yIntercept.y = sqrtf(yInterceptSquared) + _revCenterPt.y;
 			}
 		}
 	} else if (distance->x > 0) {
@@ -522,9 +522,9 @@ bool CCollisionCylinder::circleOutOfObject(const CCollisionBox &targetObject, U3
 													&yIntercept);
 		} else {
 			if (revDirection == kClockwise) {
-				yIntercept.y = sqrt(yInterceptSquared) + _revCenterPt.y;
+				yIntercept.y = sqrtf(yInterceptSquared) + _revCenterPt.y;
 			} else {
-				yIntercept.y = -sqrt(yInterceptSquared) + _revCenterPt.y;
+				yIntercept.y = -sqrtf(yInterceptSquared) + _revCenterPt.y;
 			}
 		}
 	} else {
@@ -701,7 +701,7 @@ bool CCollisionCylinder::nudgeObject(const CCollisionCylinder &targetObject, U32
 			centerDistance = parallelDistance;
 		}
 
-		float perdistance = sqrt(centerDistance * centerDistance - parallelDistance * parallelDistance);
+		float perdistance = sqrtf(centerDistance * centerDistance - parallelDistance * parallelDistance);
 
 		// Now we need to find the point along the velocity vector where the distance 
 		// between that point and the center of the target cylinder equals intersectionDist.
@@ -717,7 +717,7 @@ bool CCollisionCylinder::nudgeObject(const CCollisionCylinder &targetObject, U32
 			intersectionDist = perdistance;
 		}
 
-		float xyCollisionDist = parallelDistance - sqrt(intersectionDist * intersectionDist - perdistance * perdistance);
+		float xyCollisionDist = parallelDistance - sqrtf(intersectionDist * intersectionDist - perdistance * perdistance);
 		collisionTimeFinal = (_velocity.xyMagnitude() == 0) ? 0 : (xyCollisionDist / _velocity.xyMagnitude());
 	} else {
 		collisionTimeFinal = -getPenetrationTime(targetObject, *distance, Z_INDEX);

--- a/engines/scumm/he/basketball/collision/bball_collision_sphere.cpp
+++ b/engines/scumm/he/basketball/collision/bball_collision_sphere.cpp
@@ -87,7 +87,7 @@ float CCollisionSphere::getObjectDistance(const CCollisionCylinder &targetObject
 	if (zDistance < 0)
 		zDistance = 0;
 
-	float totalDistance = sqrt((xyDistance * xyDistance) + (zDistance * zDistance));
+	float totalDistance = sqrtf((xyDistance * xyDistance) + (zDistance * zDistance));
 
 	return totalDistance;
 }
@@ -381,7 +381,7 @@ bool CCollisionSphere::nudgeObject(const CCollisionCylinder &targetObject, U32Di
 			centerDistance = parallelDistance;
 		}
 
-		float perdistance = sqrt(centerDistance * centerDistance - parallelDistance * parallelDistance);
+		float perdistance = sqrtf(centerDistance * centerDistance - parallelDistance * parallelDistance);
 
 		// Now we need to find the point along the velocity vector where the distance 
 		// between that point and the center of the target cylinder equals intersectionDist.
@@ -397,7 +397,7 @@ bool CCollisionSphere::nudgeObject(const CCollisionCylinder &targetObject, U32Di
 			intersectionDist = perdistance;
 		}
 
-		float xyCollisionDist = parallelDistance - sqrt(intersectionDist * intersectionDist - perdistance * perdistance);
+		float xyCollisionDist = parallelDistance - sqrtf(intersectionDist * intersectionDist - perdistance * perdistance);
 		collisionTimeFinal = (_velocity.xyMagnitude() == 0) ? 0 : (xyCollisionDist / _velocity.xyMagnitude());
 	} else {
 		collisionTimeFinal = -getPenetrationTime(targetObject, *distance, Z_INDEX);
@@ -591,7 +591,7 @@ void CCollisionSphere::handleCollisions(CCollisionObjectVector *collisionVector,
 }
 
 bool CCollisionSphere::isOnObject(const CCollisionBox &targetObject, const U32Distance3D &distance) const {
-	float distancePercentage = fabs(distance.z - radius) / radius;
+	float distancePercentage = fabsf(distance.z - radius) / radius;
 
 	// See if bouncing has slowed to the point that we are rolling...
 	return ((distancePercentage < .1) &&
@@ -600,7 +600,7 @@ bool CCollisionSphere::isOnObject(const CCollisionBox &targetObject, const U32Di
 }
 
 bool CCollisionSphere::isOnObject(const CCollisionCylinder &targetObject, const U32Distance3D &distance) const {
-	float distancePercentage = fabs(distance.z - radius) / radius;
+	float distancePercentage = fabsf(distance.z - radius) / radius;
 
 	// See if bouncing has slowed to the point that we are rolling...
 	return ((distancePercentage < .1) &&

--- a/engines/scumm/he/basketball/geo_translation.cpp
+++ b/engines/scumm/he/basketball/geo_translation.cpp
@@ -100,13 +100,13 @@ static U32FltPoint2D worldToScreenTranslation(const U32FltPoint3D &worldPoint, L
 	// this compression after a certain point on the screen. This 'if block' handles that
 	// case...
 	if (worldPoint.y < logic->_bottomScalingPointCutoff) {
-		slope = 1 / (2 * sqrt(a * logic->_bottomScalingPointCutoff + a * c));
+		slope = 1 / (2 * sqrtf(a * logic->_bottomScalingPointCutoff + a * c));
 		pixelsFromBottom = slope * (worldPoint.y - logic->_bottomScalingPointCutoff) + BOTTOM_SCALING_PIXEL_CUTOFF;
 	} else if (worldPoint.y < logic->_topScalingPointCutoff) {
-		slope = 1 / (2 * sqrt(a * worldPoint.y + a * c));
-		pixelsFromBottom = (sqrt(worldPoint.y + c) - sqrt(c)) / sqrt(a);
+		slope = 1 / (2 * sqrtf(a * worldPoint.y + a * c));
+		pixelsFromBottom = (sqrtf(worldPoint.y + c) - sqrtf(c)) / sqrtf(a);
 	} else {
-		slope = 1 / (2 * sqrt(a * logic->_topScalingPointCutoff + a * c));
+		slope = 1 / (2 * sqrtf(a * logic->_topScalingPointCutoff + a * c));
 		pixelsFromBottom = slope * (worldPoint.y - logic->_topScalingPointCutoff) + TOP_SCALING_PIXEL_CUTOFF;
 	}
 
@@ -115,17 +115,17 @@ static U32FltPoint2D worldToScreenTranslation(const U32FltPoint3D &worldPoint, L
 	// Let's find x...
 
 	if (pixelsFromBottom < BOTTOM_SCALING_PIXEL_CUTOFF) {
-		courtWidth = TRANSLATED_NEAR_MAX_X - (2.0 * (BOTTOM_SCALING_PIXEL_CUTOFF / tan(logic->_courtAngle)));
-		xOffset = (tan((BBALL_M_PI / 2.0) - logic->_courtAngle) * BOTTOM_SCALING_PIXEL_CUTOFF) + COURT_X_OFFSET;
+		courtWidth = TRANSLATED_NEAR_MAX_X - (2.0 * (BOTTOM_SCALING_PIXEL_CUTOFF / tanf(logic->_courtAngle)));
+		xOffset = (tanf((BBALL_M_PI / 2.0) - logic->_courtAngle) * BOTTOM_SCALING_PIXEL_CUTOFF) + COURT_X_OFFSET;
 	} else if (pixelsFromBottom < TOP_SCALING_PIXEL_CUTOFF) {
-		courtWidth = (TRANSLATED_NEAR_MAX_X - (2.0 * (pixelsFromBottom / tan(logic->_courtAngle))));
-		xOffset = (tan((BBALL_M_PI / 2.0) - logic->_courtAngle) * pixelsFromBottom) + COURT_X_OFFSET;
+		courtWidth = (TRANSLATED_NEAR_MAX_X - (2.0 * (pixelsFromBottom / tanf(logic->_courtAngle))));
+		xOffset = (tanf((BBALL_M_PI / 2.0) - logic->_courtAngle) * pixelsFromBottom) + COURT_X_OFFSET;
 	} else {
 		// Find the width of the court in pixels at the current y coordinate...
-		courtWidth = TRANSLATED_NEAR_MAX_X - (2.0 * (TOP_SCALING_PIXEL_CUTOFF / tan(logic->_courtAngle)));
+		courtWidth = TRANSLATED_NEAR_MAX_X - (2.0 * (TOP_SCALING_PIXEL_CUTOFF / tanf(logic->_courtAngle)));
 
 		// Find the number of pixels beetween the left side of the screen and the beginning of the court at the current y coordinate...
-		xOffset = tan(((BBALL_M_PI / 2.0) - logic->_courtAngle) * TOP_SCALING_PIXEL_CUTOFF) + COURT_X_OFFSET;
+		xOffset = tanf(((BBALL_M_PI / 2.0) - logic->_courtAngle) * TOP_SCALING_PIXEL_CUTOFF) + COURT_X_OFFSET;
 	}
 
 	// Find the screen x based on the world x and y...
@@ -186,17 +186,17 @@ int LogicHEBasketball::u32_userScreenToWorldTranslation(const U32FltPoint2D &scr
 	// -Let's find x...
 
 	if (pixelsFromBottom < BOTTOM_SCALING_PIXEL_CUTOFF) {
-		courtWidth = TRANSLATED_NEAR_MAX_X - (2.0 * (BOTTOM_SCALING_PIXEL_CUTOFF / tan(_courtAngle)));
+		courtWidth = TRANSLATED_NEAR_MAX_X - (2.0 * (BOTTOM_SCALING_PIXEL_CUTOFF / tanf(_courtAngle)));
 		xOffset = (tan((BBALL_M_PI / 2.0) - _courtAngle) * BOTTOM_SCALING_PIXEL_CUTOFF) + COURT_X_OFFSET;
 	} else if (pixelsFromBottom < TOP_SCALING_PIXEL_CUTOFF) {
 		// Find the width of the court in pixels at the current y coordinate...
-		courtWidth = TRANSLATED_NEAR_MAX_X - (2.0 * (pixelsFromBottom / tan(_courtAngle)));
+		courtWidth = TRANSLATED_NEAR_MAX_X - (2.0 * (pixelsFromBottom / tanf(_courtAngle)));
 
 		// Find the number of pixels beetween the left side of the screen and the beginning of the court at the current y coordinate...
 		xOffset = (tan((BBALL_M_PI / 2.0) - _courtAngle) * pixelsFromBottom) + COURT_X_OFFSET;
 	} else {
 		// Find the width of the court in pixels at the current y coordinate...
-		courtWidth = TRANSLATED_NEAR_MAX_X - (2.0 * (TOP_SCALING_PIXEL_CUTOFF / tan(_courtAngle)));
+		courtWidth = TRANSLATED_NEAR_MAX_X - (2.0 * (TOP_SCALING_PIXEL_CUTOFF / tanf(_courtAngle)));
 
 		// Find the number of pixels beetween the left side of the screen and the beginning of the court at the current y coordinate...
 		xOffset = (tan((BBALL_M_PI / 2.0) - _courtAngle) * TOP_SCALING_PIXEL_CUTOFF) + COURT_X_OFFSET;
@@ -241,7 +241,7 @@ int LogicHEBasketball::u32_userComputePointsForPixels(int pixels, int screenYPos
 #endif
 	} else {
 		// Find the width of the court in pixels at the current y coordinate...
-		courtWidth = TRANSLATED_NEAR_MAX_X - (2.0 * (pixelsFromBottom / tan(courtAngle)));
+		courtWidth = TRANSLATED_NEAR_MAX_X - (2.0 * (pixelsFromBottom / tanf(courtAngle)));
 	}
 
 	points = (MAX_WORLD_X / courtWidth) * pixels;

--- a/engines/scumm/he/basketball/passing.cpp
+++ b/engines/scumm/he/basketball/passing.cpp
@@ -40,7 +40,7 @@ static float getBallImpactTime(CCollisionSphere *ball, int gravity, int height) 
 		tFinal = 0;
 	} else {
 		// See how long before the ball hits the ground...
-		tFinal = (-b - sqrt(b * b - 4 * a * c)) / (2 * a);
+		tFinal = (-b - sqrtf(b * b - 4 * a * c)) / (2 * a);
 		tFinal = MAX(0.0, tFinal);
 	}
 
@@ -104,8 +104,8 @@ int LogicHEBasketball::u32_userHitMovingTarget(U32FltPoint2D sourcePlayer, U32Fl
 	if (((b * b) < (4 * a * c)) || (a == 0)) {
 		tFinal = 0.0;
 	} else {
-		double t1 = (-b + sqrt(b * b - 4 * a * c)) / (2 * a);
-		double t2 = (-b - sqrt(b * b - 4 * a * c)) / (2 * a);
+		double t1 = (-b + sqrtf(b * b - 4 * a * c)) / (2 * a);
+		double t2 = (-b - sqrtf(b * b - 4 * a * c)) / (2 * a);
 		tFinal = MIN_GREATER_THAN_ZERO(t1, t2);
 		tFinal -= BALL_LEAD_TIME; // Put the player at the target spot a few frames
 								  // before the ball to give them a chance to get ready
@@ -287,9 +287,9 @@ int LogicHEBasketball::u32_userGetBallIntercept(int playerID, int ballID, int pl
 				}
 			} else {
 				// Find the closest place we could intercept the ball...
-				tFinal = (-b - sqrt(b * b - 4 * a * c)) / (2 * a);
+				tFinal = (-b - sqrtf(b * b - 4 * a * c)) / (2 * a);
 				if (tFinal < 0) {
-					tFinal = (-b + sqrt(b * b - 4 * a * c)) / (2 * a);
+					tFinal = (-b + sqrtf(b * b - 4 * a * c)) / (2 * a);
 				}
 
 				// See if the ball will come down low enough to catch by that time...

--- a/engines/scumm/he/basketball/shooting.cpp
+++ b/engines/scumm/he/basketball/shooting.cpp
@@ -70,7 +70,7 @@ int LogicHEBasketball::u32_userComputeInitialShotVelocity(int theta, int hDist, 
 			if ((numerator / denominator) < 0) {
 				velocity = 0;
 			} else {
-				velocity = sqrt(numerator / denominator);
+				velocity = sqrtf(numerator / denominator);
 			}
 
 			// Hack, because this is off somehow, or because to go in the hoop,

--- a/engines/scumm/he/basketball/trajectory.cpp
+++ b/engines/scumm/he/basketball/trajectory.cpp
@@ -36,20 +36,20 @@ int LogicHEBasketball::u32_userComputeTrajectoryToTarget(const U32FltPoint3D &so
 	yDist = targetPoint.y - sourcePoint.y;
 	zDist = targetPoint.z - sourcePoint.z;
 
-	hDist = sqrt((xDist * xDist) + (yDist * yDist));
-	totalDist = sqrt((hDist * hDist) + (zDist * zDist));
+	hDist = sqrtf((xDist * xDist) + (yDist * yDist));
+	totalDist = sqrtf((hDist * hDist) + (zDist * zDist));
 
 	if (totalDist < speed)
 		speed = (int)(totalDist + 0.5F);
 
-	hAngle = atan2(yDist, xDist);
-	vAngle = atan2(zDist, totalDist);
+	hAngle = atan2f(yDist, xDist);
+	vAngle = atan2f(zDist, totalDist);
 
-	hSpeed = speed * cos(vAngle);
+	hSpeed = speed * cosf(vAngle);
 
-	trajectory.x = hSpeed * cos(hAngle);
-	trajectory.y = hSpeed * sin(hAngle);
-	trajectory.z = speed * sin(vAngle);
+	trajectory.x = hSpeed * cosf(hAngle);
+	trajectory.y = hSpeed * sinf(hAngle);
+	trajectory.z = speed * sinf(vAngle);
 
 	writeScummVar(_vm1->VAR_U32_USER_VAR_A, _vm->_basketball->u32FloatToInt(trajectory.x));
 	writeScummVar(_vm1->VAR_U32_USER_VAR_B, _vm->_basketball->u32FloatToInt(trajectory.y));
@@ -68,14 +68,14 @@ int LogicHEBasketball::u32_userComputeLaunchTrajectory(const U32FltPoint2D &sour
 	xDist = targetPoint.x - sourcePoint.x;
 	yDist = targetPoint.y - sourcePoint.y;
 
-	hAngle = atan2(yDist, xDist);
+	hAngle = atan2f(yDist, xDist);
 	vAngle = (launchAngle * BBALL_M_PI) / 180;
 
-	hVelocity = iVelocity * cos(vAngle);
+	hVelocity = iVelocity * cosf(vAngle);
 
-	trajectory.x = hVelocity * cos(hAngle);
-	trajectory.y = hVelocity * sin(hAngle);
-	trajectory.z = iVelocity * sin(vAngle);
+	trajectory.x = hVelocity * cosf(hAngle);
+	trajectory.y = hVelocity * sinf(hAngle);
+	trajectory.z = iVelocity * sinf(vAngle);
 
 	writeScummVar(_vm1->VAR_U32_USER_VAR_A, _vm->_basketball->u32FloatToInt(trajectory.x));
 	writeScummVar(_vm1->VAR_U32_USER_VAR_B, _vm->_basketball->u32FloatToInt(trajectory.y));
@@ -100,7 +100,7 @@ int LogicHEBasketball::u32_userComputeAngleBetweenVectors(const U32FltVector3D &
 			radiansCosine = -1;
 		}
 
-		radians = acos(radiansCosine);
+		radians = acosf(radiansCosine);
 		angle = (radians * 180) / BBALL_M_PI;
 	}
 

--- a/engines/scumm/he/logic/puttrace.cpp
+++ b/engines/scumm/he/logic/puttrace.cpp
@@ -142,7 +142,7 @@ int32 LogicHErace::op_1003(int32 *args) {
 int32 LogicHErace::op_1004(int32 *args) {
 	int value = args[1] ? args[1] : 1;
 
-	writeScummVar(108, (int32)(sqrt((float)args[0]) * value));
+	writeScummVar(108, (int32)(sqrtf((float)args[0]) * value));
 
 	return 1;
 }

--- a/engines/scumm/he/logic/soccer.cpp
+++ b/engines/scumm/he/logic/soccer.cpp
@@ -853,7 +853,7 @@ int LogicHEsoccer::findCollisionWith(int objId, float inX, float inY, float inZ,
 		getPointsForFace(faceId, x1, y1, z1, x2, y2, z2, x3, y3, z3, x4, y4, z4, objPoints);
 		crossProduct(x1, y1, z1, x2, y2, z2, x1, y1, z1, x3, y3, z3, faceCrossX, faceCrossY, faceCrossZ);
 
-		float faceArea = sqrt(faceCrossX * faceCrossX + faceCrossY * faceCrossY + faceCrossZ * faceCrossZ);
+		float faceArea = sqrtf(faceCrossX * faceCrossX + faceCrossY * faceCrossY + faceCrossZ * faceCrossZ);
 
 		// The original did not initialize these variables and would
 		// use them uninitialized if faceArea == 0.0

--- a/engines/scumm/he/moonbase/ai_main.cpp
+++ b/engines/scumm/he/moonbase/ai_main.cpp
@@ -377,8 +377,8 @@ int AI::masterControlProgram(const int paramCount, const int32 *params) {
 		if (!getCoordinateVisibility(targetX, targetY, currentPlayer)) {
 			int closestHub = getClosestUnit(targetX, targetY, getMaxX(), currentPlayer, 1, BUILDING_MAIN_BASE, 1, 0);
 			int targetAngle = calcAngle(getHubX(closestHub), getHubY(closestHub), targetX, targetY);
-			int testX = static_cast<int>(getHubX(closestHub) + (500 * cos(degToRad(targetAngle))) + getMaxX()) % getMaxX();
-			int testY = static_cast<int>(getHubY(closestHub) + (500 * sin(degToRad(targetAngle))) + getMaxY()) % getMaxY();
+			int testX = static_cast<int>(getHubX(closestHub) + (500 * cosf(degToRad(targetAngle))) + getMaxX()) % getMaxX();
+			int testY = static_cast<int>(getHubY(closestHub) + (500 * sinf(degToRad(targetAngle))) + getMaxY()) % getMaxY();
 
 			int balloonFlag = 0;
 
@@ -1812,8 +1812,8 @@ Tree *AI::initApproachTarget(int targetX, int targetY, Node **retNode) {
 
 	//target adjustment so that room is allowed for the appropriate shot
 	int tempAngle = calcAngle(getHubX(sourceHub), getHubY(sourceHub), targetX, targetY);
-	int adjX = -120 * cos(degToRad(tempAngle));
-	int adjY = -120 * sin(degToRad(tempAngle));
+	int adjX = -120 * cosf(degToRad(tempAngle));
+	int adjY = -120 * sinf(degToRad(tempAngle));
 
 	Traveller::setTargetPosX(targetX + adjX);
 	Traveller::setTargetPosY(targetY + adjY);
@@ -2099,7 +2099,7 @@ int *AI::energizeTarget(int &targetX, int &targetY, int index) {
 							testAngle = (_vm->_rnd.getRandomNumber(89) + minAngle) % 360;
 							testDist = radius;
 
-							xPos = targetX + testDist * cos(degToRad(testAngle));
+							xPos = targetX + testDist * cosf(degToRad(testAngle));
 							yPos = targetY + testDist * sin(degToRad(testAngle));
 						} else {
 							switch (_vm->_rnd.getRandomNumber(1)) {
@@ -2113,8 +2113,8 @@ int *AI::energizeTarget(int &targetX, int &targetY, int index) {
 							}
 
 							testDist = (((((double)n - (double)attempt) / n) * .5) + .5) * (getDistance(getHubX(nextUnit), getHubY(nextUnit), targetX, targetY) / .8);
-							xPos = getHubX(nextUnit) + testDist * cos(degToRad(testAngle));
-							yPos = getHubY(nextUnit) + testDist * sin(degToRad(testAngle));
+							xPos = getHubX(nextUnit) + testDist * cosf(degToRad(testAngle));
+							yPos = getHubY(nextUnit) + testDist * sinf(degToRad(testAngle));
 						}
 
 						// check if points are good
@@ -2815,8 +2815,8 @@ int AI::simulateBuildingLaunch(int x, int y, int power, int angle, int numSteps,
 
 	if (!sXSpeed && !sYSpeed) {
 		sZSpeed = (static_cast<int>(.70711 * power));
-		sXSpeed = (static_cast<int>(cos(degToRad(angle)) * sZSpeed));
-		sYSpeed = (static_cast<int>(sin(degToRad(angle)) * sZSpeed));
+		sXSpeed = (static_cast<int>(cosf(degToRad(angle)) * sZSpeed));
+		sYSpeed = (static_cast<int>(sinf(degToRad(angle)) * sZSpeed));
 
 		sZSpeed *= SCALE_Z;
 
@@ -2963,8 +2963,8 @@ int AI::simulateWeaponLaunch(int x, int y, int power, int angle, int numSteps) {
 
 	if (!sXSpeed && !sYSpeed) {
 		sZSpeed = (static_cast<int>(.70711 * power));
-		sXSpeed = (static_cast<int>(cos(degToRad(angle)) * sZSpeed));
-		sYSpeed = (static_cast<int>(sin(degToRad(angle)) * sZSpeed));
+		sXSpeed = (static_cast<int>(cosf(degToRad(angle)) * sZSpeed));
+		sYSpeed = (static_cast<int>(sinf(degToRad(angle)) * sZSpeed));
 
 		sZSpeed *= SCALE_Z;
 
@@ -3054,8 +3054,8 @@ int AI::fakeSimulateWeaponLaunch(int x, int y, int power, int angle) {
 	int maxX = getMaxX();
 	int maxY = getMaxY();
 
-	x += distance * cos(radAngle);
-	y += distance * sin(radAngle);
+	x += distance * cosf(radAngle);
+	y += distance * sinf(radAngle);
 
 	x = (x + maxX) % maxX;
 	y = (y + maxY) % maxY;

--- a/engines/scumm/he/moonbase/ai_targetacquisition.cpp
+++ b/engines/scumm/he/moonbase/ai_targetacquisition.cpp
@@ -444,8 +444,8 @@ int Defender::calculateDefenseUnitPosition(int targetX, int targetY, int index) 
 			int randAngle = directAngleToHub + _ai->_vm->_rnd.getRandomNumber(179) - 90;
 			int randDist = _ai->_vm->_rnd.getRandomNumber(109) + 40;
 
-			int x = (int)(targetX + randDist * cos(_ai->degToRad(randAngle)));
-			int y = (int)(targetY + randDist * sin(_ai->degToRad(randAngle)));
+			int x = (int)(targetX + randDist * cosf(_ai->degToRad(randAngle)));
+			int y = (int)(targetY + randDist * sinf(_ai->degToRad(randAngle)));
 
 			int powAngle = _ai->getPowerAngleFromPoint(hubX, hubY, x, y, 20);
 

--- a/engines/scumm/imuse_digi/dimuse_engine.cpp
+++ b/engines/scumm/imuse_digi/dimuse_engine.cpp
@@ -117,7 +117,7 @@ IMuseDigital::IMuseDigital(ScummEngine_v7 *scumm, int sampleRate, Audio::Mixer *
 	if (_mixer->getOutputBufSize() != 0) {
 		// Let's find the optimal value for the maximum number of streams which can stay in the queue at once;
 		// (A number which is too low can lead to buffer underrun, while the higher the number is, the higher is the audio latency)
-		_maxQueuedStreams = (int)ceil((_mixer->getOutputBufSize() / _waveOutPreferredFeedSize) / ((float)_mixer->getOutputRate() / _internalSampleRate));
+		_maxQueuedStreams = (int)ceilf((_mixer->getOutputBufSize() / _waveOutPreferredFeedSize) / ((float)_mixer->getOutputRate() / _internalSampleRate));
 
 		// This mixer's optimal output sample rate for this audio engine is one which is a multiple of 22050Hz;
 		// if we're dealing with one which is a multiple of 48000Hz, compensate the number of queued streams...

--- a/engines/sludge/floor.cpp
+++ b/engines/sludge/floor.cpp
@@ -417,7 +417,7 @@ bool FloorManager::doBorderStuff(OnScreenPerson *moveMe) {
 	float yDiff = moveMe->thisStepY - moveMe->y;
 	float xDiff = moveMe->x - moveMe->thisStepX;
 	if (xDiff || yDiff) {
-		moveMe->wantAngle = 180 + ANGLEFIX * atan2(xDiff, yDiff * 2);
+		moveMe->wantAngle = 180 + ANGLEFIX * atan2f(xDiff, yDiff * 2);
 		moveMe->spinning = true;
 	}
 

--- a/engines/stark/resources/floorface.cpp
+++ b/engines/stark/resources/floorface.cpp
@@ -102,7 +102,7 @@ bool FloorFace::intersectRay(const Math::Ray &ray, Math::Vector3d &intersection)
 	float num = -Math::Vector3d::dotProduct(n, ray.getOrigin() - _vertices[0]);
 	float denom = Math::Vector3d::dotProduct(n, ray.getDirection());
 
-	if (fabs(denom) < 0.00001) {
+	if (fabsf(denom) < 0.00001f) {
 		// The ray is parallel to the plane
 		return false;
 	}

--- a/engines/stark/ui/dialogbox.cpp
+++ b/engines/stark/ui/dialogbox.cpp
@@ -259,7 +259,7 @@ Gfx::Bitmap *DialogBox::loadBackground(Gfx::Driver *gfx) {
 
 void DialogBox::onRender() {
 	if (_background) {
-		uint32 backgroundRepeatX = ceil(_foreground->width() / (float)_background->width());
+		uint32 backgroundRepeatX = ceilf(_foreground->width() / (float)_background->width());
 		for (uint i = 0; i < backgroundRepeatX; i++) {
 			_surfaceRenderer->render(_background, Common::Point(i * _background->width(), 0));
 		}

--- a/engines/stark/visual/effects/fireflies.cpp
+++ b/engines/stark/visual/effects/fireflies.cpp
@@ -108,7 +108,7 @@ void VisualEffectFireFlies::setParams(const Common::String &params) {
 		Frame &frame = _frames[i];
 
 		// Barycentric coordinates
-		float t = (cos((_frames.size() - i) / (float)_frames.size() * 2.1415f + 0.5f) + 1.0f) * 0.5f;
+		float t = (cosf((_frames.size() - i) / (float)_frames.size() * 2.1415f + 0.5f) + 1.0f) * 0.5f;
 		frame.weight1 = (1.0f - t) * (1.0f - t) * (1.0f - t) / 6.0f;
 		frame.weight2 = (t * t * t * 3.0f - t * t * 6.0f + 4.0f) / 6.0f;
 		frame.weight3 = (((3.0f - t * 3.0f) * t + 3.0f) * t + 1.0f) / 6.0f;

--- a/engines/sword25/math/region.cpp
+++ b/engines/sword25/math/region.cpp
@@ -265,11 +265,11 @@ Vertex Region::findClosestPointOnLine(const Vertex &lineStart, const Vertex &lin
 	float vector1Y = static_cast<float>(point.y - lineStart.y);
 	float vector2X = static_cast<float>(lineEnd.x - lineStart.x);
 	float vector2Y = static_cast<float>(lineEnd.y - lineStart.y);
-	float vector2Length = sqrt(vector2X * vector2X + vector2Y * vector2Y);
+	float vector2Length = sqrtf(vector2X * vector2X + vector2Y * vector2Y);
 	vector2X /= vector2Length;
 	vector2Y /= vector2Length;
-	float distance = sqrt(static_cast<float>((lineStart.x - lineEnd.x) * (lineStart.x - lineEnd.x) +
-	                       (lineStart.y - lineEnd.y) * (lineStart.y - lineEnd.y)));
+	float distance = sqrtf(static_cast<float>((lineStart.x - lineEnd.x) * (lineStart.x - lineEnd.x) +
+	                                              (lineStart.y - lineEnd.y) * (lineStart.y - lineEnd.y)));
 	float dot = vector1X * vector2X + vector1Y * vector2Y;
 
 	if (dot <= 0)

--- a/engines/tetraedge/game/character.cpp
+++ b/engines/tetraedge/game/character.cpp
@@ -529,12 +529,12 @@ bool Character::onBonesUpdate(const Common::String &boneName, TeMatrix4x4 &boneM
 			// Return the head to the centerpoint if there is no anchor.
 			const float lastHeadX = _lastHeadRotation.getX();
 			const float headXAdjust = (lastHeadX > 0) ? -0.1 : 0.1;
-			const float newX = (fabs(headXAdjust) > fabs(lastHeadX)) ? 0.0 : lastHeadX + headXAdjust;
+			const float newX = (fabsf(headXAdjust) > fabsf(lastHeadX)) ? 0.0 : lastHeadX + headXAdjust;
 			_lastHeadRotation.setX(newX);
 
 			const float lastHeadY = _lastHeadRotation.getY();
 			const float headYAdjust = (lastHeadY > 0) ? -0.1 : 0.1;
-			const float newY = (fabs(headYAdjust) > fabs(lastHeadY)) ? 0.0 : lastHeadY + headYAdjust;
+			const float newY = (fabsf(headYAdjust) > fabsf(lastHeadY)) ? 0.0 : lastHeadY + headYAdjust;
 			_lastHeadRotation.setY(newY);
 
 			_headRotation = _lastHeadRotation;
@@ -943,7 +943,7 @@ void Character::update(double msFromStart) {
 	_curve->pseudoTangent(offset, t1, t2);
 	const TeVector3f32 normalizedTangent = (t2 - t1).getNormalized();
 	float angle = TeVector3f32(0.0, 0.0, 1.0).dotProduct(normalizedTangent);
-	angle = acos(angle);
+	angle = acosf(angle);
 	TeVector3f32 crossprod = TeVector3f32::crossProduct(TeVector3f32(0.0, 0.0, 1.0), normalizedTangent);
 	if (crossprod.y() >= 0.0f) {
 		angle = -angle;
@@ -953,7 +953,7 @@ void Character::update(double msFromStart) {
 	_model->setRotation(rot);
 
 	const Common::String endGAnim = walkAnim(WalkPart_EndG);
-	if (_walkCurveLast == _walkCurveEnd || fabs(_walkCurveEnd - _walkCurveStart) < fabs(_walkCurveLast - _walkCurveStart)) {
+	if (_walkCurveLast == _walkCurveEnd || fabs(_walkCurveEnd - _walkCurveStart) < fabsf(_walkCurveLast - _walkCurveStart)) {
 		if (_walkToFlag) {
 			_walkToFlag = false;
 			endMove();

--- a/engines/tetraedge/game/in_game_scene.cpp
+++ b/engines/tetraedge/game/in_game_scene.cpp
@@ -190,7 +190,7 @@ bool InGameScene::aroundAnchorZone(const AnchorZone *zone) {
 
 	float xoff = charpos.x() - zone->_loc.x();
 	float zoff = charpos.z() - zone->_loc.z();
-	return sqrt(xoff * xoff + zoff * zoff) <= zone->_radius;
+	return sqrtf(xoff * xoff + zoff * zoff) <= zone->_radius;
 }
 
 TeLayout *InGameScene::background() {

--- a/engines/tetraedge/te/te_free_move_zone.cpp
+++ b/engines/tetraedge/te/te_free_move_zone.cpp
@@ -227,7 +227,7 @@ void TeFreeMoveZone::calcGridMatrix() {
 		const TeVector3f32 diff = v2 - v1;
 		const TeVector2f32 diff2(diff.x(), diff.z());
 		float len = diff2.length();
-		float f = fmod(atan2(diff.z(), diff.x()), M_PI_2);
+		float f = fmodf(atan2f(diff.z(), diff.x()), (float)M_PI_2);
 		if (f < 0)
 			f += (float)M_PI_2;
 

--- a/engines/tinsel/polygons.cpp
+++ b/engines/tinsel/polygons.cpp
@@ -683,7 +683,7 @@ void FindBestPoint(HPOLYGON hp, int *x, int *y, int *pline) {
 		assert(b*c == bc);
 
 		assert(a2pb2 == a*a + b*b);
-		assert(ra2pb2 == (int)sqrt((float)a*a + (float)b*b));
+		assert(ra2pb2 == (int)sqrtf((float)a*a + (float)b*b));
 #endif
 
 
@@ -712,7 +712,7 @@ void FindBestPoint(HPOLYGON hp, int *x, int *y, int *pline) {
 		if ((d1 < 0 && d2 < 0) || (d1 > 0 && d2 > 0))
 			continue;
 //#endif
-		dropD = ((a * h) + (b * k) + c) / (int)sqrt((float)a*a + (float)b*b);
+		dropD = ((a * h) + (b * k) + c) / (int)sqrtf((float)a*a + (float)b*b);
 		dropD = ABS(dropD);
 		if (dropD < shortestD) {
 			shortestD = dropD;

--- a/engines/titanic/star_control/fpoint.cpp
+++ b/engines/titanic/star_control/fpoint.cpp
@@ -24,10 +24,10 @@
 namespace Titanic {
 
 float FPoint::normalize() {
-	float hyp = sqrt(_x * _x + _y * _y);
+	float hyp = sqrtf(_x * _x + _y * _y);
 	assert(hyp != 0.0);
 
-	float fraction = 1.0 / hyp;
+	float fraction = 1.0f / hyp;
 	_x *= fraction;
 	_y *= fraction;
 	return hyp;

--- a/engines/titanic/star_control/fvector.cpp
+++ b/engines/titanic/star_control/fvector.cpp
@@ -55,7 +55,7 @@ void FVector::rotVectAxisY(float angleDeg) {
 }
 
 bool FVector::normalize(float & hyp) {
-	hyp = sqrt(_x * _x + _y * _y + _z * _z);
+	hyp = sqrtf(_x * _x + _y * _y + _z * _z);
 	if (hyp==0) {
 		return false;
 	}
@@ -82,9 +82,9 @@ FVector FVector::getPolarCoord() const {
 		assert(dest._x);
 	}
 
-	dest._y = acos(vector._y);	// radian distance/angle that this vector's y component is from the +y axis,
+	dest._y = acosf(vector._y);	// radian distance/angle that this vector's y component is from the +y axis,
 								// result is restricted to [0,pi]
-	dest._z = atan2(vector._x,vector._z); // result is restricted to [-pi,pi]
+	dest._z = atan2f(vector._x,vector._z); // result is restricted to [-pi,pi]
 
 	return dest;
 }
@@ -94,7 +94,7 @@ float FVector::getDistance(const FVector &src) const {
 	float yd = src._y - _y;
 	float zd = src._z - _z;
 
-	return sqrt(xd * xd + yd * yd + zd * zd);
+	return sqrtf(xd * xd + yd * yd + zd * zd);
 }
 
 FVector FVector::matProdRowVect(const FPose &pose) const {

--- a/engines/titanic/star_control/star_closeup.cpp
+++ b/engines/titanic/star_control/star_closeup.cpp
@@ -222,8 +222,8 @@ void CStarCloseup::draw(const FPose &pose, const FVector &vector, const FVector 
 			f3 = (f1 + entryP->_fieldC) & 0x1FF;
 			f4 = _sineTable[f1 & 0x1FF] * entryP->_field10;
 			f5 = _sineTable[f3];
-			f6 = cos(f4);
-			f7 = sin(f4);
+			f6 = cosf(f4);
+			f7 = sinf(f4);
 			f8 = _sineTable[f3 + 128];
 			f9 = f7;
 			f10 = f6 * f8;
@@ -517,9 +517,9 @@ bool CStarCloseup::setupEntry(int width, int height, int index, float val) {
 				angle = Math::deg2rad<float>(degrees);
 
 				FVector &tempV = entry._data2[idx];
-				tempV._x = sin(angle) * sinVal * val;
+				tempV._x = sinf(angle) * sinVal * val;
 				tempV._y = cosVal * val;
-				tempV._z = cos(angle) * sinVal * val;
+				tempV._z = cosf(angle) * sinVal * val;
 			}
 		}
 	}

--- a/engines/trecision/actor.cpp
+++ b/engines/trecision/actor.cpp
@@ -373,8 +373,8 @@ void Actor::actorDoAction(int action) {
 	_vm->_pathFind->reset(0, px, pz, theta);
 
 	float t = ((270.0f - theta) * M_PI * 2) / 360.0f;
-	float ox = cos(t);
-	float oz = sin(t);
+	float ox = cosf(t);
+	float oz = sinf(t);
 
 	SVertex *v = _characterArea;
 	float firstFrame = frameCenter(v);

--- a/engines/trecision/pathfinding3d.cpp
+++ b/engines/trecision/pathfinding3d.cpp
@@ -695,7 +695,7 @@ void PathFinding3D::setPosition(int num) {
 		if (_vm->floatComp(ox, 0.0f) == 0 && _vm->floatComp(oz, 0.0f) == 0) // ox == 0.0f && oz == 0.0f
 			warning("setPosition: Unknown error : null light");
 
-		float t = sqrt(ox * ox + oz * oz);
+		float t = sqrtf(ox * ox + oz * oz);
 		ox /= t;
 		oz /= t;
 
@@ -760,7 +760,7 @@ void PathFinding3D::lookAt(float x, float z) {
 		return;
 	}
 
-	float t = sqrt(ox * ox + oz * oz);
+	float t = sqrtf(ox * ox + oz * oz);
 	ox /= t;
 	oz /= t;
 
@@ -1000,7 +1000,7 @@ void PathFinding3D::buildFramelist() {
 		if (_vm->floatComp(ox, 0.0f) == 0 && _vm->floatComp(oz, 0.0f) == 0)
 			continue;
 
-		approx = sqrt(ox * ox + oz * oz);
+		approx = sqrtf(ox * ox + oz * oz);
 		ox /= approx;
 		oz /= approx;
 
@@ -1053,11 +1053,11 @@ void PathFinding3D::buildFramelist() {
 
 			theta = _step[index]._theta;
 
-			curLen = sqrt(_step[index]._dx * _step[index]._dx + _step[index]._dz * _step[index]._dz);
+			curLen = sqrtf(_step[index]._dx * _step[index]._dx + _step[index]._dz * _step[index]._dz);
 
 			theta = ((270.0f - theta) * M_PI) / 180.0f;
-			ox = cos(theta) * curLen;
-			oz = sin(theta) * curLen;
+			ox = cosf(theta) * curLen;
+			oz = sinf(theta) * curLen;
 
 			cx = _step[index]._px + _step[index]._dx;
 			float cz = _step[index]._pz + _step[index]._dz;
@@ -1092,11 +1092,11 @@ void PathFinding3D::buildFramelist() {
 
 			oldTheta = _step[index - 1]._theta;
 
-			curLen = sqrt(_step[index - 1]._dx * _step[index - 1]._dx + _step[index - 1]._dz * _step[index - 1]._dz);
+			curLen = sqrtf(_step[index - 1]._dx * _step[index - 1]._dx + _step[index - 1]._dz * _step[index - 1]._dz);
 
 			oldTheta = ((270.0f - oldTheta) * M_PI) / 180.0f;
-			ox = cos(oldTheta) * curLen;
-			oz = sin(oldTheta) * curLen;
+			ox = cosf(oldTheta) * curLen;
+			oz = sinf(oldTheta) * curLen;
 
 			cx = _step[index - 1]._px + _step[index - 1]._dx;
 			float cz = _step[index - 1]._pz + _step[index - 1]._dz;
@@ -1114,11 +1114,11 @@ void PathFinding3D::buildFramelist() {
 			oldTheta = theta;
 			theta = _step[index]._theta;
 
-			curLen = sqrt(_step[index]._dx * _step[index]._dx + _step[index]._dz * _step[index]._dz);
+			curLen = sqrtf(_step[index]._dx * _step[index]._dx + _step[index]._dz * _step[index]._dz);
 
 			theta = ((270.0f - theta) * M_PI) / 180.0f;
-			ox = cos(theta) * curLen;
-			oz = sin(theta) * curLen;
+			ox = cosf(theta) * curLen;
+			oz = sinf(theta) * curLen;
 
 			cx = _step[index]._px + _step[index]._dx;
 			cz = _step[index]._pz + _step[index]._dz;
@@ -1435,7 +1435,7 @@ void PathFinding3D::pointOut() {
 	SPan *panel = &_panel[_curPanel];
 	float nx = panel->_z1 - panel->_z2;
 	float nz = panel->_x2 - panel->_x1;
-	float temp = sqrt(nx * nx + nz * nz);
+	float temp = sqrtf(nx * nx + nz * nz);
 	nx /= temp;
 	nz /= temp;
 
@@ -1558,14 +1558,14 @@ bool PathFinding3D::intersectLinePanel(SPan *p, float x, float y, float z) {
 	float dx = (x - x1);
 	float dy = (y - y1);
 	float dz = (z - z1);
-	float t = sqrt(dx * dx + dy * dy + dz * dz);
+	float t = sqrtf(dx * dx + dy * dy + dz * dz);
 	dx /= t;
 	dy /= t;
 	dz /= t;
 
 	float nx = p->_z1 - p->_z2;
 	float nz = p->_x2 - p->_x1;
-	t = sqrt(nx * nx + nz * nz);
+	t = sqrtf(nx * nx + nz * nz);
 	nx /= t;
 	nz /= t;
 	// ny is always equal to zero for panels
@@ -1609,7 +1609,7 @@ bool PathFinding3D::intersectLineFloor(float x, float y, float z) {
 	float dx = (x - x1);
 	float dy = (y - y1);
 	float dz = (z - z1);
-	float t = sqrt(dx * dx + dy * dy + dz * dz);
+	float t = sqrtf(dx * dx + dy * dy + dz * dz);
 	dx /= t;
 	dy /= t;
 	dz /= t;
@@ -1666,7 +1666,7 @@ void PathFinding3D::actorOrder() {
 
 	float ox = actor->_px + actor->_dx - actor->_camera->_ex;
 	float oz = actor->_pz + actor->_dz - actor->_camera->_ez;
-	float dist = sqrt(ox * ox + oz * oz);
+	float dist = sqrtf(ox * ox + oz * oz);
 	float lx = (-oz / dist) * largeValue;
 	float lz = (ox / dist) * largeValue;
 

--- a/engines/trecision/renderer3d.cpp
+++ b/engines/trecision/renderer3d.cpp
@@ -503,8 +503,8 @@ void Renderer3D::calcCharacterPoints() {
 	actor->_area[5] = -32000;
 
 	float t = (actor->_theta * M_PI * 2) / 360.0;
-	float cost = cos(t);
-	float sint = sin(t);
+	float cost = cosf(t);
+	float sint = sinf(t);
 
 	// Put all vertices in dark color
 	for (int i = 0; i < MAXVERTEX; ++i)
@@ -527,7 +527,7 @@ void Renderer3D::calcCharacterPoints() {
 			ty = light->_y;
 
 			if (light->_position) {                       // if it's attenuated
-				dist = sqrt(tx * tx + ty * ty + tz * tz); // Distance light <--> actor
+				dist = sqrtf(tx * tx + ty * ty + tz * tz); // Distance light <--> actor
 
 				// adjust light intensity due to the distance
 				if (_vm->floatComp(dist, light->_outr) == 1) // if it's out of range it's off
@@ -542,7 +542,7 @@ void Renderer3D::calcCharacterPoints() {
 			l0 = tx * cost - tz * sint;
 			l2 = tx * sint + tz * cost;
 			l1 = ty;
-			t = sqrt(l0 * l0 + l1 * l1 + l2 * l2);
+			t = sqrtf(l0 * l0 + l1 * l1 + l2 * l2);
 			l0 /= t;
 			l1 /= t;
 			l2 /= t;
@@ -556,12 +556,12 @@ void Renderer3D::calcCharacterPoints() {
 				pa1 = light->_dy;
 				pa2 = light->_dx * sint + light->_dz * cost;
 
-				t = sqrt(pa0 * pa0 + pa1 * pa1 + pa2 * pa2);
+				t = sqrtf(pa0 * pa0 + pa1 * pa1 + pa2 * pa2);
 				pa0 /= t;
 				pa1 /= t;
 				pa2 /= t;
 
-				tz = acos((pa0 * l0) + (pa1 * l1) + (pa2 * l2)) * 360.0 / (M_PI * 2);
+				tz = acosf((pa0 * l0) + (pa1 * l1) + (pa2 * l2)) * 360.0 / (M_PI * 2);
 				tz = CLIP(tz, 0.f, 180.f);
 
 				// tx falloff
@@ -613,7 +613,7 @@ void Renderer3D::calcCharacterPoints() {
 				pa1 = curVertex->_ny;
 				pa2 = curVertex->_nz;
 
-				lint = (int)((acos(pa0 * l0 + pa1 * l1 + pa2 * l2) * 360.0) / M_PI);
+				lint = (int)((acosf(pa0 * l0 + pa1 * l1 + pa2 * l2) * 360.0) / M_PI);
 				lint = CLIP(lint, 0, 180);
 
 				_vVertex[j]._angle -= (180 - lint);

--- a/engines/trecision/utils.cpp
+++ b/engines/trecision/utils.cpp
@@ -189,10 +189,10 @@ float TrecisionEngine::sinCosAngle(float sinus, float cosinus) {
 	// 1e3 & 2e4 quad
 	if (floatComp(sinus, 0.0f) >= 0)
 		// 1 & 2 quad
-		return (float)acos(cosinus);
+		return acosf(cosinus);
 
 	// 3 quad
-	return (M_PI * 2) - (float)acos(cosinus);
+	return (M_PI * 2) - acosf(cosinus);
 }
 
 void TrecisionEngine::processTime() {

--- a/engines/tsage/ringworld2/ringworld2_scenes1.cpp
+++ b/engines/tsage/ringworld2/ringworld2_scenes1.cpp
@@ -1475,7 +1475,7 @@ void Scene1500::signal() {
 
 void Scene1500::dispatch() {
 	if (_sceneMode > 10) {
-		float yDiff = sqrt((float) (_smallShip._position.x * _smallShip._position.x) + (_smallShip._position.y * _smallShip._position.y));
+		float yDiff = sqrtf((float) (_smallShip._position.x * _smallShip._position.x) + (_smallShip._position.y * _smallShip._position.y));
 		if (yDiff > 6)
 			_smallShip.setPosition(_smallShip._position, (int)yDiff);
 	}

--- a/engines/twine/scene/movements.cpp
+++ b/engines/twine/scene/movements.cpp
@@ -94,7 +94,7 @@ int32 Movements::getAngle(int32 x0, int32 z0, int32 x1, int32 z1) {
 		flag = false;
 	}
 
-	_targetActorDistance = (int32)sqrt((float)(newX + newZ));
+	_targetActorDistance = (int32)sqrtf((float)(newX + newZ));
 
 	if (!_targetActorDistance) {
 		return 0;

--- a/engines/twine/shared.cpp
+++ b/engines/twine/shared.cpp
@@ -79,19 +79,19 @@ void LBAAngles::lba2() {
 
 
 int32 getDistance2D(int32 x1, int32 z1, int32 x2, int32 z2) {
-	return (int32)sqrt((float)((x2 - x1) * (x2 - x1) + (z2 - z1) * (z2 - z1)));
+	return (int32)sqrtf((float)((x2 - x1) * (x2 - x1) + (z2 - z1) * (z2 - z1)));
 }
 
 int32 getDistance2D(const IVec3 &v1, const IVec3 &v2) {
-	return (int32)sqrt((float)((v2.x - v1.x) * (v2.x - v1.x) + (v2.z - v1.z) * (v2.z - v1.z)));
+	return (int32)sqrtf((float)((v2.x - v1.x) * (v2.x - v1.x) + (v2.z - v1.z) * (v2.z - v1.z)));
 }
 
 int32 getDistance3D(int32 x1, int32 y1, int32 z1, int32 x2, int32 y2, int32 z2) {
-	return (int32)sqrt((float)((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1) + (z2 - z1) * (z2 - z1)));
+	return (int32)sqrtf((float)((x2 - x1) * (x2 - x1) + (y2 - y1) * (y2 - y1) + (z2 - z1) * (z2 - z1)));
 }
 
 int32 getDistance3D(const IVec3 &v1, const IVec3 &v2) {
-	return (int32)sqrt((float)((v2.x - v1.x) * (v2.x - v1.x) + (v2.y - v1.y) * (v2.y - v1.y) + (v2.z - v1.z) * (v2.z - v1.z)));
+	return (int32)sqrtf((float)((v2.x - v1.x) * (v2.x - v1.x) + (v2.y - v1.y) * (v2.y - v1.y) + (v2.z - v1.z) * (v2.z - v1.z)));
 }
 
 }

--- a/engines/twp/camera.cpp
+++ b/engines/twp/camera.cpp
@@ -109,7 +109,7 @@ void Camera::update(Common::SharedPtr<Room> room, Common::SharedPtr<Object> foll
 		else
 			y = cameraPos.getY() + (d.getY() > 0 ? MIN(delta.getY(), d.getY()) : MAX(delta.getY(), d.getY()));
 		setAtCore(Math::Vector2d(x, y));
-		if (!sameActor && (fabs(pos.getX() - x) < 1.f) && (fabs(pos.getY() - y) < 1.f))
+		if (!sameActor && (fabsf(pos.getX() - x) < 1.f) && (fabsf(pos.getY() - y) < 1.f))
 			_follow = follow;
 	}
 }

--- a/engines/twp/genlib.cpp
+++ b/engines/twp/genlib.cpp
@@ -299,7 +299,7 @@ static SQInteger distance(HSQUIRRELVM v) {
 	if (!obj2)
 		return sq_throwerror(v, "failed to get object2 or actor2");
 	Math::Vector2d d = obj1->_node->getAbsPos() - obj2->_node->getAbsPos();
-	sqpush(v, sqrt(d.getX() * d.getX() + d.getY() * d.getY()));
+	sqpush(v, sqrtf(d.getX() * d.getX() + d.getY() * d.getY()));
 	return 1;
 }
 

--- a/engines/twp/hud.cpp
+++ b/engines/twp/hud.cpp
@@ -36,7 +36,7 @@ private:
 	virtual void onUpdate(float elapsed) override {
 		_shakeTime += 40.f * elapsed;
 		_elapsed += elapsed;
-		_slot->_shakeOffset = Math::Vector2d(_amount * cos(_shakeTime + 0.3f), _amount * sin(_shakeTime));
+		_slot->_shakeOffset = Math::Vector2d(_amount * cosf(_shakeTime + 0.3f), _amount * sinf(_shakeTime));
 	}
 
 private:

--- a/engines/twp/motor.cpp
+++ b/engines/twp/motor.cpp
@@ -133,7 +133,7 @@ Shake::Shake(Node *node, float amount)
 void Shake::onUpdate(float elapsed) {
 	_shakeTime += 40.f * elapsed;
 	_elapsed += elapsed;
-	_node->setShakeOffset(Math::Vector2d(_amount * cos(_shakeTime + 0.3f), _amount * sin(_shakeTime)));
+	_node->setShakeOffset(Math::Vector2d(_amount * cosf(_shakeTime + 0.3f), _amount * sinf(_shakeTime)));
 }
 
 OverlayTo::OverlayTo(float duration, Common::SharedPtr<Room> room, const Color &to)
@@ -194,7 +194,7 @@ WalkTo::WalkTo(Common::SharedPtr<Object> obj, const Math::Vector2d &dest, int fa
 
 	// don't know yet why walkspeed is so slow, so I cheat
 	Math::Vector2d walkSpeed = obj->_walkSpeed * 2;
-	_wsd = sqrt(walkSpeed.getX() * walkSpeed.getX() + walkSpeed.getY() * walkSpeed.getY());
+	_wsd = sqrtf(walkSpeed.getX() * walkSpeed.getX() + walkSpeed.getY() * walkSpeed.getY());
 	if (sqrawexists(obj->_table, "preWalking"))
 		sqcall(obj->_table, "preWalking");
 }
@@ -678,7 +678,7 @@ Jiggle::~Jiggle() = default;
 
 void Jiggle::onUpdate(float elapsed) {
 	_jiggleTime += 20.f * elapsed;
-	_node->setRotationOffset(_amount * sin(_jiggleTime));
+	_node->setRotationOffset(_amount * sinf(_jiggleTime));
 }
 
 MoveCursorTo::MoveCursorTo(const Math::Vector2d &pos, float time)

--- a/engines/twp/object.cpp
+++ b/engines/twp/object.cpp
@@ -849,7 +849,7 @@ void Object::walk(Common::SharedPtr<Object> actor, Common::SharedPtr<Object> obj
 		const float dy = dst.getY() - src.getY();
 		const float minDistX = 30.f;
 		const float minDistY = 15.f;
-		if ((fabs(dx) > 1.f) || (fabs(dy) > 1.f)) {
+		if ((fabsf(dx) > 1.f) || (fabsf(dy) > 1.f)) {
 			float angle = atan2f(dy, dx) * 180.f / M_PI;
 			if (angle < 0.f)
 				angle += 360.f;

--- a/engines/twp/room.cpp
+++ b/engines/twp/room.cpp
@@ -521,7 +521,7 @@ bool Walkbox::contains(const Math::Vector2d &position, bool toleranceOnOutside) 
 		Math::Vector2d newPoint = (Math::Vector2d)_polygon[i];
 		float newSqDist = distanceSquared(newPoint, point);
 
-		if (oldSqDist + newSqDist + 2.0f * sqrt(oldSqDist * newSqDist) - distanceSquared(newPoint, oldPoint) < epsilon)
+		if (oldSqDist + newSqDist + 2.0f * sqrtf(oldSqDist * newSqDist) - distanceSquared(newPoint, oldPoint) < epsilon)
 			return toleranceOnOutside;
 
 		Math::Vector2d left;

--- a/engines/twp/scenegraph.cpp
+++ b/engines/twp/scenegraph.cpp
@@ -51,7 +51,7 @@ protected:
 	void onUpdate(float elapsed) override {
 		_shakeTime += 40.f * elapsed;
 		_elapsed += elapsed;
-		_shakeOffset = Math::Vector2d(_amount * cos(_shakeTime + 0.3f), _amount * sin(_shakeTime));
+		_shakeOffset = Math::Vector2d(_amount * cosf(_shakeTime + 0.3f), _amount * sinf(_shakeTime));
 	}
 
 private:
@@ -692,7 +692,7 @@ void Inventory::drawItems(const Math::Matrix4 &trsf) {
 			t.translate(Math::Vector3d(pos.getX(), pos.getY(), 0.f));
 			if (obj->_jiggle) {
 				Math::Matrix3 rot;
-				rot.buildAroundZ(18.f * sin(_jiggleTime));
+				rot.buildAroundZ(18.f * sinf(_jiggleTime));
 				t.setRotation(rot);
 			}
 			float s = obj->getScale();

--- a/engines/twp/util.cpp
+++ b/engines/twp/util.cpp
@@ -147,11 +147,11 @@ float distanceToSegmentSquared(const Math::Vector2d &p, const Math::Vector2d &v,
 }
 
 float distanceToSegment(const Math::Vector2d &p, const Math::Vector2d &v, const Math::Vector2d &w) {
-	return sqrt(distanceToSegmentSquared(p, v, w));
+	return sqrtf(distanceToSegmentSquared(p, v, w));
 }
 
 float distance(const Math::Vector2d &p1, const Math::Vector2d &p2) {
-	return sqrt(distanceSquared(p1, p2));
+	return sqrtf(distanceSquared(p1, p2));
 }
 
 Common::String join(const Common::Array<Common::String> &array, const Common::String &sep) {
@@ -200,7 +200,7 @@ float dot(const Math::Vector2d &u, const Math::Vector2d &v) {
 	return (u.getX() * v.getX()) + (u.getY() * v.getY());
 }
 
-float length(const Math::Vector2d &v) { return sqrt(dot(v, v)); }
+float length(const Math::Vector2d &v) { return sqrtf(dot(v, v)); }
 
 bool lineSegmentsCross(const Math::Vector2d &a, const Math::Vector2d &b, const Math::Vector2d &c, const Math::Vector2d &d) {
 	const float EPSILON = 1e-3f;

--- a/engines/ultima/nuvie/core/tile_manager.cpp
+++ b/engines/ultima/nuvie/core/tile_manager.cpp
@@ -665,10 +665,10 @@ void TileManager::get_rotated_tile(const Tile *tileP, Tile *dest_tile, float rot
 
 	float theta = float(rotate * M_PI / 180.0); /* Convert to radians.  */
 
-	int32 const stx = int32((sin(theta)) * 8192.0);
-	int32 const ctx = int32((cos(theta)) * 8192.0);
-	int32 const sty = int32((sin(theta)) * 8192.0);
-	int32 const cty = int32((cos(theta)) * 8192.0);
+	int32 const stx = int32((sinf(theta)) * 8192.0);
+	int32 const ctx = int32((cosf(theta)) * 8192.0);
+	int32 const sty = int32((sinf(theta)) * 8192.0);
+	int32 const cty = int32((cosf(theta)) * 8192.0);
 	int32 const mx = int32(px * 8192.0);
 	int32 const my = int32(py * 8192.0);
 

--- a/engines/ultima/nuvie/gui/gui_font.cpp
+++ b/engines/ultima/nuvie/gui/gui_font.cpp
@@ -157,7 +157,7 @@ void GUI_Font:: textExtent(const char *text, int *w, int *h, int line_wrap) {
 	}
 
 	if (line_wrap && len > line_wrap) {
-		*h = (int)ceil((float)len / (float)line_wrap);
+		*h = (int)ceilf((float)len / (float)line_wrap);
 		*h *= _charH - 1;
 	} else
 		*h = _charH - 1;

--- a/engines/ultima/nuvie/screen/screen.cpp
+++ b/engines/ultima/nuvie/screen/screen.cpp
@@ -786,7 +786,7 @@ void Screen::buildalphamap8() {
 				//Unitize
 				r /= sqrtf(sqr(globeradius_2[i]) + sqr(globeradius_2[i]));
 				//Calculate brightness
-				r  = (float)exp(-(10 * r * r));
+				r  = (float)expf(-(10 * r * r));
 				//Fit into a byte
 				r *= 255;
 				//Place it

--- a/engines/ultima/nuvie/sound/decoder/pc_speaker_stream.cpp
+++ b/engines/ultima/nuvie/sound/decoder/pc_speaker_stream.cpp
@@ -115,8 +115,8 @@ int PCSpeakerSweepFreqStream::readBuffer(sint16 *buffer, const int numSamples) {
 		if ((float)i + n > (float)samples)
 			n = (float)(samples - i);
 
-		float remainder = n - floor(n);
-		n = floor(n);
+		float remainder = n - floorf(n);
+		n = floorf(n);
 		pcspkr->PCSPEAKER_CallBack(&buffer[i], (uint32)n);
 		sample_pos += n;
 
@@ -281,7 +281,7 @@ int PCSpeakerStutterStream::readBuffer(sint16 *buffer, const int numSamples) {
 	uint32 s = 0;
 
 	for (; cx > 0 && s < (uint32)numSamples; cx--) {
-		uint32 n = (uint32)floor(delay_remaining);
+		uint32 n = (uint32)floorf(delay_remaining);
 		if (n > 0) {
 			pcspkr->PCSPEAKER_CallBack(&buffer[s], n);
 			delay_remaining -= n;
@@ -306,7 +306,7 @@ int PCSpeakerStutterStream::readBuffer(sint16 *buffer, const int numSamples) {
 		          }
 		       }
 		*/
-		n = (uint32)floor(delay);
+		n = (uint32)floorf(delay);
 		if (s + n > (uint32)numSamples)
 			n = numSamples - s;
 

--- a/engines/ultima/ultima8/world/fireball_process.cpp
+++ b/engines/ultima/ultima8/world/fireball_process.cpp
@@ -102,7 +102,7 @@ void FireballProcess::run() {
 	}
 
 	// limit speed
-	int speed = static_cast<int>(sqrt(static_cast<float>(_xSpeed * _xSpeed + _ySpeed * _ySpeed)));
+	int speed = static_cast<int>(sqrtf(static_cast<float>(_xSpeed * _xSpeed + _ySpeed * _ySpeed)));
 	if (speed > 32) {
 		_xSpeed = (_xSpeed * 32) / speed;
 		_ySpeed = (_ySpeed * 32) / speed;

--- a/engines/wintermute/ad/ad_actor_3dx.cpp
+++ b/engines/wintermute/ad/ad_actor_3dx.cpp
@@ -721,9 +721,9 @@ void AdActor3DX::getNextStep3D() {
 void AdActor3DX::initLine3D(DXVector3 startPt, DXVector3 endPt, bool firstStep) {
 	if (firstStep) {
 		_nextState = STATE_FOLLOWING_PATH;
-		turnTo(radToDeg(-atan2(endPt._z - startPt._z, endPt._x - startPt._x)) - 90);
+		turnTo(radToDeg(-atan2f(endPt._z - startPt._z, endPt._x - startPt._x)) - 90);
 	} else {
-		_turningLeft = prepareTurn(radToDeg(-atan2(endPt._z - startPt._z, endPt._x - startPt._x)) - 90);
+		_turningLeft = prepareTurn(radToDeg(-atan2f(endPt._z - startPt._z, endPt._x - startPt._x)) - 90);
 	}
 }
 
@@ -823,8 +823,8 @@ bool AdActor3DX::prepareTurn(float targetAngle) {
 	delta2 = targetAngle + 360 - _angle;
 	delta3 = targetAngle - 360 - _angle;
 
-	delta1 = (fabs(delta1) <= fabs(delta2)) ? delta1 : delta2;
-	delta = (fabs(delta1) <= fabs(delta3)) ? delta1 : delta3;
+	delta1 = (fabsf(delta1) <= fabsf(delta2)) ? delta1 : delta2;
+	delta = (fabsf(delta1) <= fabsf(delta3)) ? delta1 : delta3;
 
 	_targetAngle = _angle + delta;
 	turnLeft = (delta < 0);
@@ -1680,7 +1680,7 @@ bool AdActor3DX::scCallMethod(ScScript *script, ScStack *stack, ScStack *thisSta
 			BaseObject *obj = (BaseObject *)val->getNative();
 			DXVector3 objPos;
 			((AdGame *)_game)->_scene->_geom->convert2Dto3D(obj->_posX, obj->_posY, &objPos);
-			angle = radToDeg(-atan2(objPos._z - _posVector._z, objPos._x - _posVector._x)) - 90;
+			angle = radToDeg(-atan2f(objPos._z - _posVector._z, objPos._x - _posVector._x)) - 90;
 		} else {
 			// otherwise turn to direction
 			dir = val->getInt();

--- a/engines/wintermute/ad/ad_inventory_box.cpp
+++ b/engines/wintermute/ad/ad_inventory_box.cpp
@@ -108,8 +108,8 @@ bool AdInventoryBox::display() {
 	}
 
 	int itemsX, itemsY;
-	itemsX = (int)floor((float)((_itemsArea.right - _itemsArea.left + _spacing) / (_itemWidth + _spacing)));
-	itemsY = (int)floor((float)((_itemsArea.bottom - _itemsArea.top + _spacing) / (_itemHeight + _spacing)));
+	itemsX = (int)floorf((float)((_itemsArea.right - _itemsArea.left + _spacing) / (_itemWidth + _spacing)));
+	itemsY = (int)floorf((float)((_itemsArea.bottom - _itemsArea.top + _spacing) / (_itemHeight + _spacing)));
 
 	if (_window) {
 		_window->enableWidget("prev", _scrollOffset > 0);

--- a/engines/wintermute/ad/ad_scene_geometry.cpp
+++ b/engines/wintermute/ad/ad_scene_geometry.cpp
@@ -490,7 +490,7 @@ float AdSceneGeometry::getHeightAt(DXVector3 pos, float tolerance, bool *intFoun
 					continue; // only fall down
 				}
 
-				if (!intFoundTmp || fabs(ret - pos._y) > fabs(intersection._y - pos._y)) {
+				if (!intFoundTmp || fabsf(ret - pos._y) > fabsf(intersection._y - pos._y)) {
 					ret = intersection._y;
 				}
 
@@ -946,7 +946,7 @@ bool AdSceneGeometry::enableLights(DXVector3 point, BaseArray<char *> &ignoreLig
 				dif = _lights[i]->_pos - point;
 			}
 
-			_lights[i]->_distance = fabs(DXVec3Length(&dif));
+			_lights[i]->_distance = fabsf(DXVec3Length(&dif));
 
 			activeLights.add(_lights[i]);
 		}

--- a/engines/wintermute/base/base_sub_frame.cpp
+++ b/engines/wintermute/base/base_sub_frame.cpp
@@ -219,7 +219,7 @@ bool BaseSubFrame::loadBuffer(char *buffer, int lifeTime, bool keepLoaded) {
 //////////////////////////////////////////////////////////////////////
 bool BaseSubFrame::draw(int x, int y, BaseObject *registerOwner, float zoomX, float zoomY, bool precise, uint32 alpha, float rotate, Graphics::TSpriteBlendMode blendMode) {
 
-	rotate = fmod(rotate, 360.0f);
+	rotate = fmodf(rotate, 360.0f);
 	if (rotate < 0) {
 		rotate += 360.0f;
 	}

--- a/engines/wintermute/base/gfx/3dcamera.cpp
+++ b/engines/wintermute/base/gfx/3dcamera.cpp
@@ -80,18 +80,18 @@ void Camera3D::rotateView(float x, float y, float z) {
 	// Rotate the view along the desired axis
 	if (x) {
 		// Rotate the view vector up or down, then add it to our position
-		_target._z = (float)(_position._z + sin(x) * vVector._y + cos(x) * vVector._z);
-		_target._y = (float)(_position._y + cos(x) * vVector._y - sin(x) * vVector._z);
+		_target._z = (float)(_position._z + sinf(x) * vVector._y + cosf(x) * vVector._z);
+		_target._y = (float)(_position._y + cosf(x) * vVector._y - sinf(x) * vVector._z);
 	}
 	if (y) {
 		// Rotate the view vector right or left, then add it to our position
-		_target._z = (float)(_position._z + sin(y) * vVector._x + cos(y) * vVector._z);
-		_target._x = (float)(_position._x + cos(y) * vVector._x - sin(y) * vVector._z);
+		_target._z = (float)(_position._z + sinf(y) * vVector._x + cosf(y) * vVector._z);
+		_target._x = (float)(_position._x + cosf(y) * vVector._x - sinf(y) * vVector._z);
 	}
 	if (z) {
 		// Rotate the view vector diagnally right or diagnally down, then add it to our position
-		_target._x = (float)(_position._x + sin(z) * vVector._y + cos(z) * vVector._x);
-		_target._y = (float)(_position._y + cos(z) * vVector._y - sin(z) * vVector._x);
+		_target._x = (float)(_position._x + sinf(z) * vVector._y + cosf(z) * vVector._x);
+		_target._y = (float)(_position._y + cosf(z) * vVector._y - sinf(z) * vVector._x);
 	}
 }
 

--- a/engines/wintermute/base/gfx/3dutils.cpp
+++ b/engines/wintermute/base/gfx/3dutils.cpp
@@ -98,12 +98,12 @@ DXMatrix *C3DUtils::matrixSetTranslation(DXMatrix *mat, DXVector3 *vec) {
 }
 
 DXMatrix *C3DUtils::matrixSetRotation(DXMatrix *mat, DXVector3 *vec) {
-	double cr = cos(vec->_x);
-	double sr = sin(vec->_x);
-	double cp = cos(vec->_y);
-	double sp = sin(vec->_y);
-	double cy = cos(vec->_z);
-	double sy = sin(vec->_z);
+	double cr = cosf(vec->_x);
+	double sr = sinf(vec->_x);
+	double cp = cosf(vec->_y);
+	double sp = sinf(vec->_y);
+	double cy = cosf(vec->_z);
+	double sy = sinf(vec->_z);
 
 	mat->matrix._11 = (float)(cp * cy);
 	mat->matrix._12 = (float)(cp * sy);

--- a/engines/wintermute/base/particles/part_particle.cpp
+++ b/engines/wintermute/base/particles/part_particle.cpp
@@ -156,7 +156,7 @@ bool PartParticle::update(PartEmitter *emitter, uint32 currentTime, uint32 timer
 
 			case PartForce::FORCE_POINT: {
 				DXVector2 vecDist = force->_pos - _pos;
-				float dist = fabs(DXVec2Length(&vecDist));
+				float dist = fabsf(DXVec2Length(&vecDist));
 
 				dist = 100.0f / dist;
 

--- a/engines/wintermute/math/math_util.cpp
+++ b/engines/wintermute/math/math_util.cpp
@@ -32,18 +32,18 @@ namespace Wintermute {
 
 //////////////////////////////////////////////////////////////////////////
 float MathUtil::round(float val) {
-	float result = floor(val);
+	float result = floorf(val);
 	if (val - result >= 0.5f) {
-		result += 1.0;
+		result += 1.0f;
 	}
 	return result;
 }
 
 //////////////////////////////////////////////////////////////////////////
 float MathUtil::roundUp(float val) {
-	float result = floor(val);
+	float result = floorf(val);
 	if (val - result > 0) {
-		result += 1.0;
+		result += 1.0f;
 	}
 	return result;
 }

--- a/engines/zvision/graphics/effects/wave.cpp
+++ b/engines/zvision/graphics/effects/wave.cpp
@@ -51,7 +51,7 @@ WaveFx::WaveFx(ZVision *engine, uint32 key, Common::Rect region, bool ported, in
 				int16 dx = (x - quarterWidth);
 				int16 dy = (y - quarterHeight);
 
-				_ampls[i][x + y * _halfWidth] = (int8)(ampl * sin(sqrt(dx * dx / (float)centerX + dy * dy / (float)centerY) / (-waveln * 3.1415926) + phase));
+				_ampls[i][x + y * _halfWidth] = (int8)(ampl * sinf(sqrtf(dx * dx / (float)centerX + dy * dy / (float)centerY) / (-waveln * 3.1415926f) + phase));
 			}
 		phase += spd;
 	}

--- a/engines/zvision/graphics/render_table.cpp
+++ b/engines/zvision/graphics/render_table.cpp
@@ -209,11 +209,11 @@ void RenderTable::generateLookupTable(bool tilt) {
 		// polarCoord is the coordinate of the working window pixel parallel to the direction of camera rotation
 		// halfPolarSize is the distance from the central axis to the outermost working window pixel in the direction of camera rotation
 		// alpha represents the angle in the direction of camera rotation between the view axis and the centre of a pixel at the given polar coordinate
-		const float alpha = atan(((float)polarCoord - halfPolarSize) / cylinderRadius);
+		const float alpha = atanf(((float)polarCoord - halfPolarSize) / cylinderRadius);
 		// To map the polar coordinate to the cylinder surface coordinates, we just need to calculate the arc length
 		// We also scale it by linearScale
 		polarCoordInCylinderCoords = (cylinderRadius * scale * alpha) + halfPolarSize;
-		cosAlpha = cos(alpha);
+		cosAlpha = cosf(alpha);
 	};
 	auto innerLoop = [&](uint & polarCoord, uint & linearCoord, float & halfLinearSize,  float & polarOffset, float & linearOffset) {
 		// To calculate linear coordinate in cylinder coordinates, we can do similar triangles comparison,
@@ -232,8 +232,8 @@ void RenderTable::generateLookupTable(bool tilt) {
 		_internalBuffer[indexBR].flipH();
 	};
 	if (tilt) {
-		cylinderRadius = (_halfWidth + 0.5f) / tan(_tiltOptions.verticalFOV);
-		_tiltOptions.gap = cylinderRadius * atan2((float)(_halfHeight / cylinderRadius), 1.0f) * _tiltOptions.linearScale;
+		cylinderRadius = (_halfWidth + 0.5f) / tanf(_tiltOptions.verticalFOV);
+		_tiltOptions.gap = cylinderRadius * atan2f((float)(_halfHeight / cylinderRadius), 1.0f) * _tiltOptions.linearScale;
 		for (uint y = 0; y <= _halfRows; ++y) {
 			outerLoop(y, _halfHeight, _tiltOptions.linearScale);
 			const uint32 columnIndexTL = y * _numColumns;
@@ -249,7 +249,7 @@ void RenderTable::generateLookupTable(bool tilt) {
 			}
 		}
 	} else {
-		cylinderRadius = (_halfHeight + 0.5f) / tan(_panoramaOptions.verticalFOV);
+		cylinderRadius = (_halfHeight + 0.5f) / tanf(_panoramaOptions.verticalFOV);
 		for (uint x = 0; x <= _halfColumns; ++x) {
 			const uint32 columnIndexL = x;
 			const uint32 columnIndexR = (_numColumns - 1) - x;

--- a/engines/zvision/scripting/controls/safe_control.cpp
+++ b/engines/zvision/scripting/controls/safe_control.cpp
@@ -154,7 +154,7 @@ bool SafeControl::onMouseUp(const Common::Point &screenSpacePos, const Common::P
 
 			// Coverity complains about the order of arguments here,
 			// but changing that breaks the Zork Nemesis safe puzzle.
-			float dd = atan2((float)tmp.x, (float)tmp.y) * 57.29578;
+			float dd = atan2f((float)tmp.x, (float)tmp.y) * 57.29578f;
 
 			int16 dp_state = 360 / _statesCount;
 

--- a/engines/zvision/sound/volume_manager.cpp
+++ b/engines/zvision/sound/volume_manager.cpp
@@ -145,7 +145,7 @@ uint8 VolumeManager::convert(uint8 inputValue, Math::Angle azimuth, uint8 direct
 }
 
 uint8 VolumeManager::convert(uint8 inputValue, volumeScaling &mode, Math::Angle azimuth, uint8 directionality) {
-	uint8 index = abs(round(azimuth.getDegrees(-180)));
+	uint8 index = abs(roundf(azimuth.getDegrees(-180)));
 	uint32 output = convert(inputValue, mode);
 	uint32 directionalOutput = (output * directionalAmplitude[index]) * directionality;
 	directionalOutput /= 0xFF;

--- a/graphics/blit/blit-scale.cpp
+++ b/graphics/blit/blit-scale.cpp
@@ -338,8 +338,8 @@ void rotoscaleBlitLogic(byte *dst, const byte *src,
 
 	uint32 invAngle = 360 - (transform._angle % 360);
 	float invAngleRad = Math::deg2rad<uint32,float>(invAngle);
-	float invCos = cos(invAngleRad);
-	float invSin = sin(invAngleRad);
+	float invCos = cosf(invAngleRad);
+	float invSin = sinf(invAngleRad);
 
 	int icosx = (int)(invCos * (65536.0f * kDefaultZoomX / transform._zoom.x));
 	int isinx = (int)(invSin * (65536.0f * kDefaultZoomX / transform._zoom.x));

--- a/graphics/tinygl/light.cpp
+++ b/graphics/tinygl/light.cpp
@@ -226,7 +226,7 @@ void GLContext::gl_shade_vertex(GLVertex *v) {
 			d.X = l->position.X - v->ec.X;
 			d.Y = l->position.Y - v->ec.Y;
 			d.Z = l->position.Z - v->ec.Z;
-			dist = sqrt(d.X * d.X + d.Y * d.Y + d.Z * d.Z);
+			dist = sqrtf(d.X * d.X + d.Y * d.Y + d.Z * d.Z);
 			att = 1.0f / (l->attenuation[0] +
 			              dist * (l->attenuation[1] +
 			              dist * l->attenuation[2]));
@@ -258,7 +258,7 @@ void GLContext::gl_shade_vertex(GLVertex *v) {
 					} else {
 						// TODO: optimize
 						if (l->spot_exponent > 0) {
-							att = att * pow(dot_spot, l->spot_exponent);
+							att = att * powf(dot_spot, l->spot_exponent);
 						}
 					}
 				}
@@ -284,7 +284,7 @@ void GLContext::gl_shade_vertex(GLVertex *v) {
 					if (dot_spec > 0) {
 						GLSpecBuf *specbuf;
 						int idx;
-						dot_spec = dot_spec / sqrt(s.X * s.X + s.Y * s.Y + s.Z * s.Z);
+						dot_spec = dot_spec / sqrtf(s.X * s.X + s.Y * s.Y + s.Z * s.Z);
 						// TODO: optimize
 						// testing specular buffer code
 						// dot_spec= pow(dot_spec,m->shininess)

--- a/graphics/tinygl/matrix.cpp
+++ b/graphics/tinygl/matrix.cpp
@@ -161,14 +161,14 @@ void GLContext::glopRotate(GLParam *p) {
 		float len = u[0] * u[0] + u[1] * u[1] + u[2] * u[2];
 		if (len == 0.0f)
 			return;
-		len = 1.0f / sqrt(len);
+		len = 1.0f / sqrtf(len);
 		u[0] *= len;
 		u[1] *= len;
 		u[2] *= len;
 
 		// store cos and sin values
-		cost = cos(angle);
-		sint = sin(angle);
+		cost = cosf(angle);
+		sint = sinf(angle);
 
 		// fill in the values
 		m._m[3][0] = 0.0f;

--- a/graphics/tinygl/specbuf.cpp
+++ b/graphics/tinygl/specbuf.cpp
@@ -34,7 +34,7 @@ static void calc_buf(GLSpecBuf *buf, const float shininess) {
 	val = 0.0f;
 	inc = 1.0f / SPECULAR_BUFFER_SIZE;
 	for (int i = 0; i <= SPECULAR_BUFFER_SIZE; i++) {
-		buf->buf[i] = pow(val, shininess);
+		buf->buf[i] = powf(val, shininess);
 		val += inc;
 	}
 }

--- a/graphics/tinygl/zblit.cpp
+++ b/graphics/tinygl/zblit.cpp
@@ -640,8 +640,8 @@ void BlitImage::tglBlitRotoScale(int dstX, int dstY, int width, int height, int 
 		clampHeight = destinationRectangle.height();
 
 	uint32 invAngle = 360 - (rotation % 360);
-	float invCos = cos(invAngle * (float)M_PI / 180.0f);
-	float invSin = sin(invAngle * (float)M_PI / 180.0f);
+	float invCos = cosf(invAngle * (float)M_PI / 180.0f);
+	float invSin = sinf(invAngle * (float)M_PI / 180.0f);
 
 	int icosx = (int)(invCos * (65536.0f * srcWidth / width));
 	int isinx = (int)(invSin * (65536.0f * srcWidth / width));
@@ -826,8 +826,8 @@ void tglCleanupImages() {
 Common::Point transformPoint(float x, float y, int rotation) {
 	float rotateRad = rotation * (float)M_PI / 180.0f;
 	Common::Point newPoint;
-	newPoint.x = x * cos(rotateRad) - y * sin(rotateRad);
-	newPoint.y = x * sin(rotateRad) + y * cos(rotateRad);
+	newPoint.x = x * cosf(rotateRad) - y * sinf(rotateRad);
+	newPoint.y = x * sinf(rotateRad) + y * cosf(rotateRad);
 	return newPoint;
 }
 
@@ -844,10 +844,10 @@ Common::Rect rotateRectangle(int x, int y, int width, int height, int rotation, 
 	float right = MAX(nw.x, MAX(ne.x, MAX(sw.x, se.x)));
 
 	Common::Rect res;
-	res.top = (int32)(floor(top)) + originY;
-	res.bottom = (int32)(ceil(bottom)) + originY;
-	res.left = (int32)(floor(left)) + originX;
-	res.right = (int32)(ceil(right)) + originX;
+	res.top = (int32)(floorf(top)) + originY;
+	res.bottom = (int32)(ceilf(bottom)) + originY;
+	res.left = (int32)(floorf(left)) + originX;
+	res.right = (int32)(ceilf(right)) + originX;
 
 	return res;
 }

--- a/graphics/tinygl/zmath.cpp
+++ b/graphics/tinygl/zmath.cpp
@@ -163,7 +163,7 @@ static int MatrixInverse(float *m) {
 }
 
 void Vector3::normalize() {
-	float n = sqrt(X * X + Y * Y + Z * Z);
+	float n = sqrtf(X * X + Y * Y + Z * Z);
 	if (n != 0) {
 		X /= n;
 		Y /= n;
@@ -276,8 +276,8 @@ void Matrix4::rotation(float t, int u) {
 		v = 0;
 	if ((w = v + 1) > 2)
 		w = 0;
-	s = sin(t);
-	c = cos(t);
+	s = sinf(t);
+	c = cosf(t);
 	_m[v][v] = c;
 	_m[v][w] = -s;
 	_m[w][v] = s;

--- a/graphics/transform_tools.cpp
+++ b/graphics/transform_tools.cpp
@@ -41,8 +41,8 @@ FloatPoint TransformTools::transformPoint(FloatPoint point, const float rotate, 
 		y *= -1;
 #endif
 	FloatPoint newPoint;
-	newPoint.x = x * cos(rotateRad) - y * sin(rotateRad);
-	newPoint.y = x * sin(rotateRad) + y * cos(rotateRad);
+	newPoint.x = x * cosf(rotateRad) - y * sinf(rotateRad);
+	newPoint.y = x * sinf(rotateRad) + y * cosf(rotateRad);
 	if (mirrorX) {
 		newPoint.x *= -1;
 	}
@@ -71,15 +71,15 @@ Common::Rect TransformTools::newRect(const Common::Rect &oldRect, const Transfor
 	float right = MAX(nw1.x, MAX(ne1.x, MAX(sw1.x, se1.x)));
 
 	if (newHotspot) {
-		newHotspot->y = (uint32)(-floor(top));
-		newHotspot->x = (uint32)(-floor(left));
+		newHotspot->y = (uint32)(-floorf(top));
+		newHotspot->x = (uint32)(-floorf(left));
 	}
 
 	Common::Rect res;
-	res.top = (int32)(floor(top)) + transform._hotspot.y;
-	res.bottom = (int32)(ceil(bottom)) + transform._hotspot.y;
-	res.left = (int32)(floor(left)) + transform._hotspot.x;
-	res.right = (int32)(ceil(right)) + transform._hotspot.x;
+	res.top = (int32)(floorf(top)) + transform._hotspot.y;
+	res.bottom = (int32)(ceilf(bottom)) + transform._hotspot.y;
+	res.left = (int32)(floorf(left)) + transform._hotspot.x;
+	res.right = (int32)(ceilf(right)) + transform._hotspot.x;
 
 	return res;
 }

--- a/math/angle.cpp
+++ b/math/angle.cpp
@@ -79,10 +79,10 @@ float Angle::getRadians() const {
 float Angle::getDegrees(float low) const {
 	float degrees = _degrees;
 	if (degrees >= low + 360.f) {
-		float x = floor((degrees - low) / 360.f);
+		float x = floorf((degrees - low) / 360.f);
 		degrees -= 360.f * x;
 	} else if (degrees < low) {
-		float x = floor((degrees - low) / 360.f);
+		float x = floorf((degrees - low) / 360.f);
 		degrees -= 360.f * x;
 	}
 	return degrees;

--- a/math/line2d.cpp
+++ b/math/line2d.cpp
@@ -45,7 +45,7 @@ Vector2d Line2d::getDirection() const {
 }
 
 float Line2d::getDistanceTo(const Vector2d &point, Vector2d *intersection) const {
-	float dist = fabsf(_a * point.getX() + _b * point.getY() - _c) / sqrt(_a * _a + _b * _b);
+	float dist = fabsf(_a * point.getX() + _b * point.getY() - _c) / sqrtf(_a * _a + _b * _b);
 
 	if (intersection) {
 		intersectsLine(getPerpendicular(point), intersection);

--- a/math/quat.cpp
+++ b/math/quat.cpp
@@ -138,21 +138,21 @@ void Quaternion::fromMatrix(const Matrix3 &m) {
 			h = 2;
 
 		if (h == 0) {
-			s = sqrt(m.getValue(0, 0) - (m.getValue(1,1) + m.getValue(2, 2)) + 1.0f);
+			s = sqrtf(m.getValue(0, 0) - (m.getValue(1,1) + m.getValue(2, 2)) + 1.0f);
 			qx = s * 0.5f;
 			s = 0.5f / s;
 			qy = (m.getValue(0, 1) + m.getValue(1, 0)) * s;
 			qz = (m.getValue(2, 0) + m.getValue(0, 2)) * s;
 			qw = (m.getValue(2, 1) - m.getValue(1, 2)) * s;
 		} else if (h == 1) {
-			s = sqrt(m.getValue(1, 1) - (m.getValue(2,2) + m.getValue(0, 0)) + 1.0f);
+			s = sqrtf(m.getValue(1, 1) - (m.getValue(2,2) + m.getValue(0, 0)) + 1.0f);
 			qy = s * 0.5f;
 			s = 0.5f / s;
 			qz = (m.getValue(1, 2) + m.getValue(2, 1)) * s;
 			qx = (m.getValue(0, 1) + m.getValue(1, 0)) * s;
 			qw = (m.getValue(0, 2) - m.getValue(2, 0)) * s;
 		} else {
-			s = sqrt(m.getValue(2, 2) - (m.getValue(0,0) + m.getValue(1, 1)) + 1.0f);
+			s = sqrtf(m.getValue(2, 2) - (m.getValue(0,0) + m.getValue(1, 1)) + 1.0f);
 			qz = s * 0.5f;
 			s = 0.5f / s;
 			qx = (m.getValue(2, 0) + m.getValue(0, 2)) * s;
@@ -208,7 +208,7 @@ Vector3d Quaternion::directionVector(const int col) const {
 
 Angle Quaternion::getAngleBetween(const Quaternion &to) {
 	Quaternion q = this->inverse() * to;
-	Angle diff(Math::rad2deg(2 * acos(q.w())));
+	Angle diff(Math::rad2deg(2 * acosf(q.w())));
 	return diff;
 }
 
@@ -274,10 +274,10 @@ Quaternion& Quaternion::operator+=(const Quaternion &o) {
 }
 
 bool Quaternion::operator==(const Quaternion &o) const {
-	float dw = fabs(w() - o.w());
-	float dx = fabs(x() - o.x());
-	float dy = fabs(y() - o.y());
-	float dz = fabs(z() - o.z());
+	float dw = fabsf(w() - o.w());
+	float dx = fabsf(x() - o.x());
+	float dy = fabsf(y() - o.y());
+	float dz = fabsf(z() - o.z());
 	// Threshold of equality
 	float th = 1E-5f;
 

--- a/math/ray.cpp
+++ b/math/ray.cpp
@@ -91,7 +91,7 @@ bool Ray::intersectTriangle(const Vector3d &v0, const Vector3d &v1,
 	const Vector3d h = Vector3d::crossProduct(_direction, e2);
 
 	float a = e1.dotProduct(h);
-	if (fabs(a) < 1e-6f)
+	if (fabsf(a) < 1e-6f)
 		return false;
 
 	float f = 1.0f / a;

--- a/math/rect2d.cpp
+++ b/math/rect2d.cpp
@@ -98,7 +98,7 @@ bool Rect2d::intersectsCircle(const Vector2d &center, float radius) const {
 	Math::Angle angle = (_topRight - _topLeft).getAngle();
 
 	if (angle == 0) {
-		Vector2d circleDistance(fabs(center.getX() - c.getX()), fabs(center.getY() - c.getY()));
+		Vector2d circleDistance(fabsf(center.getX() - c.getX()), fabsf(center.getY() - c.getY()));
 
 		if (circleDistance.getX() > (w / 2.f + radius)) {
 			return false;
@@ -114,8 +114,8 @@ bool Rect2d::intersectsCircle(const Vector2d &center, float radius) const {
 			return true;
 		}
 
-		float cornerDistance_sq = pow(circleDistance.getX() - w / 2.f, 2.f) +
-		                              pow(circleDistance.getY() - h / 2.f, 2.f);
+		float cornerDistance_sq = powf(circleDistance.getX() - w / 2.f, 2.f) +
+		                          powf(circleDistance.getY() - h / 2.f, 2.f);
 
 		return (cornerDistance_sq <= radius * radius);
 	} else { //The rectangle was rotated
@@ -167,20 +167,20 @@ float Rect2d::getWidth() const {
 	float x = _topRight.getX() - _topLeft.getX();
 	float y = _topRight.getY() - _topLeft.getY();
 
-	return sqrt(x * x + y * y);
+	return sqrtf(x * x + y * y);
 }
 
 float Rect2d::getHeight() const {
 	float x = _bottomLeft.getX() - _topLeft.getX();
 	float y = _bottomLeft.getY() - _topLeft.getY();
 
-	return sqrt(x * x + y * y);
+	return sqrtf(x * x + y * y);
 }
 
 Vector2d Rect2d::getIntersection(const Vector2d &start, const Vector2d &dir, Segment2d *edge) const {
 	float w = getWidth();
 	float h = getHeight();
-	float d = sqrt(w * w + h * h);
+	float d = sqrtf(w * w + h * h);
 
 	Segment2d line(start, start + dir.getNormalized() * 2*d);
 	Vector2d intersection;

--- a/video/bink_decoder.cpp
+++ b/video/bink_decoder.cpp
@@ -1591,7 +1591,7 @@ void BinkDecoder::BinkAudioTrack::readAudioCoeffs(float *coeffs) {
 		int value = _audioInfo->bits->getBits<8>();
 
 		//                              0.066399999 / log10(M_E)
-		quant[i] = exp(MIN(value, 95) * 0.15289164787221953823f) * _audioInfo->root;
+		quant[i] = expf(MIN(value, 95) * 0.15289164787221953823f) * _audioInfo->root;
 	}
 
 	float q = 0.0;

--- a/video/qtvr_decoder.cpp
+++ b/video/qtvr_decoder.cpp
@@ -304,7 +304,7 @@ void QuickTimeDecoder::setPanAngle(float angle) {
 	PanoSampleDesc *desc = (PanoSampleDesc *)_panoTrack->sampleDescs[0];
 
 	float panRange = abs(desc->_hPanEnd - desc->_hPanStart);
-	angle = fmod(angle, panRange);
+	angle = fmodf(angle, panRange);
 
 	if (desc->_hPanStart != desc->_hPanEnd && (desc->_hPanStart != 0.0 || desc->_hPanEnd != 360.0)) {
 		if (angle < desc->_hPanStart + _hfov) {
@@ -1039,7 +1039,7 @@ Common::Point QuickTimeDecoder::PanoTrackHandler::projectPoint(int16 mx, int16 m
 		} else if (warpMode == 2) {
 			xCoord = t * mousePixelVector[0] / mousePixelVector[2];
 		}
-		yawRatio = atan(xCoord) / (2.0 * M_PI);
+		yawRatio = atanf(xCoord) / (2.0 * M_PI);
 	}
 
 	float angleT = (360.0f - _decoder->_panAngle) / 360.0f;
@@ -1048,14 +1048,14 @@ Common::Point QuickTimeDecoder::PanoTrackHandler::projectPoint(int16 mx, int16 m
 	hotX = (1.0f - (angleT + yawRatio)) * (float)hotHeight;
 
 	if (warpMode == 0) {
-		float tiltFactor = tan(verticalFovRadians / 2.0f);
+		float tiltFactor = tanf(verticalFovRadians / 2.0f);
 		float normalizedY = ((float)my / (float)(h - 1)) * 2.0f - 1.0f;  // Range [-1, 1]
-		float projectedY = (normalizedY * tiltFactor) + tan(tiltAngleRadians);
+		float projectedY = (normalizedY * tiltFactor) + tanf(tiltAngleRadians);
 		hotY = static_cast<int32>((projectedY + 1.0f) / 2.0f * hotWidth);
 	} else {
 		// To get the vertical coordinate, need to project the vector on to a unit cylinder.
 		// To do that, compute the length of the XZ vector,
-		float xzVectorLen = sqrt(xCoord * xCoord + 1.0f);
+		float xzVectorLen = sqrtf(xCoord * xCoord + 1.0f);
 
 		float projectedY = xzVectorLen * mousePixelVector[1] / mousePixelVector[2];
 		float normalizedYCoordinate = (projectedY - minTiltY) / (maxTiltY - minTiltY);
@@ -1188,7 +1188,7 @@ void QuickTimeDecoder::PanoTrackHandler::projectPanorama(uint8 scaleFactor,
 	float maxProjectedY = bottomRightVector[1] / bottomRightVector[2];
 
 	float panRange = abs(desc->_hPanEnd - desc->_hPanStart);
-	float angleT = fmod((panRange - panAngle) / panRange, 1.0f);
+	float angleT = fmodf((panRange - panAngle) / panRange, 1.0f);
 	if (angleT < 0.0f) {
 		angleT += 1.0f;
 	}
@@ -1279,7 +1279,7 @@ void QuickTimeDecoder::PanoTrackHandler::projectPanorama(uint8 scaleFactor,
 			float xCoord = t * maxProjectedX;
 
 			float yCoords[2] = {minProjectedY, maxProjectedY};
-			float length = sqrt(xCoord * xCoord + 1.0f);
+			float length = sqrtf(xCoord * xCoord + 1.0f);
 
 			// Compute projection ranges
 			for (int v = 0; v < 2; v++) {
@@ -1288,7 +1288,7 @@ void QuickTimeDecoder::PanoTrackHandler::projectPanorama(uint8 scaleFactor,
 				cylinderProjectionRanges[x * 2 + v] = (newY - minTiltY) / (maxTiltY - minTiltY);
 			}
 
-			cylinderAngleOffsets[x] = atan(xCoord) * 0.5f / M_PI;
+			cylinderAngleOffsets[x] = atanf(xCoord) * 0.5f / M_PI;
 		}
 	}
 
@@ -1343,9 +1343,9 @@ void QuickTimeDecoder::PanoTrackHandler::projectPanorama(uint8 scaleFactor,
 			int32 sourceYCoord;
 
 			if (warpMode == 0) {
-				float tiltFactor = tan(verticalFovRadians / 2.0f);
+				float tiltFactor = tanf(verticalFovRadians / 2.0f);
 				float normalizedY = ((float)y / (float)(h - 1)) * 2.0f - 1.0f;
-				float projectedY = (normalizedY * tiltFactor) - tan(tiltAngleRadians);
+				float projectedY = (normalizedY * tiltFactor) - tanf(tiltAngleRadians);
 				sourceYCoord = static_cast<int32>((projectedY + 1.0f) / 2.0f * panoHeight);
 			} else {
 				sourceYCoord = (2 * y + 1) * (bottomSrcCoord - topSrcCoord) / (2 * h) + topSrcCoord;
@@ -1550,7 +1550,7 @@ void QuickTimeDecoder::handleObjectMouseMove(int16 x, int16 y) {
 	bool changed = false;
 
 	if (ABS(mouseDeltaY) >= sensitivity) {
-		int newFrame = track->getCurFrame() - round(speedY) * _nav.columns;
+		int newFrame = track->getCurFrame() - roundf(speedY) * _nav.columns;
 
 		if (newFrame >= 0 && newFrame < track->getFrameCount()) {
 			track->setCurFrame(newFrame);


### PR DESCRIPTION
The code base seems to have a lot of needless float-double conversion. In many places a double math function is called with a float argument, and the result is converted back to a float.

Godbolt indicates that this does not get optimized away [EDIT: this is conditional, see below]. The double function is called and float-double conversion happens before and after. This may of course depend on further specifics and the platform.

This can be remedied by switching from the double to the float math functions.

EDIT:
Additional research in Godbolt has yielded some more results. Compiler optimization can substitute the double functions with float functions and skip the conversions - but this happening is highly susceptible to circumstances.

GCC and Clang will do the substitution when including `<math.h>`, but not with `<cmath>`. For MSVC it is the opposite.

Expressions as function arguments, especially when number literals are involved, also affect the optimization behavior. For example, with float literals as in 
`float foo(float x) { return cos(x + 0.5f); }`
the substitution is likely to happen. But with a double literal as in
`float bar(float x) { return cos(x + 0.5); }`
there is no substitution.

Assisted-by: [Resharper] [clang-tidy]