### PR TITLE
ALL: use arrow dereferencing operator

### DIFF
--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -432,7 +432,7 @@ void PluginManagerUncached::updateConfigWithFileName(const Common::String &engin
 
 		Common::ConfigManager::Domain *domain = ConfMan.getDomain("engine_plugin_files");
 		assert(domain);
-		(*domain).setVal(engineId, (*_currentPlugin)->getFileName().toConfig());
+		domain->setVal(engineId, (*_currentPlugin)->getFileName().toConfig());
 
 		ConfMan.flushToDisk();
 	}

--- a/common/config-manager.cpp
+++ b/common/config-manager.cpp
@@ -598,7 +598,7 @@ void ConfigManager::set(const String &key, const String &value) {
 	// Write the new key/value pair into the active domain, resp. into
 	// the application domain if no game domain is active.
 	if (_activeDomain)
-		(*_activeDomain).setVal(key, value);
+		_activeDomain->setVal(key, value);
 	else
 		_appDomain.setVal(key, value);
 }
@@ -634,7 +634,7 @@ void ConfigManager::set(const String &key, const String &value, const String &do
 	if (domName != kSessionDomain && domName != kTransientDomain)
 		_sessionDomain.erase(key);
 
-	(*domain).setVal(key, value);
+	domain->setVal(key, value);
 
 		// TODO/FIXME: We used to erase the given key from the transient domain
 	// here. Do we still want to do that?

--- a/common/formats/json.cpp
+++ b/common/formats/json.cpp
@@ -1071,9 +1071,9 @@ String JSONValue::stringifyImpl(size_t const indentDepth) const {
 		ret_string = indentDepth ? "{\n" + indentStr1 : "{";
 		JSONObject::const_iterator iter = _objectValue->begin();
 		while (iter != _objectValue->end()) {
-			ret_string += stringifyString((*iter)._key);
+			ret_string += stringifyString(iter->_key);
 			ret_string += ":";
-			ret_string += (*iter)._value->stringifyImpl(indentDepth1);
+			ret_string += iter->_value->stringifyImpl(indentDepth1);
 
 			// Not at the end - add a separator
 			if (++iter != _objectValue->end())

--- a/engines/ags/shared/game/main_game_file.cpp
+++ b/engines/ags/shared/game/main_game_file.cpp
@@ -543,7 +543,7 @@ void UpgradeAudio(GameSetupStruct &game, LoadedGameEntities &ents, GameDataVersi
 		folder.getChildren(files, Common::FSNode::kListFilesOnly);
 
 		for (Common::FSList::iterator it = files.begin(); it != files.end(); ++it) {
-			Common::String name = (*it).getName();
+			Common::String name = it->getName();
 
 			if (name.hasPrefixIgnoreCase("music") || name.hasPrefixIgnoreCase("sound"))
 				assets.push_back(name.c_str());

--- a/engines/bagel/hodjnpodj/archeroids/usercfg.cpp
+++ b/engines/bagel/hodjnpodj/archeroids/usercfg.cpp
@@ -341,18 +341,18 @@ bool CUserCfgDlg::OnInitDialog() {
 	ReleaseDC(pDC);
 
 	if ((pOKButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pOKButton).SetPalette(m_pPalette);                        // set the palette to use
-		(*pOKButton).SetControl(ID_OK, this);               // tie to the dialog control
+		pOKButton->SetPalette(m_pPalette);                        // set the palette to use
+		pOKButton->SetControl(ID_OK, this);               // tie to the dialog control
 	}
 
 	if ((pCancelButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pCancelButton).SetPalette(m_pPalette);                        // set the palette to use
-		(*pCancelButton).SetControl(ID_CANCEL, this);               // tie to the dialog control
+		pCancelButton->SetPalette(m_pPalette);                        // set the palette to use
+		pCancelButton->SetControl(ID_CANCEL, this);               // tie to the dialog control
 	}
 
 	if ((pDefaultsButton = new CColorButton) != nullptr) {                 // build a color QUIT button to let us exit
-		(*pDefaultsButton).SetPalette(m_pPalette);                      // set the palette to use
-		(*pDefaultsButton).SetControl(ID_RESET, this);              // tie to the dialog control
+		pDefaultsButton->SetPalette(m_pPalette);                      // set the palette to use
+		pDefaultsButton->SetControl(ID_RESET, this);              // tie to the dialog control
 	}
 
 

--- a/engines/bagel/hodjnpodj/artparts/artparts.cpp
+++ b/engines/bagel/hodjnpodj/artparts/artparts.cpp
@@ -172,9 +172,9 @@ CMainWindow::CMainWindow() {
 	tmpRect.SetRect(SCROLL_BUTTON_X, SCROLL_BUTTON_Y,
 	                SCROLL_BUTTON_X + SCROLL_BUTTON_DX - 1,
 	                SCROLL_BUTTON_Y + SCROLL_BUTTON_DY - 1);
-	bSuccess = (*m_pScrollButton).Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, tmpRect, this, IDC_SCROLL);
+	bSuccess = m_pScrollButton->Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, tmpRect, this, IDC_SCROLL);
 	ASSERT(bSuccess);
-	bSuccess = (*m_pScrollButton).LoadBitmaps(SCROLLUP, SCROLLDOWN, SCROLLUP, SCROLLUP);
+	bSuccess = m_pScrollButton->LoadBitmaps(SCROLLUP, SCROLLDOWN, SCROLLUP, SCROLLUP);
 	ASSERT(bSuccess);
 	m_bIgnoreScrollClick = false;
 
@@ -191,7 +191,7 @@ CMainWindow::CMainWindow() {
 	tmpRect.SetRect(TIME_LOCATION_X, TIME_LOCATION_Y,
 	                TIME_LOCATION_X + TIME_WIDTH, TIME_LOCATION_Y + TIME_HEIGHT);
 	if ((m_pTimeText = new CText()) != nullptr) {
-		(*m_pTimeText).SetupText(pDC, pGamePalette, &tmpRect, JUSTIFY_CENTER);
+		m_pTimeText->SetupText(pDC, pGamePalette, &tmpRect, JUSTIFY_CENTER);
 	}
 
 	ReleaseDC(pDC);
@@ -206,14 +206,14 @@ CMainWindow::CMainWindow() {
 		if (pGameInfo->bMusicEnabled) {
 			pGameSound = new CSound(this, GAME_THEME, SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 			if (pGameSound != nullptr) {
-				(*pGameSound).midiLoopPlaySegment(2300, 32000, 0, FMT_MILLISEC);
+				pGameSound->midiLoopPlaySegment(2300, 32000, 0, FMT_MILLISEC);
 			} // end if pGameSound
 		}
 	} else {
 		if (pGameInfo->bMusicEnabled) {
 			pGameSound = new CSound(this, GAME_THEME, SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 			if (pGameSound != nullptr) {
-				(*pGameSound).midiLoopPlaySegment(2300, 32000, 0, FMT_MILLISEC);
+				pGameSound->midiLoopPlaySegment(2300, 32000, 0, FMT_MILLISEC);
 			} // end if pGameSound
 		}
 		PostMessage(WM_COMMAND, IDC_SCROLL, BN_CLICKED);         // Activate the Options dialog
@@ -259,8 +259,8 @@ void CMainWindow::OnPaint() {
 	char        msg[64];
 
 	pDC = GetDC();                                                                  // Get screen DC
-	pPalOld = (*pDC).SelectPalette(pGamePalette, false);                            // Select Game Palette
-	(*pDC).RealizePalette();                                                        // Use it
+	pPalOld = pDC->SelectPalette(pGamePalette, false);                            // Select Game Palette
+	pDC->RealizePalette();                                                        // Use it
 
 	InvalidateRect(nullptr, false);            // invalidate the entire window
 	BeginPaint(&lpPaint);
@@ -274,13 +274,13 @@ void CMainWindow::OnPaint() {
 		else {
 			Common::sprintf_s(msg, "Time Left: %02d:%02d", nMinutes, nSeconds);
 		}
-		(*m_pTimeText).DisplayString(pDC, msg, FONT_SIZE, FW_SEMIBOLD, OPTIONS_COLOR);
+		m_pTimeText->DisplayString(pDC, msg, FONT_SIZE, FW_SEMIBOLD, OPTIONS_COLOR);
 	} else {
 		PaintBitmap(pDC, pGamePalette, pLocaleBitmap, TIME_LOCATION_X, TIME_LOCATION_Y);
 	}
 
 	EndPaint(&lpPaint);
-	(*pDC).SelectPalette(pPalOld, false);                                            // Select back old palette
+	pDC->SelectPalette(pPalOld, false);                                            // Select back old palette
 	ReleaseDC(pDC);                                                                 // Release the DC
 
 	if (bStartOkay && (bGameStarted == false)) {
@@ -321,12 +321,12 @@ void CMainWindow::SplashScratch() {
 	CPalette    *pPalOld = nullptr;                                                    // Old palette holder
 
 	pDC = GetDC();                                                                  // Get screen DC
-	pPalOld = (*pDC).SelectPalette(pGamePalette, false);                            // Select Game Palette
-	(*pDC).RealizePalette();                                                        // Use it
+	pPalOld = pDC->SelectPalette(pGamePalette, false);                            // Select Game Palette
+	pDC->RealizePalette();                                                        // Use it
 
 	pDC->BitBlt(SIDE_BORDER, TOP_BORDER, ART_WIDTH, ART_HEIGHT, pScratch2DC, 0, 0, SRCCOPY);     // Draw Scratch2
 
-	(*pDC).SelectPalette(pPalOld, false);                                                // Select back old palette
+	pDC->SelectPalette(pPalOld, false);                                                // Select back old palette
 	ReleaseDC(pDC);                                                                     // Release the DC
 
 	pScratch1DC->BitBlt(0, 0, ART_WIDTH, ART_HEIGHT, pScratch2DC, 0, 0, SRCCOPY);        // Copy New parts locations
@@ -346,8 +346,8 @@ void CMainWindow::SplashScratchPaint() {
 	             *pOldBmp = nullptr;
 
 	pDC = GetDC();
-	pOldPalScreen = (*pDC).SelectPalette(pGamePalette, false);                            // Select Game Palette
-	(*pDC).RealizePalette();                                                        // Use it
+	pOldPalScreen = pDC->SelectPalette(pGamePalette, false);                            // Select Game Palette
+	pDC->RealizePalette();                                                        // Use it
 
 	if (bFramed) {
 		pSourceDC = new CDC();
@@ -364,12 +364,12 @@ void CMainWindow::SplashScratchPaint() {
 			return;
 		}
 
-		(*pSourceDoc).OpenDocument(szCurrentArt);
+		pSourceDoc->OpenDocument(szCurrentArt);
 
 		pOldPalSource = pSourceDC->SelectPalette(pGamePalette, false);
 		pSourceDC->RealizePalette();
 
-		hDIB = (*pSourceDoc).GetHDIB();
+		hDIB = pSourceDoc->GetHDIB();
 
 		if (hDIB) {
 			rcDest.SetRect(0, 0, ART_WIDTH + (2 * FRAME_WIDTH), ART_HEIGHT + (2 * FRAME_HEIGHT));
@@ -392,7 +392,7 @@ void CMainWindow::SplashScratchPaint() {
 				rcDIB.top = 0;
 				rcDIB.bottom = cyDIB;
 			}
-			PaintDIB((*pSourceDC).m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
+			PaintDIB(pSourceDC->m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
 			pSourceDC->BitBlt(FRAME_WIDTH, FRAME_HEIGHT, ART_WIDTH, ART_HEIGHT,      // Copy the Scrambled art to
 			                  pScratch2DC, 0, 0, SRCCOPY);                            //... the Frame + Art bitmap
 			pDC->BitBlt(SIDE_BORDER - FRAME_WIDTH, TOP_BORDER - FRAME_HEIGHT,            // Copy the Frame + Scrambled
@@ -419,7 +419,7 @@ void CMainWindow::SplashScratchPaint() {
 
 	}                                                                                               //...on screen
 
-	(*pDC).SelectPalette(pOldPalScreen, false);                                                  // Select back old palette
+	pDC->SelectPalette(pOldPalScreen, false);                                                  // Select back old palette
 	ReleaseDC(pDC);
 
 	pScratch1DC->BitBlt(0, 0, ART_WIDTH, ART_HEIGHT, pScratch2DC, 0, 0, SRCCOPY);        // Copy New parts locations
@@ -448,7 +448,7 @@ void CMainWindow::SplashScreen() {
 		rcDIB.top = rcDIB.left = 0;
 		rcDIB.right = cxDIB;
 		rcDIB.bottom = cyDIB;
-		PaintDIB((*pDC).m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
+		PaintDIB(pDC->m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
 	}
 	ReleaseDC(pDC);
 }
@@ -487,23 +487,23 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 			CSound::waitWaveSounds();
 
 			m_bIgnoreScrollClick = true;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 
 			RulesDlg.DoModal();
 			m_bIgnoreScrollClick = false;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 			break;
 
 		case IDC_SCROLL:
 
 			KillTimer(DISPLAY_TIMER);                                // Stop the Displayed Time timer
 			if (m_bIgnoreScrollClick) {
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 				break;
 			}
 
 			m_bIgnoreScrollClick = true;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 			SendDlgItemMessage(IDC_SCROLL, BM_SETSTATE, true, 0L);
 			m_bPlaying = false;                                     // Not playing the game
 			bSwitched = false;                                      // Prevent ability to Undo after Command is done
@@ -511,22 +511,22 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 			CheckForWin();                                          // Get current score
 
 			if (bGameStarted) {
-				pPalOld = (*pDC).SelectPalette(pGamePalette, false);    // Select in the artwork's palette
-				(*pDC).RealizePalette();                                // Use it
+				pPalOld = pDC->SelectPalette(pGamePalette, false);    // Select in the artwork's palette
+				pDC->RealizePalette();                                // Use it
 
 				pBrushNew = new CBrush();                               // Construct a new brush object
 				if (pBrushNew != nullptr) {                                 // If the constructor was successful:
 					pBrushNew->CreateSolidBrush(PALETTERGB(128, 0, 0));           // Create my backdrop color brush
-					pBrushOld = (*pDC).SelectObject(pBrushNew);                  // Select into the DC my new brush
+					pBrushOld = pDC->SelectObject(pBrushNew);                  // Select into the DC my new brush
 					pDC->SetROP2(R2_COPYPEN);                                    // Set Draw mode to use the pen color
 					if (bFramed)
-						(*pDC).Rectangle(SIDE_BORDER - FRAME_WIDTH, TOP_BORDER - FRAME_HEIGHT,
+						pDC->Rectangle(SIDE_BORDER - FRAME_WIDTH, TOP_BORDER - FRAME_HEIGHT,
 						                 GAME_WIDTH - (SIDE_BORDER - FRAME_WIDTH),
 						                 GAME_HEIGHT - (BOTTOM_BORDER - FRAME_HEIGHT));
 					else
-						(*pDC).Rectangle(SIDE_BORDER, TOP_BORDER, GAME_WIDTH - SIDE_BORDER, GAME_HEIGHT - BOTTOM_BORDER);
-					(*pDC).SelectObject(pBrushOld);                          // Select in the old brush
-					(*pDC).SelectPalette(pPalOld, false);                        // Select in the old palette
+						pDC->Rectangle(SIDE_BORDER, TOP_BORDER, GAME_WIDTH - SIDE_BORDER, GAME_HEIGHT - BOTTOM_BORDER);
+					pDC->SelectObject(pBrushOld);                          // Select in the old brush
+					pDC->SelectPalette(pPalOld, false);                        // Select in the old palette
 					delete pBrushNew;                                           // Delete the new brush
 				}
 			} // end if bGameStarted
@@ -536,7 +536,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 			switch (COptionsWind.DoModal()) {
 
 			case IDC_OPTIONS_NEWGAME:                           // Selected New Game
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				m_bIgnoreScrollClick = false;
 				if (!pGameInfo->bPlayingMetagame)
 					NewGame();
@@ -545,7 +545,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 				break;
 
 			case IDC_OPTIONS_RETURN:
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				m_bIgnoreScrollClick = false;
 				m_bPlaying = true;
 				if (bGameStarted && (m_nTime != (nSeconds + (nMinutes * 60)))) {     // have started
@@ -572,18 +572,18 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 				}
 				if (pGameSound != nullptr) {
 					if (!pGameSound->playing())
-						(*pGameSound).midiLoopPlaySegment(2300, 32000, 0, FMT_MILLISEC);
+						pGameSound->midiLoopPlaySegment(2300, 32000, 0, FMT_MILLISEC);
 				} // end if pGameSound
 			}
 
-			(*pDC).SelectPalette(pPalOld, false);
+			pDC->SelectPalette(pPalOld, false);
 			InvalidateRect(nullptr, false);            // force a redraw of the entire window
 			//...and stop any other WM_PAINT messages
 		} //end switch(wParam)
 
 		ReleaseDC(pDC);
 	} // end if
-	(*this).SetFocus();                     // Reset focus back to the main window
+	(this)->SetFocus();                     // Reset focus back to the main window
 	return true;
 }
 
@@ -668,7 +668,7 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 					pEffect = new CSound((CWnd *)this, WIN_SOUND,
 					                     SOUND_WAVE | SOUND_ASYNCH |
 					                     SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
-					(*pEffect).play();                                                      //...play the narration
+					pEffect->play();                                                      //...play the narration
 				}
 				MSG lpmsg;
 				while (PeekMessage(&lpmsg, nullptr, WM_MOUSEFIRST, WM_MOUSELAST, PM_REMOVE | PM_NOYIELD)) ;
@@ -686,7 +686,7 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 					pEffect = new CSound((CWnd *)this, SWITCH_SOUND,
 					                     SOUND_WAVE | SOUND_ASYNCH |
 					                     SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
-					(*pEffect).play();                                                      //...play the narration
+					pEffect->play();                                                      //...play the narration
 				} // end if pGameInfo->bSoundEffectsEnabled
 			} // end else
 		}// end else if (m_bFirst)
@@ -745,7 +745,7 @@ void CMainWindow::OnLButtonUp(unsigned int nFlags, CPoint point) {
 					pEffect = new CSound((CWnd *)this, PICK_SOUND,
 					                     SOUND_WAVE | SOUND_ASYNCH |
 					                     SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
-					(*pEffect).play();                                                      //...play the narration
+					pEffect->play();                                                      //...play the narration
 				}
 
 				Center.x = First.x + SIDE_BORDER + (OldRect.Width() / 2); // Center is in Screen coords
@@ -948,7 +948,7 @@ void CMainWindow::OnRButtonDown(unsigned int nFlags, CPoint point) {
 				pEffect = new CSound((CWnd *)this, UNDO_SOUND,
 				                     SOUND_WAVE | SOUND_ASYNCH |
 				                     SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
-				(*pEffect).play();                                                      //...play the narration
+				pEffect->play();                                                      //...play the narration
 			}
 
 			if (m_bFirst) {                              // Deselect area
@@ -1097,7 +1097,7 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 		else {
 			Common::sprintf_s(msg, "Time Left: %02d:%02d", nMinutes, nSeconds);
 		}
-		(*m_pTimeText).DisplayString(pDC, msg, FONT_SIZE, FW_SEMIBOLD, OPTIONS_COLOR);
+		m_pTimeText->DisplayString(pDC, msg, FONT_SIZE, FW_SEMIBOLD, OPTIONS_COLOR);
 
 		if (nMinutes == 0 && nSeconds == 0) {
 			char buf[64];
@@ -1110,7 +1110,7 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 				pEffect = new CSound((CWnd *)this, LOSE_SOUND,
 				                     SOUND_WAVE | SOUND_ASYNCH |
 				                     SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
-				(*pEffect).play();                                          //...play the narration
+				pEffect->play();                                          //...play the narration
 			}
 			CheckForWin();                              // Update the score
 			MSG lpmsg;
@@ -1403,11 +1403,11 @@ bool CMainWindow::LoadArtWork() {
 	Common::sprintf_s(bufName, "art\\%s", ArtName);
 	Common::sprintf_s(szCurrentArt, "%s", bufName);                  // copy to a global for use in OnPaint
 
-	(*pSourceDoc).OpenDocument(bufName);
+	pSourceDoc->OpenDocument(bufName);
 
 	// Acquire the shared palette for our game from the art
 	if (!pGamePalette) {
-		pGamePalette = (*pSourceDoc).DetachPalette();
+		pGamePalette = pSourceDoc->DetachPalette();
 	} else {
 		// WORKAROUND: Keep a single pGamePalette, since there
 		// are UI elements that have pointers to it
@@ -1427,7 +1427,7 @@ bool CMainWindow::LoadArtWork() {
 		pSourceDC->RealizePalette();
 	}
 
-	hDIB = (*pSourceDoc).GetHDIB();
+	hDIB = pSourceDoc->GetHDIB();
 
 	if (hDIB) {
 		if (bFramed)
@@ -1454,11 +1454,11 @@ bool CMainWindow::LoadArtWork() {
 			rcDIB.bottom = cyDIB;
 		}
 		if (bFramed) {
-			PaintDIB((*pSourceDC).m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
+			PaintDIB(pSourceDC->m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
 			pScratch1DC->BitBlt(0, 0, ART_WIDTH, ART_HEIGHT, pSourceDC,
 			                    FRAME_WIDTH, FRAME_HEIGHT, SRCCOPY);
 		} else {
-			PaintDIB((*pScratch1DC).m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
+			PaintDIB(pScratch1DC->m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
 
 		}
 	}
@@ -1602,24 +1602,24 @@ void CMainWindow::NewGame() {
 
 	pDC = GetDC();
 
-	pPalOld = (*pDC).SelectPalette(pGamePalette, false);            // Select in the artwork's palette
-	(*pDC).RealizePalette();                                        // Use it
+	pPalOld = pDC->SelectPalette(pGamePalette, false);            // Select in the artwork's palette
+	pDC->RealizePalette();                                        // Use it
 
 	PaintBitmap(pDC, pGamePalette, pLocaleBitmap, TIME_LOCATION_X, TIME_LOCATION_Y);
 
 	pBrushNew = new CBrush();                                       // Construct a new brush object
 	if (pBrushNew != nullptr) {                                         // If the constructor was successful:
 		pBrushNew->CreateSolidBrush(PALETTERGB(128, 0, 0));           // Create my backdrop color brush
-		pBrushOld = (*pDC).SelectObject(pBrushNew);                  // Select into the DC my new brush
+		pBrushOld = pDC->SelectObject(pBrushNew);                  // Select into the DC my new brush
 		pDC->SetROP2(R2_COPYPEN);                                    // Set Draw mode to use the pen color
 		if (bFramed)
-			(*pDC).Rectangle(SIDE_BORDER - FRAME_WIDTH, TOP_BORDER - FRAME_HEIGHT,
+			pDC->Rectangle(SIDE_BORDER - FRAME_WIDTH, TOP_BORDER - FRAME_HEIGHT,
 			                 GAME_WIDTH - (SIDE_BORDER - FRAME_WIDTH),
 			                 GAME_HEIGHT - (BOTTOM_BORDER - FRAME_HEIGHT));
 		else
-			(*pDC).Rectangle(SIDE_BORDER, TOP_BORDER, GAME_WIDTH - SIDE_BORDER, GAME_HEIGHT - BOTTOM_BORDER);
-		(*pDC).SelectObject(pBrushOld);                          // Select in the old brush
-		(*pDC).SelectPalette(pPalOld, false);                        // Select in the old palette
+			pDC->Rectangle(SIDE_BORDER, TOP_BORDER, GAME_WIDTH - SIDE_BORDER, GAME_HEIGHT - BOTTOM_BORDER);
+		pDC->SelectObject(pBrushOld);                          // Select in the old brush
+		pDC->SelectPalette(pPalOld, false);                        // Select in the old palette
 		delete pBrushNew;                                           // Delete the new brush
 	}
 	m_bNewGame = true;
@@ -1639,11 +1639,11 @@ void CMainWindow::NewGame() {
 	else {
 		Common::sprintf_s(msg, "Time Left: %02d:%02d", nMinutes, nSeconds);
 	}
-	(*m_pTimeText).DisplayString(pDC, msg, FONT_SIZE, FW_SEMIBOLD, OPTIONS_COLOR);
+	m_pTimeText->DisplayString(pDC, msg, FONT_SIZE, FW_SEMIBOLD, OPTIONS_COLOR);
 
 	EndWaitCursor();
 
-	(*pDC).SelectPalette(pPalOld, false);
+	pDC->SelectPalette(pPalOld, false);
 	ReleaseDC(pDC);
 
 	InvalidateRect(nullptr, false);                                     // force a redraw of the entire window
@@ -1787,8 +1787,8 @@ void CMainWindow::MyFocusRect(CDC *pDC, CRect rect, int nDrawMode) {
 	pMyBrush->CreateBrushIndirect(&lb);              // Create a new brush
 	pMyPen->CreatePen(PS_INSIDEFRAME, HILITE_BORDER, RGB(255, 255, 255));    // Create a new pen
 
-	pPalOld = (*pDC).SelectPalette(pGamePalette, false);     // Select in game palette
-	(*pDC).RealizePalette();                                // Use it
+	pPalOld = pDC->SelectPalette(pGamePalette, false);     // Select in game palette
+	pDC->RealizePalette();                                // Use it
 	pOldPen = pDC->SelectObject(pMyPen);         // Select the new pen & save old
 	pOldBrush = pDC->SelectObject(pMyBrush);     // Select the new brush & save old
 	OldDrawMode = pDC->SetROP2(nDrawMode);       // Set pen mode, saving old state
@@ -1796,7 +1796,7 @@ void CMainWindow::MyFocusRect(CDC *pDC, CRect rect, int nDrawMode) {
 	pDC->SelectObject(pOldPen);                  // Select the old pen
 	pDC->SelectObject(pOldBrush);                // Select the old brush
 	pDC->SetROP2(OldDrawMode);                   // Set pen mode back to old state
-	(*pDC).SelectPalette(pPalOld, false);           // Select back the old palette
+	pDC->SelectPalette(pPalOld, false);           // Select back the old palette
 
 	pMyBrush->DeleteObject();
 	delete pMyBrush;
@@ -1860,7 +1860,7 @@ void CMainWindow::OnClose() {
 	pDC = GetDC();
 	myRect.SetRect(0, 0, GAME_WIDTH, GAME_HEIGHT);
 	myBrush.CreateStockObject(BLACK_BRUSH);
-	(*pDC).FillRect(&myRect, &myBrush);
+	pDC->FillRect(&myRect, &myBrush);
 	ReleaseDC(pDC);
 
 	// delete the game theme song

--- a/engines/bagel/hodjnpodj/artparts/optndlg.cpp
+++ b/engines/bagel/hodjnpodj/artparts/optndlg.cpp
@@ -121,12 +121,12 @@ bool COptnDlg::OnInitDialog() {
 
 	statRect.SetRect(LEFT_SIDE, 45, LEFT_SIDE + 100, 60);
 	if ((m_pPartsText = new CText()) != nullptr) {
-		(*m_pPartsText).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pPartsText->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	statRect.SetRect(LEFT_SIDE, 65, LEFT_SIDE + 100, 80);
 	if ((m_pColumnText = new CText()) != nullptr) {
-		(*m_pColumnText).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pColumnText->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	m_ScrollColumns.SetScrollRange(0, nCFacs - 1, 0);   // Array starts at zero, so
@@ -137,7 +137,7 @@ bool COptnDlg::OnInitDialog() {
 
 	statRect.SetRect(LEFT_SIDE, 99, LEFT_SIDE + 100, 114);
 	if ((m_pRowText = new CText()) != nullptr) {
-		(*m_pRowText).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pRowText->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	m_ScrollRows.SetScrollRange(0, nRFacs - 1, 0);       //...last element is Max - 1
@@ -150,7 +150,7 @@ bool COptnDlg::OnInitDialog() {
 
 	statRect.SetRect(LEFT_SIDE, 132, LEFT_SIDE + 100, 146);
 	if ((m_pTimerText = new CText()) != nullptr) {
-		(*m_pTimerText).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pTimerText->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	m_ScrollTime.SetScrollRange(TIMER_START, TIMER_MAX - 1, 0);
@@ -165,18 +165,18 @@ bool COptnDlg::OnInitDialog() {
 	statRect.SetRect(155, 45, 205, 60);
 
 	if ((pOKButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pOKButton).SetPalette(pSubOptionsPalette);                        // set the palette to use
-		(*pOKButton).SetControl(IDOK, this);            // tie to the dialog control
+		pOKButton->SetPalette(pSubOptionsPalette);                        // set the palette to use
+		pOKButton->SetControl(IDOK, this);            // tie to the dialog control
 	}
 
 	if ((pCancelButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pCancelButton).SetPalette(pSubOptionsPalette);                        // set the palette to use
-		(*pCancelButton).SetControl(IDCANCEL, this);            // tie to the dialog control
+		pCancelButton->SetPalette(pSubOptionsPalette);                        // set the palette to use
+		pCancelButton->SetControl(IDCANCEL, this);            // tie to the dialog control
 	}
 
 	if ((pFramedButton = new CCheckButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pFramedButton).SetPalette(pSubOptionsPalette);                        // set the palette to use
-		(*pFramedButton).SetControl(IDC_FRAMED, this);              // tie to the dialog control
+		pFramedButton->SetPalette(pSubOptionsPalette);                        // set the palette to use
+		pFramedButton->SetControl(IDC_FRAMED, this);              // tie to the dialog control
 	}
 	((CWnd *)this)->CheckDlgButton(IDC_FRAMED, m_bFramed);           // Set the frame option box
 
@@ -226,7 +226,7 @@ void COptnDlg::OnHScroll(unsigned int nSBCode, unsigned int nPos, CScrollBar* pS
 	if (NewPos > pMax) NewPos = pMax;
 
 	if (NewPos != OldPos) {                              //To prevent "flicker"
-		(*pScrollBar).SetScrollPos(NewPos, true);        //...only update when
+		pScrollBar->SetScrollPos(NewPos, true);        //...only update when
 	}                                                   //...changed
 
 	UpdateScrollbars();
@@ -279,28 +279,28 @@ void COptnDlg::UpdateScrollbars() {
 
 			Common::sprintf_s(msg, "Time Limit: %02d:%02d", nMins, nSecs);
 		}
-		(*m_pTimerText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+		m_pTimerText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 	}
 
 	OldValue = m_nColumns;
 	m_nColumns = m_nColumnFactors[m_ScrollColumns.GetScrollPos()];
 	if (OldValue != m_nColumns) {
 		Common::sprintf_s(msg, "Columns: %d", m_nColumns);
-		(*m_pColumnText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+		m_pColumnText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 	}
 
 	OldValue = m_nRows;
 	m_nRows = m_nRowFactors[m_ScrollRows.GetScrollPos()];
 	if (OldValue != m_nRows) {
 		Common::sprintf_s(msg, "Rows: %d", m_nRows);
-		(*m_pRowText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+		m_pRowText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 	}
 
 	OldValue = m_nNumParts;
 	m_nNumParts = m_nColumns * m_nRows;
 	if (OldValue != m_nNumParts) {
 		Common::sprintf_s(msg, "Parts: %d", m_nNumParts);
-		(*m_pPartsText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+		m_pPartsText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 	}
 
 	ReleaseDC(pDC);
@@ -333,13 +333,13 @@ void COptnDlg::OnPaint() {
 	pDC = GetDC();
 
 	Common::sprintf_s(msg, "Parts: %d", m_nNumParts);
-	(*m_pPartsText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+	m_pPartsText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 
 	Common::sprintf_s(msg, "Columns: %d", m_nColumns);
-	(*m_pColumnText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+	m_pColumnText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 
 	Common::sprintf_s(msg, "Rows: %d", m_nRows);
-	(*m_pRowText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+	m_pRowText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 
 	if (m_nTime == m_nTimeScale[TIMER_MAX - 1])
 		Common::sprintf_s(msg, "Time Limit: None");
@@ -348,7 +348,7 @@ void COptnDlg::OnPaint() {
 		nSecs = m_nTime % 60;
 		Common::sprintf_s(msg, "Time Limit: %02d:%02d", nMins, nSecs);
 	}
-	(*m_pTimerText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+	m_pTimerText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 
 	ReleaseDC(pDC);
 

--- a/engines/bagel/hodjnpodj/barbershop/animate.cpp
+++ b/engines/bagel/hodjnpodj/barbershop/animate.cpp
@@ -59,11 +59,11 @@ bool CAnimate::Clown(CDC *pDC, CPoint point) {
 		return false;
 
 	m_pSprite = new CSprite;
-	(*m_pSprite).SharePalette(pGamePalette);
-	bSuccess = (*m_pSprite).LoadCels(pDC, CLOWN_BMP, CLOWN_FRAMES);
+	m_pSprite->SharePalette(pGamePalette);
+	bSuccess = m_pSprite->LoadCels(pDC, CLOWN_BMP, CLOWN_FRAMES);
 	ASSERT(bSuccess);
-	(*m_pSprite).SetMasked(false);
-	(*m_pSprite).SetMobile(false);
+	m_pSprite->SetMasked(false);
+	m_pSprite->SetMobile(false);
 
 	if (pGameParams->bSoundEffectsEnabled != false) {
 		m_pSound->initialize(
@@ -74,9 +74,9 @@ bool CAnimate::Clown(CDC *pDC, CPoint point) {
 	} // end if
 
 	if (bSuccess == true) {
-		(*m_pSprite).SetCel(CLOWN_FRAMES);
+		m_pSprite->SetCel(CLOWN_FRAMES);
 		for (i = 0; i < CLOWN_FRAMES - 1; i++) {
-			(*m_pSprite).PaintSprite(
+			m_pSprite->PaintSprite(
 			    pDC,
 			    m_cClownRect.TopLeft()
 			);
@@ -100,11 +100,11 @@ bool CAnimate::UFO(CDC *pDC, CPoint point) {
 		return false;
 
 	m_pSprite = new CSprite;
-	(*m_pSprite).SharePalette(pGamePalette);
-	bSuccess = (*m_pSprite).LoadCels(pDC, UFOA_BMP, UFOA_FRAMES);
+	m_pSprite->SharePalette(pGamePalette);
+	bSuccess = m_pSprite->LoadCels(pDC, UFOA_BMP, UFOA_FRAMES);
 	ASSERT(bSuccess);
-	(*m_pSprite).SetMasked(false);
-	(*m_pSprite).SetMobile(false);
+	m_pSprite->SetMasked(false);
+	m_pSprite->SetMobile(false);
 
 	if (pGameParams->bSoundEffectsEnabled != false) {
 		m_pSound->initialize(
@@ -116,10 +116,10 @@ bool CAnimate::UFO(CDC *pDC, CPoint point) {
 
 	if (bSuccess == true) {
 		int j;
-		(*m_pSprite).SetCel(UFOA_FRAMES);
+		m_pSprite->SetCel(UFOA_FRAMES);
 
 		for (i = 0; i < 8; i++) {
-			(*m_pSprite).PaintSprite(
+			m_pSprite->PaintSprite(
 			    pDC,
 			    m_cUFORect.TopLeft()
 			);
@@ -141,7 +141,7 @@ bool CAnimate::UFO(CDC *pDC, CPoint point) {
 		} // end if
 
 		for (j = i; j < UFOA_FRAMES - 1; j++) {
-			(*m_pSprite).PaintSprite(
+			m_pSprite->PaintSprite(
 			    pDC,
 			    m_cUFORect.TopLeft()
 			);
@@ -151,10 +151,10 @@ bool CAnimate::UFO(CDC *pDC, CPoint point) {
 
 	Sleep(UFO_PAUSE);                                    // pause for a few seconds between animations
 
-	bSuccess = (*m_pSprite).LoadCels(pDC, UFOB_BMP, UFOB_FRAMES);
+	bSuccess = m_pSprite->LoadCels(pDC, UFOB_BMP, UFOB_FRAMES);
 	ASSERT(bSuccess);
-	(*m_pSprite).SetMasked(false);
-	(*m_pSprite).SetMobile(false);
+	m_pSprite->SetMasked(false);
+	m_pSprite->SetMobile(false);
 
 	if (pGameParams->bSoundEffectsEnabled != false) {
 		m_pSound->initialize(
@@ -166,10 +166,10 @@ bool CAnimate::UFO(CDC *pDC, CPoint point) {
 
 	if (bSuccess == true) {
 		int j;
-		(*m_pSprite).SetCel(UFOB_FRAMES);
+		m_pSprite->SetCel(UFOB_FRAMES);
 
 		for (i = 0; i < 9; i++) {
-			(*m_pSprite).PaintSprite(
+			m_pSprite->PaintSprite(
 			    pDC,
 			    m_cUFORect.TopLeft()
 			);
@@ -191,7 +191,7 @@ bool CAnimate::UFO(CDC *pDC, CPoint point) {
 		} // end if
 
 		for (j = i; j < UFOB_FRAMES - 1; j++) {
-			(*m_pSprite).PaintSprite(
+			m_pSprite->PaintSprite(
 			    pDC,
 			    m_cUFORect.TopLeft()
 			);

--- a/engines/bagel/hodjnpodj/barbershop/barb.cpp
+++ b/engines/bagel/hodjnpodj/barbershop/barb.cpp
@@ -628,13 +628,13 @@ void CBarber::OnLButtonUp(CWnd *pWnd) {
 	/*************************
 	* Update visual display. *
 	*************************/
-	pDC = (*pWnd).GetDC();
+	pDC = pWnd->GetDC();
 	if (bSuccess != true) {                                  // card dropped over stack?
 		m_cPnt->UpdateCard(pDC, m_pCrd);                    // no - redraw card over original stack
 	} else {
 		m_cPnt->Stack(pDC, m_pCrd);                         // draw card apro stack
 	} // end if
-	(*pWnd).ReleaseDC(pDC);
+	pWnd->ReleaseDC(pDC);
 
 	m_pCrd = nullptr;                                          // clear current card
 	if (m_cBrd->GetStack(stock)->IsEmpty() == true)

--- a/engines/bagel/hodjnpodj/barbershop/jay.cpp
+++ b/engines/bagel/hodjnpodj/barbershop/jay.cpp
@@ -43,8 +43,8 @@ void MyFocusRect(CDC *pDC, CRect rect, int nDrawMode) {
 	pMyBrush->CreateBrushIndirect(&lb);              // Create a new brush
 	pMyPen->CreatePen(PS_INSIDEFRAME, HILITE_BORDER, RGBCOLOR_DARKRED);      // Create a new pen
 
-	pPalOld = (*pDC).SelectPalette(pGamePalette, false);     // Select in game palette
-	(*pDC).RealizePalette();                                // Use it
+	pPalOld = pDC->SelectPalette(pGamePalette, false);     // Select in game palette
+	pDC->RealizePalette();                                // Use it
 	pOldPen = pDC->SelectObject(pMyPen);         // Select the new pen & save old
 	pOldBrush = pDC->SelectObject(pMyBrush);     // Select the new brush & save old
 	OldDrawMode = pDC->SetROP2(nDrawMode);       // Set pen mode, saving old state
@@ -52,7 +52,7 @@ void MyFocusRect(CDC *pDC, CRect rect, int nDrawMode) {
 	pDC->SelectObject(pOldPen);                  // Select the old pen
 	pDC->SelectObject(pOldBrush);                // Select the old brush
 	pDC->SetROP2(OldDrawMode);                   // Set pen mode back to old state
-	(*pDC).SelectPalette(pPalOld, false);           // Select back the old palette
+	pDC->SelectPalette(pPalOld, false);           // Select back the old palette
 
 	pMyBrush->DeleteObject();
 	delete pMyBrush;

--- a/engines/bagel/hodjnpodj/barbershop/paint.cpp
+++ b/engines/bagel/hodjnpodj/barbershop/paint.cpp
@@ -88,12 +88,12 @@ CPaint::CPaint(CDC *pDC) {
 			ASSERT(pCard);
 
 			m_cCardSet[(i * CARDS_PER_ROW) + j] = new OSpr();   // Initize the individual letter of the alphabet list
-			bSuccess = (*m_cCardSet[(i * CARDS_PER_ROW) + j]).LoadSprite(pCard, pGamePalette);
+			bSuccess = m_cCardSet[(i * CARDS_PER_ROW) + j]->LoadSprite(pCard, pGamePalette);
 			ASSERT(bSuccess);
 
-			(*m_cCardSet[(i * CARDS_PER_ROW) + j]).SetHotspot(CARD_HOT_X, CARD_HOT_Y);
-			(*m_cCardSet[(i * CARDS_PER_ROW) + j]).SetMobile(true);
-			(*m_cCardSet[(i * CARDS_PER_ROW) + j]).SetMasked(true);
+			m_cCardSet[(i * CARDS_PER_ROW) + j]->SetHotspot(CARD_HOT_X, CARD_HOT_Y);
+			m_cCardSet[(i * CARDS_PER_ROW) + j]->SetMobile(true);
+			m_cCardSet[(i * CARDS_PER_ROW) + j]->SetMasked(true);
 		}  // end for
 
 		delete pBmpCardSet;
@@ -209,13 +209,13 @@ void CPaint::Board(CDC *pDC, CBoard *pBoard) {
 		if (pCard[j] == pCard[j]->m_pStack->Top()) {
 			m_cCardSet[pCard[j]->GetValue()]->DuplicateSprite(pDC, (CSprite*) m_pSprite);
 			m_pSprite->m_cCard = pCard[j];
-			(*m_pSprite).LinkSprite();
+			m_pSprite->LinkSprite();
 
 			pCard[j]->m_bIsBack = false;
 		} else {
 			m_cCardSet[m_nCardBack]->DuplicateSprite(pDC, (CSprite*) m_pSprite);
 			m_pSprite->m_cCard = pCard[j];
-			(*m_pSprite).LinkSprite();
+			m_pSprite->LinkSprite();
 
 			pCard[j]->m_bIsBack = true;
 		} // end if
@@ -233,7 +233,7 @@ void CPaint::Board(CDC *pDC, CBoard *pBoard) {
 	while (pCard[0] != nullptr) {
 		m_pSprite = new OSpr();             // set up visual sprite
 		m_cCardSet[m_nCardBack]->DuplicateSprite(pDC, (CSprite*) m_pSprite);
-		(*m_pSprite).LinkSprite();
+		m_pSprite->LinkSprite();
 
 		m_pSprite->m_cCard  = pCard[0];     // update internal card struct
 		pCard[0]->m_pSprite = m_pSprite;
@@ -338,10 +338,10 @@ void CPaint::FlipCard(CDC *pDC, CCard *pCard) {
 	******************************************************************/
 	pCard->m_pSprite = new OSpr();
 	if (pCard->m_bIsBack == true) {
-		(*m_cCardSet[pCard->GetValue()]).DuplicateSprite(pDC, (CSprite*) pCard->m_pSprite);
+		m_cCardSet[pCard->GetValue()]->DuplicateSprite(pDC, (CSprite*) pCard->m_pSprite);
 		pCard->m_bIsBack = false;
 	} else {
-		(*m_cCardSet[m_nCardBack]).DuplicateSprite(pDC, (CSprite*) pCard->m_pSprite);
+		m_cCardSet[m_nCardBack]->DuplicateSprite(pDC, (CSprite*) pCard->m_pSprite);
 		pCard->m_bIsBack = true;
 	}
 
@@ -508,7 +508,7 @@ void CPaint::ChangeBack(CDC *pDC, CBoard *pBoard, int nBack) {
 			delete pCard->m_pSprite;
 
 			pCard->m_pSprite = new OSpr();
-			(*m_cCardSet[m_nCardBack]).DuplicateSprite(pDC, (CSprite*) pCard->m_pSprite);
+			m_cCardSet[m_nCardBack]->DuplicateSprite(pDC, (CSprite*) pCard->m_pSprite);
 			pCard->m_pSprite->LinkSprite();
 			pCard->m_pSprite->SetPosition(pCard->m_cOrigin);
 			pCard->m_pSprite->m_cCard = pCard;                      // update internal rep

--- a/engines/bagel/hodjnpodj/barbershop/usercfg.cpp
+++ b/engines/bagel/hodjnpodj/barbershop/usercfg.cpp
@@ -68,13 +68,13 @@ bool CUserCfgDlg::OnInitDialog() {
 		bool    bAssertCheck;
 
 		tmpRect.SetRect(TEXT_LEFT, TEXT_TOP, TEXT_RIG, TEXT_BOT);
-		bAssertCheck = (*m_ctextBox).SetupText(pDC, pGamePalette, &tmpRect, JUSTIFY_CENTER);
+		bAssertCheck = m_ctextBox->SetupText(pDC, pGamePalette, &tmpRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	} // end if
 
 	if ((m_pOKButton = new CColorButton) != nullptr) {     // build a color OK button
-		(*m_pOKButton).SetPalette(pGamePalette);        // set the palette to use
-		(*m_pOKButton).SetControl(IDOK, this);          // tie to the dialog control
+		m_pOKButton->SetPalette(pGamePalette);        // set the palette to use
+		m_pOKButton->SetControl(IDOK, this);          // tie to the dialog control
 	} // end if
 
 	ReleaseDC(pDC);
@@ -99,7 +99,7 @@ void CUserCfgDlg::OnPaint() {
 	} // end if
 
 	Common::sprintf_s(msg, "Select a card back");   // top message
-	bAssertCheck = (*m_ctextBox).DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, RGBCOLOR_BLACK);
+	bAssertCheck = m_ctextBox->DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, RGBCOLOR_BLACK);
 	ASSERT(bAssertCheck);
 
 	ReleaseDC(pDC);
@@ -206,8 +206,8 @@ void CUserCfgDlg::MyFocusRect(CDC *pDC, CRect rect, int nDrawMode, COLORREF rgbC
 	pMyBrush->CreateBrushIndirect(&lb);              // Create a new brush
 	pMyPen->CreatePen(PS_INSIDEFRAME, DELTA, rgbColor); // Create a new pen
 
-	pPalOld = (*pDC).SelectPalette(pGamePalette, false);     // Select in game palette
-	(*pDC).RealizePalette();                                // Use it
+	pPalOld = pDC->SelectPalette(pGamePalette, false);     // Select in game palette
+	pDC->RealizePalette();                                // Use it
 
 	pOldPen = pDC->SelectObject(pMyPen);         // Select the new pen & save old
 	pOldBrush = pDC->SelectObject(pMyBrush);     // Select the new brush & save old
@@ -218,7 +218,7 @@ void CUserCfgDlg::MyFocusRect(CDC *pDC, CRect rect, int nDrawMode, COLORREF rgbC
 	pDC->SelectObject(pOldPen);                  // Select the old pen
 	pDC->SelectObject(pOldBrush);                // Select the old brush
 	pDC->SetROP2(OldDrawMode);                   // Set pen mode back to old state
-	(*pDC).SelectPalette(pPalOld, false);           // Select back the old palette
+	pDC->SelectPalette(pPalOld, false);           // Select back the old palette
 
 	pMyBrush->DeleteObject();
 	delete pMyBrush;

--- a/engines/bagel/hodjnpodj/battlefish/usercfg.cpp
+++ b/engines/bagel/hodjnpodj/battlefish/usercfg.cpp
@@ -93,18 +93,18 @@ bool CUserCfgDlg::OnInitDialog() {
 	}
 
 	if ((m_pOKButton = new CColorButton) != nullptr) {       // build a color QUIT button to let us exit
-		(*m_pOKButton).SetPalette(m_pPalette);            // set the palette to use
-		(*m_pOKButton).SetControl(IDOK, this);            // tie to the dialog control
+		m_pOKButton->SetPalette(m_pPalette);            // set the palette to use
+		m_pOKButton->SetControl(IDOK, this);            // tie to the dialog control
 	}
 
 	if ((m_pCancelButton = new CColorButton) != nullptr) {   // build a color QUIT button to let us exit
-		(*m_pCancelButton).SetPalette(m_pPalette);        // set the palette to use
-		(*m_pCancelButton).SetControl(IDCANCEL, this);    // tie to the dialog control
+		m_pCancelButton->SetPalette(m_pPalette);        // set the palette to use
+		m_pCancelButton->SetControl(IDCANCEL, this);    // tie to the dialog control
 	}
 
 	if ((m_pDefaultsButton = new CColorButton) != nullptr) { // build a color QUIT button to let us exit
-		(*m_pDefaultsButton).SetPalette(m_pPalette);      // set the palette to use
-		(*m_pDefaultsButton).SetControl(ID_RESET, this);  // tie to the dialog control
+		m_pDefaultsButton->SetPalette(m_pPalette);      // set the palette to use
+		m_pDefaultsButton->SetControl(ID_RESET, this);  // tie to the dialog control
 	}
 
 	if ((m_pUserButton = new CRadioButton) != nullptr) {

--- a/engines/bagel/hodjnpodj/beacon/beacon.cpp
+++ b/engines/bagel/hodjnpodj/beacon/beacon.cpp
@@ -160,9 +160,9 @@ CMainWindow::CMainWindow() {
 	ScrollRect.SetRect(SCROLL_BUTTON_X, SCROLL_BUTTON_Y,
 	                   SCROLL_BUTTON_X + SCROLL_BUTTON_DX - 1,
 	                   SCROLL_BUTTON_Y + SCROLL_BUTTON_DY - 1);
-	bSuccess = (*m_pScrollButton).Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, ScrollRect, this, IDC_SCROLL);
+	bSuccess = m_pScrollButton->Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, ScrollRect, this, IDC_SCROLL);
 	ASSERT(bSuccess);
-	bSuccess = (*m_pScrollButton).LoadBitmaps(pGamePalette, pScrollUp, pScrollDown, nullptr, nullptr);
+	bSuccess = m_pScrollButton->LoadBitmaps(pGamePalette, pScrollUp, pScrollDown, nullptr, nullptr);
 	pScrollUp = nullptr;
 	pScrollDown = nullptr;
 
@@ -209,9 +209,9 @@ CMainWindow::CMainWindow() {
 		colorBlock[i].nColorIndex = BUTTON_ENTRY + i;
 
 		pMyBrush = new CBrush();                        // Construct new brush
-		(*pMyBrush).CreateSolidBrush(PALETTEINDEX((uint16)(colorBlock[i].nColorIndex)));
+		pMyBrush->CreateSolidBrush(PALETTEINDEX((uint16)(colorBlock[i].nColorIndex)));
 
-		(*pArtDC).FillRect(colorBlock[i].rLocation, pMyBrush);
+		pArtDC->FillRect(colorBlock[i].rLocation, pMyBrush);
 
 		MyFocusRect(pArtDC, colorBlock[i].rLocation, false);     // standard highlight on button
 
@@ -226,15 +226,15 @@ CMainWindow::CMainWindow() {
 
 	statRect.SetRect(BLOCK_OFFSET_X + 5, TOP_BORDER + 5, GAME_WIDTH - SIDE_BORDER, TOP_BORDER + 25);
 	if ((m_pScoreTxt = new CText()) != nullptr) {
-		(*m_pScoreTxt).SetupText(pDC, pGamePalette, &statRect, JUSTIFY_LEFT);
+		m_pScoreTxt->SetupText(pDC, pGamePalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	statRect.SetRect(BLOCK_OFFSET_X + 5, TOP_BORDER + 25, GAME_WIDTH - SIDE_BORDER, TOP_BORDER + 45);
 	if ((m_pSweepTxt = new CText()) != nullptr) {
-		(*m_pSweepTxt).SetupText(pDC, pGamePalette, &statRect, JUSTIFY_LEFT);
+		m_pSweepTxt->SetupText(pDC, pGamePalette, &statRect, JUSTIFY_LEFT);
 	}
 
-	(*pDC).SelectPalette(pOldPal, false);           // Select back the old palette
+	pDC->SelectPalette(pOldPal, false);           // Select back the old palette
 	ReleaseDC(pDC);
 
 	//srand((unsigned) time(nullptr));         // seed the random number generator
@@ -243,7 +243,7 @@ CMainWindow::CMainWindow() {
 	if (pGameInfo->bMusicEnabled) {
 		pGameSound = new CSound(this, GAME_THEME, SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 		if (pGameSound != nullptr) {
-			(*pGameSound).midiLoopPlaySegment(1300, 36500, 0, FMT_MILLISEC);
+			pGameSound->midiLoopPlaySegment(1300, 36500, 0, FMT_MILLISEC);
 		} // end if pGameSound
 	}
 
@@ -301,8 +301,8 @@ void CMainWindow::OnPaint() {
 	char    msg[64];
 
 	pDC = GetDC();
-	pOldPal = (*pDC).SelectPalette(pGamePalette, false);
-	(*pDC).RealizePalette();
+	pOldPal = pDC->SelectPalette(pGamePalette, false);
+	pDC->RealizePalette();
 
 	InvalidateRect(nullptr, false);            // invalidate the entire window
 	BeginPaint(&lpPaint);
@@ -317,17 +317,17 @@ void CMainWindow::OnPaint() {
 	pDC->BitBlt(0, 0, GAME_WIDTH, GAME_HEIGHT, pArtDC, 0, 0, SRCCOPY);
 
 	Common::sprintf_s(msg, "Score: %.0f %%", m_Score);
-	(*m_pScoreTxt).DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
+	m_pScoreTxt->DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
 
 	if ((m_nSweeps < MAX_SWEEPS) && bPlaying)
 		Common::sprintf_s(msg, "Sweeps: %d", m_nSweepCount - 1);                     // Update text on screen
 	else
 		Common::sprintf_s(msg, "Sweeps: %d", m_nSweepCount);
-	(*m_pSweepTxt).DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
+	m_pSweepTxt->DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
 
 	EndPaint(&lpPaint);
 
-	(*pDC).SelectPalette(pOldPal, false);
+	pDC->SelectPalette(pOldPal, false);
 	ReleaseDC(pDC);
 }
 
@@ -347,8 +347,8 @@ void CMainWindow::DrawBeams(CDC *pDC) {
 	int     radius;
 	float   degrees, x, y, radians, rads;
 
-	pPalOld = (*pDC).SelectPalette(pGamePalette, false);     // Select in game palette
-	(*pDC).RealizePalette();                                // Use it
+	pPalOld = pDC->SelectPalette(pGamePalette, false);     // Select in game palette
+	pDC->RealizePalette();                                // Use it
 
 	pBigBmp = new CBitmap();
 	pBigDC = new CDC();
@@ -387,21 +387,21 @@ void CMainWindow::DrawBeams(CDC *pDC) {
 		StartPt.y = Center.y + (int)(y * radius);
 
 		pMyPen = new CPen();                            // Construct new pen
-		(*pMyPen).CreatePen(PS_SOLID, 1, PALETTEINDEX((uint16)(i + START_ENTRY)));
-		pOldPen = (*pBigDC).SelectObject(pMyPen);
+		pMyPen->CreatePen(PS_SOLID, 1, PALETTEINDEX((uint16)(i + START_ENTRY)));
+		pOldPen = pBigDC->SelectObject(pMyPen);
 		pMyBrush = new CBrush();                        // Construct new brush
-		(*pMyBrush).CreateSolidBrush(PALETTEINDEX((uint16)(i + START_ENTRY)));
-		pOldBrush = (*pBigDC).SelectObject(pMyBrush);
+		pMyBrush->CreateSolidBrush(PALETTEINDEX((uint16)(i + START_ENTRY)));
+		pOldBrush = pBigDC->SelectObject(pMyBrush);
 
-		(*pBigDC).Pie(&rect, StartPt, EndPt);
+		pBigDC->Pie(&rect, StartPt, EndPt);
 
-		(*pBigDC).SelectObject(pOldPen);
+		pBigDC->SelectObject(pOldPen);
 
 		pMyPen->DeleteObject();
 		delete pMyPen;
 		pMyPen = nullptr;
 
-		(*pBigDC).SelectObject(pOldBrush);
+		pBigDC->SelectObject(pOldBrush);
 
 		pMyBrush->DeleteObject();
 		delete pMyBrush;
@@ -414,8 +414,8 @@ void CMainWindow::DrawBeams(CDC *pDC) {
 		EndPt.y = Center.y + (int)(y * radius);
 	}
 
-	(*pDC).BitBlt(SIDE_BORDER, TOP_BORDER, ART_WIDTH, ART_HEIGHT, pBigDC, ART_WIDTH / 2, ART_HEIGHT / 2, SRCCOPY);
-	(*pDC).SelectPalette(pPalOld, false);           // Select back the old palette
+	pDC->BitBlt(SIDE_BORDER, TOP_BORDER, ART_WIDTH, ART_HEIGHT, pBigDC, ART_WIDTH / 2, ART_HEIGHT / 2, SRCCOPY);
+	pDC->SelectPalette(pPalOld, false);           // Select back the old palette
 
 	if (pBigBmpOld != nullptr)                         // Get rid of Big stuff
 		pBigDC->SelectObject(pBigBmpOld);
@@ -459,11 +459,11 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 			CSound::waitWaveSounds();
 
 			m_bIgnoreScrollClick = true;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 
 			RulesDlg.DoModal();
 			m_bIgnoreScrollClick = false;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 
 			if (bPlaying) SetTimer(BEACON_TIMER, SPEED_BASE - (m_nSpeed * SPEED_STEP), nullptr);
 			SetBeamEntries(pDC);
@@ -471,12 +471,12 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 		case IDC_SCROLL:
 			if (m_bIgnoreScrollClick) {
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 				break;
 			}
 
 			m_bIgnoreScrollClick = true;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 			SendDlgItemMessage(IDC_SCROLL, BM_SETSTATE, true, 0L);
 
 			switch (COptionsWind.DoModal()) {
@@ -487,17 +487,17 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 				NewGame();
 				char        msg[64];
 				Common::sprintf_s(msg, "Score: %.0f %%", m_Score);
-				(*m_pScoreTxt).DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
+				m_pScoreTxt->DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
 
 				Common::sprintf_s(msg, "Sweeps: %d", m_nSweepCount);
-				(*m_pSweepTxt).DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
+				m_pSweepTxt->DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
 
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				m_bIgnoreScrollClick = false;
 				break;
 
 			case IDC_OPTIONS_RETURN:
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				m_bIgnoreScrollClick = false;
 				if (bPlaying)
 					SetTimer(BEACON_TIMER, SPEED_BASE - (m_nSpeed * SPEED_STEP), nullptr);
@@ -524,7 +524,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 				}
 				if (pGameSound != nullptr) {
 					if (!pGameSound->playing())
-						(*pGameSound).midiLoopPlaySegment(1300, 36500, 0, FMT_MILLISEC);
+						pGameSound->midiLoopPlaySegment(1300, 36500, 0, FMT_MILLISEC);
 				} // end if pGameSound
 			} // end else..musicenabled check
 
@@ -533,7 +533,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 	} // end if
 
 	ReleaseDC(pDC);
-	(*this).SetFocus();                     // Reset focus back to the main window
+	(this)->SetFocus();                     // Reset focus back to the main window
 	return true;
 }
 
@@ -582,11 +582,11 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 		NewGame();                          // Activate New Game
 		char        msg[64];
 		Common::sprintf_s(msg, "Score: %.0f %%", m_Score);
-		(*m_pScoreTxt).DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
+		m_pScoreTxt->DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
 
 		if (m_nSweepCount < 0)  m_nSweepCount = 0;                          // Make sure it doesn't go neg
 		Common::sprintf_s(msg, "Sweeps: %d", m_nSweepCount);
-		(*m_pSweepTxt).DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
+		m_pSweepTxt->DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
 	}
 
 	ReleaseDC(pDC);
@@ -654,7 +654,7 @@ void CMainWindow::OnLButtonUp(unsigned int nFlags, CPoint point) {
 				Common::sprintf_s(msg, "Sweeps: %d", m_nSweepCount - 1);                     // Update text on screen
 			else
 				Common::sprintf_s(msg, "Sweeps: %d", m_nSweepCount);                         // Update text on screen
-			(*m_pSweepTxt).DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
+			m_pSweepTxt->DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
 		}
 	}
 
@@ -789,14 +789,14 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 				Common::sprintf_s(msg, "Sweeps: %d", m_nSweepCount - 1);                     // Update text on screen
 			else
 				Common::sprintf_s(msg, "Sweeps: %d", m_nSweepCount);                         // Update text on screen
-			(*m_pSweepTxt).DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
+			m_pSweepTxt->DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
 
 			m_Score = ((float) m_nRemoved / (float) m_nTotalSquares) * 100;         // Score is the percentage
 			if ((m_Score > 99.00) && (m_nRemoved < m_nTotalSquares))
 				Common::sprintf_s(msg, "Score: 99%%");
 			else
 				Common::sprintf_s(msg, "Score: %.0f %%", m_Score);                           // Update score on screen
-			(*m_pScoreTxt).DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
+			m_pScoreTxt->DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
 
 			if (m_bAutomatic) {                                                      // Game plays by itself
 				if (++nNextIndex >= (BUTTON_ENTRY + NUM_BUTTONS))                    // Step through colors
@@ -820,10 +820,10 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 					NewGame();
 
 					Common::sprintf_s(msg, "Score: %.0f %%", m_Score);
-					(*m_pScoreTxt).DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
+					m_pScoreTxt->DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
 
 					Common::sprintf_s(msg, "Sweeps: %d", m_nSweepCount);
-					(*m_pSweepTxt).DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
+					m_pSweepTxt->DisplayString(pDC, msg, 16, FW_BOLD, OPTIONS_COLOR);
 				} else {
 					if (pGameInfo->bSoundEffectsEnabled)
 						sndPlaySound(WIN_SOUND, SND_ASYNC);              // Make a "you won" noise
@@ -891,28 +891,28 @@ void CMainWindow::MoveBeam() {
 	PALETTEENTRY    tempent[2];
 
 	pDC = GetDC();
-	pOldPal = (*pDC).SelectPalette(pGamePalette, false);     // Select in game palette
+	pOldPal = pDC->SelectPalette(pGamePalette, false);     // Select in game palette
 
 	tempent[1].peRed = 255;                                 // Make entry [1] white
 	tempent[1].peGreen = 255;
 	tempent[1].peBlue = 254;
 	tempent[1].peFlags = PC_RESERVED;                       // Assign it the "changeable" flag
 
-	(*pGamePalette).GetPaletteEntries(nCurrentIndex, 1, (LPPALETTEENTRY)&tempent[0]);    // Entry [0] is the chosen
+	pGamePalette->GetPaletteEntries(nCurrentIndex, 1, (LPPALETTEENTRY)&tempent[0]);    // Entry [0] is the chosen
 	tempent[0].peFlags = PC_RESERVED;                                                   //...color & changeable
 
 	if (nSlice == START_ENTRY) {
-		(*pGamePalette).AnimatePalette(nSlice, 1, (LPPALETTEENTRY)&tempent[1]);
-		(*pGamePalette).AnimatePalette(NUM_BEAMS + START_ENTRY - 1, 1,
+		pGamePalette->AnimatePalette(nSlice, 1, (LPPALETTEENTRY)&tempent[1]);
+		pGamePalette->AnimatePalette(NUM_BEAMS + START_ENTRY - 1, 1,
 		                               (LPPALETTEENTRY)&tempent[0]);
 	} else
-		(*pGamePalette).AnimatePalette(nSlice - 1, 2, (LPPALETTEENTRY)tempent);
+		pGamePalette->AnimatePalette(nSlice - 1, 2, (LPPALETTEENTRY)tempent);
 
 	if (++nSlice >= (NUM_BEAMS + START_ENTRY)) {
 		nSlice = START_ENTRY;
 	}
 
-	(*pDC).SelectPalette(pOldPal, false);           // Select back the old palette
+	pDC->SelectPalette(pOldPal, false);           // Select back the old palette
 	ReleaseDC(pDC);
 
 } // end MoveBeam
@@ -1030,13 +1030,13 @@ bool CMainWindow::CompareColors(CDC *pDC, CPoint point) {
 	PALETTEENTRY    tempent[1];
 	unsigned int        index;
 
-	test = (*pDC).GetPixel(point);
+	test = pDC->GetPixel(point);
 
 	ar = GetRValue(test);
 	ag = GetGValue(test);
 	ab = GetBValue(test);
 
-	(*pGamePalette).GetPaletteEntries(nCurrentIndex, 1, (LPPALETTEENTRY)tempent);
+	pGamePalette->GetPaletteEntries(nCurrentIndex, 1, (LPPALETTEENTRY)tempent);
 
 	br = tempent[0].peRed;
 	bg = tempent[0].peGreen;
@@ -1055,7 +1055,7 @@ bool CMainWindow::CompareColors(CDC *pDC, CPoint point) {
 		return true;
 	}
 
-	index = (*pGamePalette).GetNearestPaletteIndex(test);        // get the nearest index of test color
+	index = pGamePalette->GetNearestPaletteIndex(test);        // get the nearest index of test color
 	if (((index < BUTTON_ENTRY) && (index >= START_ENTRY))       // if it's in the beam area
 	        && (index != nSlice))                               // and doesn't match the beam's index
 		return false;  //true );                                           //
@@ -1244,22 +1244,22 @@ bool CMainWindow::LoadArtWork(CDC *pDC) {
 	char bufName[MAX_FILE_LENGTH + 10];
 	Common::sprintf_s(bufName, "art\\%s", ArtName);
 
-	(*pSourceDoc).OpenDocument(bufName);
+	pSourceDoc->OpenDocument(bufName);
 
 	ASSERT(pTempPalette == nullptr);
-	pTempPalette = (*pSourceDoc).DetachPalette();       // Acquire the shared palette for our game from the art
+	pTempPalette = pSourceDoc->DetachPalette();       // Acquire the shared palette for our game from the art
 
-	pPalOld = (*pDC).SelectPalette(pGamePalette, false);                            // Select Game Palette
-	(*pDC).RealizePalette();                                                        // Use it
+	pPalOld = pDC->SelectPalette(pGamePalette, false);                            // Select Game Palette
+	pDC->RealizePalette();                                                        // Use it
 
 	// Transfer the button colors to Game Palette
 	LPPALETTEENTRY  ButtonEntry[NUM_BUTTONS];
 
-	(*pTempPalette).GetPaletteEntries(BUTTON_ENTRY, NUM_BUTTONS, (LPPALETTEENTRY)ButtonEntry);
-	(*pGamePalette).SetPaletteEntries(BUTTON_ENTRY, NUM_BUTTONS, (LPPALETTEENTRY)ButtonEntry);
-	(*pDC).RealizePalette();
+	pTempPalette->GetPaletteEntries(BUTTON_ENTRY, NUM_BUTTONS, (LPPALETTEENTRY)ButtonEntry);
+	pGamePalette->SetPaletteEntries(BUTTON_ENTRY, NUM_BUTTONS, (LPPALETTEENTRY)ButtonEntry);
+	pDC->RealizePalette();
 
-	hDIB = (*pSourceDoc).GetHDIB();
+	hDIB = pSourceDoc->GetHDIB();
 
 	if (hDIB) {
 		rcDest.SetRect(SIDE_BORDER, TOP_BORDER, ART_WIDTH + SIDE_BORDER, ART_HEIGHT + TOP_BORDER);
@@ -1290,7 +1290,7 @@ bool CMainWindow::LoadArtWork(CDC *pDC) {
 			rcDIB.bottom = ART_HEIGHT;  //cyDIB;
 		}
 
-		PaintDIB((*pDC).m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
+		PaintDIB(pDC->m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
 
 	}
 
@@ -1301,9 +1301,9 @@ bool CMainWindow::LoadArtWork(CDC *pDC) {
 	for (i = 0; i < NUM_BUTTONS; i++) {
 		CBrush  *pMyBrush = nullptr;
 		pMyBrush = new CBrush();                                // Construct new brush
-		(*pMyBrush).CreateSolidBrush(PALETTEINDEX((uint16)(colorBlock[i].nColorIndex)));
+		pMyBrush->CreateSolidBrush(PALETTEINDEX((uint16)(colorBlock[i].nColorIndex)));
 
-		(*pArtDC).FillRect(colorBlock[i].rLocation, pMyBrush);
+		pArtDC->FillRect(colorBlock[i].rLocation, pMyBrush);
 
 		MyFocusRect(pArtDC, colorBlock[i].rLocation, false);     // standard highlight on button
 
@@ -1314,7 +1314,7 @@ bool CMainWindow::LoadArtWork(CDC *pDC) {
 
 	pBeaconBitmap = FetchResourceBitmap(pDC, nullptr, IDB_BEACON_BMP);          // Add the lighthouse
 
-	(*pDC).SelectPalette(pPalOld, false);
+	pDC->SelectPalette(pPalOld, false);
 
 	pTempPalette->DeleteObject();
 	delete pTempPalette;
@@ -1440,8 +1440,8 @@ void MyFocusRect(CDC *pDC, CRect rect, bool nPressed) {
 	pDarkPen->CreatePen(PS_INSIDEFRAME, HILITE_BORDER,
 	                    PALETTEINDEX((uint16)(DARK_TRIM)));        // Create a new pen
 
-	pPalOld = (*pDC).SelectPalette(pGamePalette, false);     // Select in game palette
-	(*pDC).RealizePalette();                                // Use it
+	pPalOld = pDC->SelectPalette(pGamePalette, false);     // Select in game palette
+	pDC->RealizePalette();                                // Use it
 	pOldBrush = pDC->SelectObject(pMyBrush);     // Select the new brush & save old
 
 	if (nPressed)
@@ -1464,7 +1464,7 @@ void MyFocusRect(CDC *pDC, CRect rect, bool nPressed) {
 	pDC->SelectObject(pOldPen);                  // Select the old pen
 	pDC->SelectObject(pOldBrush);                // Select the old brush
 
-	(*pDC).SelectPalette(pPalOld, false);           // Select back the old palette
+	pDC->SelectPalette(pPalOld, false);           // Select back the old palette
 
 	pMyBrush->DeleteObject();
 	delete pMyBrush;
@@ -1526,10 +1526,10 @@ void CMainWindow::NewGame() {
 	pBrushNew = new CBrush();                                       // Construct a new brush object
 	if (pBrushNew != nullptr) {                                         // If the constructor was successful:
 		pBrushNew->CreateSolidBrush(PALETTERGB(0, 0, 0));         // Create my backdrop color brush
-		pBrushOld = (*pDC).SelectObject(pBrushNew);                  // Select into the DC my new brush
-		(*pDC).Rectangle(SIDE_BORDER, TOP_BORDER, ART_WIDTH + SIDE_BORDER, ART_HEIGHT + TOP_BORDER);
-		(*pDC).SelectObject(pBrushOld);                          // Select in the old brush
-		(*pDC).SelectPalette(pOldPal, false);                        // Select in the old palette
+		pBrushOld = pDC->SelectObject(pBrushNew);                  // Select into the DC my new brush
+		pDC->Rectangle(SIDE_BORDER, TOP_BORDER, ART_WIDTH + SIDE_BORDER, ART_HEIGHT + TOP_BORDER);
+		pDC->SelectObject(pBrushOld);                          // Select in the old brush
+		pDC->SelectPalette(pOldPal, false);                        // Select in the old palette
 		delete pBrushNew;                                           // Delete the new brush
 	}
 
@@ -1584,7 +1584,7 @@ void CMainWindow::NewGame() {
 		MyFocusRect(pDC, colorBlock[nNextIndex - BUTTON_ENTRY].rLocation, true);     // draw hightlight on nNextIndex
 	}
 
-	(*pDC).SelectPalette(pOldPal, false);
+	pDC->SelectPalette(pOldPal, false);
 	ReleaseDC(pDC);
 
 	bNewGame = true;
@@ -1606,7 +1606,7 @@ void CMainWindow::SetBeamEntries(CDC *pDC) {
 		entry[i].peFlags = PC_RESERVED;
 	}
 
-	(*pGamePalette).SetPaletteEntries(START_ENTRY, NUM_BEAMS, (LPPALETTEENTRY)entry);
+	pGamePalette->SetPaletteEntries(START_ENTRY, NUM_BEAMS, (LPPALETTEENTRY)entry);
 	pDC->RealizePalette();                              //...and realize it
 
 } // End SetBeamEntries
@@ -1622,7 +1622,7 @@ void CMainWindow::OnClose() {
 	pDC = GetDC();
 	myRect.SetRect(0, 0, GAME_WIDTH, GAME_HEIGHT);
 	myBrush.CreateStockObject(BLACK_BRUSH);
-	(*pDC).FillRect(&myRect, &myBrush);
+	pDC->FillRect(&myRect, &myBrush);
 	ReleaseDC(pDC);
 
 	sndPlaySound(nullptr, SND_ASYNC);                                   // kill any wav that's playing

--- a/engines/bagel/hodjnpodj/beacon/optndlg.cpp
+++ b/engines/bagel/hodjnpodj/beacon/optndlg.cpp
@@ -119,12 +119,12 @@ bool COptnDlg::OnInitDialog() {
 
 	statRect.SetRect(LEFT_SIDE, 35, LEFT_SIDE + 185, 50);
 	if ((m_pScoreText = new CText()) != nullptr) {
-		(*m_pScoreText).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pScoreText->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	statRect.SetRect(LEFT_SIDE, 20, LEFT_SIDE + 185, 35);
 	if ((m_pSweepsText = new CText()) != nullptr) {
-		(*m_pSweepsText).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pSweepsText->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	m_ScrollSweeps.SetScrollRange(0, nSweepSets - 1, 0);
@@ -135,31 +135,31 @@ bool COptnDlg::OnInitDialog() {
 
 	statRect.SetRect(LEFT_SIDE, 70, LEFT_SIDE + 115, 88);
 	if ((m_pSpeedText = new CText()) != nullptr) {
-		(*m_pSpeedText).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pSpeedText->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	m_ScrollSpeed.SetScrollRange(MIN_SPEED, MAX_SPEED, 0);
 	m_ScrollSpeed.SetScrollPos(m_nSpeed, true);
 
 	if ((pOKButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pOKButton).SetPalette(pSubOptionsPalette);                        // set the palette to use
-		(*pOKButton).SetControl(IDOK, this);            // tie to the dialog control
+		pOKButton->SetPalette(pSubOptionsPalette);                        // set the palette to use
+		pOKButton->SetControl(IDOK, this);            // tie to the dialog control
 	}
 
 	if ((pCancelButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pCancelButton).SetPalette(pSubOptionsPalette);                        // set the palette to use
-		(*pCancelButton).SetControl(IDCANCEL, this);            // tie to the dialog control
+		pCancelButton->SetPalette(pSubOptionsPalette);                        // set the palette to use
+		pCancelButton->SetControl(IDCANCEL, this);            // tie to the dialog control
 	}
 
 	if ((pAutoButton = new CCheckButton) != nullptr) {                 // build a color QUIT button to let us exit
-		(*pAutoButton).SetPalette(pSubOptionsPalette);                      // set the palette to use
-		(*pAutoButton).SetControl(IDC_AUTOMATIC, this);             // tie to the dialog control
+		pAutoButton->SetPalette(pSubOptionsPalette);                      // set the palette to use
+		pAutoButton->SetControl(IDC_AUTOMATIC, this);             // tie to the dialog control
 	}
 	((CWnd *)this)->CheckDlgButton(IDC_AUTOMATIC, m_bAutomatic);         // Set the Auto option box
 
 	if ((pChangeButton = new CCheckButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pChangeButton).SetPalette(pSubOptionsPalette);                        // set the palette to use
-		(*pChangeButton).SetControl(IDC_CHANGE, this);              // tie to the dialog control
+		pChangeButton->SetPalette(pSubOptionsPalette);                        // set the palette to use
+		pChangeButton->SetControl(IDC_CHANGE, this);              // tie to the dialog control
 	}
 	((CWnd *)this)->CheckDlgButton(IDC_CHANGE, m_bChangeAtTwelve);       // Set the Auto option box
 
@@ -252,7 +252,7 @@ void COptnDlg::OnHScroll(unsigned int nSBCode, unsigned int nPos, CScrollBar* pS
 	if (NewPos > pMax) NewPos = pMax;
 
 	if (NewPos != OldPos) {                              //To prevent "flicker"
-		(*pScrollBar).SetScrollPos(NewPos, true);        //...only update when
+		pScrollBar->SetScrollPos(NewPos, true);        //...only update when
 	}                                                   //...changed
 
 	UpdateScrollbars();
@@ -300,14 +300,14 @@ void COptnDlg::UpdateScrollbars() {
 			Common::sprintf_s(msg, "Number of Sweeps: Unlimited");
 		else
 			Common::sprintf_s(msg, "Number of Sweeps: %d", m_nSweeps);
-		(*m_pSweepsText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+		m_pSweepsText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 	}
 
 	OldValue = m_nSpeed;
 	m_nSpeed = m_ScrollSpeed.GetScrollPos();
 	if (OldValue != m_nSpeed) {
 		Common::sprintf_s(msg, "Speed:  %s", mSpeedTable[m_nSpeed].c_str());
-		(*m_pSpeedText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+		m_pSpeedText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 	}
 
 	ReleaseDC(pDC);
@@ -343,16 +343,16 @@ void COptnDlg::OnPaint() {
 	pDC = GetDC();
 
 	Common::sprintf_s(msg, "(Effective on New Game)");
-	(*m_pScoreText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+	m_pScoreText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 
 	if (m_nSweeps == MAX_SWEEPS)
 		Common::sprintf_s(msg, "Number of Sweeps: Unlimited");
 	else
 		Common::sprintf_s(msg, "Number of Sweeps: %d", m_nSweeps);
-	(*m_pSweepsText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+	m_pSweepsText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 
 	Common::sprintf_s(msg, "Speed:  %s", mSpeedTable[m_nSpeed].c_str());
-	(*m_pSpeedText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+	m_pSpeedText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 
 	ReleaseDC(pDC);
 

--- a/engines/bagel/hodjnpodj/crypt/crypt.cpp
+++ b/engines/bagel/hodjnpodj/crypt/crypt.cpp
@@ -256,7 +256,7 @@ bool CCryptogram::HandleUserUpdate(CDC *pDC, CPoint cpointClicked) {
 	/********************
 	* Symbol hilited?   *
 	********************/
-	nClickedCode = (*pSprite).GetTypeCode();
+	nClickedCode = pSprite->GetTypeCode();
 	if (m_cPaintGram->IsSymbolChar(nClickedCode) == true) {
 		return false;                                   // Yes - do not hilite symbols
 	}

--- a/engines/bagel/hodjnpodj/crypt/main.cpp
+++ b/engines/bagel/hodjnpodj/crypt/main.cpp
@@ -117,9 +117,9 @@ CMainWindow::CMainWindow(HWND hCallingWnd, LPGAMESTRUCT lpGameStruct) {
 
 	pDibDoc = new CDibDoc();                        // create an object to hold our splash screen
 	ASSERT(pDibDoc);                                // ... and verify we got it
-	bSuccess = (*pDibDoc).OpenDocument(SPLASHSPEC); // next load in the actual DIB based artwork
+	bSuccess = pDibDoc->OpenDocument(SPLASHSPEC); // next load in the actual DIB based artwork
 	ASSERT(bSuccess);                               // next load in the actual DIB based artwork
-	pGamePalette = (*pDibDoc).DetachPalette();      // grab its palette and save it for later use
+	pGamePalette = pDibDoc->DetachPalette();      // grab its palette and save it for later use
 	delete pDibDoc;                                 // now discard the splash screen
 
 	MainRect.left = (pDC->GetDeviceCaps(HORZRES) - GAME_WIDTH) >> 1;
@@ -156,11 +156,11 @@ CMainWindow::CMainWindow(HWND hCallingWnd, LPGAMESTRUCT lpGameStruct) {
 	                   SCROLL_BUTTON_Y,
 	                   SCROLL_BUTTON_X + SCROLL_BUTTON_DX,
 	                   SCROLL_BUTTON_Y + SCROLL_BUTTON_DY + 1);
-	bSuccess = (*m_pScrollButton).Create(nullptr,              // create the actual button
+	bSuccess = m_pScrollButton->Create(nullptr,              // create the actual button
 	                                     BS_OWNERDRAW | WS_CHILD | WS_VISIBLE,
 	                                     ScrollRect, this, IDC_SCROLL);
 	ASSERT(bSuccess);
-	bSuccess = (*m_pScrollButton).LoadBitmaps(    // load the artwork for the button states
+	bSuccess = m_pScrollButton->LoadBitmaps(    // load the artwork for the button states
 	               "SCROLLUP",
 	               "SCROLLDOWN",
 	               "SCROLLUP",
@@ -236,7 +236,7 @@ CMainWindow::CMainWindow(HWND hCallingWnd, LPGAMESTRUCT lpGameStruct) {
 	pGameSound = new CSound(this, GAME_THEME, SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 	if (m_lpGameStruct->bMusicEnabled) {
 		if (pGameSound != nullptr) {
-			(*pGameSound).midiLoopPlaySegment(1080, 32500, 0, FMT_MILLISEC);    //32750
+			pGameSound->midiLoopPlaySegment(1080, 32500, 0, FMT_MILLISEC);    //32750
 		} // end if pGameSound
 	}
 
@@ -370,14 +370,14 @@ void CMainWindow::SplashScreen() {
 	rcDIB.top = rcDIB.left = 0;                         // setup the source rectangle from which
 	rcDIB.right = cxDIB;                                // ... we'll do the painting
 	rcDIB.bottom = cyDIB;
-	PaintDIB((*pDC).m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);    // transfer the image to the screen
+	PaintDIB(pDC->m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);    // transfer the image to the screen
 
 	pSprite = CSprite::GetSpriteChain();                // now get a pointer to the sprite chain
 	while (pSprite) {                                   // ... and for each sprite, clear its saved
-		(*pSprite).ClearBackground();                   // ... background and repaint its image, thus
-		bSuccess = (*pSprite).RefreshSprite(pDC);       // ... restoring the image but forcing it to
+		pSprite->ClearBackground();                   // ... background and repaint its image, thus
+		bSuccess = pSprite->RefreshSprite(pDC);       // ... restoring the image but forcing it to
 		ASSERT(bSuccess);                               // ... restoring the image but forcing it to
-		pSprite = (*pSprite).GetNextSprite();
+		pSprite = pSprite->GetNextSprite();
 	}          // ... fetch/save the background it covers up
 
 	if (m_bIsFirstTimeHack == true) {
@@ -391,8 +391,8 @@ void CMainWindow::DisplayStats(CDC *pDC) {
 	bool        bSuccess;
 
 	if (m_cCryptograms->m_cStats->m_nTime != MAX_TIME) {
-		(*m_pHourGlass).ClearBackground();                  // ... background and repaint its image, thus
-		bSuccess = (*m_pHourGlass).RefreshSprite(pDC);      // ... restoring the image but forcing it to
+		m_pHourGlass->ClearBackground();                  // ... background and repaint its image, thus
+		bSuccess = m_pHourGlass->RefreshSprite(pDC);      // ... restoring the image but forcing it to
 		ASSERT(bSuccess);                                   // ... restoring the image but forcing it to
 	}
 
@@ -406,8 +406,8 @@ void CMainWindow::RefreshStats() {
 
 	if (m_cCryptograms->m_cStats->m_nTime != MAX_TIME) {                // Game is timed
 		if (m_pHourGlass != nullptr) {
-			(*m_pHourGlass).ClearBackground();                  // ... background and repaint its image, thus
-			(*m_pHourGlass).RefreshSprite(pDC);      // ... restoring the image but forcing it to
+			m_pHourGlass->ClearBackground();                  // ... background and repaint its image, thus
+			m_pHourGlass->RefreshSprite(pDC);      // ... restoring the image but forcing it to
 		}
 	}
 	if (m_cCryptograms->bIsGameOver == true) {
@@ -504,7 +504,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 		case IDC_OPTIONS_RULES:
 			m_bIgnoreScrollClick = true;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 
 			CSound::waitWaveSounds();
 			RulesDlg.DoModal();
@@ -548,7 +548,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 			ReleaseDC(pDC);
 
 			m_bIgnoreScrollClick = false;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 			if (m_cCryptograms->IsSolved() == true) {
 				GameWin();
 				if (m_lpGameStruct->bPlayingMetagame)
@@ -560,24 +560,24 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 		case IDC_SCROLL:
 			if (m_bIgnoreScrollClick) {
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 				break;
 			}
 			m_bIgnoreScrollClick = true;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 			SendDlgItemMessage(IDC_SCROLL, BM_SETSTATE, true, 0L);
 
 			switch (COptionsWind.DoModal()) {
 
 			case IDC_OPTIONS_RETURN:
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				m_bIgnoreScrollClick = false;
 				m_bPause = false;
 				break;
 
 			case IDC_OPTIONS_NEWGAME:
 				pDC = GetDC();
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				m_bIgnoreScrollClick = false;
 
 				//UpdateWindow();
@@ -591,7 +591,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 			} //end switch(ComDlg.DoModal())
 			if ((m_lpGameStruct->bMusicEnabled == false) && (pGameSound != nullptr)) {
 				if (pGameSound->playing())
-					(*pGameSound).stop();
+					pGameSound->stop();
 			} else if (m_lpGameStruct->bMusicEnabled) {
 				if (pGameSound == nullptr) {
 					pGameSound = new CSound(this, GAME_THEME,
@@ -599,7 +599,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 				}
 				if (pGameSound != nullptr) {
 					if (!pGameSound->playing())
-						(*pGameSound).midiLoopPlaySegment(1080, 32500, 0, FMT_MILLISEC);
+						pGameSound->midiLoopPlaySegment(1080, 32500, 0, FMT_MILLISEC);
 				} // end if pGameSound
 			}
 			break;
@@ -608,7 +608,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 	}
 
-	(*this).SetFocus();                     // Reset focus back to the main window
+	(this)->SetFocus();                     // Reset focus back to the main window
 	return true;
 }
 
@@ -760,7 +760,7 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	hourRect.SetRect(HOUR_X, HOUR_Y, HOUR_X + HOUR_DX, HOUR_Y + HOUR_DY);
 
 	pDC = GetDC();
-	if ((*m_cCryptograms).HandleUserUpdate(pDC, point) == true) {
+	if (m_cCryptograms->HandleUserUpdate(pDC, point) == true) {
 		GameWin();
 		if (m_lpGameStruct->bPlayingMetagame)
 			PostMessage(WM_CLOSE, 0, 0);
@@ -773,11 +773,11 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	else if (skullRect.PtInRect(point)) {
 		pDC = GetDC();
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pGamePalette);
-		bSuccess = (*pSprite).LoadCels(pDC, "art\\skull.bmp", NUM_SKULL_CELS);
+		pSprite->SharePalette(pGamePalette);
+		bSuccess = pSprite->LoadCels(pDC, "art\\skull.bmp", NUM_SKULL_CELS);
 		ASSERT(bSuccess);
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
 		if (m_lpGameStruct->bSoundEffectsEnabled) {
 			nPick = brand() % NUM_SKULL_SOUNDS;
@@ -809,20 +809,20 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 			}
 			pEffect = new CSound((CWnd *)this, bufName, SOUND_QUEUE |
 			                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-			(*pEffect).play();                                                      //...play the narration
+			pEffect->play();                                                      //...play the narration
 		} else      // no sound playing
 			nSleepTime = SKULL_SLEEP;
 
 		if (bSuccess) {
-			(*pSprite).SetCel(NUM_SKULL_CELS);
+			pSprite->SetCel(NUM_SKULL_CELS);
 			for (i = 0; i < NUM_SKULL_CELS; i++) {
-				(*pSprite).PaintSprite(pDC, SKULL_X, SKULL_Y);
+				pSprite->PaintSprite(pDC, SKULL_X, SKULL_Y);
 				if (i < (NUM_SKULL_CELS - 1))
 					Sleep(nSleepTime);
 			}
 			if (nPick == 1) {
 				for (i = 0; i < NUM_SKULL_CELS; i++) {
-					(*pSprite).PaintSprite(pDC, SKULL_X, SKULL_Y);
+					pSprite->PaintSprite(pDC, SKULL_X, SKULL_Y);
 					Sleep(JOKE2B_SLEEP);
 				}
 			}
@@ -834,21 +834,21 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	} else if (urn1Rect.PtInRect(point)) {
 		pDC = GetDC();
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pGamePalette);
-		bSuccess = (*pSprite).LoadCels(pDC, "art\\urn01.bmp", NUM_URN1_CELS);
+		pSprite->SharePalette(pGamePalette);
+		bSuccess = pSprite->LoadCels(pDC, "art\\urn01.bmp", NUM_URN1_CELS);
 		ASSERT(bSuccess);
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
 		if (m_lpGameStruct->bSoundEffectsEnabled) {
 			pEffect = new CSound((CWnd *)this, WAV_URN1, SOUND_QUEUE |
 			                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-			(*pEffect).play();                                                      //...play the narration
+			pEffect->play();                                                      //...play the narration
 		}
 		if (bSuccess) {
-			(*pSprite).SetCel(NUM_URN1_CELS);
+			pSprite->SetCel(NUM_URN1_CELS);
 			for (i = 0; i < NUM_URN1_CELS; i++) {
-				(*pSprite).PaintSprite(pDC, URN1_X, URN1_Y);
+				pSprite->PaintSprite(pDC, URN1_X, URN1_Y);
 				Sleep(URN1_SLEEP);
 			}
 		}
@@ -859,21 +859,21 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	} else if (urn2Rect.PtInRect(point)) {
 		pDC = GetDC();
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pGamePalette);
-		bSuccess = (*pSprite).LoadCels(pDC, "art\\urn02.bmp", NUM_URN2_CELS);
+		pSprite->SharePalette(pGamePalette);
+		bSuccess = pSprite->LoadCels(pDC, "art\\urn02.bmp", NUM_URN2_CELS);
 		ASSERT(bSuccess);
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
 		if (m_lpGameStruct->bSoundEffectsEnabled) {
 			pEffect = new CSound((CWnd *)this, WAV_URN2, SOUND_QUEUE |
 			                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-			(*pEffect).play();                                                      //...play the narration
+			pEffect->play();                                                      //...play the narration
 		}
 		if (bSuccess) {
-			(*pSprite).SetCel(NUM_URN2_CELS);
+			pSprite->SetCel(NUM_URN2_CELS);
 			for (i = 0; i < NUM_URN2_CELS; i++) {
-				(*pSprite).PaintSprite(pDC, URN2_X, URN2_Y);
+				pSprite->PaintSprite(pDC, URN2_X, URN2_Y);
 				Sleep(URN2_SLEEP);
 			}
 		}
@@ -884,21 +884,21 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	} else if (urn3Rect.PtInRect(point)) {
 		pDC = GetDC();
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pGamePalette);
-		bSuccess = (*pSprite).LoadCels(pDC, "art\\urn03.bmp", NUM_URN3_CELS);
+		pSprite->SharePalette(pGamePalette);
+		bSuccess = pSprite->LoadCels(pDC, "art\\urn03.bmp", NUM_URN3_CELS);
 		ASSERT(bSuccess);
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
 		if (m_lpGameStruct->bSoundEffectsEnabled) {
 			pEffect = new CSound((CWnd *)this, WAV_URN3, SOUND_QUEUE |
 			                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-			(*pEffect).play();                                                      //...play the narration
+			pEffect->play();                                                      //...play the narration
 		}
 		if (bSuccess) {
-			(*pSprite).SetCel(NUM_URN3_CELS);
+			pSprite->SetCel(NUM_URN3_CELS);
 			for (i = 0; i < NUM_URN3_CELS; i++) {
-				(*pSprite).PaintSprite(pDC, URN3_X, URN3_Y);
+				pSprite->PaintSprite(pDC, URN3_X, URN3_Y);
 				Sleep(URN3_SLEEP);
 			}
 		}
@@ -909,22 +909,22 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	} else if (gryphRect.PtInRect(point) && (m_lpGameStruct->bSoundEffectsEnabled)) {
 		pEffect = new CSound((CWnd *)this, WAV_GRYPH, SOUND_QUEUE |
 		                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-		(*pEffect).play();                                                      //...play the narration
+		pEffect->play();                                                      //...play the narration
 	} else if (stepsRect.PtInRect(point) && (m_lpGameStruct->bSoundEffectsEnabled)) {
 		pEffect = new CSound((CWnd *)this, WAV_STEPS, SOUND_QUEUE |
 		                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-		(*pEffect).play();                                                      //...play the narration
+		pEffect->play();                                                      //...play the narration
 	} else if (m_cCryptograms->m_cStats->m_nTime < MAX_TIME &&
 	           (hourRect.PtInRect(point) && (m_lpGameStruct->bSoundEffectsEnabled))) {
 		pEffect = new CSound((CWnd *)this, WAV_HOUR, SOUND_QUEUE |
 		                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-		(*pEffect).play();                                                      //...play the narration
+		pEffect->play();                                                      //...play the narration
 	} else if (((torch1Rect.PtInRect(point)) || (torch2Rect.PtInRect(point))) ||
 	           ((torch3Rect.PtInRect(point)) || (torch4Rect.PtInRect(point)))) {
 		if (m_lpGameStruct->bSoundEffectsEnabled) {
 			pEffect = new CSound((CWnd *)this, WAV_TORCH, SOUND_QUEUE |
 			                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-			(*pEffect).play();                                                      //...play the narration
+			pEffect->play();                                                      //...play the narration
 		}
 	}
 }
@@ -938,7 +938,7 @@ void CMainWindow::OnLButtonDblClk(unsigned int nFlags, CPoint point) {
 	CDC *pDC;
 
 	pDC = GetDC();
-	if ((*m_cCryptograms).HandleUserUpdate(pDC, point) == true) {
+	if (m_cCryptograms->HandleUserUpdate(pDC, point) == true) {
 		GameWin();
 		if (m_lpGameStruct->bPlayingMetagame)
 			PostMessage(WM_CLOSE, 0, 0);
@@ -1088,11 +1088,11 @@ void CMainWindow::OnSysKeyDown(unsigned int nChar, unsigned int nRepCnt, unsigne
 void CMainWindow::OnKeyDown(unsigned int nChar, unsigned int nRepCnt, unsigned int nFlags) {
 	if (nChar == VK_F1) {                                  // F1 key is hit
 		SendMessage(WM_COMMAND, IDC_OPTIONS_RULES, BN_CLICKED);  // Activate the Options dialog
-		(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L); // Reset scroll button to up state
+		m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L); // Reset scroll button to up state
 		m_bIgnoreScrollClick = false;
 	} else if (nChar == VK_F2) {                                 // F2 key is hit
 		SendMessage(WM_COMMAND, IDC_SCROLL, BN_CLICKED);     // Activate the Rules dialog
-		(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L); // Reset scroll button to up state
+		m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L); // Reset scroll button to up state
 		m_bIgnoreScrollClick = false;
 	}
 }
@@ -1349,9 +1349,9 @@ void CALLBACK GetGameParams(CWnd *pParentWnd) {
 //		(*pParentWnd).PostMessage(WM_COMMAND, IDC_OPTIONS_NEWGAME, BN_CLICKED);
 		tempLetters = cOpnDlg.m_nLttrsSlvd;
 		tempTimeLimit = cOpnDlg.m_nTime;
-		(*pParentWnd).PostMessage(WM_COMMAND, IDC_SCROLL, BN_CLICKED);
+		pParentWnd->PostMessage(WM_COMMAND, IDC_SCROLL, BN_CLICKED);
 	} else {
-		(*pParentWnd).PostMessage(WM_COMMAND, IDC_SCROLL, BN_CLICKED);
+		pParentWnd->PostMessage(WM_COMMAND, IDC_SCROLL, BN_CLICKED);
 	}
 
 }

--- a/engines/bagel/hodjnpodj/crypt/optn.cpp
+++ b/engines/bagel/hodjnpodj/crypt/optn.cpp
@@ -168,7 +168,7 @@ bool COptn::OnInitDialog() {
 	);
 
 	if ((m_pLttrsSlvd = new CText()) != nullptr) {
-		bAssertCheck = (*m_pLttrsSlvd).SetupText(pDC, pGamePalette, &statsRect, JUSTIFY_LEFT);
+		bAssertCheck = m_pLttrsSlvd->SetupText(pDC, pGamePalette, &statsRect, JUSTIFY_LEFT);
 		ASSERT(bAssertCheck);               // initialize the text objext
 	}
 	m_LttrsSlvd.SetScrollRange(MIN_LTTRSSLVD, MAX_LTTRSSLVD, false);    // setup Letters Solved defaults
@@ -183,7 +183,7 @@ bool COptn::OnInitDialog() {
 	);
 
 	if ((m_pTime = new CText()) != nullptr) {
-		bAssertCheck = (*m_pTime).SetupText(pDC, pGamePalette, &statsRect, JUSTIFY_LEFT);
+		bAssertCheck = m_pTime->SetupText(pDC, pGamePalette, &statsRect, JUSTIFY_LEFT);
 		ASSERT(bAssertCheck);               // initialize the text objext
 	}
 
@@ -191,13 +191,13 @@ bool COptn::OnInitDialog() {
 	m_Time.SetScrollPos(m_nTime, true);
 
 	if ((pOKButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pOKButton).SetPalette(pGamePalette);                      // set the palette to use
-		(*pOKButton).SetControl(IDOK, this);            // tie to the dialog control
+		pOKButton->SetPalette(pGamePalette);                      // set the palette to use
+		pOKButton->SetControl(IDOK, this);            // tie to the dialog control
 	}
 
 	if ((pCancelButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pCancelButton).SetPalette(pGamePalette);                      // set the palette to use
-		(*pCancelButton).SetControl(IDCANCEL, this);            // tie to the dialog control
+		pCancelButton->SetPalette(pGamePalette);                      // set the palette to use
+		pCancelButton->SetControl(IDCANCEL, this);            // tie to the dialog control
 	}
 
 	ReleaseDC(pDC);
@@ -257,7 +257,7 @@ void COptn::OnHScroll(unsigned int nSBCode, unsigned int nPos, CScrollBar* pScro
 			m_nLttrsSlvd = MAX_LTTRSSLVD;
 
 		Common::sprintf_s(msg, "Letters Solved: %d", m_nLttrsSlvd);
-		bAssertCheck = (*m_pLttrsSlvd).DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
+		bAssertCheck = m_pLttrsSlvd->DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
 		ASSERT(bAssertCheck);
 		pScrollBar->SetScrollPos(m_nLttrsSlvd, true);
 
@@ -295,7 +295,7 @@ void COptn::OnHScroll(unsigned int nSBCode, unsigned int nPos, CScrollBar* pScro
 
 		Common::sprintf_s(msg, "Time Limit: %s", m_chTime[m_nTime].c_str());
 
-		bAssertCheck = (*m_pTime).DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
+		bAssertCheck = m_pTime->DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
 		ASSERT(bAssertCheck);   // paint the text
 
 		pScrollBar->SetScrollPos(m_nTime, true);
@@ -317,11 +317,11 @@ void COptn::OnPaint() {
 	pDC = GetDC();
 
 	Common::sprintf_s(msg, "Letters Solved: %d", m_nLttrsSlvd); // Display Letters Solved stats
-	bAssertCheck = (*m_pLttrsSlvd).DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
+	bAssertCheck = m_pLttrsSlvd->DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
 	ASSERT(bAssertCheck);
 
 	Common::sprintf_s(msg, "Time: %s", m_chTime[m_nTime].c_str());      // Display Time stats
-	bAssertCheck = (*m_pTime).DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
+	bAssertCheck = m_pTime->DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
 	ASSERT(bAssertCheck);
 
 	ReleaseDC(pDC);

--- a/engines/bagel/hodjnpodj/crypt/pnt_gram.cpp
+++ b/engines/bagel/hodjnpodj/crypt/pnt_gram.cpp
@@ -90,7 +90,7 @@ CPaintGram::CPaintGram(CDC *pDC)
 
 	for (i = 0; i < SYMBOLS ; i++) {         // Initialize master alphabet list
 		m_cAlphabet[i] = new CSprite();     // Initize the individual letter of the alphabet list
-		(*m_cAlphabet[i]).SharePalette(pGamePalette);
+		m_cAlphabet[i]->SharePalette(pGamePalette);
 		if ((i < ALPHABET)) {
 			pFontCel = ExtractBitmap(pDC, pFontSource, pGamePalette,
 			                         i * STANDARD_CHAR_WIDTH, ALPHA_ROW * STANDARD_CHAR_HEIGHT,
@@ -102,40 +102,40 @@ CPaintGram::CPaintGram(CDC *pDC)
 			                         nFontWidth[i - ALPHABET], STANDARD_CHAR_HEIGHT);
 			nExtraWidth += nFontWidth[i - ALPHABET];
 		}
-		bSuccess = (*m_cAlphabet[i]).LoadSprite(pFontCel, pGamePalette);
+		bSuccess = m_cAlphabet[i]->LoadSprite(pFontCel, pGamePalette);
 		ASSERT(bSuccess);
 
-		(*m_cAlphabet[i]).SetMobile(true);
-		(*m_cAlphabet[i]).SetMasked(true);
-		(*m_cAlphabet[i]).SetTypeCode(IndexToChar(i));  // set user defined Type Code to corres to the letter
+		m_cAlphabet[i]->SetMobile(true);
+		m_cAlphabet[i]->SetMasked(true);
+		m_cAlphabet[i]->SetTypeCode(IndexToChar(i));  // set user defined Type Code to corres to the letter
 	}  // end for
 
 	for (i = 0; i < USED_SYMBOLS ; i++) {        // Initialize master alphabet-used list
 		m_cUsedAlphabet[i] = new CSprite();     // Initialize High-lighted chars
-		(*m_cUsedAlphabet[i]).SharePalette(pGamePalette);
+		m_cUsedAlphabet[i]->SharePalette(pGamePalette);
 		pFontCel = ExtractBitmap(pDC, pFontSource, pGamePalette,
 		                         i * STANDARD_CHAR_WIDTH, USED_ROW * STANDARD_CHAR_HEIGHT,
 		                         STANDARD_CHAR_WIDTH, STANDARD_CHAR_HEIGHT);
-		bSuccess = (*m_cUsedAlphabet[i]).LoadSprite(pFontCel, pGamePalette);
+		bSuccess = m_cUsedAlphabet[i]->LoadSprite(pFontCel, pGamePalette);
 		ASSERT(bSuccess);
 
-		(*m_cUsedAlphabet[i]).SetMobile(true);
-		(*m_cUsedAlphabet[i]).SetMasked(true);
-		(*m_cUsedAlphabet[i]).SetTypeCode(SetAlphaType(IndexToChar(i)));    // set user defined Type Code to corres to the letter
+		m_cUsedAlphabet[i]->SetMobile(true);
+		m_cUsedAlphabet[i]->SetMasked(true);
+		m_cUsedAlphabet[i]->SetTypeCode(SetAlphaType(IndexToChar(i)));    // set user defined Type Code to corres to the letter
 	}  // end for
 
 	for (i = 0; i < REVEAL_SYMBOLS ; i++) {          // Initialize master alphabet-used list
 		m_cRevealAlphabet[i] = new CSprite();       // Initialize High-lighted chars
-		(*m_cRevealAlphabet[i]).SharePalette(pGamePalette);
+		m_cRevealAlphabet[i]->SharePalette(pGamePalette);
 		pFontCel = ExtractBitmap(pDC, pFontSource, pGamePalette,
 		                         i * STANDARD_CHAR_WIDTH, REVEAL_ROW * STANDARD_CHAR_HEIGHT,
 		                         STANDARD_CHAR_WIDTH, STANDARD_CHAR_HEIGHT);
-		bSuccess = (*m_cRevealAlphabet[i]).LoadSprite(pFontCel, pGamePalette);
+		bSuccess = m_cRevealAlphabet[i]->LoadSprite(pFontCel, pGamePalette);
 		ASSERT(bSuccess);
 
-		(*m_cRevealAlphabet[i]).SetMobile(true);
-		(*m_cRevealAlphabet[i]).SetMasked(true);
-		(*m_cRevealAlphabet[i]).SetTypeCode(SetAlphaType(IndexToChar(i)));  // set user defined Type Code to corres to the letter
+		m_cRevealAlphabet[i]->SetMobile(true);
+		m_cRevealAlphabet[i]->SetMasked(true);
+		m_cRevealAlphabet[i]->SetTypeCode(SetAlphaType(IndexToChar(i)));  // set user defined Type Code to corres to the letter
 	}  // end for
 
 	// Delete temporary font bitmaps
@@ -146,12 +146,12 @@ CPaintGram::CPaintGram(CDC *pDC)
 	}
 
 	m_cHiLite = new CSprite();              // HiLite box area
-	bSuccess = (*m_cHiLite).LoadResourceSprite(pDC, HILITE_RESOURCE_ID);
+	bSuccess = m_cHiLite->LoadResourceSprite(pDC, HILITE_RESOURCE_ID);
 	ASSERT(bSuccess);
 
-	(*m_cHiLite).SetMobile(true);
-	(*m_cHiLite).SetMasked(true);
-	(*m_cHiLite).SetTypeCode(SetHiLiteTypeOn(false));
+	m_cHiLite->SetMobile(true);
+	m_cHiLite->SetMasked(true);
+	m_cHiLite->SetTypeCode(SetHiLiteTypeOn(false));
 
 }
 
@@ -640,11 +640,11 @@ void CPaintGram::PaintAlphabet(CDC *pDC) {
 
 	for (i = 0; i < ALPHABET ; i++) {    // Initialize the displayed alphabet
 		//  list on bottom of screen
-		m_cDisplayLetters = (*m_cAlphabet[i]).DuplicateSprite(pDC);
-		(*m_cDisplayLetters).SetTypeCode(SetAlphaType(IndexToChar(i)));
-		cLetterDim = (*m_cDisplayLetters).GetSize();
-		(*m_cDisplayLetters).LinkSprite();
-		(*m_cDisplayLetters).PaintSprite(
+		m_cDisplayLetters = m_cAlphabet[i]->DuplicateSprite(pDC);
+		m_cDisplayLetters->SetTypeCode(SetAlphaType(IndexToChar(i)));
+		cLetterDim = m_cDisplayLetters->GetSize();
+		m_cDisplayLetters->LinkSprite();
+		m_cDisplayLetters->PaintSprite(
 		    pDC,
 		    m_cAlphaRegion.TopLeft().x + cLetterPos.cx, // Advances col pos
 		    (m_cAlphaRegion.TopLeft()).y +              // Advances row pos
@@ -741,7 +741,7 @@ void CPaintGram::PaintGram(CDC *pDC, const char *lpszCryptedGram) {
 		} // end if
 
 		if ((nIndexChar = SymbToIndex(lpszCryptedGram[i])) != false) {   // '.' thru ':'
-			nLineLength += ((*m_cAlphabet[nIndexChar]).GetSize()).cx + m_nGramLetterSpacing;
+			nLineLength += (m_cAlphabet[nIndexChar]->GetSize()).cx + m_nGramLetterSpacing;
 		} // end if
 	} // end for
 
@@ -797,11 +797,11 @@ void CPaintGram::PaintLine(CDC *pDC, const char *lpszCryptedGram, CSize cPos, in
 
 		if (IsAlphaChar(lpszCryptedGram[j]) == true) {   // A - Z char?
 			nChar = CharToIndex(lpszCryptedGram[j]);
-			m_cDisplayLetters = (*m_cAlphabet[nChar]).DuplicateSprite(pDC);
+			m_cDisplayLetters = m_cAlphabet[nChar]->DuplicateSprite(pDC);
 			//(*m_cDisplayLetters).SetTypeCode(SetGramType(IndexToAlpha(i)));
 			//cLetterDim = (*m_cDisplayLetters).GetSize();
-			(*m_cDisplayLetters).LinkSprite();
-			(*m_cDisplayLetters).PaintSprite(pDC, cPos.cx, cPos.cy);
+			m_cDisplayLetters->LinkSprite();
+			m_cDisplayLetters->PaintSprite(pDC, cPos.cx, cPos.cy);
 			cPos.cx += m_nStandardCharWidth + m_nGramLetterSpacing;
 			continue;
 			//cLetterDim.cx + m_nGramLetterSpacing;
@@ -809,11 +809,11 @@ void CPaintGram::PaintLine(CDC *pDC, const char *lpszCryptedGram, CSize cPos, in
 
 		if (IsSymbolChar(lpszCryptedGram[j]) == true) {      // '.' thru ':'
 			nChar = CharToIndex(lpszCryptedGram[j]);
-			m_cDisplayLetters = (*m_cAlphabet[nChar]).DuplicateSprite(pDC);
-			(*m_cDisplayLetters).LinkSprite();
-			(*m_cDisplayLetters).PaintSprite(pDC, cPos.cx, cPos.cy);
+			m_cDisplayLetters = m_cAlphabet[nChar]->DuplicateSprite(pDC);
+			m_cDisplayLetters->LinkSprite();
+			m_cDisplayLetters->PaintSprite(pDC, cPos.cx, cPos.cy);
 
-			cLetterDim = (*m_cDisplayLetters).GetSize();
+			cLetterDim = m_cDisplayLetters->GetSize();
 			cPos.cx += cLetterDim.cx + m_nGramLetterSpacing;
 		} // end if
 	}
@@ -836,8 +836,8 @@ int CPaintGram::CenterGramVert(CCryptRecord *pRec) {
 	int     nEstimate;
 	int     i;
 
-	lpszGram        = (*pRec).GetGram();
-	lpszSource      = (*pRec).GetSource();
+	lpszGram        = pRec->GetGram();
+	lpszSource      = pRec->GetSource();
 	nEstimate       = 0;
 
 	/****************************************************************
@@ -884,7 +884,7 @@ int CPaintGram::CenterGramVert(CCryptRecord *pRec) {
 		} // end if
 
 		if (IsSymbolChar(lpszGram[i])) {
-			nLineLength += (*m_cAlphabet[SymbToIndex(lpszGram[i])]).GetSize().cx + m_nGramLetterSpacing;
+			nLineLength += m_cAlphabet[SymbToIndex(lpszGram[i])]->GetSize().cx + m_nGramLetterSpacing;
 			//((*m_cAlphabet[nChar]).GetSize()).cx + m_nGramLetterSpacing;
 		} // end if
 	} // end for
@@ -929,7 +929,7 @@ int CPaintGram::CenterGramVert(CCryptRecord *pRec) {
 		} // end if
 
 		if (IsSymbolChar(lpszSource[i])) {
-			nLineLength += (*m_cAlphabet[SymbToIndex(lpszSource[i])]).GetSize().cx + m_nGramLetterSpacing;
+			nLineLength += m_cAlphabet[SymbToIndex(lpszSource[i])]->GetSize().cx + m_nGramLetterSpacing;
 			//((*m_cAlphabet[nChar]).GetSize()).cx + m_nGramLetterSpacing;
 		} // end if
 	} // end for
@@ -967,10 +967,10 @@ int CPaintGram::CenterGramVert(CCryptRecord *pRec) {
 bool CPaintGram::IsHiLiteOn() {
 	m_cDisplayLetters = CSprite::GetSpriteChain();
 	while (m_cDisplayLetters != nullptr) {
-		if (IsHiLiteType((*m_cDisplayLetters).GetTypeCode()) == true) {
+		if (IsHiLiteType(m_cDisplayLetters->GetTypeCode()) == true) {
 			return true;
 		}
-		m_cDisplayLetters = (*m_cDisplayLetters).GetNextSprite();
+		m_cDisplayLetters = m_cDisplayLetters->GetNextSprite();
 	}
 
 	return false;
@@ -1007,18 +1007,18 @@ int CPaintGram::GetHiLiteType(CDC *pDC) {
 
 	m_cDisplayLetters = CSprite::GetSpriteChain();
 	while (m_cDisplayLetters != nullptr) {
-		if (IsHiLiteType((*m_cDisplayLetters).GetTypeCode()) == true) {
-			crectSprite = (*m_cDisplayLetters).GetRect();
-			m_cDisplayLetters = (*m_cDisplayLetters).Interception(&crectSprite);
-			nTypeCode = (*m_cDisplayLetters).GetTypeCode();
+		if (IsHiLiteType(m_cDisplayLetters->GetTypeCode()) == true) {
+			crectSprite = m_cDisplayLetters->GetRect();
+			m_cDisplayLetters = m_cDisplayLetters->Interception(&crectSprite);
+			nTypeCode = m_cDisplayLetters->GetTypeCode();
 
 			if (IsHiLiteType(nTypeCode) == true) {
-				return (*m_cDisplayLetters).Interception(&crectSprite, m_cDisplayLetters)->GetTypeCode();
+				return m_cDisplayLetters->Interception(&crectSprite, m_cDisplayLetters)->GetTypeCode();
 			} else {
 				return nTypeCode;
 			}
 		}
-		m_cDisplayLetters = (*m_cDisplayLetters).GetNextSprite();
+		m_cDisplayLetters = m_cDisplayLetters->GetNextSprite();
 	}
 
 	return false;
@@ -1060,17 +1060,17 @@ void CPaintGram::HiLiteOff(CDC *pDC) {
 
 	m_cDisplayLetters = CSprite::GetSpriteChain();
 	while (m_cDisplayLetters != nullptr) {
-		nTypeCode = (*m_cDisplayLetters).GetTypeCode();         // Get sprite's Hilite Code
+		nTypeCode = m_cDisplayLetters->GetTypeCode();         // Get sprite's Hilite Code
 
 		if (IsHiLiteType(nTypeCode) == true) {               // Is this sprite hi-lited?
-			pSprite = (*m_cDisplayLetters).GetNextSprite();     // Yes - save current pos in sprite chain
-			(*m_cDisplayLetters).RefreshBackground(pDC);        // ...repaint background
-			(*m_cDisplayLetters).UnlinkSprite();                // ...unlink it from chain
+			pSprite = m_cDisplayLetters->GetNextSprite();     // Yes - save current pos in sprite chain
+			m_cDisplayLetters->RefreshBackground(pDC);        // ...repaint background
+			m_cDisplayLetters->UnlinkSprite();                // ...unlink it from chain
 			delete m_cDisplayLetters;
 
 			m_cDisplayLetters = pSprite;                        // faster than GetNextSprite call
 		} else {
-			m_cDisplayLetters = (*m_cDisplayLetters).GetNextSprite();
+			m_cDisplayLetters = m_cDisplayLetters->GetNextSprite();
 		}
 	}
 }
@@ -1113,20 +1113,20 @@ void CPaintGram::HiLiteOn(CDC *pDC, int nTypeCode) {
 
 	m_cDisplayLetters = CSprite::GetSpriteChain();  // Get entire sprite chain
 	while (m_cDisplayLetters != nullptr) {              // Hilite all matching chars
-		if (nTypeCode == (*m_cDisplayLetters).GetTypeCode()) {   // Is this a char to hilite?
-			cpointSprite = (*m_cDisplayLetters).GetPosition();      // Yes - get old sprite's position
-			pSprite = (*m_cDisplayLetters).GetNextSprite();         // save current pos in sprite chain
+		if (nTypeCode == m_cDisplayLetters->GetTypeCode()) {   // Is this a char to hilite?
+			cpointSprite = m_cDisplayLetters->GetPosition();      // Yes - get old sprite's position
+			pSprite = m_cDisplayLetters->GetNextSprite();         // save current pos in sprite chain
 
-			m_cDisplayLetters = (*m_cHiLite).DuplicateSprite(pDC);  // setup hilited sprite
-			(*m_cDisplayLetters).LinkSprite();
-			(*m_cDisplayLetters).PaintSprite(pDC, cpointSprite);
+			m_cDisplayLetters = m_cHiLite->DuplicateSprite(pDC);  // setup hilited sprite
+			m_cDisplayLetters->LinkSprite();
+			m_cDisplayLetters->PaintSprite(pDC, cpointSprite);
 
 			if (IsAlphabetType(nTypeCode) == true)               // Hilited char in alpha region?
 				break;                                              // Yes - break out
 
 			m_cDisplayLetters = pSprite;                            // faster than GetNextSprite call
 		} else {
-			m_cDisplayLetters = (*m_cDisplayLetters).GetNextSprite();
+			m_cDisplayLetters = m_cDisplayLetters->GetNextSprite();
 		} // end if
 	} // end while
 }
@@ -1170,29 +1170,29 @@ void CPaintGram::ReplaceLetter(CDC *pDC, int nOldType, int nNewType) {
 	m_cDisplayLetters = CSprite::GetSpriteChain();
 
 	while (m_cDisplayLetters != nullptr) {
-		nTypeCode = (*m_cDisplayLetters).GetTypeCode();
+		nTypeCode = m_cDisplayLetters->GetTypeCode();
 		if (nOldType == nTypeCode) {                                 // Is this a char to change?
 
-			cpointSprite = (*m_cDisplayLetters).GetPosition();      // Yes - get old sprite's position
-			pSprite = (*m_cDisplayLetters).GetNextSprite();         // save current pos in sprite chain
+			cpointSprite = m_cDisplayLetters->GetPosition();      // Yes - get old sprite's position
+			pSprite = m_cDisplayLetters->GetNextSprite();         // save current pos in sprite chain
 
-			(*m_cDisplayLetters).RefreshBackground(pDC);            // ...repaint background
-			(*m_cDisplayLetters).UnlinkSprite();                    // ...unlink it from chain
+			m_cDisplayLetters->RefreshBackground(pDC);            // ...repaint background
+			m_cDisplayLetters->UnlinkSprite();                    // ...unlink it from chain
 			delete m_cDisplayLetters;
 
 			nIndexCode = CharToIndex(nNewType);
 			assert(nIndexCode < REVEAL_SYMBOLS);
 
 			if (IsRevealType(nNewType) == true) {
-				m_cDisplayLetters = (*m_cRevealAlphabet[nIndexCode]).DuplicateSprite(pDC);  // setup new sprite
+				m_cDisplayLetters = m_cRevealAlphabet[nIndexCode]->DuplicateSprite(pDC);  // setup new sprite
 			} else if (IsUsedType(nNewType) == true) {
-				m_cDisplayLetters = (*m_cUsedAlphabet[nIndexCode]).DuplicateSprite(pDC);    // setup new sprite
+				m_cDisplayLetters = m_cUsedAlphabet[nIndexCode]->DuplicateSprite(pDC);    // setup new sprite
 			} else {
-				m_cDisplayLetters = (*m_cAlphabet[nIndexCode]).DuplicateSprite(pDC);        // setup new sprite
-				(*m_cDisplayLetters).SetTypeCode(nNewType);                                 // save type code
+				m_cDisplayLetters = m_cAlphabet[nIndexCode]->DuplicateSprite(pDC);        // setup new sprite
+				m_cDisplayLetters->SetTypeCode(nNewType);                                 // save type code
 			}
-			(*m_cDisplayLetters).LinkSprite();
-			(*m_cDisplayLetters).PaintSprite(pDC, cpointSprite);
+			m_cDisplayLetters->LinkSprite();
+			m_cDisplayLetters->PaintSprite(pDC, cpointSprite);
 
 			if ((IsAlphabetType(nNewType) == true) ||
 			        (IsAlphabetType(nOldType) == true))                 // Replacing letter in the Alphabet region?
@@ -1200,7 +1200,7 @@ void CPaintGram::ReplaceLetter(CDC *pDC, int nOldType, int nNewType) {
 
 			m_cDisplayLetters = pSprite;                            // faster than GetNextSprite call
 		} else {
-			m_cDisplayLetters = (*m_cDisplayLetters).GetNextSprite();
+			m_cDisplayLetters = m_cDisplayLetters->GetNextSprite();
 		} // end if
 	} // end while
 }

--- a/engines/bagel/hodjnpodj/dfa/dfa.cpp
+++ b/engines/bagel/hodjnpodj/dfa/dfa.cpp
@@ -140,7 +140,7 @@ CMainDFAWindow::CMainDFAWindow(HWND hCallingWnd, LPGAMESTRUCT lpGameStruct) :
 	ASSERT(pDibDoc);                                    // ... and verify we got it
 	bTestDibDoc = pDibDoc->OpenDocument(SPLASHSPEC);    // next load in the actual DIB based artwork
 	ASSERT(bTestDibDoc);
-	pGamePalette = (*pDibDoc).DetachPalette();          // grab its palette and save it for later use
+	pGamePalette = pDibDoc->DetachPalette();          // grab its palette and save it for later use
 	delete pDibDoc;                                     // now discard the splash screen
 
 	// set window coordinates to center game on screeen
@@ -303,7 +303,7 @@ CMainDFAWindow::CMainDFAWindow(HWND hCallingWnd, LPGAMESTRUCT lpGameStruct) :
 	pGameSound = new CSound(this, GAME_THEME, SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 	if (m_lpGameStruct->bMusicEnabled) {
 		if (pGameSound != nullptr)
-			(*pGameSound).midiLoopPlaySegment(1480, 30700, 0, FMT_MILLISEC);
+			pGameSound->midiLoopPlaySegment(1480, 30700, 0, FMT_MILLISEC);
 	} // end if pGameSound
 
 
@@ -415,7 +415,7 @@ void CMainDFAWindow::SplashScreen() {
 	rcDIB.top = rcDIB.left = 0;                                     // setup the source rectangle from which
 	rcDIB.right = cxDIB;                                            // ... we'll do the painting
 	rcDIB.bottom = cyDIB;
-	PaintDIB((*pDC).m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);  // transfer the image to the screen
+	PaintDIB(pDC->m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);  // transfer the image to the screen
 
 	if (m_nTimeForGame > 0) {
 		pTimerSprite->SetCel(nCurrentCel);
@@ -641,14 +641,14 @@ bool CMainDFAWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 			if ((m_lpGameStruct->bMusicEnabled == false) && (pGameSound != nullptr)) {
 				if (pGameSound->playing())
-					(*pGameSound).stop();
+					pGameSound->stop();
 			} else if (m_lpGameStruct->bMusicEnabled == true) {
 				if (pGameSound == nullptr) {
 					pGameSound = new CSound(this, GAME_THEME,
 					                        SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 				}
 				if (pGameSound != nullptr) {
-					(*pGameSound).midiLoopPlaySegment(1480, 30700, 0, FMT_MILLISEC);
+					pGameSound->midiLoopPlaySegment(1480, 30700, 0, FMT_MILLISEC);
 				} // end if pGameSound
 			}
 
@@ -669,7 +669,7 @@ bool CMainDFAWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 		}
 	}
 
-	(*this).SetFocus();                         // Reset focus back to the main window
+	(this)->SetFocus();                         // Reset focus back to the main window
 	return true;
 }
 
@@ -718,7 +718,7 @@ void CMainDFAWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 		sndPlaySound(nullptr, 0);
 		pEffect = new CSound((CWnd *)this, WATCH_WAV,
 		                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-		(*pEffect).play();                                                      //...play the narration
+		pEffect->play();                                                      //...play the narration
 	}
 
 	else if (rLake.PtInRect(point) && m_lpGameStruct->bSoundEffectsEnabled)   {
@@ -726,7 +726,7 @@ void CMainDFAWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 		sndPlaySound(nullptr, 0);
 		pEffect = new CSound((CWnd *)this, LAKE_WAV,
 		                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-		(*pEffect).play();                                                      //...play the narration
+		pEffect->play();                                                      //...play the narration
 	}
 
 	else if (rMount.PtInRect(point) && m_lpGameStruct->bSoundEffectsEnabled)  {
@@ -734,7 +734,7 @@ void CMainDFAWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 		sndPlaySound(nullptr, 0);
 		pEffect = new CSound((CWnd *)this, MOUNT_WAV,
 		                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-		(*pEffect).play();                                                      //...play the narration
+		pEffect->play();                                                      //...play the narration
 	}
 
 	else if (rFlowers.PtInRect(point) && m_lpGameStruct->bSoundEffectsEnabled)    {
@@ -742,7 +742,7 @@ void CMainDFAWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 		sndPlaySound(nullptr, 0);
 		pEffect = new CSound((CWnd *)this, BEE_WAV,
 		                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-		(*pEffect).play();                                                      //...play the narration
+		pEffect->play();                                                      //...play the narration
 	}
 
 	if (bEndGame)
@@ -917,7 +917,7 @@ void CMainDFAWindow::OnTimer(uintptr nWhichTimer) {
 				sndPlaySound(nullptr, 0);
 				pEffect = new CSound((CWnd *)this, TIME_WAV,
 				                     SOUND_WAVE | SOUND_ASYNCH /*| SOUND_QUEUE*/ | SOUND_AUTODELETE);    //...Wave file, to delete itself
-				(*pEffect).play();                                                      //...play the narration
+				pEffect->play();                                                      //...play the narration
 			}
 
 			msgBox.SetInitialOptions(1, m_lScore);

--- a/engines/bagel/hodjnpodj/garfunkle/garfunkle.cpp
+++ b/engines/bagel/hodjnpodj/garfunkle/garfunkle.cpp
@@ -169,9 +169,9 @@ CMainWindow::CMainWindow() {
 	StartRect.SetRect(SCROLL_BUTTON_X, SCROLL_BUTTON_Y,
 	                  SCROLL_BUTTON_X + SCROLL_BUTTON_DX - 1,
 	                  SCROLL_BUTTON_Y + SCROLL_BUTTON_DY - 1);
-	bSuccess = (*m_pScrollButton).Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, StartRect, this, IDC_SCROLL);
+	bSuccess = m_pScrollButton->Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, StartRect, this, IDC_SCROLL);
 	ASSERT(bSuccess);
-	bSuccess = (*m_pScrollButton).LoadBitmaps(SCROLLUP, SCROLLDOWN, 0, 0);
+	bSuccess = m_pScrollButton->LoadBitmaps(SCROLLUP, SCROLLDOWN, 0, 0);
 	ASSERT(bSuccess);
 	m_bIgnoreScrollClick = false;
 
@@ -197,21 +197,21 @@ CMainWindow::CMainWindow() {
 			pMusicians[(i * 2) + j] = FetchResourceBitmap(pDC, nullptr, FIRST_MUSICIAN + (i * 2) + j);
 		}
 		pAnimSprite[i] = new CSprite;
-		(*pAnimSprite[i]).SharePalette(pGamePalette);
-		bSuccess = (*pAnimSprite[i]).LoadCels(pDC, cAnimName[i], nNumCels[i]);
+		pAnimSprite[i]->SharePalette(pGamePalette);
+		bSuccess = pAnimSprite[i]->LoadCels(pDC, cAnimName[i], nNumCels[i]);
 		ASSERT(bSuccess);
-		(*pAnimSprite[i]).SetMasked(false);
-		(*pAnimSprite[i]).SetMobile(false);
+		pAnimSprite[i]->SetMasked(false);
+		pAnimSprite[i]->SetMobile(false);
 	}
 
 	// Set up the text on the sign to display the current series length
 	StartRect.SetRect(SIGN_LOCATION_X, SIGN_LOCATION_Y,
 	                  SIGN_LOCATION_X + SIGN_WIDTH, SIGN_LOCATION_Y + SIGN_HEIGHT);
 	if ((m_pSignText = new CText()) != nullptr) {
-		(*m_pSignText).SetupText(pDC, pGamePalette, &StartRect, JUSTIFY_CENTER);
+		m_pSignText->SetupText(pDC, pGamePalette, &StartRect, JUSTIFY_CENTER);
 	}
 
-	(*pDC).SelectPalette(pOldPal, false);           // Select back the old palette
+	pDC->SelectPalette(pOldPal, false);           // Select back the old palette
 	ReleaseDC(pDC);
 
 	//srand((unsigned) time(nullptr));                 // seed the random number generator
@@ -337,12 +337,12 @@ void CMainWindow::SplashScreen() {
 		rcDIB.top = rcDIB.left = 0;
 		rcDIB.right = cxDIB;
 		rcDIB.bottom = cyDIB;
-		PaintDIB((*pDC).m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
+		PaintDIB(pDC->m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
 	}
 
 	if (m_bPlayGame) {
 		Common::sprintf_s(msg, "%d", nNoteCount - 1);
-		(*m_pSignText).DisplayString(pDC, msg, 32, FW_NORMAL, SIGN_COLOR);
+		m_pSignText->DisplayString(pDC, msg, 32, FW_NORMAL, SIGN_COLOR);
 		if (pGameInfo->bPlayingMetagame && (nNoteCount > m_nWinCondition)) {
 			PaintMaskedBitmap(pDC, pGamePalette, pRibbon, RIBBON_X, RIBBON_Y);
 		}
@@ -422,7 +422,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 					if (pGameInfo->bSoundEffectsEnabled) {
 						pEffect = new CSound((CWnd *)this, WRONG_SOUND,
 						                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-						(*pEffect).play();                                                      //...play the narration
+						pEffect->play();                                                      //...play the narration
 					}
 					MSG lpmsg;                                  // Clear out any extraneous mouse clicks
 					while (PeekMessage(&lpmsg, m_hWnd, WM_MOUSEFIRST, WM_MOUSELAST, PM_REMOVE)) ;
@@ -443,7 +443,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 					if (nNoteCount == MAX_SEQUENCE) {
 						nNoteCount++;                           // Hitting MAX increments NoteCount to MAX + 1
 						Common::sprintf_s(msg, "%d", nNoteCount - 1);    //...so return is correct
-						(*m_pSignText).DisplayString(pDC, msg, 32, FW_NORMAL, SIGN_COLOR);
+						m_pSignText->DisplayString(pDC, msg, 32, FW_NORMAL, SIGN_COLOR);
 
 						if (pGameInfo->bPlayingMetagame && (nNoteCount > m_nWinCondition)) {
 							PaintMaskedBitmap(pDC, pGamePalette, pRibbon, RIBBON_X, RIBBON_Y);
@@ -452,7 +452,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 						if (pGameInfo->bSoundEffectsEnabled) {
 							pEffect = new CSound((CWnd *)this, WIN_SOUND,
 							                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-							(*pEffect).play();                                                      //...play the narration
+							pEffect->play();                                                      //...play the narration
 						}
 						MSG lpmsg;
 						while (PeekMessage(&lpmsg, m_hWnd, WM_MOUSEFIRST, WM_MOUSELAST, PM_REMOVE)) ;
@@ -467,7 +467,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 					} else {
 						nNoteCount++;
 						Common::sprintf_s(msg, "%d", nNoteCount - 1);
-						(*m_pSignText).DisplayString(pDC, msg, 32, FW_NORMAL, SIGN_COLOR);
+						m_pSignText->DisplayString(pDC, msg, 32, FW_NORMAL, SIGN_COLOR);
 
 						if (pGameInfo->bPlayingMetagame && (nNoteCount > m_nWinCondition)) {
 							PaintMaskedBitmap(pDC, pGamePalette, pRibbon, RIBBON_X, RIBBON_Y);
@@ -493,22 +493,22 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 		case IDC_RULES:
 			m_bIgnoreScrollClick = true;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 
 			CSound::waitWaveSounds();
 			RulesDlg.DoModal();
 			m_bIgnoreScrollClick = false;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 			break;
 
 		case IDC_SCROLL:
 			if (m_bIgnoreScrollClick) {
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 				break;
 			}
 
 			m_bIgnoreScrollClick = true;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 			SendDlgItemMessage(IDC_SCROLL, BM_SETSTATE, true, 0L);
 
 			switch (COptionsWind.DoModal()) {
@@ -516,12 +516,12 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 			case IDC_OPTIONS_NEWGAME:
 				if (!pGameInfo->bPlayingMetagame)
 					NewGame();
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				m_bIgnoreScrollClick = false;
 				break;
 
 			case IDC_OPTIONS_RETURN:
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				m_bIgnoreScrollClick = false;
 				if (m_bPlayGame && m_bNewGame) {                         // playing repeat game & already
 					wait_awhile(PAUSE_TIME);                             // started...pause for a second
@@ -539,7 +539,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 	} // end if
 
 	ReleaseDC(pDC);
-	(*this).SetFocus();                     // Reset focus back to the main window
+	(this)->SetFocus();                     // Reset focus back to the main window
 	return true;
 }
 
@@ -631,7 +631,7 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 			KillTimer(PLAYER_TIMER);                                             // so it doesn't run out
 			pEffect = new CSound((CWnd *)this, TREES_SOUND,
 			                     SOUND_WAVE | SOUND_AUTODELETE); // Wave file, sync, to delete itself
-			(*pEffect).play();                                                      // Play the sound
+			pEffect->play();                                                      // Play the sound
 			if (m_bPlayGame && m_bNewGame)
 				SetTimer(PLAYER_TIMER, TIME_LIMIT, nullptr);                        // Reset response time limit
 		}
@@ -658,7 +658,7 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 			}
 			pEffect = new CSound((CWnd *)this, bufName,
 			                     SOUND_WAVE | SOUND_AUTODELETE);             // Wave file, to delete itself
-			(*pEffect).play();                                                  // play the sound
+			pEffect->play();                                                  // play the sound
 			if (m_bPlayGame && m_bNewGame)
 				SetTimer(PLAYER_TIMER, TIME_LIMIT, nullptr);                            // Reset response time limit
 		}
@@ -667,7 +667,7 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 			KillTimer(PLAYER_TIMER);                                             // so it doesn't run out
 			pEffect = new CSound((CWnd *)this, BENCH_SOUND,
 			                     SOUND_WAVE | SOUND_AUTODELETE);             // Wave file, to delete itself
-			(*pEffect).play();                                                  // Play the sound
+			pEffect->play();                                                  // Play the sound
 			if (m_bPlayGame && m_bNewGame)
 				SetTimer(PLAYER_TIMER, TIME_LIMIT, nullptr);                            // Reset response time limit
 		}
@@ -877,7 +877,7 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 		if (pGameInfo->bSoundEffectsEnabled) {
 			pEffect = new CSound((CWnd *)this, SLOW_SOUND,
 			                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-			(*pEffect).play();                                                      //...play the narration
+			pEffect->play();                                                      //...play the narration
 		}
 		MSG lpmsg;
 		while (PeekMessage(&lpmsg, m_hWnd, WM_MOUSEFIRST, WM_MOUSELAST, PM_REMOVE)) ;
@@ -894,8 +894,8 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 	break;
 
 	case ANIM_TIMER:
-		(*pAnimSprite[m_nButID]).PaintSprite(pDC, rectMusic[m_nButID].TopLeft().x - Offset[m_nButID].x,
-		                                     rectMusic[m_nButID].TopLeft().y - Offset[m_nButID].y);
+		pAnimSprite[m_nButID]->PaintSprite(pDC, rectMusic[m_nButID].TopLeft().x - Offset[m_nButID].x,
+		                                  rectMusic[m_nButID].TopLeft().y - Offset[m_nButID].y);
 		break;
 
 	default:
@@ -938,7 +938,7 @@ void CMainWindow::NewGame() {
 
 	pDC = GetDC();
 
-	(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+	m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 	m_bIgnoreScrollClick = false;
 
 	m_bPlayGame = tempPlayGame;
@@ -955,11 +955,11 @@ void CMainWindow::NewGame() {
 		nNoteCount = 1;
 		nCheckCount = 0;
 		Common::sprintf_s(msg, "%d", nNoteCount - 1);
-		(*m_pSignText).DisplayString(pDC, msg, 32, FW_NORMAL, SIGN_COLOR);
+		m_pSignText->DisplayString(pDC, msg, 32, FW_NORMAL, SIGN_COLOR);
 	} else {
 		m_bPlaying = true;                                  // Make sure we can play music
 		Common::strcpy_s(msg, "");
-		(*m_pSignText).DisplayString(pDC, msg, 32, FW_NORMAL, SIGN_COLOR);
+		m_pSignText->DisplayString(pDC, msg, 32, FW_NORMAL, SIGN_COLOR);
 	}
 
 	ReleaseDC(pDC);
@@ -970,19 +970,19 @@ void CMainWindow::StartAnimation() {
 
 	pDC = GetDC();
 
-	(*pAnimSprite[m_nButID]).SetCel(nNumCels[m_nButID]);
+	pAnimSprite[m_nButID]->SetCel(nNumCels[m_nButID]);
 	SetTimer(ANIM_TIMER, ANIM_SLEEP, nullptr);
 
 	if (pGameInfo->bSoundEffectsEnabled) {
 		pMusic = new CSound((CWnd *)this, cSoundName[m_nButID],
 		                    SOUND_MIDI | SOUND_ASYNCH |
 		                    SOUND_LOOP | SOUND_NOTIFY);         //...Midi file, looping | SOUND_NOTIFY
-		(*pMusic).play();                                           //...play the sound
+		pMusic->play();                                           //...play the sound
 	}
 
-	(*pAnimSprite[m_nButID]).PaintSprite(pDC,
-	                                     rectMusic[m_nButID].TopLeft().x - Offset[m_nButID].x,
-	                                     rectMusic[m_nButID].TopLeft().y - Offset[m_nButID].y);
+	pAnimSprite[m_nButID]->PaintSprite(pDC,
+	                                  rectMusic[m_nButID].TopLeft().x - Offset[m_nButID].x,
+	                                  rectMusic[m_nButID].TopLeft().y - Offset[m_nButID].y);
 
 	ReleaseDC(pDC);
 }
@@ -1000,7 +1000,7 @@ void CMainWindow::StopAnimation() {
 	}
 
 	if (pMusic != nullptr) {
-		(*pMusic).stop();
+		pMusic->stop();
 		delete pMusic;
 		pMusic = nullptr;
 	}
@@ -1057,7 +1057,7 @@ void CMainWindow::ActivateButtons(unsigned int nNumActive, bool bState) {
 		i++;
 	}
 
-	(*pDC).SelectPalette(pOldPal, false);                        // Select back the old palette
+	pDC->SelectPalette(pOldPal, false);                        // Select back the old palette
 	ReleaseDC(pDC);
 
 }//end ActivateButtons()
@@ -1069,8 +1069,8 @@ void add_note_to_series(int nNewValue) {
 	if ((pNewNote = new CNote()) == 0) {
 		MessageBox(nullptr, "Could not create note!!", nullptr, MB_ICONEXCLAMATION);
 	}
-	(*pNewNote).SetValue(nNewValue);
-	(*pNewNote).LinkNote();                 //Add the new note to the bottom of the list
+	pNewNote->SetValue(nNewValue);
+	pNewNote->LinkNote();                 //Add the new note to the bottom of the list
 }//end add_note_to_series
 
 void CMainWindow::PlayBackSeries(int nNumNotes) {
@@ -1155,7 +1155,7 @@ void CMainWindow::OnClose() {
 	pDC = GetDC();
 	myRect.SetRect(0, 0, GAME_WIDTH, GAME_HEIGHT);
 	myBrush.CreateStockObject(BLACK_BRUSH);
-	(*pDC).FillRect(&myRect, &myBrush);
+	pDC->FillRect(&myRect, &myBrush);
 	ReleaseDC(pDC);
 
 	CNote::FlushNoteList();                     // Delete list from memory

--- a/engines/bagel/hodjnpodj/garfunkle/note.cpp
+++ b/engines/bagel/hodjnpodj/garfunkle/note.cpp
@@ -101,7 +101,7 @@ void CNote::LinkNote() {
 	m_pPrev = m_pNoteTail;          //... by pointing it back at the current
 	//... tail, making it the tail, and
 	if (m_pNoteTail)                //... pointing it at nullptr (the list terminator)
-		(*m_pNoteTail).m_pNext = this;
+		m_pNoteTail->m_pNext = this;
 	else
 		m_pNoteHead = this;
 	m_pNoteTail = this;
@@ -122,12 +122,12 @@ void CNote::LinkNote() {
 
 void CNote::UnLinkNote() {
 	if (m_pPrev)                            // disconnect us from the note chain
-		(*m_pPrev).m_pNext = m_pNext;       // ... by pointing the one before us, and
+		m_pPrev->m_pNext = m_pNext;       // ... by pointing the one before us, and
 	else                                    // ... the one after us, at each other
 		m_pNoteHead = m_pNext;              // special case the instances where the
 	// ... note to be removed is the first
 	if (m_pNext)                            // ...  or the last in the list, update
-		(*m_pNext).m_pPrev = m_pPrev;       // ... the head of chain pointer
+		m_pNext->m_pPrev = m_pPrev;       // ... the head of chain pointer
 	else
 		m_pNoteTail = m_pPrev;
 
@@ -151,7 +151,7 @@ void CNote::FlushNoteList() {
 	CNote   *pNote;
 
 	while ((pNote = CNote::GetNoteHead())) {
-		(*pNote).UnLinkNote();
+		pNote->UnLinkNote();
 		delete pNote;
 	}
 }

--- a/engines/bagel/hodjnpodj/garfunkle/optndlg.cpp
+++ b/engines/bagel/hodjnpodj/garfunkle/optndlg.cpp
@@ -115,7 +115,7 @@ bool COptnDlg::OnInitDialog() {
 
 	statRect.SetRect(LEFT_SIDE, 26, LEFT_SIDE + 175, 41);
 	if ((m_pButtonsText = new CText()) != nullptr) {
-		(*m_pButtonsText).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pButtonsText->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	m_ScrollButtons.SetScrollRange(MIN_BUTTONS, MAX_BUTTONS, 0);
@@ -123,31 +123,31 @@ bool COptnDlg::OnInitDialog() {
 
 	statRect.SetRect(LEFT_SIDE, 65, LEFT_SIDE + 175, 80);
 	if ((m_pSpeedText = new CText()) != nullptr) {
-		(*m_pSpeedText).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pSpeedText->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	m_ScrollSpeed.SetScrollRange(MIN_SPEED, MAX_SPEED, 0);
 	m_ScrollSpeed.SetScrollPos(m_nSpeed, true);
 
 	if ((pOKButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pOKButton).SetPalette(pSubOptionsPalette);                        // set the palette to use
-		(*pOKButton).SetControl(IDOK, this);            // tie to the dialog control
+		pOKButton->SetPalette(pSubOptionsPalette);                        // set the palette to use
+		pOKButton->SetControl(IDOK, this);            // tie to the dialog control
 	}
 
 	if ((pCancelButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pCancelButton).SetPalette(pSubOptionsPalette);                        // set the palette to use
-		(*pCancelButton).SetControl(IDCANCEL, this);            // tie to the dialog control
+		pCancelButton->SetPalette(pSubOptionsPalette);                        // set the palette to use
+		pCancelButton->SetControl(IDCANCEL, this);            // tie to the dialog control
 	}
 
 	if ((pGameButton = new CRadioButton) != nullptr) {                 // build a color QUIT button to let us exit
-		(*pGameButton).SetPalette(pSubOptionsPalette);                      // set the palette to use
-		(*pGameButton).SetControl(IDC_PLAYGAME, this);              // tie to the dialog control
+		pGameButton->SetPalette(pSubOptionsPalette);                      // set the palette to use
+		pGameButton->SetControl(IDC_PLAYGAME, this);              // tie to the dialog control
 	}
 
 
 	if ((pMusicButton = new CRadioButton) != nullptr) {                    // build a color QUIT button to let us exit
-		(*pMusicButton).SetPalette(pSubOptionsPalette);                     // set the palette to use
-		(*pMusicButton).SetControl(IDC_PLAYMUSIC, this);            // tie to the dialog control
+		pMusicButton->SetPalette(pSubOptionsPalette);                     // set the palette to use
+		pMusicButton->SetControl(IDC_PLAYMUSIC, this);            // tie to the dialog control
 	}
 
 
@@ -169,14 +169,14 @@ bool COptnDlg::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 		case IDC_PLAYGAME:
 			m_bPlayGame = true;
-			(*pGameButton).SetCheck(m_bPlayGame);
-			(*pMusicButton).SetCheck(!m_bPlayGame);
+			pGameButton->SetCheck(m_bPlayGame);
+			pMusicButton->SetCheck(!m_bPlayGame);
 			break;
 
 		case IDC_PLAYMUSIC:
 			m_bPlayGame = false;
-			(*pGameButton).SetCheck(m_bPlayGame);
-			(*pMusicButton).SetCheck(!m_bPlayGame);
+			pGameButton->SetCheck(m_bPlayGame);
+			pMusicButton->SetCheck(!m_bPlayGame);
 			break;
 
 		case IDOK:
@@ -237,7 +237,7 @@ void COptnDlg::OnHScroll(unsigned int nSBCode, unsigned int nPos, CScrollBar* pS
 	if (NewPos > pMax) NewPos = pMax;
 
 	if (NewPos != OldPos) {                              //To prevent "flicker"
-		(*pScrollBar).SetScrollPos(NewPos, true);        //...only update when
+		pScrollBar->SetScrollPos(NewPos, true);        //...only update when
 	}                                                   //...changed
 
 	UpdateScrollbars();
@@ -282,14 +282,14 @@ void COptnDlg::UpdateScrollbars() {
 	m_nNumButtons = m_ScrollButtons.GetScrollPos();
 	if (OldValue != m_nNumButtons) {
 		Common::sprintf_s(msg, "Number of Musicians:  %d", m_nNumButtons);
-		(*m_pButtonsText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+		m_pButtonsText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 	}
 
 	OldValue = m_nSpeed;
 	m_nSpeed = m_ScrollSpeed.GetScrollPos();
 	if (OldValue != m_nSpeed) {
 		Common::sprintf_s(msg, "Speed:  %s", mSpeedTable[m_nSpeed].c_str());
-		(*m_pSpeedText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+		m_pSpeedText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 	}
 
 	ReleaseDC(pDC);
@@ -314,13 +314,13 @@ void COptnDlg::OnPaint() {
 	pDC = GetDC();
 
 	Common::sprintf_s(msg, "Number of Musicians:  %d", m_nNumButtons);
-	(*m_pButtonsText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+	m_pButtonsText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 
 	Common::sprintf_s(msg, "Speed:  %s", mSpeedTable[m_nSpeed].c_str());
-	(*m_pSpeedText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+	m_pSpeedText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 
-	(*pGameButton).SetCheck(m_bPlayGame);
-	(*pMusicButton).SetCheck(!m_bPlayGame);
+	pGameButton->SetCheck(m_bPlayGame);
+	pMusicButton->SetCheck(!m_bPlayGame);
 
 	ReleaseDC(pDC);
 

--- a/engines/bagel/hodjnpodj/hnplibs/bitmaps.cpp
+++ b/engines/bagel/hodjnpodj/hnplibs/bitmaps.cpp
@@ -35,8 +35,8 @@ CBitmap *FetchScreenBitmap(CDC *pDC, CPalette *pPalette, const int x, const int 
 	             *pWorkOld = nullptr;
 
 	if (pPalette != nullptr) {                                 // map in color palette to be used
-		pPalOld = (*pDC).SelectPalette(pPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	pWorkDC = new CDC();                                    // create the context and bitmap objects
@@ -44,31 +44,31 @@ CBitmap *FetchScreenBitmap(CDC *pDC, CPalette *pPalette, const int x, const int 
 
 	if ((pWorkDC != nullptr) &&                                // construct an offscreen bitmap that we
 	        (pWork != nullptr) &&                                  // ... can use as a work area, and then
-	        (*pWorkDC).CreateCompatibleDC(pDC) &&               // ... use as a return value to the caller
-	        (*pWork).CreateCompatibleBitmap(pDC, dx, dy)) {     // create a bitmap of the appropriate size
+	        pWorkDC->CreateCompatibleDC(pDC) &&               // ... use as a return value to the caller
+	        pWork->CreateCompatibleBitmap(pDC, dx, dy)) {     // create a bitmap of the appropriate size
 		if (pPalette != nullptr) {                             // map the palette into the work area
-			pPalOldWork = (*pWorkDC).SelectPalette(pPalette, false);
-			(*pWorkDC).RealizePalette();
+			pPalOldWork = pWorkDC->SelectPalette(pPalette, false);
+			pWorkDC->RealizePalette();
 		}
-		pWorkOld = (*pWorkDC).SelectObject(pWork);          // now map in the work area's bitmap
+		pWorkOld = pWorkDC->SelectObject(pWork);          // now map in the work area's bitmap
 		if (pWorkOld != nullptr)                               // capture the desired pixels
-			bSuccess = (*pWorkDC).BitBlt(0, 0, dx, dy, pDC, x, y, SRCCOPY);
+			bSuccess = pWorkDC->BitBlt(0, 0, dx, dy, pDC, x, y, SRCCOPY);
 	}
 
 	if (pPalOld != nullptr)                                    // relinquish the resources we built
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 	if (pWorkOld != nullptr)
-		(*pWorkDC).SelectObject(pWorkOld);
+		pWorkDC->SelectObject(pWorkOld);
 	if (pPalOldWork != nullptr)
-		(*pWorkDC).SelectPalette(pPalOldWork, false);
+		pWorkDC->SelectPalette(pPalOldWork, false);
 	if (!bSuccess &&                                        // release the bitmap result we built
 	        (pWork != nullptr)) {                                  // ... if something failed
-		(*pWork).DeleteObject();
+		pWork->DeleteObject();
 		delete pWork;
 		pWork = nullptr;
 	}
 	if (pWorkDC != nullptr) {
-		(*pWorkDC).DeleteDC();
+		pWorkDC->DeleteDC();
 		delete pWorkDC;
 	}
 
@@ -84,12 +84,12 @@ CBitmap *FetchBitmap(CDC *pDC, CPalette **pPalette, const char *pszPathName) {
 	pDIB = new CDibDoc();                               // create an object for our DIB
 
 	if ((pDIB != nullptr) &&                               // verify we have the objects we just created
-	        (*pDIB).OpenDocument(pszPathName)) {            // .... bitmap file
-		pThisPalette = (*pDIB).GetDocPalette();
-		hDIB = (*pDIB).GetHDIB();
+	        pDIB->OpenDocument(pszPathName)) {            // .... bitmap file
+		pThisPalette = pDIB->GetDocPalette();
+		hDIB = pDIB->GetHDIB();
 		pBitmap = ConvertDIB(pDC, hDIB, pThisPalette);
 		if (pPalette != nullptr)
-			*pPalette = (*pDIB).DetachPalette();
+			*pPalette = pDIB->DetachPalette();
 	}
 
 	delete pDIB;
@@ -105,8 +105,8 @@ CBitmap *FetchBitmap(CDC *pDC, CPalette *pPalette, const char *pszPathName) {
 	pDIB = new CDibDoc();                               // create an object for our DIB
 
 	if ((pDIB != nullptr) &&                               // verify we have the objects we just created
-	        (*pDIB).OpenDocument(pszPathName)) {            // .... bitmap file
-		hDIB = (*pDIB).GetHDIB();
+	        pDIB->OpenDocument(pszPathName)) {            // .... bitmap file
+		hDIB = pDIB->GetHDIB();
 		pBitmap = ConvertDIB(pDC, hDIB, pPalette);
 	}
 
@@ -125,12 +125,12 @@ CBitmap *FetchResourceBitmap(CDC *pDC, CPalette **pPalette, const char *pszName)
 	pDIB = new CDibDoc();                               // create an object for our DIB
 
 	if ((pDIB != nullptr) &&                               // verify we have the objects we just created
-	        (*pDIB).OpenResourceDocument(pszName)) {        // .... bitmap file
-		pThisPalette = (*pDIB).GetDocPalette();
-		hDIB = (*pDIB).GetHDIB();
+	        pDIB->OpenResourceDocument(pszName)) {        // .... bitmap file
+		pThisPalette = pDIB->GetDocPalette();
+		hDIB = pDIB->GetHDIB();
 		pBitmap = ConvertDIB(pDC, hDIB, pThisPalette);
 		if (pPalette != nullptr)
-			*pPalette = (*pDIB).DetachPalette();
+			*pPalette = pDIB->DetachPalette();
 	}
 
 	if (pDIB != nullptr)
@@ -151,12 +151,12 @@ CBitmap *FetchResourceBitmap(CDC *pDC, CPalette **pPalette, const int nResID) {
 	pDIB = new CDibDoc();                               // create an object for our DIB
 
 	if ((pDIB != nullptr) &&                               // verify we have the objects we just created
-	        (*pDIB).OpenResourceDocument(chResName)) {      // .... bitmap file
-		pThisPalette = (*pDIB).GetDocPalette();
-		hDIB = (*pDIB).GetHDIB();
+	        pDIB->OpenResourceDocument(chResName)) {      // .... bitmap file
+		pThisPalette = pDIB->GetDocPalette();
+		hDIB = pDIB->GetHDIB();
 		pBitmap = ConvertDIB(pDC, hDIB, pThisPalette);
 		if (pPalette != nullptr)
-			*pPalette = (*pDIB).DetachPalette();
+			*pPalette = pDIB->DetachPalette();
 	}
 
 	if (pDIB != nullptr)
@@ -177,8 +177,8 @@ CBitmap *ExtractBitmap(CDC *pDC, CBitmap *pBitmap, CPalette *pPalette, const int
 	              *pBaseOld = nullptr;
 
 	if (pPalette != nullptr) {                                 // map in color palette to be used
-		pPalOld = (*pDC).SelectPalette(pPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	pWorkDC = new CDC();                                    // create the context and bitmap objects
@@ -188,44 +188,44 @@ CBitmap *ExtractBitmap(CDC *pDC, CBitmap *pBitmap, CPalette *pPalette, const int
 	if ((pWorkDC != nullptr) &&                                // construct an offscreen bitmap that we
 	        (pWork != nullptr) &&                                  // ... can use as a work area, and then
 	        (pBaseDC != nullptr) &&                                // ... use as a return value to the caller
-	        (*pWorkDC).CreateCompatibleDC(pDC) &&               // setup a context for the source bitmap
-	        (*pBaseDC).CreateCompatibleDC(pDC) &&
-	        (*pWork).CreateCompatibleBitmap(pDC, dx, dy)) {     // create a bitmap of the appropriate size
+	        pWorkDC->CreateCompatibleDC(pDC) &&               // setup a context for the source bitmap
+	        pBaseDC->CreateCompatibleDC(pDC) &&
+	        pWork->CreateCompatibleBitmap(pDC, dx, dy)) {     // create a bitmap of the appropriate size
 		if (pPalette != nullptr) {                             // map the palette into the contexts
-			pPalOldWork = (*pWorkDC).SelectPalette(pPalette, false);
-			(*pWorkDC).RealizePalette();
-			pPalOldBase = (*pBaseDC).SelectPalette(pPalette, false);
-			(*pBaseDC).RealizePalette();
+			pPalOldWork = pWorkDC->SelectPalette(pPalette, false);
+			pWorkDC->RealizePalette();
+			pPalOldBase = pBaseDC->SelectPalette(pPalette, false);
+			pBaseDC->RealizePalette();
 		}
-		pWorkOld = (*pWorkDC).SelectObject(pWork);          // now map in the work area's bitmap
-		pBaseOld = (*pBaseDC).SelectObject(pBitmap);        // ... as well as the source bitmap
+		pWorkOld = pWorkDC->SelectObject(pWork);          // now map in the work area's bitmap
+		pBaseOld = pBaseDC->SelectObject(pBitmap);        // ... as well as the source bitmap
 		if ((pWorkOld != nullptr) &&
 		        (pBaseOld != nullptr))                             // grab the bitmap section if all is well
-			bSuccess = (*pWorkDC).BitBlt(0, 0, dx, dy, pBaseDC, x, y, SRCCOPY);
+			bSuccess = pWorkDC->BitBlt(0, 0, dx, dy, pBaseDC, x, y, SRCCOPY);
 	}
 
 	if (pPalOld != nullptr)                                    // relinquish the resources we built
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 	if (pWorkOld != nullptr)
-		(*pWorkDC).SelectObject(pWorkOld);
+		pWorkDC->SelectObject(pWorkOld);
 	if (pBaseOld != nullptr)
-		(*pBaseDC).SelectObject(pBaseOld);
+		pBaseDC->SelectObject(pBaseOld);
 	if (pPalOldWork != nullptr)
-		(*pWorkDC).SelectPalette(pPalOldWork, false);
+		pWorkDC->SelectPalette(pPalOldWork, false);
 	if (pPalOldBase != nullptr)
-		(*pBaseDC).SelectPalette(pPalOldBase, false);
+		pBaseDC->SelectPalette(pPalOldBase, false);
 	if (!bSuccess &&                                        // release the bitmap result we built
 	        (pWork != nullptr)) {                                  // ... if something failed
-		(*pWork).DeleteObject();
+		pWork->DeleteObject();
 		delete pWork;
 		pWork = nullptr;
 	}
 	if (pWorkDC != nullptr) {
-		(*pWorkDC).DeleteDC();
+		pWorkDC->DeleteDC();
 		delete pWorkDC;
 	}
 	if (pBaseDC != nullptr) {
-		(*pBaseDC).DeleteDC();
+		pBaseDC->DeleteDC();
 		delete pBaseDC;
 	}
 
@@ -260,56 +260,56 @@ bool BltBitmap(CDC *pDC, CPalette *pPalette, CBitmap *pBitmap, CRect *pSrcRect, 
 	CBitmap     *pWorkOld = nullptr;
 
 	if (pPalette != nullptr) {                                 // map in color palette to be used
-		pPalOld = (*pDC).SelectPalette(pPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	pWorkDC = new CDC();                                    // create the context and bitmap objects
 
 	if ((pWorkDC != nullptr) &&                                // verify we got what we asked for
 	        (pBitmap != nullptr) &&
-	        (*pWorkDC).CreateCompatibleDC(pDC)) {               // create a context for our bitmap
+	        pWorkDC->CreateCompatibleDC(pDC)) {               // create a context for our bitmap
 		if (pPalette != nullptr) {                             // map the palette into the context
-			pPalOldWork = (*pWorkDC).SelectPalette(pPalette, false);
-			(*pWorkDC).RealizePalette();
+			pPalOldWork = pWorkDC->SelectPalette(pPalette, false);
+			pWorkDC->RealizePalette();
 		}
-		pWorkOld = (*pWorkDC).SelectObject(pBitmap);        // now map in our bitmap
+		pWorkOld = pWorkDC->SelectObject(pBitmap);        // now map in our bitmap
 		if (pWorkOld != nullptr) {                             // paint back the saved pixels
-			if ((((*pSrcRect).right - (*pSrcRect).left) != ((*pDstRect).right - (*pDstRect).left)) ||
-			        (((*pSrcRect).bottom - (*pSrcRect).top) != ((*pDstRect).bottom - (*pDstRect).top))) {
-				(*pDC).SetStretchBltMode(STRETCH_DELETESCANS);
-				assert(GetDeviceCaps((*pDC).m_hDC, RASTERCAPS) & RC_STRETCHBLT);
-				bSuccess = (*pDC).StretchBlt((*pDstRect).left,
-					(*pDstRect).top,
-					(*pDstRect).right - (*pDstRect).left,
-					(*pDstRect).bottom - (*pDstRect).top,
+			if (((pSrcRect->right - pSrcRect->left) != (pDstRect->right - pDstRect->left)) ||
+			        ((pSrcRect->bottom - pSrcRect->top) != (pDstRect->bottom - pDstRect->top))) {
+				pDC->SetStretchBltMode(STRETCH_DELETESCANS);
+				assert(GetDeviceCaps(pDC->m_hDC, RASTERCAPS) & RC_STRETCHBLT);
+				bSuccess = pDC->StretchBlt(pDstRect->left,
+					pDstRect->top,
+					pDstRect->right - pDstRect->left,
+					pDstRect->bottom - pDstRect->top,
 					pWorkDC,
-					(*pSrcRect).left,
-					(*pSrcRect).top,
-					(*pSrcRect).right - (*pSrcRect).left,
-					(*pSrcRect).bottom - (*pSrcRect).top,
+					pSrcRect->left,
+					pSrcRect->top,
+					pSrcRect->right - pSrcRect->left,
+					pSrcRect->bottom - pSrcRect->top,
 					dwMode);
 			} else {
-				bSuccess = (*pDC).BitBlt((*pDstRect).left,
-					(*pDstRect).top,
-					(*pSrcRect).right - (*pSrcRect).left,
-					(*pSrcRect).bottom - (*pSrcRect).top,
+				bSuccess = pDC->BitBlt(pDstRect->left,
+					pDstRect->top,
+					pSrcRect->right - pSrcRect->left,
+					pSrcRect->bottom - pSrcRect->top,
 					pWorkDC,
-					(*pSrcRect).left,
-					(*pSrcRect).top,
+					pSrcRect->left,
+					pSrcRect->top,
 					dwMode);
 			}
 		}
 	}
 
 	if (pPalOld != nullptr)                                    // relinquish the resources we built
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 	if (pWorkOld != nullptr)
-		(*pWorkDC).SelectObject(pWorkOld);
+		pWorkDC->SelectObject(pWorkOld);
 	if (pPalOldWork != nullptr)
-		(*pWorkDC).SelectPalette(pPalOldWork, false);
+		pWorkDC->SelectPalette(pPalOldWork, false);
 	if (pWorkDC != nullptr) {
-		(*pWorkDC).DeleteDC();
+		pWorkDC->DeleteDC();
 		delete pWorkDC;
 	}
 
@@ -356,8 +356,8 @@ bool BltMaskedBitmap(CDC *pDC, CPalette *pPalette, CBitmap *pBitmap, CRect *pSrc
 	CRect       dstRect;
 
 	if (pPalette != nullptr) {
-		pPalOld = (*pDC).SelectPalette(pPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	pImageDC = new CDC();                               // create the necessary objects
@@ -373,34 +373,34 @@ bool BltMaskedBitmap(CDC *pDC, CPalette *pPalette, CBitmap *pBitmap, CRect *pSrc
 	        (pImage != nullptr) &&
 	        (pMask != nullptr) &&
 	        (pWork != nullptr) &&
-	        (*pImageDC).CreateCompatibleDC(pDC) &&              // now create all the compatible contexts
-	        (*pMaskDC).CreateCompatibleDC(pDC) &&               // ... that we need to hold our bitmaps
-	        (*pWorkDC).CreateCompatibleDC(pDC)) {
+	        pImageDC->CreateCompatibleDC(pDC) &&              // now create all the compatible contexts
+	        pMaskDC->CreateCompatibleDC(pDC) &&               // ... that we need to hold our bitmaps
+	        pWorkDC->CreateCompatibleDC(pDC)) {
 
-		dx = (*pSrcRect).right - (*pSrcRect).left;
-		dy = (*pSrcRect).bottom - (*pSrcRect).top;
+		dx = pSrcRect->right - pSrcRect->left;
+		dy = pSrcRect->bottom - pSrcRect->top;
 
 		if (pPalette != nullptr) {                     // map in the color palette if specified
-			pPalOldImage = (*pImageDC).SelectPalette(pPalette, false);
-			(*pImageDC).RealizePalette();
-			pPalOldWork = (*pWorkDC).SelectPalette(pPalette, false);
-			(*pWorkDC).RealizePalette();
+			pPalOldImage = pImageDC->SelectPalette(pPalette, false);
+			pImageDC->RealizePalette();
+			pPalOldWork = pWorkDC->SelectPalette(pPalette, false);
+			pWorkDC->RealizePalette();
 		}
 
-		if ((*pImage).CreateCompatibleBitmap(pDC, dx, dy) &&
-		        (*pWork).CreateCompatibleBitmap(pDC, dx, dy) &&
-		        (*pMask).CreateBitmap(dx, dy, 1, 1, nullptr)) {
+		if (pImage->CreateCompatibleBitmap(pDC, dx, dy) &&
+		        pWork->CreateCompatibleBitmap(pDC, dx, dy) &&
+		        pMask->CreateBitmap(dx, dy, 1, 1, nullptr)) {
 
-			pImageOld = (*pImageDC).SelectObject(pImage);
-			pMaskOld = (*pMaskDC).SelectObject(pMask);  // map the work and mask bitmaps into
-			pWorkOld = (*pWorkDC).SelectObject(pWork);  // ... their contexts
+			pImageOld = pImageDC->SelectObject(pImage);
+			pMaskOld = pMaskDC->SelectObject(pMask);  // map the work and mask bitmaps into
+			pWorkOld = pWorkDC->SelectObject(pWork);  // ... their contexts
 
 			dstRect.SetRect(0, 0, dx, dy);
 			BltBitmap(pImageDC, pPalette, pBitmap, pSrcRect, &dstRect, (uint32) SRCCOPY);
 
 			if ((pMaskOld != nullptr) &&                   // verify so far so good
 			        (pWorkOld != nullptr)) {
-				(*pWorkDC).BitBlt(     // grab what the background looks like
+				pWorkDC->BitBlt(     // grab what the background looks like
 				    0,                              // ... putting it in the work area
 				    0,
 				    dx,
@@ -409,42 +409,42 @@ bool BltMaskedBitmap(CDC *pDC, CPalette *pPalette, CBitmap *pBitmap, CRect *pSrc
 				    x,
 				    y,
 				    SRCCOPY);
-				(*pMaskDC).BitBlt(     // create the mask by inverting the image
+				pMaskDC->BitBlt(     // create the mask by inverting the image
 				    0, 0,                           // ... i.e. the pixels occupied by the image
 				    dx,
 				    dy,
 				    pImageDC,
 				    0, 0,
 				    NOTSRCCOPY);
-				(*pImageDC).BitBlt(     // remove the image's "transparent" white area
+				pImageDC->BitBlt(     // remove the image's "transparent" white area
 				    0, 0,                           // ... i.e. its background becomes black
 				    dx,
 				    dy,
 				    pMaskDC,
 				    0, 0,
 				    SRCAND);
-				(*pMaskDC).BitBlt(     // invert the mask
+				pMaskDC->BitBlt(     // invert the mask
 				    0, 0,
 				    dx,
 				    dy,
 				    pMaskDC,
 				    0, 0,
 				    DSTINVERT);
-				(*pWorkDC).BitBlt(     // remove the image's space from the work area
+				pWorkDC->BitBlt(     // remove the image's space from the work area
 				    0, 0,                           // ... i.e. the pixels where the image will go
 				    dx,
 				    dy,
 				    pMaskDC,
 				    0, 0
 				    , SRCAND);
-				(*pWorkDC).BitBlt(     // paint the image into the cleared (black) space
+				pWorkDC->BitBlt(     // paint the image into the cleared (black) space
 				    0, 0,                           // ... we made in the work area
 				    dx,
 				    dy,
 				    pImageDC,
 				    0, 0,
 				    SRCPAINT);
-				bSuccess = (*pDC).BitBlt(    // now splat the result to the destination context
+				bSuccess = pDC->BitBlt(    // now splat the result to the destination context
 				               x,
 				               y,
 				               dx,
@@ -458,43 +458,43 @@ bool BltMaskedBitmap(CDC *pDC, CPalette *pPalette, CBitmap *pBitmap, CRect *pSrc
 	}
 
 	if (pPalOld != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	if (pImageOld != nullptr)                              // select out bitmaps out of their contexts
-		(*pImageDC).SelectObject(pImageOld);
+		pImageDC->SelectObject(pImageOld);
 	if (pWorkOld != nullptr)
-		(*pWorkDC).SelectObject(pWorkOld);
+		pWorkDC->SelectObject(pWorkOld);
 	if (pMaskOld != nullptr)
-		(*pMaskDC).SelectObject(pMaskOld);
+		pMaskDC->SelectObject(pMaskOld);
 
 	if (pPalOldImage != nullptr)                           // map out the palettes we used
-		(*pImageDC).SelectPalette(pPalOldImage, false);
+		pImageDC->SelectPalette(pPalOldImage, false);
 	if (pPalOldWork != nullptr)
-		(*pWorkDC).SelectPalette(pPalOldWork, false);
+		pWorkDC->SelectPalette(pPalOldWork, false);
 
 	if (pImage != nullptr) {                                // delete the bitmaps we created
-		(*pImage).DeleteObject();
+		pImage->DeleteObject();
 		delete pImage;
 	}
 	if (pWork != nullptr) {
-		(*pWork).DeleteObject();
+		pWork->DeleteObject();
 		delete pWork;
 	}
 	if (pMask != nullptr) {
-		(*pMask).DeleteObject();
+		pMask->DeleteObject();
 		delete pMask;
 	}
 
 	if (pImageDC != nullptr) {                             // delete the contexts we created
-		(*pImageDC).DeleteDC();
+		pImageDC->DeleteDC();
 		delete pImageDC;
 	}
 	if (pWorkDC != nullptr) {
-		(*pWorkDC).DeleteDC();
+		pWorkDC->DeleteDC();
 		delete pWorkDC;
 	}
 	if (pMaskDC != nullptr) {
-		(*pMaskDC).DeleteDC();
+		pMaskDC->DeleteDC();
 		delete pMaskDC;
 	}
 
@@ -529,41 +529,41 @@ bool PaintBitmap(CDC *pDC, CPalette *pPalette, CBitmap *pBitmap, const int x, co
 	BITMAP      cBitmapData;
 	CRect       SrcRect, DstRect;
 
-	(*pBitmap).GetObject(sizeof(BITMAP), &cBitmapData);
+	pBitmap->GetObject(sizeof(BITMAP), &cBitmapData);
 
 	if (pPalette != nullptr) {                                 // map in color palette to be used
-		pPalOld = (*pDC).SelectPalette(pPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	pWorkDC = new CDC();                                    // create the context and bitmap objects
 
-	if ((*pWorkDC).CreateCompatibleDC(pDC)) {               // create a context for our bitmap
+	if (pWorkDC->CreateCompatibleDC(pDC)) {               // create a context for our bitmap
 		if (pPalette != nullptr) {                             // map the palette into the context
-			pPalOldWork = (*pWorkDC).SelectPalette(pPalette, false);
-			(*pWorkDC).RealizePalette();
+			pPalOldWork = pWorkDC->SelectPalette(pPalette, false);
+			pWorkDC->RealizePalette();
 		}
-		pWorkOld = (*pWorkDC).SelectObject(pBitmap);        // now map in our bitmap
+		pWorkOld = pWorkDC->SelectObject(pBitmap);        // now map in our bitmap
 		if (pWorkOld != nullptr) {                             // paint back the saved pixels
 			if ((dx != 0) && (dy != 0) &&
 			        ((dx != cBitmapData.bmWidth) || (dy != cBitmapData.bmHeight))) {
-				(*pDC).SetStretchBltMode(STRETCH_DELETESCANS);
-				assert(GetDeviceCaps((*pDC).m_hDC, RASTERCAPS) & RC_STRETCHBLT);
-				bSuccess = (*pDC).StretchBlt(x, y, dx, dy, pWorkDC, 0, 0, cBitmapData.bmWidth, cBitmapData.bmHeight, SRCCOPY);
+				pDC->SetStretchBltMode(STRETCH_DELETESCANS);
+				assert(GetDeviceCaps(pDC->m_hDC, RASTERCAPS) & RC_STRETCHBLT);
+				bSuccess = pDC->StretchBlt(x, y, dx, dy, pWorkDC, 0, 0, cBitmapData.bmWidth, cBitmapData.bmHeight, SRCCOPY);
 			} else {
-				bSuccess = (*pDC).BitBlt(x, y, cBitmapData.bmWidth, cBitmapData.bmHeight, pWorkDC, 0, 0, SRCCOPY);
+				bSuccess = pDC->BitBlt(x, y, cBitmapData.bmWidth, cBitmapData.bmHeight, pWorkDC, 0, 0, SRCCOPY);
 			}
 		}
 	}
 
 	if (pPalOld != nullptr)                                    // relinquish the resources we built
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 	if (pWorkOld != nullptr)
-		(*pWorkDC).SelectObject(pWorkOld);
+		pWorkDC->SelectObject(pWorkOld);
 	if (pPalOldWork != nullptr)
-		(*pWorkDC).SelectPalette(pPalOldWork, false);
+		pWorkDC->SelectPalette(pPalOldWork, false);
 	if (pWorkDC != nullptr) {
-		(*pWorkDC).DeleteDC();
+		pWorkDC->DeleteDC();
 		delete pWorkDC;
 	}
 
@@ -614,7 +614,7 @@ bool PaintBitmap(CDC *pDC, CPalette *pPalette, const char *pszPathName, const in
 				rcDest.SetRect(x, y, x + cxDIB, y + cyDIB);
 			else
 				rcDest.SetRect(x, y, x + dx, y + dy);
-			bSuccess = PaintDIB((*pDC).m_hDC, &rcDest, hDIB, &rcDIB, pPalette);
+			bSuccess = PaintDIB(pDC->m_hDC, &rcDest, hDIB, &rcDIB, pPalette);
 		}
 	}
 
@@ -649,7 +649,7 @@ bool PaintMaskedDIB(CDC *pDC, CPalette *pPalette, const char *pszPathName, const
 	pDIB = new CDibDoc();                               // create an object for our DIB
 
 	if ((pDIB != nullptr) &&                               // verify we have the objects we just created
-	        (*pDIB).OpenDocument(pszPathName))              // .... bitmap file
+	        pDIB->OpenDocument(pszPathName))              // .... bitmap file
 		bSuccess = PaintMaskedDIB(pDC, pPalette, pDIB, x, y, dx, dy) ;
 
 	if (pDIB != nullptr)
@@ -689,7 +689,7 @@ bool PaintMaskedResource(CDC *pDC, CPalette *pPalette, const int nResID, const i
 	pDIB = new CDibDoc();                               // create an object for our DIB
 
 	if ((pDIB != nullptr) &&                               // verify we have the objects we just created
-	        (*pDIB).OpenResourceDocument(chResName))        // .... bitmap file
+	        pDIB->OpenResourceDocument(chResName))        // .... bitmap file
 		bSuccess = PaintMaskedDIB(pDC, pPalette, pDIB, x, y, dx, dy) ;
 
 	if (pDIB != nullptr)
@@ -727,7 +727,7 @@ bool PaintMaskedResource(CDC *pDC, CPalette *pPalette, const char *pszName, cons
 	pDIB = new CDibDoc();                               // create an object for our DIB
 
 	if ((pDIB != nullptr) &&                               // verify we have the objects we just created
-	        (*pDIB).OpenResourceDocument(pszName))          // .... bitmap file
+	        pDIB->OpenResourceDocument(pszName))          // .... bitmap file
 		bSuccess = PaintMaskedDIB(pDC, pPalette, pDIB, x, y, dx, dy) ;
 
 	if (pDIB != nullptr)
@@ -764,16 +764,16 @@ bool PaintMaskedDIB(CDC *pDC, CPalette *pPalette, CDibDoc *pDIB, const int x, co
 	HDIB        hDIB = nullptr;
 
 	if (pPalette == nullptr)
-		pMyPalette = (*pDIB).GetDocPalette();
+		pMyPalette = pDIB->GetDocPalette();
 	else
 		pMyPalette = pPalette;
 
-	hDIB = (*pDIB).GetHDIB();
+	hDIB = pDIB->GetHDIB();
 	pBitmap = ConvertDIB(pDC, hDIB, pMyPalette);
 
 	if (pBitmap != nullptr) {
 		bSuccess = PaintMaskedBitmap(pDC, pMyPalette, pBitmap, x, y, dx, dy);
-		(*pBitmap).DeleteObject();
+		pBitmap->DeleteObject();
 		delete pBitmap;
 	}
 
@@ -819,8 +819,8 @@ bool PaintMaskedBitmap(CDC *pDC, CPalette *pPalette, CBitmap *pBitmap, const int
 	CSize       cSize;
 
 	if (pPalette != nullptr) {
-		pPalOld = (*pDC).SelectPalette(pPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	pImageDC = new CDC();                               // create the necessary objects
@@ -836,11 +836,11 @@ bool PaintMaskedBitmap(CDC *pDC, CPalette *pPalette, CBitmap *pBitmap, const int
 	        (pImage != nullptr) &&
 	        (pMask != nullptr) &&
 	        (pWork != nullptr) &&
-	        (*pImageDC).CreateCompatibleDC(pDC) &&              // now create all the compatible contexts
-	        (*pMaskDC).CreateCompatibleDC(pDC) &&               // ... that we need to hold our bitmaps
-	        (*pWorkDC).CreateCompatibleDC(pDC)) {
+	        pImageDC->CreateCompatibleDC(pDC) &&              // now create all the compatible contexts
+	        pMaskDC->CreateCompatibleDC(pDC) &&               // ... that we need to hold our bitmaps
+	        pWorkDC->CreateCompatibleDC(pDC)) {
 
-		(*pBitmap).GetObject(sizeof(BITMAP), &myBitmap);  // get the image's sizing info
+		pBitmap->GetObject(sizeof(BITMAP), &myBitmap);  // get the image's sizing info
 		cSize.cx = myBitmap.bmWidth;
 		cSize.cy = myBitmap.bmHeight;
 
@@ -851,25 +851,25 @@ bool PaintMaskedBitmap(CDC *pDC, CPalette *pPalette, CBitmap *pBitmap, const int
 		}
 
 		if (pPalette != nullptr) {                     // map in the color palette if specified
-			pPalOldImage = (*pImageDC).SelectPalette(pPalette, false);
-			(*pImageDC).RealizePalette();
-			pPalOldWork = (*pWorkDC).SelectPalette(pPalette, false);
-			(*pWorkDC).RealizePalette();
+			pPalOldImage = pImageDC->SelectPalette(pPalette, false);
+			pImageDC->RealizePalette();
+			pPalOldWork = pWorkDC->SelectPalette(pPalette, false);
+			pWorkDC->RealizePalette();
 		}
 
-		if ((*pImage).CreateCompatibleBitmap(pDC, cSize.cx, cSize.cy) &&
-		        (*pWork).CreateCompatibleBitmap(pDC, cSize.cx, cSize.cy) &&
-		        (*pMask).CreateBitmap(cSize.cx, cSize.cy, 1, 1, nullptr)) {
+		if (pImage->CreateCompatibleBitmap(pDC, cSize.cx, cSize.cy) &&
+		        pWork->CreateCompatibleBitmap(pDC, cSize.cx, cSize.cy) &&
+		        pMask->CreateBitmap(cSize.cx, cSize.cy, 1, 1, nullptr)) {
 
-			pImageOld = (*pImageDC).SelectObject(pImage);
-			pMaskOld = (*pMaskDC).SelectObject(pMask);  // map the work and mask bitmaps into
-			pWorkOld = (*pWorkDC).SelectObject(pWork);  // ... their contexts
+			pImageOld = pImageDC->SelectObject(pImage);
+			pMaskOld = pMaskDC->SelectObject(pMask);  // map the work and mask bitmaps into
+			pWorkOld = pWorkDC->SelectObject(pWork);  // ... their contexts
 
 			PaintBitmap(pImageDC, pPalette, pBitmap, 0, 0, dx, dy);
 
 			if ((pMaskOld != nullptr) &&                   // verify so far so good
 			        (pWorkOld != nullptr)) {
-				(*pWorkDC).BitBlt(     // grab what the background looks like
+				pWorkDC->BitBlt(     // grab what the background looks like
 				    0,                              // ... putting it in the work area
 				    0,
 				    cSize.cx,
@@ -878,42 +878,42 @@ bool PaintMaskedBitmap(CDC *pDC, CPalette *pPalette, CBitmap *pBitmap, const int
 				    x,
 				    y,
 				    SRCCOPY);
-				(*pMaskDC).BitBlt(     // create the mask by inverting the image
+				pMaskDC->BitBlt(     // create the mask by inverting the image
 				    0, 0,                           // ... i.e. the pixels occupied by the image
 				    cSize.cx,
 				    cSize.cy,
 				    pImageDC,
 				    0, 0,
 				    NOTSRCCOPY);
-				(*pImageDC).BitBlt(     // remove the image's "transparent" white area
+				pImageDC->BitBlt(     // remove the image's "transparent" white area
 				    0, 0,                           // ... i.e. its background becomes black
 				    cSize.cx,
 				    cSize.cy,
 				    pMaskDC,
 				    0, 0,
 				    SRCAND);
-				(*pMaskDC).BitBlt(     // invert the mask
+				pMaskDC->BitBlt(     // invert the mask
 				    0, 0,
 				    cSize.cx,
 				    cSize.cy,
 				    pMaskDC,
 				    0, 0,
 				    DSTINVERT);
-				(*pWorkDC).BitBlt(     // remove the image's space from the work area
+				pWorkDC->BitBlt(     // remove the image's space from the work area
 				    0, 0,                           // ... i.e. the pixels where the image will go
 				    cSize.cx,
 				    cSize.cy,
 				    pMaskDC,
 				    0, 0
 				    , SRCAND);
-				(*pWorkDC).BitBlt(     // paint the image into the cleared (black) space
+				pWorkDC->BitBlt(     // paint the image into the cleared (black) space
 				    0, 0,                           // ... we made in the work area
 				    cSize.cx,
 				    cSize.cy,
 				    pImageDC,
 				    0, 0,
 				    SRCPAINT);
-				bSuccess = (*pDC).BitBlt(    // now splat the result to the destination context
+				bSuccess = pDC->BitBlt(    // now splat the result to the destination context
 				               x,
 				               y,
 				               cSize.cx,
@@ -927,43 +927,43 @@ bool PaintMaskedBitmap(CDC *pDC, CPalette *pPalette, CBitmap *pBitmap, const int
 	}
 
 	if (pPalOld != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	if (pImageOld != nullptr)                              // select out bitmaps out of their contexts
-		(*pImageDC).SelectObject(pImageOld);
+		pImageDC->SelectObject(pImageOld);
 	if (pWorkOld != nullptr)
-		(*pWorkDC).SelectObject(pWorkOld);
+		pWorkDC->SelectObject(pWorkOld);
 	if (pMaskOld != nullptr)
-		(*pMaskDC).SelectObject(pMaskOld);
+		pMaskDC->SelectObject(pMaskOld);
 
 	if (pPalOldImage != nullptr)                           // map out the palettes we used
-		(*pImageDC).SelectPalette(pPalOldImage, false);
+		pImageDC->SelectPalette(pPalOldImage, false);
 	if (pPalOldWork != nullptr)
-		(*pWorkDC).SelectPalette(pPalOldWork, false);
+		pWorkDC->SelectPalette(pPalOldWork, false);
 
 	if (pImage != nullptr) {                                // delete the bitmaps we created
-		(*pImage).DeleteObject();
+		pImage->DeleteObject();
 		delete pImage;
 	}
 	if (pWork != nullptr) {
-		(*pWork).DeleteObject();
+		pWork->DeleteObject();
 		delete pWork;
 	}
 	if (pMask != nullptr) {
-		(*pMask).DeleteObject();
+		pMask->DeleteObject();
 		delete pMask;
 	}
 
 	if (pImageDC != nullptr) {                             // delete the contexts we created
-		(*pImageDC).DeleteDC();
+		pImageDC->DeleteDC();
 		delete pImageDC;
 	}
 	if (pWorkDC != nullptr) {
-		(*pWorkDC).DeleteDC();
+		pWorkDC->DeleteDC();
 		delete pWorkDC;
 	}
 	if (pMaskDC != nullptr) {
-		(*pMaskDC).DeleteDC();
+		pMaskDC->DeleteDC();
 		delete pMaskDC;
 	}
 
@@ -1009,7 +1009,7 @@ bool PaintBlockEffect(CDC *pDC, CDibDoc *pDIB, CPalette* pPalette, int nBlockSiz
 	        (pDIB == nullptr))
 		return false;
 
-	hDIB = (*pDIB).GetHDIB();
+	hDIB = pDIB->GetHDIB();
 	pBitmap = ConvertDIB(pDC, hDIB, pPalette);
 
 	bSuccess = PaintBlockEffect(pDC, pBitmap, pPalette, nBlockSize);
@@ -1059,20 +1059,20 @@ bool PaintBlockEffect(CDC *pDC, CBitmap *pBitmap, CPalette* pPalette, int nBlock
 		return false;
 
 	if (pPalette != nullptr) {
-		pOldPal = (*pDC).SelectPalette(pPalette, false);
-		(*pDC).RealizePalette();
+		pOldPal = pDC->SelectPalette(pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	pMemDC = new CDC();
 	if ((pMemDC == nullptr) ||
-	        ((*pMemDC).CreateCompatibleDC(pDC) == false))
+	        (pMemDC->CreateCompatibleDC(pDC) == false))
 		goto clean_up;
 
-	pOldPal2 = (*pMemDC).SelectPalette(pPalette, false);
-	(*pMemDC).RealizePalette();
-	pBitmapOld = (*pMemDC).SelectObject(pBitmap);
+	pOldPal2 = pMemDC->SelectPalette(pPalette, false);
+	pMemDC->RealizePalette();
+	pBitmapOld = pMemDC->SelectObject(pBitmap);
 
-	(*pBitmap).GetObject(sizeof(BITMAP), &myBitmap);
+	pBitmap->GetObject(sizeof(BITMAP), &myBitmap);
 	width = myBitmap.bmWidth / nBlockSize;
 	height = myBitmap.bmHeight;
 
@@ -1100,7 +1100,7 @@ bool PaintBlockEffect(CDC *pDC, CBitmap *pBitmap, CPalette* pPalette, int nBlock
 			continue;
 		y = (value / width) * nBlockSize;
 		x = (value % width) * nBlockSize;
-		(*pDC).BitBlt((uint16) x,
+		pDC->BitBlt((uint16) x,
 		              (uint16) y,
 		              nBlockSize,
 		              nBlockSize,
@@ -1110,7 +1110,7 @@ bool PaintBlockEffect(CDC *pDC, CBitmap *pBitmap, CPalette* pPalette, int nBlock
 		              SRCCOPY);
 	}
 
-	(*pDC).BitBlt(0,
+	pDC->BitBlt(0,
 	              0,
 	              nBlockSize,
 	              nBlockSize,
@@ -1123,14 +1123,14 @@ bool PaintBlockEffect(CDC *pDC, CBitmap *pBitmap, CPalette* pPalette, int nBlock
 
 clean_up:
 	if (pBitmapOld != nullptr)
-		(*pMemDC).SelectObject(pBitmapOld);
+		pMemDC->SelectObject(pBitmapOld);
 	if (pOldPal2 != nullptr)
-		(*pMemDC).SelectPalette(pOldPal2, false);
+		pMemDC->SelectPalette(pOldPal2, false);
 	if (pMemDC != nullptr)
 		delete pMemDC;
 
 	if (pOldPal != nullptr)
-		(*pDC).SelectPalette(pOldPal, false);
+		pDC->SelectPalette(pOldPal, false);
 
 	return bSuccess;
 }
@@ -1171,8 +1171,8 @@ bool PaintBlockEffect(CDC *pDC, COLORREF rgbColor, CPalette* pPalette, int nBloc
 		return false;
 
 	if (pPalette != nullptr) {
-		pOldPal = (*pDC).SelectPalette(pPalette, false);
-		(*pDC).RealizePalette();
+		pOldPal = pDC->SelectPalette(pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	myBrush.CreateSolidBrush(rgbColor);
@@ -1205,16 +1205,16 @@ bool PaintBlockEffect(CDC *pDC, COLORREF rgbColor, CPalette* pPalette, int nBloc
 		y = (value / width) * nBlockSize;
 		x = (value % width) * nBlockSize;
 		fillRect.SetRect(nX + x, nY + y, nX + x + nBlockSize, nY + y + nBlockSize);
-		(*pDC).FillRect(&fillRect, &myBrush);
+		pDC->FillRect(&fillRect, &myBrush);
 	}
 
 	fillRect.SetRect(nX, nY, nX + nBlockSize, nY + nBlockSize);
-	(*pDC).FillRect(&fillRect, &myBrush);
+	pDC->FillRect(&fillRect, &myBrush);
 
 	bSuccess = true;
 
 	if (pOldPal != nullptr)
-		(*pDC).SelectPalette(pOldPal, false);
+		pDC->SelectPalette(pOldPal, false);
 
 	return bSuccess;
 }
@@ -1238,7 +1238,7 @@ CSize GetBitmapSize(CBitmap *pBitmap) {
 	CSize   mySize;
 	BITMAP  cBitmapData;
 
-	(*pBitmap).GetObject(sizeof(BITMAP), &cBitmapData);
+	pBitmap->GetObject(sizeof(BITMAP), &cBitmapData);
 	mySize.cx = cBitmapData.bmWidth;
 	mySize.cy = cBitmapData.bmHeight;
 	return mySize;

--- a/engines/bagel/hodjnpodj/hnplibs/button.cpp
+++ b/engines/bagel/hodjnpodj/hnplibs/button.cpp
@@ -67,7 +67,7 @@ CBmpButton::CBmpButton() {
 
 CBmpButton::~CBmpButton() {
 	if (m_pPalette != nullptr) {               // release the palette resource
-		(*m_pPalette).DeleteObject();
+		m_pPalette->DeleteObject();
 		delete m_pPalette;
 		m_pPalette = nullptr;
 	}
@@ -115,7 +115,7 @@ void CBmpButton::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 	pParentWnd = GetParent();
 	if (!IsWindowVisible() ||                       // punt if not visible
 	        (pParentWnd == nullptr) ||
-	        !(*pParentWnd).IsWindowVisible())
+	        !pParentWnd->IsWindowVisible())
 		return;
 	/*
 	    pActiveWindow = GetActiveWindow();              // get the active window and if it is
@@ -124,29 +124,29 @@ void CBmpButton::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 	        bActiveWindow = true;                       // ... in a foreground mode
 	*/
 	pDC = new CDC;                                  // setup the device context given to us
-	(*pDC).Attach((*lpDrawItemStruct).hDC);         // ... as a pointer to a CDC object
+	pDC->Attach(lpDrawItemStruct->hDC);         // ... as a pointer to a CDC object
 
 	if (m_pPalette != nullptr) {                       // map the palette into the context
-		pPalOld = (*pDC).SelectPalette(m_pPalette, true);
-		(*pDC).RealizePalette();              // ... and tell the system to use it
+		pPalOld = pDC->SelectPalette(m_pPalette, true);
+		pDC->RealizePalette();              // ... and tell the system to use it
 	}
 
-	if (((*lpDrawItemStruct).itemState & ODS_GRAYED) || // display the correct bitmap based on state
-	        ((*lpDrawItemStruct).itemState & ODS_DISABLED))
+	if ((lpDrawItemStruct->itemState & ODS_GRAYED) || // display the correct bitmap based on state
+	        (lpDrawItemStruct->itemState & ODS_DISABLED))
 		pBitmap = &m_bitmapDisabled;
-	else if ((*lpDrawItemStruct).itemState & ODS_SELECTED)
+	else if (lpDrawItemStruct->itemState & ODS_SELECTED)
 		pBitmap = &m_bitmapSel;
-	else if ((*lpDrawItemStruct).itemState & ODS_FOCUS)
+	else if (lpDrawItemStruct->itemState & ODS_FOCUS)
 		pBitmap = &m_bitmapFocus;
 	else
 		pBitmap = &m_bitmap;
 
-	PaintBitmap(pDC, nullptr, pBitmap, (*lpDrawItemStruct).rcItem.left, (*lpDrawItemStruct).rcItem.top);
+	PaintBitmap(pDC, nullptr, pBitmap, lpDrawItemStruct->rcItem.left, lpDrawItemStruct->rcItem.top);
 
 	if (pPalOld != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
-	(*pDC).Detach();                          // dismantle the temporary CDC we built
+	pDC->Detach();                          // dismantle the temporary CDC we built
 	delete pDC;
 }
 
@@ -242,27 +242,27 @@ bool CBmpButton::LoadBitmaps(CPalette *pPalette, CBitmap *pBase, CBitmap *pSelec
 	}
 
 	m_bitmap.DeleteObject();
-	hBitmap = (HBITMAP)(*pBase).Detach();
+	hBitmap = (HBITMAP)pBase->Detach();
 	m_bitmap.Attach(hBitmap);
 	delete pBase;
 
 	m_bitmapSel.DeleteObject();
 	if (pSelected != nullptr) {
-		hBitmap = (HBITMAP)(*pSelected).Detach();
+		hBitmap = (HBITMAP)pSelected->Detach();
 		m_bitmapSel.Attach(hBitmap);
 		delete pSelected;
 	}
 
 	m_bitmapFocus.DeleteObject();
 	if (pFocus != nullptr) {
-		hBitmap = (HBITMAP)(*pFocus).Detach();
+		hBitmap = (HBITMAP)pFocus->Detach();
 		m_bitmapFocus.Attach(hBitmap);
 		delete pFocus;
 	}
 
 	m_bitmapDisabled.DeleteObject();
 	if (pDisabled != nullptr) {
-		hBitmap = (HBITMAP)(*pDisabled).Detach();
+		hBitmap = (HBITMAP)pDisabled->Detach();
 		m_bitmapDisabled.Attach(hBitmap);
 		delete pDisabled;
 	}
@@ -297,7 +297,7 @@ bool CBmpButton::LoadBitmaps(const int nBase, const int nSelected, const int nFo
 	bool        bSuccess = true;
 
 	if (m_pPalette != nullptr) {                       // release any existing palette resource
-		(*m_pPalette).DeleteObject();
+		m_pPalette->DeleteObject();
 		delete m_pPalette;
 		m_pPalette = nullptr;
 	}
@@ -310,7 +310,7 @@ bool CBmpButton::LoadBitmaps(const int nBase, const int nSelected, const int nFo
 		pBitmap = FetchResourceBitmap(pDC, &m_pPalette, nBase);
 		if (pBitmap != nullptr) {                      // ... and plug it into our instance
 			m_bitmap.DeleteObject();                // release what ever was already there
-			hBitmap = (HBITMAP)(*pBitmap).Detach();
+			hBitmap = (HBITMAP)pBitmap->Detach();
 			m_bitmap.Attach(hBitmap);
 			delete pBitmap;
 			if (nSelected != 0) {               // get the SELECTED bitmap and plug it in
@@ -319,7 +319,7 @@ bool CBmpButton::LoadBitmaps(const int nBase, const int nSelected, const int nFo
 					bSuccess = false;
 				else {
 					m_bitmapSel.DeleteObject();     // release what ever was already there
-					hBitmap = (HBITMAP)(*pBitmap).Detach();
+					hBitmap = (HBITMAP)pBitmap->Detach();
 					m_bitmapSel.Attach(hBitmap);
 					delete pBitmap;
 				}
@@ -331,7 +331,7 @@ bool CBmpButton::LoadBitmaps(const int nBase, const int nSelected, const int nFo
 					bSuccess = false;
 				else {
 					m_bitmapFocus.DeleteObject();   // release what ever was already there
-					hBitmap = (HBITMAP)(*pBitmap).Detach();
+					hBitmap = (HBITMAP)pBitmap->Detach();
 					m_bitmapFocus.Attach(hBitmap);
 					delete pBitmap;
 				}
@@ -343,7 +343,7 @@ bool CBmpButton::LoadBitmaps(const int nBase, const int nSelected, const int nFo
 					bSuccess = false;
 				else {
 					m_bitmapDisabled.DeleteObject();// release what ever was already there
-					hBitmap = (HBITMAP)(*pBitmap).Detach();
+					hBitmap = (HBITMAP)pBitmap->Detach();
 					m_bitmapDisabled.Attach(hBitmap);
 					delete pBitmap;
 				}
@@ -386,7 +386,7 @@ bool CBmpButton::LoadBitmaps(const char *lpszBase, const char *lpszSelected, con
 	bool        bSuccess = true;
 
 	if (m_pPalette != nullptr) {                       // release any existing palette resource
-		(*m_pPalette).DeleteObject();
+		m_pPalette->DeleteObject();
 		delete m_pPalette;
 		m_pPalette = nullptr;
 	}
@@ -399,7 +399,7 @@ bool CBmpButton::LoadBitmaps(const char *lpszBase, const char *lpszSelected, con
 		pBitmap = FetchResourceBitmap(pDC, &m_pPalette, lpszBase);
 		if (pBitmap != nullptr) {                      // ... and plug it into our instance
 			m_bitmap.DeleteObject();                // release what ever was already there
-			hBitmap = (HBITMAP)(*pBitmap).Detach();
+			hBitmap = (HBITMAP)pBitmap->Detach();
 			m_bitmap.Attach(hBitmap);
 			delete pBitmap;
 			if (lpszSelected != nullptr) {             // get the SELECTED bitmap and plug it in
@@ -408,7 +408,7 @@ bool CBmpButton::LoadBitmaps(const char *lpszBase, const char *lpszSelected, con
 					bSuccess = false;
 				else {
 					m_bitmapSel.DeleteObject();     // release what ever was already there
-					hBitmap = (HBITMAP)(*pBitmap).Detach();
+					hBitmap = (HBITMAP)pBitmap->Detach();
 					m_bitmapSel.Attach(hBitmap);
 					delete pBitmap;
 				}
@@ -420,7 +420,7 @@ bool CBmpButton::LoadBitmaps(const char *lpszBase, const char *lpszSelected, con
 					bSuccess = false;
 				else {
 					m_bitmapFocus.DeleteObject();   // release what ever was already there
-					hBitmap = (HBITMAP)(*pBitmap).Detach();
+					hBitmap = (HBITMAP)pBitmap->Detach();
 					m_bitmapFocus.Attach(hBitmap);
 					delete pBitmap;
 				}
@@ -432,7 +432,7 @@ bool CBmpButton::LoadBitmaps(const char *lpszBase, const char *lpszSelected, con
 					bSuccess = false;
 				else {
 					m_bitmapDisabled.DeleteObject();// release what ever was already there
-					hBitmap = (HBITMAP)(*pBitmap).Detach();
+					hBitmap = (HBITMAP)pBitmap->Detach();
 					m_bitmapDisabled.Attach(hBitmap);
 					delete pBitmap;
 				}
@@ -475,7 +475,7 @@ bool CBmpButton::LoadBmpBitmaps(const char *lpszBase, const char *lpszSelected, 
 	bool        bSuccess = true;
 
 	if (m_pPalette != nullptr) {                       // release any existing palette resource
-		(*m_pPalette).DeleteObject();
+		m_pPalette->DeleteObject();
 		delete m_pPalette;
 		m_pPalette = nullptr;
 	}
@@ -488,7 +488,7 @@ bool CBmpButton::LoadBmpBitmaps(const char *lpszBase, const char *lpszSelected, 
 		pBitmap = FetchBitmap(pDC, &m_pPalette, lpszBase);
 		if (pBitmap != nullptr) {                      // ... and plug it into our instance
 			m_bitmap.DeleteObject();                // release what ever was already there
-			hBitmap = (HBITMAP)(*pBitmap).Detach();
+			hBitmap = (HBITMAP)pBitmap->Detach();
 			m_bitmap.Attach(hBitmap);
 			delete pBitmap;
 			if (lpszSelected != nullptr) {             // get the SELECTED bitmap and plug it in
@@ -497,7 +497,7 @@ bool CBmpButton::LoadBmpBitmaps(const char *lpszBase, const char *lpszSelected, 
 					bSuccess = false;
 				else {
 					m_bitmapSel.DeleteObject();     // release what ever was already there
-					hBitmap = (HBITMAP)(*pBitmap).Detach();
+					hBitmap = (HBITMAP)pBitmap->Detach();
 					m_bitmapSel.Attach(hBitmap);
 					delete pBitmap;
 				}
@@ -509,7 +509,7 @@ bool CBmpButton::LoadBmpBitmaps(const char *lpszBase, const char *lpszSelected, 
 					bSuccess = false;
 				else {
 					m_bitmapFocus.DeleteObject();   // release what ever was already there
-					hBitmap = (HBITMAP)(*pBitmap).Detach();
+					hBitmap = (HBITMAP)pBitmap->Detach();
 					m_bitmapFocus.Attach(hBitmap);
 					delete pBitmap;
 				}
@@ -521,7 +521,7 @@ bool CBmpButton::LoadBmpBitmaps(const char *lpszBase, const char *lpszSelected, 
 					bSuccess = false;
 				else {
 					m_bitmapDisabled.DeleteObject();// release what ever was already there
-					hBitmap = (HBITMAP)(*pBitmap).Detach();
+					hBitmap = (HBITMAP)pBitmap->Detach();
 					m_bitmapDisabled.Attach(hBitmap);
 					delete pBitmap;
 				}
@@ -611,7 +611,7 @@ CMaskedButton::CMaskedButton() {
 
 CMaskedButton::~CMaskedButton() {
 	if (m_pPalette != nullptr) {               // release the palette resource
-		(*m_pPalette).DeleteObject();
+		m_pPalette->DeleteObject();
 		delete m_pPalette;
 		m_pPalette = nullptr;
 	}
@@ -662,44 +662,44 @@ void CMaskedButton::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 	pParentWnd = GetParent();
 	if (!IsWindowVisible() ||                       // punt if not visible
 	        (pParentWnd == nullptr) ||
-	        !(*pParentWnd).IsWindowVisible())
+	        !pParentWnd->IsWindowVisible())
 		return;
 
 	pDC = new CDC;                                  // setup the device context given to us
-	(*pDC).Attach((*lpDrawItemStruct).hDC);         // ... as a pointer to a CDC object
+	pDC->Attach(lpDrawItemStruct->hDC);         // ... as a pointer to a CDC object
 
 	if (m_pPalette != nullptr) {                       // map the palette into the context
-		pPalOld = (*pDC).SelectPalette(m_pPalette, true);
-		(*pDC).RealizePalette();              // ... and tell the system to use it
+		pPalOld = pDC->SelectPalette(m_pPalette, true);
+		pDC->RealizePalette();              // ... and tell the system to use it
 	}
 
 	if (m_pBackground == nullptr)
 		m_pBackground = FetchScreenBitmap(pDC, m_pPalette,
-		                                  (*lpDrawItemStruct).rcItem.left,
-		                                  (*lpDrawItemStruct).rcItem.top,
-		                                  (*lpDrawItemStruct).rcItem.right - (*lpDrawItemStruct).rcItem.left,
-		                                  (*lpDrawItemStruct).rcItem.bottom - (*lpDrawItemStruct).rcItem.top);
+		                                  lpDrawItemStruct->rcItem.left,
+		                                  lpDrawItemStruct->rcItem.top,
+		                                  lpDrawItemStruct->rcItem.right - lpDrawItemStruct->rcItem.left,
+		                                  lpDrawItemStruct->rcItem.bottom - lpDrawItemStruct->rcItem.top);
 	else
 		PaintBitmap(pDC, m_pPalette, m_pBackground,
-		            (*lpDrawItemStruct).rcItem.left,
-		            (*lpDrawItemStruct).rcItem.top);
+		            lpDrawItemStruct->rcItem.left,
+		            lpDrawItemStruct->rcItem.top);
 
-	if (((*lpDrawItemStruct).itemState & ODS_GRAYED) || // display the correct bitmap based on state
-	        ((*lpDrawItemStruct).itemState & ODS_DISABLED))
+	if ((lpDrawItemStruct->itemState & ODS_GRAYED) || // display the correct bitmap based on state
+	        (lpDrawItemStruct->itemState & ODS_DISABLED))
 		pBitmap = &m_bitmapDisabled;
-	else if ((*lpDrawItemStruct).itemState & ODS_SELECTED)
+	else if (lpDrawItemStruct->itemState & ODS_SELECTED)
 		pBitmap = &m_bitmapSel;
-	else if ((*lpDrawItemStruct).itemState & ODS_FOCUS)
+	else if (lpDrawItemStruct->itemState & ODS_FOCUS)
 		pBitmap = &m_bitmapFocus;
 	else
 		pBitmap = &m_bitmap;
 
-	PaintMaskedBitmap(pDC, nullptr, pBitmap, (*lpDrawItemStruct).rcItem.left, (*lpDrawItemStruct).rcItem.top);
+	PaintMaskedBitmap(pDC, nullptr, pBitmap, lpDrawItemStruct->rcItem.left, lpDrawItemStruct->rcItem.top);
 
 	if (pPalOld != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
-	(*pDC).Detach();                          // dismantle the temporary CDC we built
+	pDC->Detach();                          // dismantle the temporary CDC we built
 	delete pDC;
 }
 
@@ -892,7 +892,7 @@ void CColorButton::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 	pParentWnd = GetParent();
 	if (!IsWindowVisible() ||                       // punt if not visible
 	        (pParentWnd == nullptr) ||
-	        !(*pParentWnd).IsWindowVisible())
+	        !pParentWnd->IsWindowVisible())
 		return;
 
 	nMyTextLength = GetWindowText((char *) &chMyText, 127);
@@ -910,20 +910,20 @@ void CColorButton::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 	y = 0;
 
 	pDC = new CDC;                                  // setup the device context given to us
-	(*pDC).Attach((*lpDrawItemStruct).hDC);         // ... as a pointer to a CDC object
+	pDC->Attach(lpDrawItemStruct->hDC);         // ... as a pointer to a CDC object
 
 	if (m_pPalette != nullptr) {                       // map the palette into the context
-		pPalOld = (*pDC).SelectPalette(m_pPalette, true);
-		(*pDC).RealizePalette();              // ... and tell the system to use it
+		pPalOld = pDC->SelectPalette(m_pPalette, true);
+		pDC->RealizePalette();              // ... and tell the system to use it
 	}
 
-	if (((*lpDrawItemStruct).itemState & ODS_GRAYED) ||
-	        ((*lpDrawItemStruct).itemState & ODS_DISABLED)) {
+	if ((lpDrawItemStruct->itemState & ODS_GRAYED) ||
+	        (lpDrawItemStruct->itemState & ODS_DISABLED)) {
 		myPen.CreatePen(PS_INSIDEFRAME, BUTTON_EDGE_WIDTH, m_cButtonHighlight);
 		myInversePen.CreatePen(PS_INSIDEFRAME, 1, m_cButtonShadow);
 		myBrush.CreateSolidBrush(m_cButtonFace);
 		myTextColor = m_cButtonTextDisabled;
-	} else if ((*lpDrawItemStruct).itemState & ODS_SELECTED) {
+	} else if (lpDrawItemStruct->itemState & ODS_SELECTED) {
 		myPen.CreatePen(PS_INSIDEFRAME, BUTTON_EDGE_WIDTH, m_cButtonShadow);
 		myInversePen.CreatePen(PS_SOLID, 1, m_cButtonHighlight);
 		myBrush.CreateSolidBrush(m_cButtonFace);
@@ -937,60 +937,60 @@ void CColorButton::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 		myTextColor = m_cButtonText;
 	}
 
-	pOldPen = (*pDC).SelectObject(&myPen);                  // select in the pens and brushes
-	pOldBrush = (*pDC).SelectObject(&myBrush);
-	(*pDC).Rectangle(&(*lpDrawItemStruct).rcItem);
-	(*pDC).SelectObject(pOldPen);
-	pOldPen = (*pDC).SelectObject(&myInversePen);
+	pOldPen = pDC->SelectObject(&myPen);                  // select in the pens and brushes
+	pOldBrush = pDC->SelectObject(&myBrush);
+	pDC->Rectangle(&lpDrawItemStruct->rcItem);
+	pDC->SelectObject(pOldPen);
+	pOldPen = pDC->SelectObject(&myInversePen);
 
 	for (i = 1; i <= BUTTON_EDGE_WIDTH; i++) {              // draw the button edges
-		(*pDC).MoveTo((*lpDrawItemStruct).rcItem.left + i, (*lpDrawItemStruct).rcItem.bottom - i);
-		(*pDC).LineTo((*lpDrawItemStruct).rcItem.right - i, (*lpDrawItemStruct).rcItem.bottom - i);
-		(*pDC).LineTo((*lpDrawItemStruct).rcItem.right - i, (*lpDrawItemStruct).rcItem.top + i - 1);
+		pDC->MoveTo(lpDrawItemStruct->rcItem.left + i, lpDrawItemStruct->rcItem.bottom - i);
+		pDC->LineTo(lpDrawItemStruct->rcItem.right - i, lpDrawItemStruct->rcItem.bottom - i);
+		pDC->LineTo(lpDrawItemStruct->rcItem.right - i, lpDrawItemStruct->rcItem.top + i - 1);
 	}
 
-	(*pDC).SelectObject(pOldPen);
-	(*pDC).SelectObject(pOldBrush);
+	pDC->SelectObject(pOldPen);
+	pDC->SelectObject(pOldBrush);
 
 	myFrame.CreateSolidBrush(m_cButtonOutline);             // outline the button
-	(*pDC).FrameRect(&(*lpDrawItemStruct).rcItem, &myFrame);
+	pDC->FrameRect(&lpDrawItemStruct->rcItem, &myFrame);
 
-	(*pDC).GetTextMetrics(&fontMetrics);                    // get some info about the font
-	textInfo = (*pDC).GetTextExtent(chMyText, nMyTextLength); // get the area spanned by the text
-	dx = (*lpDrawItemStruct).rcItem.right - (*lpDrawItemStruct).rcItem.left;
-	dy = (*lpDrawItemStruct).rcItem.bottom - (*lpDrawItemStruct).rcItem.top;
+	pDC->GetTextMetrics(&fontMetrics);                    // get some info about the font
+	textInfo = pDC->GetTextExtent(chMyText, nMyTextLength); // get the area spanned by the text
+	dx = lpDrawItemStruct->rcItem.right - lpDrawItemStruct->rcItem.left;
+	dy = lpDrawItemStruct->rcItem.bottom - lpDrawItemStruct->rcItem.top;
 	x += (dx - textInfo.cx) >> 1;
 	y += (dy - textInfo.cy) >> 1;
 
-	(*pDC).SetBkMode(TRANSPARENT);                          // make the text overlay transparently
-	oldTextColor = (*pDC).SetTextColor(myTextColor);         // set the color of the text
+	pDC->SetBkMode(TRANSPARENT);                          // make the text overlay transparently
+	oldTextColor = pDC->SetTextColor(myTextColor);         // set the color of the text
 
-	(*pDC).TextOut(x, y, (const char *) &chMyText, nMyTextLength);
+	pDC->TextOut(x, y, (const char *) &chMyText, nMyTextLength);
 
 	if (nUnderscore >= 0) {
-		underscoreInfo = (*pDC).GetTextExtent(chMyText, nUnderscore);
+		underscoreInfo = pDC->GetTextExtent(chMyText, nUnderscore);
 		dx = x + underscoreInfo.cx;
-		letterInfo = (*pDC).GetTextExtent(&chMyText[nUnderscore], 1);
-		underscoreInfo = (*pDC).GetTextExtent((const char *) "_", 1);
+		letterInfo = pDC->GetTextExtent(&chMyText[nUnderscore], 1);
+		underscoreInfo = pDC->GetTextExtent((const char *) "_", 1);
 		dx += (letterInfo.cx - underscoreInfo.cx) >> 1;
-		(*pDC).TextOut(dx, y, (const char *) "_", 1);
+		pDC->TextOut(dx, y, (const char *) "_", 1);
 	}
 
-	(*pDC).SetTextColor(oldTextColor);                // set the color of the text
+	pDC->SetTextColor(oldTextColor);                // set the color of the text
 
-	if ((*lpDrawItemStruct).itemState & ODS_FOCUS) {
+	if (lpDrawItemStruct->itemState & ODS_FOCUS) {
 		focusRect.SetRect(x - FOCUS_RECT_DX,
 		                  y - FOCUS_RECT_DY,
 		                  x + textInfo.cx + FOCUS_RECT_DX,
 		                  y + textInfo.cy + FOCUS_RECT_DY + 1);
 		myQuill.CreateStockObject(DKGRAY_BRUSH);
-		(*pDC).FrameRect(&focusRect, &myQuill);
+		pDC->FrameRect(&focusRect, &myQuill);
 	}
 
 	if (pPalOld != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
-	(*pDC).Detach();                          // dismantle the temporary CDC we built
+	pDC->Detach();                          // dismantle the temporary CDC we built
 	delete pDC;
 }
 
@@ -1180,7 +1180,7 @@ void CCheckButton::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 	pParentWnd = GetParent();
 	if (!IsWindowVisible() ||                       // punt if not visible
 	        (pParentWnd == nullptr) ||
-	        !(*pParentWnd).IsWindowVisible())
+	        !pParentWnd->IsWindowVisible())
 		return;
 
 	nMyTextLength = GetWindowText((char *) &chMyText, 127);
@@ -1196,94 +1196,94 @@ void CCheckButton::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 	nMyTextLength = j - 1;
 
 	pDC = new CDC;                                  // setup the device context given to us
-	(*pDC).Attach((*lpDrawItemStruct).hDC);         // ... as a pointer to a CDC object
+	pDC->Attach(lpDrawItemStruct->hDC);         // ... as a pointer to a CDC object
 
 	if (m_pPalette != nullptr) {                       // map the palette into the context
-		pPalOld = (*pDC).SelectPalette(m_pPalette, true);
-		(*pDC).RealizePalette();              // ... and tell the system to use it
+		pPalOld = pDC->SelectPalette(m_pPalette, true);
+		pDC->RealizePalette();              // ... and tell the system to use it
 	}
 
-	if (((*lpDrawItemStruct).itemState & ODS_GRAYED) || // setup text color based on enable/disable state
-	        ((*lpDrawItemStruct).itemState & ODS_DISABLED))
+	if ((lpDrawItemStruct->itemState & ODS_GRAYED) || // setup text color based on enable/disable state
+	        (lpDrawItemStruct->itemState & ODS_DISABLED))
 		myTextColor = m_cButtonTextDisabled;
 	else
 		myTextColor = m_cButtonText;
 	// calculate the button width and height
-	dx = (*lpDrawItemStruct).rcItem.right - (*lpDrawItemStruct).rcItem.left;
-	dy = (*lpDrawItemStruct).rcItem.bottom - (*lpDrawItemStruct).rcItem.top;
+	dx = lpDrawItemStruct->rcItem.right - lpDrawItemStruct->rcItem.left;
+	dy = lpDrawItemStruct->rcItem.bottom - lpDrawItemStruct->rcItem.top;
 	// create the bounding rectangle for the box
-	controlRect.SetRect((*lpDrawItemStruct).rcItem.left + CHECK_BOX_DX,
-	                    (*lpDrawItemStruct).rcItem.top + ((dy - CHECK_BOX_SIZE) >> 1),
-	                    (*lpDrawItemStruct).rcItem.left + CHECK_BOX_DX + CHECK_BOX_SIZE,
-	                    (*lpDrawItemStruct).rcItem.top + ((dy - CHECK_BOX_SIZE) >> 1) + CHECK_BOX_SIZE);
+	controlRect.SetRect(lpDrawItemStruct->rcItem.left + CHECK_BOX_DX,
+	                    lpDrawItemStruct->rcItem.top + ((dy - CHECK_BOX_SIZE) >> 1),
+	                    lpDrawItemStruct->rcItem.left + CHECK_BOX_DX + CHECK_BOX_SIZE,
+	                    lpDrawItemStruct->rcItem.top + ((dy - CHECK_BOX_SIZE) >> 1) + CHECK_BOX_SIZE);
 	// create the pens and brushes we need
 	outlinePen.CreatePen(PS_INSIDEFRAME, 1, m_cButtonOutline);
 	faceBrush.CreateSolidBrush(m_cButtonFace);
 	controlPen.CreatePen(PS_INSIDEFRAME, 1, m_cButtonControl);
 	frameBrush.CreateSolidBrush(m_cButtonControl);
 
-	pOldBrush = (*pDC).SelectObject(&faceBrush);
-	if ((*lpDrawItemStruct).itemAction & ODA_DRAWENTIRE) {
-		pOldPen = (*pDC).SelectObject(&outlinePen); // fill in the whole control
-		(*pDC).Rectangle(&(*lpDrawItemStruct).rcItem);
+	pOldBrush = pDC->SelectObject(&faceBrush);
+	if (lpDrawItemStruct->itemAction & ODA_DRAWENTIRE) {
+		pOldPen = pDC->SelectObject(&outlinePen); // fill in the whole control
+		pDC->Rectangle(&lpDrawItemStruct->rcItem);
 	} else {
-		pOldPen = (*pDC).SelectObject(&controlPen); // fill in just the box
-		(*pDC).Rectangle(&controlRect);
+		pOldPen = pDC->SelectObject(&controlPen); // fill in just the box
+		pDC->Rectangle(&controlRect);
 	}
-	(*pDC).SelectObject(pOldPen);
-	(*pDC).SelectObject(pOldBrush);
+	pDC->SelectObject(pOldPen);
+	pDC->SelectObject(pOldBrush);
 
-	(*pDC).FrameRect(&controlRect, &frameBrush);    // paint the box and indicate selection
+	pDC->FrameRect(&controlRect, &frameBrush);    // paint the box and indicate selection
 
 	if (m_bCheckState) {                            // indicate that the box is checked
-		pOldPen = (*pDC).SelectObject(&controlPen);
-		(*pDC).MoveTo(controlRect.left, controlRect.top);
-		(*pDC).LineTo(controlRect.right - 1, controlRect.bottom - 1);
-		(*pDC).MoveTo(controlRect.left, controlRect.bottom - 1);
-		(*pDC).LineTo(controlRect.right - 1, controlRect.top);
-		(*pDC).SelectObject(pOldPen);
+		pOldPen = pDC->SelectObject(&controlPen);
+		pDC->MoveTo(controlRect.left, controlRect.top);
+		pDC->LineTo(controlRect.right - 1, controlRect.bottom - 1);
+		pDC->MoveTo(controlRect.left, controlRect.bottom - 1);
+		pDC->LineTo(controlRect.right - 1, controlRect.top);
+		pDC->SelectObject(pOldPen);
 	}
 
-	if ((*lpDrawItemStruct).itemState & ODS_SELECTED) {
+	if (lpDrawItemStruct->itemState & ODS_SELECTED) {
 		controlRect.InflateRect(-1, -1);
-		(*pDC).FrameRect(&controlRect, &frameBrush);
+		pDC->FrameRect(&controlRect, &frameBrush);
 	}
 
-	(*pDC).GetTextMetrics(&fontMetrics);                    // get some info about the font
-	textInfo = (*pDC).GetTextExtent(chMyText, nMyTextLength); // get the area spanned by the text
-	x = (*lpDrawItemStruct).rcItem.left + CHECK_TEXT_DX;
-	y = (*lpDrawItemStruct).rcItem.top + ((dy - textInfo.cy) >> 1);
+	pDC->GetTextMetrics(&fontMetrics);                    // get some info about the font
+	textInfo = pDC->GetTextExtent(chMyText, nMyTextLength); // get the area spanned by the text
+	x = lpDrawItemStruct->rcItem.left + CHECK_TEXT_DX;
+	y = lpDrawItemStruct->rcItem.top + ((dy - textInfo.cy) >> 1);
 
-	(*pDC).SetBkMode(TRANSPARENT);                      // make the text overlay transparently
-	oldTextColor = (*pDC).SetTextColor(myTextColor);    // set the color of the text
+	pDC->SetBkMode(TRANSPARENT);                      // make the text overlay transparently
+	oldTextColor = pDC->SetTextColor(myTextColor);    // set the color of the text
 
-	(*pDC).TextOut(x, y, (const char *) &chMyText, nMyTextLength);
+	pDC->TextOut(x, y, (const char *) &chMyText, nMyTextLength);
 
 	if (nUnderscore >= 0) {                         // put the underscore where it belongs
-		underscoreInfo = (*pDC).GetTextExtent(chMyText, nUnderscore);
+		underscoreInfo = pDC->GetTextExtent(chMyText, nUnderscore);
 		dx = x + underscoreInfo.cx;
-		letterInfo = (*pDC).GetTextExtent(&chMyText[nUnderscore], 1);
-		underscoreInfo = (*pDC).GetTextExtent((const char *) "_", 1);
+		letterInfo = pDC->GetTextExtent(&chMyText[nUnderscore], 1);
+		underscoreInfo = pDC->GetTextExtent((const char *) "_", 1);
 		dx += (letterInfo.cx - underscoreInfo.cx) >> 1;
-		(*pDC).TextOut(dx, y, (const char *) "_", 1);
+		pDC->TextOut(dx, y, (const char *) "_", 1);
 	}
 
-	(*pDC).SetTextColor(oldTextColor);
+	pDC->SetTextColor(oldTextColor);
 
 	focusRect.SetRect(x - FOCUS_RECT_DX,           // set the focus rectangle
 	                  y - FOCUS_RECT_DY,             // ... then paint it or clear it
 	                  x + textInfo.cx + FOCUS_RECT_DX,
 	                  y + textInfo.cy + FOCUS_RECT_DY + 1);
-	if ((*lpDrawItemStruct).itemState & ODS_FOCUS) {
+	if (lpDrawItemStruct->itemState & ODS_FOCUS) {
 		myQuill.CreateStockObject(DKGRAY_BRUSH);
-		(*pDC).FrameRect(&focusRect, &myQuill);
+		pDC->FrameRect(&focusRect, &myQuill);
 	} else
-		(*pDC).FrameRect(&focusRect, &faceBrush);
+		pDC->FrameRect(&focusRect, &faceBrush);
 
 	if (pPalOld != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
-	(*pDC).Detach();                          // dismantle the temporary CDC we built
+	pDC->Detach();                          // dismantle the temporary CDC we built
 	delete pDC;
 }
 
@@ -1526,7 +1526,7 @@ void CRadioButton::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 	pParentWnd = GetParent();
 	if (!IsWindowVisible() ||                       // punt if not visible
 	        (pParentWnd == nullptr) ||
-	        !(*pParentWnd).IsWindowVisible())
+	        !pParentWnd->IsWindowVisible())
 		return;
 
 	nMyTextLength = GetWindowText((char *) &chMyText, 127);
@@ -1542,26 +1542,26 @@ void CRadioButton::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 	nMyTextLength = j - 1;
 
 	pDC = new CDC;                                  // setup the device context given to us
-	(*pDC).Attach((*lpDrawItemStruct).hDC);         // ... as a pointer to a CDC object
+	pDC->Attach(lpDrawItemStruct->hDC);         // ... as a pointer to a CDC object
 
 	if (m_pPalette != nullptr) {                       // map the palette into the context
-		pPalOld = (*pDC).SelectPalette(m_pPalette, true);
-		(*pDC).RealizePalette();              // ... and tell the system to use it
+		pPalOld = pDC->SelectPalette(m_pPalette, true);
+		pDC->RealizePalette();              // ... and tell the system to use it
 	}
 
-	if (((*lpDrawItemStruct).itemState & ODS_GRAYED) || // setup text color based on enable/disable state
-	        ((*lpDrawItemStruct).itemState & ODS_DISABLED))
+	if ((lpDrawItemStruct->itemState & ODS_GRAYED) || // setup text color based on enable/disable state
+	        (lpDrawItemStruct->itemState & ODS_DISABLED))
 		myTextColor = m_cButtonTextDisabled;
 	else
 		myTextColor = m_cButtonText;
 	// calculate the button width and height
-	dx = (*lpDrawItemStruct).rcItem.right - (*lpDrawItemStruct).rcItem.left;
-	dy = (*lpDrawItemStruct).rcItem.bottom - (*lpDrawItemStruct).rcItem.top;
+	dx = lpDrawItemStruct->rcItem.right - lpDrawItemStruct->rcItem.left;
+	dy = lpDrawItemStruct->rcItem.bottom - lpDrawItemStruct->rcItem.top;
 	// create the bounding rectangle for the box
-	controlRect.SetRect((*lpDrawItemStruct).rcItem.left + RADIO_BOX_DX,
-	                    (*lpDrawItemStruct).rcItem.top + ((dy - RADIO_BOX_SIZE) >> 1),
-	                    (*lpDrawItemStruct).rcItem.left + RADIO_BOX_DX + RADIO_BOX_SIZE,
-	                    (*lpDrawItemStruct).rcItem.top + ((dy - RADIO_BOX_SIZE) >> 1) + RADIO_BOX_SIZE);
+	controlRect.SetRect(lpDrawItemStruct->rcItem.left + RADIO_BOX_DX,
+	                    lpDrawItemStruct->rcItem.top + ((dy - RADIO_BOX_SIZE) >> 1),
+	                    lpDrawItemStruct->rcItem.left + RADIO_BOX_DX + RADIO_BOX_SIZE,
+	                    lpDrawItemStruct->rcItem.top + ((dy - RADIO_BOX_SIZE) >> 1) + RADIO_BOX_SIZE);
 	selectRect = controlRect;
 	// create the pens and brushes we need
 	outlinePen.CreatePen(PS_INSIDEFRAME, 1, m_cButtonOutline);
@@ -1570,70 +1570,70 @@ void CRadioButton::DrawItem(LPDRAWITEMSTRUCT lpDrawItemStruct) {
 	controlBrush.CreateSolidBrush(m_cButtonControl);
 	framePen.CreatePen(PS_INSIDEFRAME, 1, m_cButtonControl);
 
-	pOldBrush = (*pDC).SelectObject(&faceBrush);
-	if ((*lpDrawItemStruct).itemAction & ODA_DRAWENTIRE) {
-		pOldPen = (*pDC).SelectObject(&outlinePen); // fill in the whole control
-		(*pDC).Rectangle(&(*lpDrawItemStruct).rcItem);
+	pOldBrush = pDC->SelectObject(&faceBrush);
+	if (lpDrawItemStruct->itemAction & ODA_DRAWENTIRE) {
+		pOldPen = pDC->SelectObject(&outlinePen); // fill in the whole control
+		pDC->Rectangle(&lpDrawItemStruct->rcItem);
 	} else {
-		pOldPen = (*pDC).SelectObject(&controlPen); // fill in just the box
-		(*pDC).Ellipse(&controlRect);
+		pOldPen = pDC->SelectObject(&controlPen); // fill in just the box
+		pDC->Ellipse(&controlRect);
 	}
-	(*pDC).SelectObject(pOldPen);
+	pDC->SelectObject(pOldPen);
 
-	pOldPen = (*pDC).SelectObject(&framePen);
-	(*pDC).Ellipse(&controlRect);       // paint the box and indicate selection
-	if ((*lpDrawItemStruct).itemState & ODS_SELECTED) {
+	pOldPen = pDC->SelectObject(&framePen);
+	pDC->Ellipse(&controlRect);       // paint the box and indicate selection
+	if (lpDrawItemStruct->itemState & ODS_SELECTED) {
 		controlRect.InflateRect(-1, -1);
-		(*pDC).Ellipse(&controlRect);
+		pDC->Ellipse(&controlRect);
 	}
-	(*pDC).SelectObject(pOldPen);
-	(*pDC).SelectObject(pOldBrush);
+	pDC->SelectObject(pOldPen);
+	pDC->SelectObject(pOldBrush);
 
 	if (m_bCheckState) {                            // indicate that the box is checked
 		selectRect.InflateRect(-2, -2);
-		pOldPen = (*pDC).SelectObject(&controlPen);
-		pOldBrush = (*pDC).SelectObject(&controlBrush);
-		(*pDC).Ellipse(&selectRect);
-		(*pDC).SelectObject(pOldBrush);
-		(*pDC).SelectObject(pOldPen);
+		pOldPen = pDC->SelectObject(&controlPen);
+		pOldBrush = pDC->SelectObject(&controlBrush);
+		pDC->Ellipse(&selectRect);
+		pDC->SelectObject(pOldBrush);
+		pDC->SelectObject(pOldPen);
 	}
 
-	(*pDC).GetTextMetrics(&fontMetrics);                    // get some info about the font
-	textInfo = (*pDC).GetTextExtent(chMyText, nMyTextLength); // get the area spanned by the text
-	x = (*lpDrawItemStruct).rcItem.left + RADIO_TEXT_DX;
-	y = (*lpDrawItemStruct).rcItem.top + ((dy - textInfo.cy) >> 1);
+	pDC->GetTextMetrics(&fontMetrics);                    // get some info about the font
+	textInfo = pDC->GetTextExtent(chMyText, nMyTextLength); // get the area spanned by the text
+	x = lpDrawItemStruct->rcItem.left + RADIO_TEXT_DX;
+	y = lpDrawItemStruct->rcItem.top + ((dy - textInfo.cy) >> 1);
 
-	(*pDC).SetBkMode(TRANSPARENT);                      // make the text overlay transparently
-	oldTextColor = (*pDC).SetTextColor(myTextColor);    // set the color of the text
+	pDC->SetBkMode(TRANSPARENT);                      // make the text overlay transparently
+	oldTextColor = pDC->SetTextColor(myTextColor);    // set the color of the text
 
-	(*pDC).TextOut(x, y, (const char *) &chMyText, nMyTextLength);
+	pDC->TextOut(x, y, (const char *) &chMyText, nMyTextLength);
 
 	if (nUnderscore >= 0) {                         // put the underscore where it belongs
-		underscoreInfo = (*pDC).GetTextExtent(chMyText, nUnderscore);
+		underscoreInfo = pDC->GetTextExtent(chMyText, nUnderscore);
 		dx = x + underscoreInfo.cx;
-		letterInfo = (*pDC).GetTextExtent(&chMyText[nUnderscore], 1);
-		underscoreInfo = (*pDC).GetTextExtent((const char *) "_", 1);
+		letterInfo = pDC->GetTextExtent(&chMyText[nUnderscore], 1);
+		underscoreInfo = pDC->GetTextExtent((const char *) "_", 1);
 		dx += (letterInfo.cx - underscoreInfo.cx) >> 1;
-		(*pDC).TextOut(dx, y, (const char *) "_", 1);
+		pDC->TextOut(dx, y, (const char *) "_", 1);
 	}
 
-	(*pDC).SetTextColor(oldTextColor);
+	pDC->SetTextColor(oldTextColor);
 
 	focusRect.SetRect(x - FOCUS_RECT_DX,                            // set the focus rectangle
 	                  y - FOCUS_RECT_DY,              // ... then paint it or clear it
 	                  x + textInfo.cx + FOCUS_RECT_DX - 1,
 	                  y + textInfo.cy + FOCUS_RECT_DY + 1);
-	if ((*lpDrawItemStruct).itemState & ODS_FOCUS) {
+	if (lpDrawItemStruct->itemState & ODS_FOCUS) {
 		myQuill.CreateStockObject(DKGRAY_BRUSH);
-		(*pDC).FrameRect(&focusRect, &myQuill);
+		pDC->FrameRect(&focusRect, &myQuill);
 	} else {
 //		(*pDC).FrameRect(&focusRect, &faceBrush);
 	}
 
 	if (pPalOld != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
-	(*pDC).Detach();                          // dismantle the temporary CDC we built
+	pDC->Detach();                          // dismantle the temporary CDC we built
 	delete pDC;
 }
 
@@ -1669,12 +1669,12 @@ LRESULT CRadioButton::OnSetCheck(WPARAM wParam, LPARAM lParam) {
 
 	if (m_bCheckState == true) {                    // if we are the control in the
 		pBase = pWnd = FromHandlePermanent(m_hWnd); // ... group being set, then we
-		pParent = (*pWnd).GetParent();              // ... need to clear all of the others
+		pParent = pWnd->GetParent();              // ... need to clear all of the others
 		while (true) {                              // so fetch the next control
-			pWnd = (*pParent).GetNextDlgGroupItem(pWnd, true);
+			pWnd = pParent->GetNextDlgGroupItem(pWnd, true);
 			if (pWnd == pBase)                      // ... and clear it if its not us
 				break;
-			(*pWnd).SendMessage(BM_SETCHECK, false, 0);
+			pWnd->SendMessage(BM_SETCHECK, false, 0);
 		}
 	}
 

--- a/engines/bagel/hodjnpodj/hnplibs/cbofdlg.cpp
+++ b/engines/bagel/hodjnpodj/hnplibs/cbofdlg.cpp
@@ -101,9 +101,9 @@ void CBmpDialog::OnDestroy() {
 		delete m_pDlgBackground;
 		m_pDlgBackground = nullptr;
 
-		bUpdateNeeded = (*m_pParentWnd).GetUpdateRect(nullptr, false);
+		bUpdateNeeded = m_pParentWnd->GetUpdateRect(nullptr, false);
 		if (bUpdateNeeded)
-			(*m_pParentWnd).ValidateRect(nullptr);
+			m_pParentWnd->ValidateRect(nullptr);
 	}
 
 	CDialog::OnDestroy();
@@ -121,7 +121,7 @@ bool CBmpDialog::OnInitDialog() {
 
 	// get the button's position and size
 
-	(*m_pParentWnd).GetWindowRect(&cWindRect);          // get pos/size of parent
+	m_pParentWnd->GetWindowRect(&cWindRect);          // get pos/size of parent
 	((CWnd *)this)->GetWindowRect(&cDlgRect);           // get pos/size of dialog
 
 	pDC = GetDC();

--- a/engines/bagel/hodjnpodj/hnplibs/cmessbox.cpp
+++ b/engines/bagel/hodjnpodj/hnplibs/cmessbox.cpp
@@ -122,7 +122,7 @@ bool CMessageBox::OnInitDialog() {
 	);
 
 	if ((m_cTextMessage1 = new CText()) != nullptr) {
-		bAssertCheck = (*m_cTextMessage1).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+		bAssertCheck = m_cTextMessage1->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	}
 
@@ -135,15 +135,15 @@ bool CMessageBox::OnInitDialog() {
 	);
 
 	if ((m_cTextMessage2 = new CText()) != nullptr) {
-		bAssertCheck = (*m_cTextMessage2).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+		bAssertCheck = m_cTextMessage2->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	}
 
 	ReleaseDC(pDC);
 
 	if ((pOKButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pOKButton).SetPalette(m_pPalette);                        // set the palette to use
-		(*pOKButton).SetControl(IDOK, this);            // tie to the dialog control
+		pOKButton->SetPalette(m_pPalette);                        // set the palette to use
+		pOKButton->SetControl(IDOK, this);            // tie to the dialog control
 	}
 
 	return true;  // return true  unless you set the focus to a control
@@ -160,12 +160,12 @@ void CMessageBox::OnPaint() {
 	pDC = GetDC();
 
 	if (m_pMessage1 != nullptr) {
-		bAssertCheck = (*m_cTextMessage1).DisplayString(pDC, m_pMessage1, 21, FW_BOLD, TEXT_COLOR);
+		bAssertCheck = m_cTextMessage1->DisplayString(pDC, m_pMessage1, 21, FW_BOLD, TEXT_COLOR);
 		ASSERT(bAssertCheck);
 	}
 
 	if (m_pMessage2 != nullptr) {
-		bAssertCheck = (*m_cTextMessage2).DisplayString(pDC, m_pMessage2, 21, FW_BOLD, TEXT_COLOR);
+		bAssertCheck = m_cTextMessage2->DisplayString(pDC, m_pMessage2, 21, FW_BOLD, TEXT_COLOR);
 		ASSERT(bAssertCheck);
 	}
 

--- a/engines/bagel/hodjnpodj/hnplibs/dibapi.cpp
+++ b/engines/bagel/hodjnpodj/hnplibs/dibapi.cpp
@@ -222,7 +222,7 @@ CPalette *DuplicatePalette(CPalette *pOrigPal) {
 	lpPal->palVersion = PALVERSION;
 	lpPal->palNumEntries = (uint16)wNumColors;
 
-	(*pOrigPal).GetPaletteEntries(0, wNumColors - 1, &lpPal->palPalEntry[0]);
+	pOrigPal->GetPaletteEntries(0, wNumColors - 1, &lpPal->palPalEntry[0]);
 
 	/* create the palette and get handle to it */
 
@@ -268,7 +268,7 @@ CBitmap *ConvertDIB(CDC *pDC, HDIB hDIB, CPalette *pPal) {
 	HBITMAP hBitmap = nullptr;
 	CBitmap *pBitmap = nullptr;
 
-	hDC = (*pDC).m_hDC;
+	hDC = pDC->m_hDC;
 
 	// Get the palette, then select it into DC
 	if (pPal != nullptr) {
@@ -285,7 +285,7 @@ CBitmap *ConvertDIB(CDC *pDC, HDIB hDIB, CPalette *pPal) {
 	if (hBitmap != nullptr) {
 		pBitmap = new CBitmap();
 		if (pBitmap != nullptr)
-			(*pBitmap).Attach(hBitmap);
+			pBitmap->Attach(hBitmap);
 	}
 
 	/* Reselect old palette */

--- a/engines/bagel/hodjnpodj/hnplibs/dibdoc.cpp
+++ b/engines/bagel/hodjnpodj/hnplibs/dibdoc.cpp
@@ -48,7 +48,7 @@ CDibDoc::~CDibDoc() {
 	delete m_hDIB;
 
 	if (m_palDIB != nullptr) {
-		(*m_palDIB).DeleteObject();
+		m_palDIB->DeleteObject();
 		delete m_palDIB;
 	}
 }

--- a/engines/bagel/hodjnpodj/hnplibs/rules.cpp
+++ b/engines/bagel/hodjnpodj/hnplibs/rules.cpp
@@ -189,21 +189,21 @@ LRESULT PrefHookProc(int code, WPARAM wParam, LPARAM lParam) {
 		case VK_NUMPAD8:                            // ... deal with all the rest
 		case VK_PRIOR:                              // go to previous page of text
 			if (nHelpPage > 0)
-				(*pRulesDialog).UpdateScroll(nHelpPage - 1);
+				pRulesDialog->UpdateScroll(nHelpPage - 1);
 			return true;
 		case VK_DOWN:                               // go to next page of text
 		case VK_NUMPAD2:
 		case VK_NEXT:
 			if (!bHelpEOF)
-				(*pRulesDialog).UpdateScroll(nHelpPage + 1);
+				pRulesDialog->UpdateScroll(nHelpPage + 1);
 			return true;
 		case VK_HOME:                               // go to first page of text
 			if (nHelpPage > 0)
-				(*pRulesDialog).UpdateScroll(0);
+				pRulesDialog->UpdateScroll(0);
 			return true;
 		case VK_END:                                // go to last page of text
 			while (!bHelpEOF) {
-				(*pRulesDialog).UpdateScroll(nHelpPage + 1);
+				pRulesDialog->UpdateScroll(nHelpPage + 1);
 			}
 			return true;
 		}
@@ -254,7 +254,7 @@ void CRules::OnDestroy() {
 	CWinApp *pMyApp;
 
 	pMyApp = AfxGetApp();
-	hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+	hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 	//if (hNewCursor != nullptr);
 	SetCursor(hNewCursor);
 
@@ -266,14 +266,14 @@ void CRules::OnDestroy() {
 	delete pFont;
 	pFont = nullptr;
 
-	(*pHelpFile).Close();                           // close and release the rules file
+	pHelpFile->Close();                           // close and release the rules file
 	delete pHelpFile;
 	pHelpFile = nullptr;
 
 	if (pBackgroundBitmap != nullptr) {
-		bUpdateNeeded = (*pParentWnd).GetUpdateRect(nullptr, false);
+		bUpdateNeeded = pParentWnd->GetUpdateRect(nullptr, false);
 		if (bUpdateNeeded)
-			(*pParentWnd).ValidateRect(nullptr);
+			pParentWnd->ValidateRect(nullptr);
 	}
 
 	if (!bBruteForce) {
@@ -302,28 +302,28 @@ bool CRules::OnInitDialog() {
 	if (pParentWnd == nullptr)                         // get our parent window
 		pParentWnd = ((CWnd *) this)->GetParent();  // ... as passed to us or inquired about
 
-	(*pParentWnd).GetWindowRect(&myRect);
+	pParentWnd->GetWindowRect(&myRect);
 	x = myRect.left + (((myRect.right - myRect.left) - ScrollRect.right) >> 1);
 	y = myRect.top + (((myRect.bottom - myRect.top) - ScrollRect.bottom) >> 1);
 	MoveWindow(x, y, ScrollRect.right, ScrollRect.bottom);      // center the dialog box on the parent
 
 	pButton = GetDlgItem((int) GetDefID());         // get the window for the okay button
 	ASSERT(pButton != nullptr);                        // ... and verify we have it
-	(*pButton).GetWindowRect(&myRect);              // get the button's position and size
+	pButton->GetWindowRect(&myRect);              // get the button's position and size
 
 	dx = myRect.right - myRect.left;                // calculate where to place the button
 	x = (ScrollRect.right - dx) >> 1;               // ... centered at the bottom edge
 	dy = myRect.bottom - myRect.top;
 	y = ScrollRect.bottom - dy - BUTTON_DY;
 
-	(*pButton).MoveWindow(x, y, dx, dy);            // reposition the button
+	pButton->MoveWindow(x, y, dx, dy);            // reposition the button
 	OkayRect.SetRect(x, y, x + dx, y + dy);
 
 	#if COLOR_BUTTONS
 	pOKButton = new CColorButton();                   // build a color QUIT button to let us exit
 	ASSERT(pOKButton != nullptr);
-	(*pOKButton).SetPalette(pScrollPalette);        // set the palette to use
-	bSuccess = (*pOKButton).SetControl((int) GetDefID(), this); // tie to the dialog control
+	pOKButton->SetPalette(pScrollPalette);        // set the palette to use
+	bSuccess = pOKButton->SetControl((int) GetDefID(), this); // tie to the dialog control
 	ASSERT(bSuccess);
 	#endif
 
@@ -376,7 +376,7 @@ void CRules::OnPaint() {
 		ReleaseCompatibleContext(pScrollBotMaskDC, pScrollBotMask, pScrollBotMaskOld, pScrollBotMaskPalOld);
 		if (pNarrative != nullptr)
 			// Play the narration
-			(*pNarrative).play();
+			pNarrative->play();
 
 	} else if (bBruteForce) {                           // need to paint directly to screen
 		pDibDoc = LoadScrollDIB(SCROLL_SPEC, nullptr);
@@ -426,11 +426,11 @@ void CRules::RefreshBackground() {
 	pDC = GetDC();                                  // get a context for our window
 
 	if (pScrollPalette != nullptr) {                   // map in our palette
-		pPalOld = (*pDC).SelectPalette(pScrollPalette, false);
-		(*pDC).RealizePalette();              // .. and make the system use it
+		pPalOld = pDC->SelectPalette(pScrollPalette, false);
+		pDC->RealizePalette();              // .. and make the system use it
 	}
 
-	(*pDC).BitBlt(        // repaint the background as it was
+	pDC->BitBlt(        // repaint the background as it was
 	    0,
 	    0,
 	    ScrollRect.right,
@@ -441,7 +441,7 @@ void CRules::RefreshBackground() {
 	    SRCCOPY);
 
 	if (pScrollPalette != nullptr)                     // map out our palette
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	ReleaseDC(pDC);                                 // release the context
 }
@@ -475,7 +475,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		return;
 	}
 
-	(*pBackgroundDC).BitBlt(      // save the entire background
+	pBackgroundDC->BitBlt(      // save the entire background
 	    0, 0,
 	    ScrollRect.right,
 	    ScrollRect.bottom,
@@ -483,7 +483,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    SRCCOPY);
 
-	(*pScrollDC).BitBlt(       // copy background to scroll context
+	pScrollDC->BitBlt(       // copy background to scroll context
 	    0, 0,                           // ... so we can construct the scroll
 	    ScrollRect.right,               // ... on top of it in a masked manner
 	    ScrollRect.bottom,
@@ -495,7 +495,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 
 	ScrollTopCurlRect = ScrollTopRect;              // record where we're putting the top curl
 
-	(*pScrollDC).BitBlt(       // mask out where the top curl goes
+	pScrollDC->BitBlt(       // mask out where the top curl goes
 	    0, 0,
 	    ScrollTopRect.right,
 	    ScrollTopRect.bottom,
@@ -503,7 +503,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    SRCAND);
 
-	(*pScrollTopMaskDC).BitBlt(     // invert the top curl mask
+	pScrollTopMaskDC->BitBlt(     // invert the top curl mask
 	    0, 0,
 	    ScrollTopRect.right,
 	    ScrollTopRect.bottom,
@@ -511,7 +511,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    DSTINVERT);
 
-	(*pScrollTopDC).BitBlt(      // remove transparent area from top curl
+	pScrollTopDC->BitBlt(      // remove transparent area from top curl
 	    0, 0,
 	    ScrollTopRect.right,
 	    ScrollTopRect.bottom,
@@ -519,7 +519,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    SRCAND);
 
-	(*pScrollTopMaskDC).BitBlt(     // restore top curl mask
+	pScrollTopMaskDC->BitBlt(     // restore top curl mask
 	    0, 0,
 	    ScrollTopRect.right,
 	    ScrollTopRect.bottom,
@@ -527,7 +527,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    DSTINVERT);
 
-	(*pScrollDC).BitBlt(       // paint top curl into the scroll
+	pScrollDC->BitBlt(       // paint top curl into the scroll
 	    0, 0,
 	    ScrollTopRect.right,
 	    ScrollTopRect.bottom,
@@ -541,7 +541,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	dstRect.top += ScrollTopRect.bottom;            // ... mid section strip of the scroll
 	dstRect.bottom += ScrollTopRect.bottom;
 
-	(*pScrollMidMaskDC).BitBlt(     // invert the mid section mask
+	pScrollMidMaskDC->BitBlt(     // invert the mid section mask
 	    0, 0,
 	    ScrollMidRect.right,
 	    ScrollMidRect.bottom,
@@ -549,7 +549,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    DSTINVERT);
 
-	(*pScrollMidDC).BitBlt(      // mask out transparent part of mid section
+	pScrollMidDC->BitBlt(      // mask out transparent part of mid section
 	    0, 0,
 	    ScrollMidRect.right,
 	    ScrollMidRect.bottom,
@@ -557,7 +557,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    SRCAND);
 
-	(*pScrollMidMaskDC).BitBlt(     // reset the mid section mask
+	pScrollMidMaskDC->BitBlt(     // reset the mid section mask
 	    0, 0,
 	    ScrollMidRect.right,
 	    ScrollMidRect.bottom,
@@ -566,7 +566,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    DSTINVERT);
 
 	for (i = 0; i < SCROLL_PIECES; i++) {           // build the scroll's mid section srip-wise
-		(*pScrollDC).BitBlt(
+		pScrollDC->BitBlt(
 		    dstRect.left,               // mask out where the image will go
 		    dstRect.top + ScrollMidRect.bottom * i,
 		    ScrollMidRect.right,
@@ -575,7 +575,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    0, 0,
 		    SRCAND);
 
-		(*pScrollDC).BitBlt(      // paint in the mid section image
+		pScrollDC->BitBlt(      // paint in the mid section image
 		    dstRect.left,
 		    dstRect.top + ScrollMidRect.bottom * i,
 		    ScrollMidRect.right,
@@ -591,7 +591,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	dstRect.bottom = dstRect.top + ScrollBotRect.bottom;
 	ScrollBotCurlRect = dstRect;
 
-	(*pScrollDC).BitBlt(       // mask out where the bottom curl image goes
+	pScrollDC->BitBlt(       // mask out where the bottom curl image goes
 	    dstRect.left,
 	    dstRect.top,
 	    ScrollBotRect.right,
@@ -600,7 +600,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    SRCAND);
 
-	(*pScrollBotMaskDC).BitBlt(     // invert the bottom curl mask
+	pScrollBotMaskDC->BitBlt(     // invert the bottom curl mask
 	    0, 0,
 	    ScrollBotRect.right,
 	    ScrollBotRect.bottom,
@@ -608,7 +608,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    DSTINVERT);
 
-	(*pScrollBotDC).BitBlt(      // mask out transparent part of curl
+	pScrollBotDC->BitBlt(      // mask out transparent part of curl
 	    0, 0,
 	    ScrollBotRect.right,
 	    ScrollBotRect.bottom,
@@ -616,7 +616,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    SRCAND);
 
-	(*pScrollBotMaskDC).BitBlt(     // reset the mask
+	pScrollBotMaskDC->BitBlt(     // reset the mask
 	    0, 0,
 	    ScrollBotRect.right,
 	    ScrollBotRect.bottom,
@@ -624,7 +624,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    DSTINVERT);
 
-	(*pScrollDC).BitBlt(       // paint in the bottom curl
+	pScrollDC->BitBlt(       // paint in the bottom curl
 	    dstRect.left,
 	    dstRect.top,
 	    ScrollBotRect.right,
@@ -658,7 +658,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 
 		dst2Rect = dstRect;
 
-		(*pWorkDC).BitBlt(      // splat in the background for top curl
+		pWorkDC->BitBlt(      // splat in the background for top curl
 		    0, 0,
 		    ScrollTopRect.right,
 		    ScrollTopRect.bottom,
@@ -667,7 +667,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    dst2Rect.top,
 		    SRCCOPY);
 
-		(*pWorkDC).BitBlt(      // mask out where the top curl goes
+		pWorkDC->BitBlt(      // mask out where the top curl goes
 		    0, 0,
 		    ScrollTopRect.right,
 		    ScrollTopRect.bottom,
@@ -675,7 +675,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    0, 0,
 		    SRCAND);
 
-		(*pWorkDC).BitBlt(      // insert the top curl background
+		pWorkDC->BitBlt(      // insert the top curl background
 		    0, 0,
 		    ScrollTopRect.right,
 		    ScrollTopRect.bottom,
@@ -684,7 +684,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    SRCPAINT);
 
 		if (i == 0) {                               // if first time, just paint curl to display
-			(*pDC).BitBlt(
+			pDC->BitBlt(
 			    dst2Rect.left,
 			    dst2Rect.top,
 			    ScrollTopRect.right,
@@ -693,7 +693,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 			    0, 0,
 			    SRCCOPY);
 		} else {
-			(*pWorkDC).BitBlt(     // ... otherwise paint in a new piece of
+			pWorkDC->BitBlt(     // ... otherwise paint in a new piece of
 			    dst2Rect.left,          // ... the middle section
 			    ScrollTopRect.bottom,
 			    dst2Rect.right,
@@ -702,7 +702,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 			    dst2Rect.left,
 			    dst2Rect.top + ScrollTopRect.bottom,
 			    SRCCOPY);
-			(*pDC).BitBlt(      // ... then paint it and the curl, thus
+			pDC->BitBlt(      // ... then paint it and the curl, thus
 			    dst2Rect.left,          // ... causing the top to seemingly unfurl
 			    dst2Rect.top,           // ... by one more strip
 			    ScrollTopRect.right,
@@ -716,7 +716,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		dst2Rect.bottom = dstRect.bottom;
 
 		if ((i == 0) || ((i == 1) && (h == 1))) {   // if first time or doing last iteration
-			(*pWorkDC).BitBlt(                // ... just paint in the bottom curl
+			pWorkDC->BitBlt(                // ... just paint in the bottom curl
 			    0, 0,
 			    dst2Rect.right,
 			    scroll_delta,
@@ -725,7 +725,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 			    dst2Rect.top,
 			    SRCCOPY);
 		} else {                                    //
-			(*pWorkDC).BitBlt(
+			pWorkDC->BitBlt(
 			    0, 0,
 			    dst2Rect.right,
 			    scroll_delta,
@@ -735,7 +735,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 			    SRCCOPY);
 		}
 
-		(*pWorkDC).BitBlt(
+		pWorkDC->BitBlt(
 		    0,
 		    scroll_delta,
 		    ScrollBotRect.right,
@@ -745,7 +745,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    dst2Rect.top + scroll_delta,
 		    SRCCOPY);
 
-		(*pWorkDC).BitBlt(
+		pWorkDC->BitBlt(
 		    0,
 		    scroll_delta,
 		    ScrollBotRect.right,
@@ -754,7 +754,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    0, 0,
 		    SRCAND);
 
-		(*pWorkDC).BitBlt(
+		pWorkDC->BitBlt(
 		    0,
 		    scroll_delta,
 		    ScrollBotRect.right,
@@ -763,7 +763,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    0, 0,
 		    SRCPAINT);
 
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 		    ScrollBotRect.left,
 		    dst2Rect.top,
 		    ScrollBotRect.right,
@@ -807,8 +807,8 @@ void CRules::UpdateScroll(int nPage) {
 	pDC = GetDC();
 
 	if (pScrollPalette != nullptr) {                   // map in our palette
-		pPalOld = (*pDC).SelectPalette(pScrollPalette, false);
-		(*pDC).RealizePalette();              // .. and make the system use it
+		pPalOld = pDC->SelectPalette(pScrollPalette, false);
+		pDC->RealizePalette();              // .. and make the system use it
 	}
 
 	dstRect = ScrollMidRect;                        // setup initial destination for blts
@@ -816,7 +816,7 @@ void CRules::UpdateScroll(int nPage) {
 	dstRect.bottom += ScrollTopRect.bottom;
 
 	for (i = 0; i < SCROLL_PIECES; i++) {           // repaint the scroll midsection artwork
-		(*pScrollDC).BitBlt(      // ... mask out where artwork goes
+		pScrollDC->BitBlt(      // ... mask out where artwork goes
 		    dstRect.left,
 		    dstRect.top + ScrollMidRect.bottom * i,
 		    ScrollMidRect.right,
@@ -825,7 +825,7 @@ void CRules::UpdateScroll(int nPage) {
 		    0, 0,
 		    SRCAND);
 
-		(*pScrollDC).BitBlt(      // ... paint in the scroll artwork
+		pScrollDC->BitBlt(      // ... paint in the scroll artwork
 		    dstRect.left,
 		    dstRect.top + ScrollMidRect.bottom * i,
 		    ScrollMidRect.right,
@@ -837,7 +837,7 @@ void CRules::UpdateScroll(int nPage) {
 
 	WritePage(pScrollDC, nPage);                    // construct the new page of text
 
-	(*pDC).BitBlt(        // paint the result to the sceen
+	pDC->BitBlt(        // paint the result to the sceen
 	    TEXT_LEFT_MARGIN,
 	    ScrollTopRect.bottom + TEXT_TOP_MARGIN,
 	    TEXT_WIDTH,
@@ -850,7 +850,7 @@ void CRules::UpdateScroll(int nPage) {
 	UpdateMore(pDC);                                // update the "more" indicator
 
 	if (pScrollPalette != nullptr)                     // map out our palette
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	ReleaseDC(pDC);
 }
@@ -869,23 +869,23 @@ void CRules::WritePage(CDC *pDC, int nPage) {
 	nHelpPage = nPage;
 	bEOF = bHelpEOF = false;
 
-	(*pHelpFile).SeekToBegin();
+	pHelpFile->SeekToBegin();
 
 	if ((nHelpPage == 0) && (nPage == 0)) {
-		dwHelpPagePosition[nHelpPage] = (*pHelpFile).GetPosition();
+		dwHelpPagePosition[nHelpPage] = pHelpFile->GetPosition();
 		bEOL = dwHelpPageEOL[nHelpPage] = true;
 	} else {
-		(*pHelpFile).Seek(dwHelpPagePosition[nPage], CFile::begin);
+		pHelpFile->Seek(dwHelpPagePosition[nPage], CFile::begin);
 		bEOL = dwHelpPageEOL[nHelpPage];
 	}
 
 	dwHelpPagePosition[nHelpPage + 1] = dwHelpPagePosition[nHelpPage];
 
-	pFontOld = (*pDC).SelectObject(pFont);
+	pFontOld = pDC->SelectObject(pFont);
 
-	(*pDC).GetTextMetrics(&fontMetrics);
+	pDC->GetTextMetrics(&fontMetrics);
 
-	(*pDC).SetBkMode(TRANSPARENT);
+	pDC->SetBkMode(TRANSPARENT);
 
 	i = 0;
 	n = 1;
@@ -898,7 +898,7 @@ try_again:
 			if (bEOF)
 				break;
 			dwHelpPagePosition[nHelpPage + 1] += i + nCropped;
-			nCount = (*pHelpFile).Read(&chInBuf, TEXT_BUFFER_SIZE);
+			nCount = pHelpFile->Read(&chInBuf, TEXT_BUFFER_SIZE);
 			if (nCount < TEXT_BUFFER_SIZE)
 				bEOF = true;
 			i = 0;
@@ -929,7 +929,7 @@ try_again:
 					break;
 				dwHelpPagePosition[nHelpPage + 1] += i + nCropped;
 				strncpy(&chInBuf[0], &chInBuf[i], n);
-				nCount = (*pHelpFile).Read(&chInBuf[n], TEXT_BUFFER_SIZE - n);
+				nCount = pHelpFile->Read(&chInBuf[n], TEXT_BUFFER_SIZE - n);
 				nCount += n;
 				if (nCount < TEXT_BUFFER_SIZE)
 					bEOF = true;
@@ -961,7 +961,7 @@ crop_byte:
 				break;
 			}
 
-			textInfo = (*pDC).GetTextExtent(&chInBuf[i], n);
+			textInfo = pDC->GetTextExtent(&chInBuf[i], n);
 			if (textInfo.cx > TEXT_WIDTH - TEXT_LEFT_MARGIN) {
 				if ((chInBuf[i + n - 1] != ' ') &&
 				        (chInBuf[i + n - 1] != '\t'))
@@ -975,7 +975,7 @@ crop_byte:
 			n += 1;
 		}
 //		(*pDC).TextOut(x,y,(const char *) &chInBuf[i],n);
-		(*pDC).TabbedTextOut(x, y, (const char *) &chInBuf[i], n, 1, &tabstop, 0);
+		pDC->TabbedTextOut(x, y, (const char *) &chInBuf[i], n, 1, &tabstop, 0);
 		if (chInBuf[i + n] == '\r')
 			i += 2;
 		else if (chInBuf[i + n] == TEXT_NEWLINE)
@@ -987,7 +987,7 @@ crop_byte:
 			break;
 	}
 
-	(*pDC).SelectObject(pFontOld);
+	pDC->SelectObject(pFontOld);
 
 	dwHelpPagePosition[nPage + 1] += i + nCropped;
 	dwHelpPageEOL[nPage + 1] = bEOL;
@@ -996,7 +996,7 @@ crop_byte:
 		if (i >= (int) nCount) {
 			if (bEOF)
 				break;
-			nCount = (*pHelpFile).Read(&chInBuf, TEXT_BUFFER_SIZE);
+			nCount = pHelpFile->Read(&chInBuf, TEXT_BUFFER_SIZE);
 			if (nCount < TEXT_BUFFER_SIZE)
 				bEOF = true;
 			i = 0;
@@ -1016,7 +1016,7 @@ crop_byte:
 	if (bEOF && (i >= (int) nCount))
 		bHelpEOF = true;
 
-	(*pDC).SelectObject(pFontOld);
+	pDC->SelectObject(pFontOld);
 
 }
 
@@ -1027,21 +1027,21 @@ void CRules::UpdateMore(CDC *pDC) {
 	TEXTMETRIC  fontMetrics;
 	CSize       textInfo;
 
-	pFontOld = (*pDC).SelectObject(pFont);
+	pFontOld = pDC->SelectObject(pFont);
 
-	(*pDC).GetTextMetrics(&fontMetrics);
+	pDC->GetTextMetrics(&fontMetrics);
 
-	(*pDC).SetBkMode(TRANSPARENT);
+	pDC->SetBkMode(TRANSPARENT);
 
 	x = ScrollRect.right - TEXT_MORE_DX;
 	y = ((ScrollTopRect.bottom - fontMetrics.tmHeight) >> 1) +
 	    TEXT_MORE_DY - 3;
-	textInfo = (*pDC).GetTextExtent(MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+	textInfo = pDC->GetTextExtent(MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 	dx = textInfo.cx;
 	dy = fontMetrics.tmHeight;
 
 	if (nHelpPage == 0)
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 		    x,
 		    y,
 		    dx,
@@ -1051,7 +1051,7 @@ void CRules::UpdateMore(CDC *pDC) {
 		    y,
 		    SRCCOPY);
 	else
-		(*pDC).TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+		pDC->TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 
 	y = ScrollRect.bottom -
 	    ScrollBotRect.bottom +
@@ -1059,7 +1059,7 @@ void CRules::UpdateMore(CDC *pDC) {
 	    TEXT_MORE_DY;
 
 	if (bHelpEOF)
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 		    x,
 		    y,
 		    dx,
@@ -1069,9 +1069,9 @@ void CRules::UpdateMore(CDC *pDC) {
 		    y,
 		    SRCCOPY);
 	else
-		(*pDC).TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+		pDC->TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 
-	(*pDC).SelectObject(pFontOld);
+	pDC->SelectObject(pFontOld);
 }
 
 
@@ -1097,16 +1097,16 @@ int CRules::OnCreate(LPCREATESTRUCT lpCreateStruct) {
 
 	pHelpFile = new CFile();
 	ASSERT(pHelpFile != nullptr);
-	bSuccess = (*pHelpFile).Open(chPathName, CFile::modeRead | CFile::typeBinary, nullptr);
+	bSuccess = pHelpFile->Open(chPathName, CFile::modeRead | CFile::typeBinary, nullptr);
 	ASSERT(bSuccess);
 	if (!bSuccess)
 		return -1;
-	nHelpFileSize = (*pHelpFile).GetLength();
+	nHelpFileSize = pHelpFile->GetLength();
 
 	AddFontResource("msserif.fon");
 	pFont = new CFont();
 	ASSERT(pFont != nullptr);
-	bSuccess = (*pFont).CreateFont(16, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, OUT_RASTER_PRECIS, 0, PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
+	bSuccess = pFont->CreateFont(16, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, OUT_RASTER_PRECIS, 0, PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
 	ASSERT(bSuccess);
 
 	if ((GetFreeSpace(0) >= (unsigned long) 1000000) &&
@@ -1182,7 +1182,7 @@ bool CRules::CreateWorkAreas(CDC *pDC) {
 	pScrollBitmap = new CBitmap();
 	if (pScrollBitmap == nullptr)
 		return false;
-	bSuccess = (*pScrollBitmap).CreateCompatibleBitmap(pDC, ScrollRect.right, ScrollRect.bottom);
+	bSuccess = pScrollBitmap->CreateCompatibleBitmap(pDC, ScrollRect.right, ScrollRect.bottom);
 	if (!bSuccess)
 		return false;
 	pScrollDC = SetupCompatibleContext(pDC, pScrollBitmap, pScrollBitmapOld, pScrollPalette, pScrollPalOld);
@@ -1192,7 +1192,7 @@ bool CRules::CreateWorkAreas(CDC *pDC) {
 	pBackgroundBitmap = new CBitmap();
 	if (pBackgroundBitmap == nullptr)
 		return false;
-	bSuccess = (*pBackgroundBitmap).CreateCompatibleBitmap(pDC, ScrollRect.right, ScrollRect.bottom);
+	bSuccess = pBackgroundBitmap->CreateCompatibleBitmap(pDC, ScrollRect.right, ScrollRect.bottom);
 	if (!bSuccess)
 		return false;
 	pBackgroundDC = SetupCompatibleContext(pDC, pBackgroundBitmap, pBackgroundBitmapOld, pScrollPalette, pBackgroundPalOld);
@@ -1206,7 +1206,7 @@ bool CRules::CreateWorkAreas(CDC *pDC) {
 	pWorkBitmap = new CBitmap();
 	if (pWorkBitmap == nullptr)
 		return false;
-	bSuccess = (*pWorkBitmap).CreateCompatibleBitmap(pDC, WorkRect.right, WorkRect.bottom);
+	bSuccess = pWorkBitmap->CreateCompatibleBitmap(pDC, WorkRect.right, WorkRect.bottom);
 	if (!bSuccess)
 		return false;
 	pWorkDC = SetupCompatibleContext(pDC, pWorkBitmap, pWorkBitmapOld, pScrollPalette, pWorkPalOld);
@@ -1235,18 +1235,18 @@ bool CRules::CreateWorkAreas(CDC *pDC) {
 CDC *CRules::SetupMask(CDC *pDC, CDC *pBitmapDC, CBitmap *pMask, CBitmap * &pMaskOld, CRect *pRect) {
 	CDC *pNewDC = nullptr;
 
-	(*pMask).CreateBitmap((*pRect).right, (*pRect).bottom, 1, 1, nullptr);
+	pMask->CreateBitmap(pRect->right, pRect->bottom, 1, 1, nullptr);
 
 	pNewDC = new CDC();
 
 	if ((pNewDC != nullptr) &&
-	        (*pNewDC).CreateCompatibleDC(pDC)) {
-		pMaskOld = (*pNewDC).SelectObject(pMask);
+	        pNewDC->CreateCompatibleDC(pDC)) {
+		pMaskOld = pNewDC->SelectObject(pMask);
 		if (pMaskOld != nullptr) {
-			(*pNewDC).BitBlt(
+			pNewDC->BitBlt(
 			    0, 0,
-			    (*pRect).right,
-			    (*pRect).bottom,
+			    pRect->right,
+			    pRect->bottom,
 			    pBitmapDC,
 			    0, 0,
 			    SRCCOPY);
@@ -1266,13 +1266,13 @@ CDC *CRules::SetupCompatibleContext(CDC *pDC, CBitmap *pBitmap,
 
 	if ((pDC != nullptr) &&
 	        (pNewDC != nullptr) &&
-	        (*pNewDC).CreateCompatibleDC(pDC)) {
+	        pNewDC->CreateCompatibleDC(pDC)) {
 		if (pPalette)
-			pPalOld = (*pNewDC).SelectPalette(pPalette, false);
+			pPalOld = pNewDC->SelectPalette(pPalette, false);
 		else
 			pPalOld = nullptr;
-		(*pNewDC).RealizePalette();
-		pBitmapOld = (*pNewDC).SelectObject(pBitmap);
+		pNewDC->RealizePalette();
+		pBitmapOld = pNewDC->SelectObject(pBitmap);
 		if (pBitmapOld != nullptr)
 			return (pNewDC);
 	}
@@ -1285,23 +1285,23 @@ CDC *CRules::SetupCompatibleContext(CDC *pDC, CBitmap *pBitmap,
 
 void CRules::ReleaseCompatibleContext(CDC *&pDC, CBitmap * &pBitmap, CBitmap *pBitmapOld, CPalette *pPalOld) {
 	if (pBitmapOld != nullptr) {
-		(*pDC).SelectObject(pBitmapOld);
+		pDC->SelectObject(pBitmapOld);
 		pBitmapOld = nullptr;
 	}
 
 	if (pPalOld != nullptr) {
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 		pPalOld = nullptr;
 	}
 
 	if (pBitmap != nullptr) {
-		(*pBitmap).DeleteObject();
+		pBitmap->DeleteObject();
 		delete pBitmap;
 		pBitmap = nullptr;
 	}
 
 	if (pDC != nullptr) {
-		(*pDC).DeleteDC();
+		pDC->DeleteDC();
 		delete pDC;
 		pDC = nullptr;
 	}
@@ -1319,9 +1319,9 @@ CDibDoc *CRules::LoadScrollDIB(const char *pszPathName, CRect *pRect) {
 	pDibDoc = new CDibDoc();
 	ASSERT(pDibDoc != nullptr);
 
-	bSuccess = (*pDibDoc).OpenDocument(pszPathName);
+	bSuccess = pDibDoc->OpenDocument(pszPathName);
 	ASSERT(bSuccess);
-	hDIB = (*pDibDoc).GetHDIB();
+	hDIB = pDibDoc->GetHDIB();
 	ASSERT(hDIB != nullptr);
 	
 	dxDIB = (int) DIBWidth(hDIB);
@@ -1329,7 +1329,7 @@ CDibDoc *CRules::LoadScrollDIB(const char *pszPathName, CRect *pRect) {
 	
 
 	if (pRect != nullptr)
-		(*pRect).SetRect(0, 0, dxDIB, dyDIB);
+		pRect->SetRect(0, 0, dxDIB, dyDIB);
 
 	return (pDibDoc);
 }
@@ -1341,7 +1341,7 @@ bool CRules::PaintScrollDIB(CDC *pDC, CDibDoc *pDibDoc) {
 	int         dxDIB, dyDIB;
 	CRect       myRect;
 
-	hDIB = (*pDibDoc).GetHDIB();
+	hDIB = pDibDoc->GetHDIB();
 	ASSERT(hDIB != nullptr);
 	
 	dxDIB = (int) DIBWidth(hDIB);
@@ -1350,7 +1350,7 @@ bool CRules::PaintScrollDIB(CDC *pDC, CDibDoc *pDibDoc) {
 
 	myRect.SetRect(0, 0, dxDIB, dyDIB);
 
-	bSuccess = PaintDIB((*pDC).m_hDC, myRect, hDIB, myRect, pScrollPalette);
+	bSuccess = PaintDIB(pDC->m_hDC, myRect, hDIB, myRect, pScrollPalette);
 
 	return bSuccess;
 }
@@ -1360,7 +1360,7 @@ CBitmap *CRules::CreateScrollBitmap(CDC *pDC, CDibDoc *pDibDoc, CPalette *pPalet
 	HDIB        hDIB;
 	CBitmap     *pBitmap = nullptr;
 
-	hDIB = (*pDibDoc).GetHDIB();
+	hDIB = pDibDoc->GetHDIB();
 	ASSERT(hDIB != nullptr);
 
 	pBitmap = ConvertDIB(pDC, hDIB, pPalette);
@@ -1394,19 +1394,19 @@ void CRules::OnMouseMove(unsigned int nFlags, CPoint point) {
 	pMyApp = AfxGetApp();
 
 	if (OkayRect.PtInRect(point))
-		hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+		hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 	else if (ScrollTopCurlRect.PtInRect(point)) {
 		if (nHelpPage == 0)
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_INVALID);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_INVALID);
 		else
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_ARROWUP);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_ARROWUP);
 	} else if (ScrollBotCurlRect.PtInRect(point)) {
 		if (bHelpEOF)
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_INVALID);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_INVALID);
 		else
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_ARROWDN);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_ARROWDN);
 	} else
-		hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+		hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 
 	//if (hNewCursor != nullptr);
 	SetCursor(hNewCursor);
@@ -1416,7 +1416,7 @@ void CRules::OnMouseMove(unsigned int nFlags, CPoint point) {
 
 
 bool CRules::OnSetCursor(CWnd *pWnd, unsigned int nHitTest, unsigned int message) {
-	if ((*pWnd).m_hWnd == (*this).m_hWnd)
+	if (pWnd->m_hWnd == (this)->m_hWnd)
 		return true;
 	else
 		return false;
@@ -1428,7 +1428,7 @@ void CRules::ShowWaitCursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).BeginWaitCursor();
+	pMyApp->BeginWaitCursor();
 }
 
 
@@ -1437,7 +1437,7 @@ void CRules::DoArrowCursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).EndWaitCursor();
+	pMyApp->EndWaitCursor();
 }
 
 } // namespace HodjNPodj

--- a/engines/bagel/hodjnpodj/hnplibs/sprite.cpp
+++ b/engines/bagel/hodjnpodj/hnplibs/sprite.cpp
@@ -153,7 +153,7 @@ void CSprite::LinkSprite() {
 	m_pNext = m_pSpriteChain;                           // link sprite into head of chain
 	m_pPrev = nullptr;                                     // ... by pointing it at the current
 	if (m_pSpriteChain != nullptr)                         // ... initial sprite, and pointing it
-		(*m_pSpriteChain).m_pPrev = this;               // ... back at us
+		m_pSpriteChain->m_pPrev = this;               // ... back at us
 	m_pSpriteChain = this;
 }
 
@@ -180,12 +180,12 @@ void CSprite::UnlinkSprite() {
 		return;
 
 	if (m_pPrev != nullptr)                                // disconnect us from the sprite chain
-		(*m_pPrev).m_pNext = m_pNext;                   // ... by pointing the one before us, and
+		m_pPrev->m_pNext = m_pNext;                   // ... by pointing the one before us, and
 	else                                                // ... the one after us, at each other
 		m_pSpriteChain = m_pNext;                       // special case the instance where the
 	// ... sprite to be removed is the first
 	if (m_pNext != nullptr)                                // ... in the list - in particular, update
-		(*m_pNext).m_pPrev = m_pPrev;                   // ... the head of chain pointer
+		m_pNext->m_pPrev = m_pPrev;                   // ... the head of chain pointer
 
 	m_pNext = m_pPrev = nullptr;
 }
@@ -208,7 +208,7 @@ void CSprite::FlushSpriteChain() {
 	CSprite *pSprite = nullptr;
 
 	while ((pSprite = CSprite::GetSpriteChain()) != nullptr) { // cycle getting head of chain
-		(*pSprite).UnlinkSprite();                          // ... unlinking it
+		pSprite->UnlinkSprite();                          // ... unlinking it
 		delete pSprite;
 	}                                    // ... and then deleting it
 }
@@ -303,14 +303,14 @@ bool CSprite::RefreshBackdrop(CDC *pDC, CPalette *pPalette) {
 		return false;
 
 	if (pPalette != nullptr) {                         // map in our palette
-		pPalOld = (*pDC).SelectPalette(pPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pPalette, false);
+		pDC->RealizePalette();
 	}
 	// zap it to the screen
-	bSuccess = (*pDC).BitBlt(0, 0, GAME_WIDTH, GAME_HEIGHT, m_pBackdropDC, 0, 0, SRCCOPY);
+	bSuccess = pDC->BitBlt(0, 0, GAME_WIDTH, GAME_HEIGHT, m_pBackdropDC, 0, 0, SRCCOPY);
 
 	if (pPalOld != nullptr)                            // map out the palette
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	ReleaseBackdropDC();                            // release backdrop context resources
 
@@ -376,8 +376,8 @@ bool CSprite::DuplicateSprite(CDC *pDC, CSprite *pSprite) {
 	CPalette    *pPalOld = nullptr;
 
 	if (m_pPalette) {
-		pPalOld = (*pDC).SelectPalette(m_pPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(m_pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	if (pSprite != nullptr) {                                  // only duplicate visible sprites                                   // ... unable to create that object
@@ -386,46 +386,46 @@ bool CSprite::DuplicateSprite(CDC *pDC, CSprite *pSprite) {
 				if (!SetupImage(pDC))
 					return false;
 				(void)SetupMask(pDC);
-				(*pSprite).m_pImageDC = m_pImageDC;
-				(*pSprite).m_pImageOld = m_pImageOld;
-				(*pSprite).m_pMaskDC = m_pMaskDC;
-				(*pSprite).m_pMaskOld = m_pMaskOld;
+				pSprite->m_pImageDC = m_pImageDC;
+				pSprite->m_pImageOld = m_pImageOld;
+				pSprite->m_pMaskDC = m_pMaskDC;
+				pSprite->m_pMaskOld = m_pMaskOld;
 			} else {
 				ReleaseImageContext();                          // release existing device contexts.
 				ReleaseMaskContext();
 			}
-			(*pSprite).m_pImage = m_pImage;
+			pSprite->m_pImage = m_pImage;
 		}
-		(*pSprite).m_pPalette = m_pPalette;
+		pSprite->m_pPalette = m_pPalette;
 		if (m_pPalette != nullptr) {
-			(*pSprite).m_bSharedPalette = true;
-			(*pSprite).m_pPalImageOld = m_pPalImageOld;
+			pSprite->m_bSharedPalette = true;
+			pSprite->m_pPalImageOld = m_pPalImageOld;
 		}
-		(*pSprite).m_cRect = m_cRect;
-		(*pSprite).m_cImageRect = m_cImageRect;
-		(*pSprite).m_cSize = m_cSize;
-		(*pSprite).m_cPosition = m_cPosition;
-		(*pSprite).m_cMovementDelta = m_cMovementDelta;
-		(*pSprite).m_cHotspot = m_cHotspot;
-		(*pSprite).m_nType = m_nType;
-		(*pSprite).m_pData = m_pData;
-		(*pSprite).m_nZOrder = m_nZOrder;
-		(*pSprite).m_nZPosition = m_nZPosition;
-		(*pSprite).m_nCelID = m_nCelID;
-		(*pSprite).m_nCelCount = m_nCelCount;
-		(*pSprite).m_bVisible = m_bVisible;
-		(*pSprite).m_bMasked = m_bMasked;
-		(*pSprite).m_bMobile = m_bMobile;
-		(*pSprite).m_bIntercepts = m_bIntercepts;
-		(*pSprite).m_bRetainBackground = m_bRetainBackground;
-		(*pSprite).m_bRetainContexts = m_bRetainContexts;
-		(*pSprite).m_bAnimated = m_bAnimated;
-		(*pSprite).m_bDuplicated = true;                    // mark it as a sprite with shared resources
+		pSprite->m_cRect = m_cRect;
+		pSprite->m_cImageRect = m_cImageRect;
+		pSprite->m_cSize = m_cSize;
+		pSprite->m_cPosition = m_cPosition;
+		pSprite->m_cMovementDelta = m_cMovementDelta;
+		pSprite->m_cHotspot = m_cHotspot;
+		pSprite->m_nType = m_nType;
+		pSprite->m_pData = m_pData;
+		pSprite->m_nZOrder = m_nZOrder;
+		pSprite->m_nZPosition = m_nZPosition;
+		pSprite->m_nCelID = m_nCelID;
+		pSprite->m_nCelCount = m_nCelCount;
+		pSprite->m_bVisible = m_bVisible;
+		pSprite->m_bMasked = m_bMasked;
+		pSprite->m_bMobile = m_bMobile;
+		pSprite->m_bIntercepts = m_bIntercepts;
+		pSprite->m_bRetainBackground = m_bRetainBackground;
+		pSprite->m_bRetainContexts = m_bRetainContexts;
+		pSprite->m_bAnimated = m_bAnimated;
+		pSprite->m_bDuplicated = true;                    // mark it as a sprite with shared resources
 		if (m_bVisible) {
 			if (!m_bMasked || CreateMask(pDC)) {                // create an image mask if needed
-				(*pSprite).m_pMask = m_pMask;
+				pSprite->m_pMask = m_pMask;
 				if (m_pPalette)
-					(*pDC).SelectPalette(pPalOld, false);
+					pDC->SelectPalette(pPalOld, false);
 				return true;
 			}
 		} else
@@ -433,7 +433,7 @@ bool CSprite::DuplicateSprite(CDC *pDC, CSprite *pSprite) {
 	}
 
 	if (m_pPalette)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	return false;
 }
@@ -479,29 +479,29 @@ bool CSprite::LoadSprite(CDC *pDC, const char *pszPathName) {
 	// ... have one assigned to this sprite
 	if ((myDib != nullptr) &&                              // verify we have the objects we just created
 	        (m_pImage != nullptr) &&                           // .. and then attempt to open the requested
-	        (*myDib).OpenDocument(pszPathName)) {           // .... bitmap file
+	        myDib->OpenDocument(pszPathName)) {           // .... bitmap file
 		m_bVisible = true;
 		if (!bHavePalette)                              // if we don't have a palette, then
-			m_pPalette = (*myDib).DetachPalette();      // ... detach the DIB's palette for our use
+			m_pPalette = myDib->DetachPalette();      // ... detach the DIB's palette for our use
 		if (m_pPalette != nullptr) {
-			pPalOld = (*pDC).SelectPalette(m_pPalette, false);
-			(*pDC).RealizePalette();
-			hPalette = (HPALETTE)(*m_pPalette).m_hObject;
+			pPalOld = pDC->SelectPalette(m_pPalette, false);
+			pDC->RealizePalette();
+			hPalette = (HPALETTE)m_pPalette->m_hObject;
 		}
 		if (CreateImageContext(pDC)) {
 			// Create a context for the image
-			HDIB hDib = (*myDib).GetHDIB();
-			(*m_pImage).m_hObject = DIBtoBitmap(
-				(*pDC).m_hDC,	// convert the DIB to a DDB
+			HDIB hDib = myDib->GetHDIB();
+			m_pImage->m_hObject = DIBtoBitmap(
+				pDC->m_hDC,	// convert the DIB to a DDB
 			    hPalette,
 			    hDib);			// ... and store it in the sprite
 
-			if ((*m_pImage).m_hObject != nullptr) {        // verify the conversion was successful
+			if (m_pImage->m_hObject != nullptr) {        // verify the conversion was successful
 				if (pPalOld != nullptr)
-					(*pDC).SelectPalette(pPalOld, false);
+					pDC->SelectPalette(pPalOld, false);
 				if (!m_bRetainContexts)                  // release the context if not optimizing
 					ReleaseImageContext();
-				m_cSize = (*myDib).GetDocSize();        // ... size related variables
+				m_cSize = myDib->GetDocSize();        // ... size related variables
 				m_cRect.right = m_cRect.left + m_cSize.cx;              // ... update rectangular dimensions
 				m_cRect.bottom = m_cRect.top + m_cSize.cy;
 				m_cImageRect.SetRect(0, 0, m_cSize.cx, m_cSize.cy);
@@ -515,13 +515,13 @@ bool CSprite::LoadSprite(CDC *pDC, const char *pszPathName) {
 	}
 
 	if (pPalOld != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	ClearImage();
 
 	if (!bHavePalette &&                                // delete the palette resource and object
 	        (m_pPalette != nullptr)) {                         // ... if it came from the DIB
-		(*m_pPalette).DeleteObject();
+		m_pPalette->DeleteObject();
 		delete m_pPalette;
 		m_pPalette = nullptr;
 	}
@@ -565,7 +565,7 @@ bool CSprite::LoadSprite(CBitmap *pBitmap, CPalette *pPalette) {
 	if (pPalette != nullptr)                               // ... and the palette, if specified
 		SharePalette(pPalette);
 
-	(*pBitmap).GetObject(sizeof(BITMAP), &cBitmapData); // get the size of the bitmap
+	pBitmap->GetObject(sizeof(BITMAP), &cBitmapData); // get the size of the bitmap
 	m_cSize.cx = cBitmapData.bmWidth;                   // ... and initialize size variables
 	m_cSize.cy = cBitmapData.bmHeight;
 	m_cRect.right = m_cRect.left + m_cSize.cx;
@@ -650,27 +650,27 @@ bool CSprite::LoadResourceSprite(CDC *pDC, const char *pszName) {
 	// ... have one assigned to this sprite
 	if ((myDib != nullptr) &&                              // verify we have the objects we just created
 	        (m_pImage != nullptr) &&                           // .. and then attempt to open the requested
-	        (*myDib).OpenResourceDocument(pszName)) {       // .... bitmap file
+	        myDib->OpenResourceDocument(pszName)) {       // .... bitmap file
 		m_bVisible = true;
 		if (!bHavePalette)                              // if we don't have a palette, then
-			m_pPalette = (*myDib).DetachPalette();      // ... detach the DIB's palette for our use
+			m_pPalette = myDib->DetachPalette();      // ... detach the DIB's palette for our use
 		if (m_pPalette != nullptr) {
-			pPalOld = (*pDC).SelectPalette(m_pPalette, false);
-			(*pDC).RealizePalette();
-			hPalette = (HPALETTE)(*m_pPalette).m_hObject;
+			pPalOld = pDC->SelectPalette(m_pPalette, false);
+			pDC->RealizePalette();
+			hPalette = (HPALETTE)m_pPalette->m_hObject;
 		}
 		if (CreateImageContext(pDC)) {
 			// Create a context for the image
-			HDIB hDib = (*myDib).GetHDIB();
-			(*m_pImage).m_hObject = DIBtoBitmap((*pDC).m_hDC,   // convert the DIB to a DDB
+			HDIB hDib = myDib->GetHDIB();
+			m_pImage->m_hObject = DIBtoBitmap(pDC->m_hDC,   // convert the DIB to a DDB
 			    hPalette,
 			    hDib);   // ... and store it in the sprite
-			if ((*m_pImage).m_hObject != nullptr) {        // verify the conversion was sucessfull
+			if (m_pImage->m_hObject != nullptr) {        // verify the conversion was sucessfull
 				if (pPalOld != nullptr)
-					(*pDC).SelectPalette(pPalOld, false);
+					pDC->SelectPalette(pPalOld, false);
 				if (!m_bRetainContexts)                  // release the context if not optimizing
 					ReleaseImageContext();
-				m_cSize = (*myDib).GetDocSize();        // ... size related variables
+				m_cSize = myDib->GetDocSize();        // ... size related variables
 				m_cRect.right = m_cRect.left + m_cSize.cx;              // ... update rectangular dimensions
 				m_cRect.bottom = m_cRect.top + m_cSize.cy;
 				m_cImageRect.SetRect(0, 0, m_cSize.cx, m_cSize.cy);
@@ -684,13 +684,13 @@ bool CSprite::LoadResourceSprite(CDC *pDC, const char *pszName) {
 	}
 
 	if (pPalOld != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	ClearImage();
 
 	if (!bHavePalette &&                                // delete the palette resource and object
 	        (m_pPalette != nullptr)) {                         // ... if it came from the DIB
-		(*m_pPalette).DeleteObject();
+		m_pPalette->DeleteObject();
 		delete m_pPalette;
 		m_pPalette = nullptr;
 	}
@@ -885,16 +885,16 @@ bool CSprite::SetupCels(const int nCels) {
 bool CSprite::SetPalette(CPalette *pPalette) {
 	if (m_pImageDC != nullptr) {                               // if we already have a palette we must
 		if (m_pImage != nullptr)                               // ... first map out any existing image
-			(*m_pImageDC).SelectObject(m_pImageOld);  // ... then map out the old palette
+			m_pImageDC->SelectObject(m_pImageOld);  // ... then map out the old palette
 		if (m_pPalette != nullptr)
-			(*m_pImageDC).SelectPalette(m_pPalImageOld, false);
+			m_pImageDC->SelectPalette(m_pPalImageOld, false);
 	}
 
 	if (m_pBackgroundDC != nullptr) {                          // similarly we need to map out our background
 		if (m_pBackground != nullptr)                          // ... bitmap as well
-			(*m_pBackgroundDC).SelectObject(m_pBackgroundOld);
+			m_pBackgroundDC->SelectObject(m_pBackgroundOld);
 		if (m_pPalette != nullptr)                             // .. then map out the palette
-			(*m_pBackgroundDC).SelectPalette(m_pPalBackOld, false);
+			m_pBackgroundDC->SelectPalette(m_pPalBackOld, false);
 	}
 
 	ClearPalette();                                         // release existing palette
@@ -903,11 +903,11 @@ bool CSprite::SetPalette(CPalette *pPalette) {
 	if (m_pImageDC == nullptr)                                 // done if no context to map it into
 		return true;
 
-	m_pPalImageOld = (*m_pImageDC).SelectPalette(m_pPalette, false); // map in the new palette and then
-	(*m_pImageDC).RealizePalette();                           // ... tell the system to use it
+	m_pPalImageOld = m_pImageDC->SelectPalette(m_pPalette, false); // map in the new palette and then
+	m_pImageDC->RealizePalette();                           // ... tell the system to use it
 
 	if (m_pImage != nullptr) {
-		m_pImageOld = (*m_pImageDC).SelectObject(m_pImage);     // map in our image bitmap if it exists
+		m_pImageOld = m_pImageDC->SelectObject(m_pImage);     // map in our image bitmap if it exists
 		if (m_pImageOld == nullptr)
 			return false;
 	}
@@ -915,11 +915,11 @@ bool CSprite::SetPalette(CPalette *pPalette) {
 	if (m_pBackgroundDC == nullptr)                            // done if no background context
 		return true;
 
-	m_pPalBackOld = (*m_pBackgroundDC).SelectPalette(m_pPalette, false); // map in the new palette and then
-	(*m_pBackgroundDC).RealizePalette();                          // ... tell the system to use it
+	m_pPalBackOld = m_pBackgroundDC->SelectPalette(m_pPalette, false); // map in the new palette and then
+	m_pBackgroundDC->RealizePalette();                          // ... tell the system to use it
 
 	if (m_pBackground != nullptr) {
-		m_pBackgroundOld = (*m_pBackgroundDC).SelectObject(m_pBackground);      // map in our background
+		m_pBackgroundOld = m_pBackgroundDC->SelectObject(m_pBackground);      // map in our background
 		if (m_pBackgroundOld == nullptr)
 			return false;
 	}
@@ -1107,8 +1107,8 @@ bool CSprite::UpdateSprite(CDC *pDC) {
 	}
 
 	if (m_pPalette != nullptr) {
-		pPalOld = (*pDC).SelectPalette(m_pPalette, false);  // map in a palette if present
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(m_pPalette, false);  // map in a palette if present
+		pDC->RealizePalette();
 	}                    // ... and tell the system we did that
 
 	if (m_bMasked)                                          // if masked, then paint the sprite, masking out
@@ -1116,7 +1116,7 @@ bool CSprite::UpdateSprite(CDC *pDC) {
 	else  {
 		bSuccess = SetupImage(pDC);                         // not masked - so just splat the entire bitmap
 		if (bSuccess) {
-			bSuccess = (*pDC).BitBlt(m_cPosition.x,
+			bSuccess = pDC->BitBlt(m_cPosition.x,
 			                         m_cPosition.y,
 			                         m_cSize.cx,
 			                         m_cSize.cy,
@@ -1130,7 +1130,7 @@ bool CSprite::UpdateSprite(CDC *pDC) {
 	}
 
 	if (m_pPalette != nullptr)                                 // map back the previous palette if needed
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	return bSuccess;
 }
@@ -1177,42 +1177,42 @@ bool CSprite::DoSpritePainting(CDC * pDC, CPoint cPoint) {
 
 		if ((pDC2 != nullptr) &&
 		        (pBitmap2 != nullptr) &&
-		        (*pDC2).CreateCompatibleDC(pDC)) {
+		        pDC2->CreateCompatibleDC(pDC)) {
 			if (m_pPalette != nullptr) {                   // map in a palette if available
-				pPal2Old = (*pDC2).SelectPalette(m_pPalette, false); // ... and for the background work area
-				(*pDC2).RealizePalette();
+				pPal2Old = pDC2->SelectPalette(m_pPalette, false); // ... and for the background work area
+				pDC2->RealizePalette();
 			}                   // ... make it real too
-			if ((*pBitmap2).CreateCompatibleBitmap(pDC, m_cSize.cx, m_cSize.cy)) {
-				pBitmap2Old = (*pDC2).SelectObject(pBitmap2);
+			if (pBitmap2->CreateCompatibleBitmap(pDC, m_cSize.cx, m_cSize.cy)) {
+				pBitmap2Old = pDC2->SelectObject(pBitmap2);
 				if (pBitmap2Old != nullptr) {
 					if (m_bHaveBackdrop) {              // get background image, either from
 						if (GetBackdropDC(pDC) == nullptr) // .. the backdrop or the sprite itselt
 							goto punt;
-						(*pDC2).BitBlt(0, 0, m_cSize.cx, m_cSize.cy, m_pBackdropDC, cPoint.x, cPoint.y, SRCCOPY);
+						pDC2->BitBlt(0, 0, m_cSize.cx, m_cSize.cy, m_pBackdropDC, cPoint.x, cPoint.y, SRCCOPY);
 						ReleaseBackdropDC();
 					} else
-						(*pDC2).BitBlt(0, 0, m_cSize.cx, m_cSize.cy, pDC, cPoint.x, cPoint.y, SRCCOPY); // get the sprite's background image
-					(*pDC2).BitBlt(0, 0, m_cSize.cx, m_cSize.cy, m_pMaskDC, m_cImageRect.left, m_cImageRect.top, SRCAND); // ... mask out where sprite will go
-					(*pDC2).BitBlt(0, 0, m_cSize.cx, m_cSize.cy, m_pImageDC, m_cImageRect.left, m_cImageRect.top, SRCPAINT); // combine image with background
-					bSuccess = (*pDC).BitBlt(cPoint.x, cPoint.y, m_cSize.cx, m_cSize.cy, pDC2, 0, 0, SRCCOPY); // paint result to the screen
+						pDC2->BitBlt(0, 0, m_cSize.cx, m_cSize.cy, pDC, cPoint.x, cPoint.y, SRCCOPY); // get the sprite's background image
+					pDC2->BitBlt(0, 0, m_cSize.cx, m_cSize.cy, m_pMaskDC, m_cImageRect.left, m_cImageRect.top, SRCAND); // ... mask out where sprite will go
+					pDC2->BitBlt(0, 0, m_cSize.cx, m_cSize.cy, m_pImageDC, m_cImageRect.left, m_cImageRect.top, SRCPAINT); // combine image with background
+					bSuccess = pDC->BitBlt(cPoint.x, cPoint.y, m_cSize.cx, m_cSize.cy, pDC2, 0, 0, SRCCOPY); // paint result to the screen
 				}
 			}
 		}
 
 punt:
 		if (pBitmap2Old != nullptr)                        // now release the temporary resources we used
-			(*pDC2).SelectObject(pBitmap2Old);
+			pDC2->SelectObject(pBitmap2Old);
 
 		if (pBitmap2 != nullptr) {
-			(*pBitmap2).DeleteObject();
+			pBitmap2->DeleteObject();
 			delete pBitmap2;
 		}
 
 		if (pPal2Old != nullptr)
-			(*pDC2).SelectPalette(pPal2Old, false);
+			pDC2->SelectPalette(pPal2Old, false);
 
 		if (pDC2 != nullptr) {
-			(*pDC2).DeleteDC();
+			pDC2->DeleteDC();
 			delete pDC2;
 		}
 	}
@@ -1265,8 +1265,8 @@ bool CSprite::DoOptimizedPainting(CDC *pDC, CRect *pDstRect) {
 		return false;
 
 	if (m_pPalette != nullptr) {                               // if there is a palette
-		pPalOld = (*pDC).SelectPalette(m_pPalette, false);  // ... select it into the context
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(m_pPalette, false);  // ... select it into the context
+		pDC->RealizePalette();
 	}                    // ... and tell the system about it
 
 	unionRect = m_cRect;                                // the work area is defined by our sprite
@@ -1278,7 +1278,7 @@ bool CSprite::DoOptimizedPainting(CDC *pDC, CRect *pDstRect) {
 	pBitmap = new CBitmap();                            // create an offscreen bitmap where we do all the
 	if (pBitmap == nullptr)                                // ... work; first create a bitmap for the enclosing
 		return false;                                 // ... rectangle, and if that fails, then punt
-	if (!(*pBitmap).CreateCompatibleBitmap(pDC, dx, dy)) {
+	if (!pBitmap->CreateCompatibleBitmap(pDC, dx, dy)) {
 		delete pBitmap;
 		return false;
 	}
@@ -1315,21 +1315,21 @@ bool CSprite::DoOptimizedPainting(CDC *pDC, CRect *pDstRect) {
 					                     0,
 					                     0,
 					                     SRCCOPY);
-					(*m_pBackgroundDC).BitBlt(0,      // save the background where the sprite will be
+					m_pBackgroundDC->BitBlt(0,      // save the background where the sprite will be
 					                                0,
 					                                m_cSize.cx,
 					                                m_cSize.cy,
 					                                &workDC,
-					                                (*pDstRect).left - unionRect.left,
-					                                (*pDstRect).top - unionRect.top,
+					                                pDstRect->left - unionRect.left,
+					                                pDstRect->top - unionRect.top,
 					                                SRCCOPY);
 					if (!m_bRetainContexts || m_bDuplicated)    // release background context if not optimizing
 						ReleaseBackgroundContext();
 				} else
 					goto punt;
 			}
-			cPoint.x = (*pDstRect).left - unionRect.left;   // determine where to paint the new sprite image
-			cPoint.y = (*pDstRect).top - unionRect.top;     // ... into the work area
+			cPoint.x = pDstRect->left - unionRect.left;   // determine where to paint the new sprite image
+			cPoint.y = pDstRect->top - unionRect.top;     // ... into the work area
 
 			bSuccess = ((!m_bMasked || SetupMask(pDC)) &&   // setup the contexts we need
 			            SetupImage(pDC));
@@ -1368,7 +1368,7 @@ bool CSprite::DoOptimizedPainting(CDC *pDC, CRect *pDstRect) {
 			}
 
 			if (bSuccess) {
-				(*pDC).BitBlt(unionRect.left,
+				pDC->BitBlt(unionRect.left,
 				                    unionRect.top,
 				                    dx,
 				                    dy,
@@ -1379,10 +1379,10 @@ bool CSprite::DoOptimizedPainting(CDC *pDC, CRect *pDstRect) {
 				workDC.SelectObject(pBitmapOldWork);     // tear down the work area's bitmap, palette
 				if (m_pPalette != nullptr) {                           // ... and device context, as well as the
 					workDC.SelectPalette(pPalOldWork, false); // ... destination's palette
-					(*pDC).SelectPalette(pPalOld, false);
+					pDC->SelectPalette(pPalOld, false);
 				}
 				workDC.DeleteDC();
-				(*pBitmap).DeleteObject();
+				pBitmap->DeleteObject();
 				delete pBitmap;
 				return bSuccess;
 			}
@@ -1398,11 +1398,11 @@ punt:
 	if (workDC.m_hDC != nullptr)                               // ... release the context
 		workDC.DeleteDC();
 
-	(*pBitmap).DeleteObject();                              // ... delete the bitmap
+	pBitmap->DeleteObject();                              // ... delete the bitmap
 	delete pBitmap;
 
 	if (pPalOld != nullptr)                                    // map out the palette from the output context
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	return false;
 }
@@ -1436,14 +1436,14 @@ bool CSprite::DoOverlapPainting(CDC *pDC, CRect *myRect) {
 		return false;
 
 	if (m_pPalette != nullptr) {                               // if there is a palette
-		pPalOld = (*pDC).SelectPalette(m_pPalette, false);  // ... select it into the context
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(m_pPalette, false);  // ... select it into the context
+		pDC->RealizePalette();
 	}                    // ... and tell the system about it
 
 	bSuccess = ReconstructBackground(pDC, myRect);          // go do the actual painting
 
 	if (m_pPalette != nullptr)                                 // map out the palette
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	return bSuccess;
 }
@@ -1480,8 +1480,8 @@ bool CSprite::RefreshBackground(CDC *pDC) {
 		return true;
 
 	if (m_pPalette != nullptr) {                               // map a palette to the destination context
-		pPalOld = (*pDC).SelectPalette(m_pPalette, false);  // ... if available
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(m_pPalette, false);  // ... if available
+		pDC->RealizePalette();
 	}
 
 	if (m_bOverlaps)                                        // paint the background bitmap to the device
@@ -1490,20 +1490,20 @@ bool CSprite::RefreshBackground(CDC *pDC) {
 		if (GetBackdropDC(pDC) == nullptr)
 			bSuccess = false;
 		else {
-			bSuccess = (*pDC).BitBlt(m_cPosition.x, m_cPosition.y, m_cSize.cx, m_cSize.cy, m_pBackdropDC, m_cPosition.x, m_cPosition.y, SRCCOPY);
+			bSuccess = pDC->BitBlt(m_cPosition.x, m_cPosition.y, m_cSize.cx, m_cSize.cy, m_pBackdropDC, m_cPosition.x, m_cPosition.y, SRCCOPY);
 			ReleaseBackdropDC();
 		}
 	} else {
 		bSuccess = SetupBackground(pDC);                    // paint the background bitmap to the device
 		if (bSuccess) {
-			bSuccess = (*pDC).BitBlt(m_cPosition.x, m_cPosition.y, m_cSize.cx, m_cSize.cy, m_pBackgroundDC, 0, 0, SRCCOPY);
+			bSuccess = pDC->BitBlt(m_cPosition.x, m_cPosition.y, m_cSize.cx, m_cSize.cy, m_pBackgroundDC, 0, 0, SRCCOPY);
 			if (!m_bRetainContexts || m_bDuplicated)
 				ReleaseBackgroundContext();
 		}
 	}
 
 	if (m_pPalette != nullptr)                                 // map out the palette from the destination
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	m_bPositioned = false;                                  // no real position now
 	m_nZPosition = m_nZOrder;                               // reset z ordering
@@ -1545,19 +1545,19 @@ bool CSprite::SaveBackground(CDC *pDC) {
 		return false;
 
 	if (m_pPalette != nullptr) {                           // map a palette to the destination context
-		pPalOld = (*pDC).SelectPalette(m_pPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(m_pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	bSuccess = SetupBackground(pDC);                    // grab the background bitmap
 	if (bSuccess) {
-		bSuccess = (*m_pBackgroundDC).BitBlt(0, 0, m_cSize.cx, m_cSize.cy, pDC, m_cPosition.x, m_cPosition.y, SRCCOPY);
+		bSuccess = m_pBackgroundDC->BitBlt(0, 0, m_cSize.cx, m_cSize.cy, pDC, m_cPosition.x, m_cPosition.y, SRCCOPY);
 		if (!m_bRetainContexts || m_bDuplicated)        // release context if not optimizing
 			ReleaseBackgroundContext();
 	}
 
 	if (m_pPalette != nullptr)                             // map out palette from destination context
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	return bSuccess;
 }
@@ -1620,16 +1620,16 @@ bool CSprite::ReconstructBackground(CDC *pDC, CRect *myRect) {
 	baseRect = unionRect;
 
 	pSprite = this;                                     // start processing from this sprite and make
-	(*pSprite).m_pZNext = nullptr;                         // ... it be the first in the z order chain
-	(*pSprite).m_pZPrev = nullptr;
+	pSprite->m_pZNext = nullptr;                         // ... it be the first in the z order chain
+	pSprite->m_pZPrev = nullptr;
 
 	pTestSprite = m_pSpriteChain;                       // set all sprites to not having been tested
 	while (pTestSprite != nullptr) {                       // ... for this reconstruction cycle
-		if ((*pTestSprite).m_bVisible && (*pTestSprite).m_bPositioned)
-			(*pTestSprite).m_bOverlapTest = false;
+		if (pTestSprite->m_bVisible && pTestSprite->m_bPositioned)
+			pTestSprite->m_bOverlapTest = false;
 		else
-			(*pTestSprite).m_bOverlapTest = true;
-		pTestSprite = (*pTestSprite).m_pNext;
+			pTestSprite->m_bOverlapTest = true;
+		pTestSprite = pTestSprite->m_pNext;
 	}
 	pTestSprite = m_pSpriteChain;                       // get first sprite to test against
 	m_bOverlapTest = true;                              // set to not test against the first sprite
@@ -1640,61 +1640,61 @@ bool CSprite::ReconstructBackground(CDC *pDC, CRect *myRect) {
 		m_bPaintOverlap = false;
 
 	while (pTestSprite != nullptr) {                       // look for sprites we overlap or which are
-		if (!(*pTestSprite).m_bOverlapTest &&           // ... overlapped by sprites that overlap us
-		        overlapRect.IntersectRect(&unionRect, &(*pTestSprite).m_cRect)) {
-			unionRect.UnionRect(unionRect, (*pTestSprite).m_cRect); // expand rectangle to encompass it
-			(*pTestSprite).m_bOverlapTest = true;       // mark it as having been tested
-			(*pTestSprite).m_bOverlaps = true;          // mark it as involved in an overlap situation
+		if (!pTestSprite->m_bOverlapTest &&           // ... overlapped by sprites that overlap us
+		        overlapRect.IntersectRect(&unionRect, &pTestSprite->m_cRect)) {
+			unionRect.UnionRect(unionRect, pTestSprite->m_cRect); // expand rectangle to encompass it
+			pTestSprite->m_bOverlapTest = true;       // mark it as having been tested
+			pTestSprite->m_bOverlaps = true;          // mark it as involved in an overlap situation
 			if ((m_bHaveBackdrop ||                     // won't paint sprites without a background
-			        ((*pTestSprite).m_pBackground != nullptr)) &&
-			        overlapRect.IntersectRect(&baseRect, &(*pTestSprite).m_cRect))
-				(*pTestSprite).m_bPaintOverlap = true;
+			        (pTestSprite->m_pBackground != nullptr)) &&
+			        overlapRect.IntersectRect(&baseRect, &pTestSprite->m_cRect))
+				pTestSprite->m_bPaintOverlap = true;
 			else
-				(*pTestSprite).m_bPaintOverlap = false;
+				pTestSprite->m_bPaintOverlap = false;
 			while (true) {                              // insert the sprite in the sorted z chain
-				if ((*pTestSprite).m_nZPosition < (*pSprite).m_nZPosition) {    // need to head leftward
-					if (((*pSprite).m_pZPrev == nullptr) ||    // put it to the left of us (i.e. overlaps us)
-					        ((*(*pSprite).m_pZPrev).m_nZPosition < (*pTestSprite).m_nZPosition)) {
-						(*pTestSprite).m_pZPrev = (*pSprite).m_pZPrev;
-						(*pTestSprite).m_pZNext = pSprite;
-						(*pSprite).m_pZPrev = pTestSprite;
-						if ((*pTestSprite).m_pZPrev != nullptr)
-							(*(*pTestSprite).m_pZPrev).m_pZNext = pTestSprite;
+				if (pTestSprite->m_nZPosition < pSprite->m_nZPosition) {    // need to head leftward
+					if ((pSprite->m_pZPrev == nullptr) ||    // put it to the left of us (i.e. overlaps us)
+					        (pSprite->m_pZPrev->m_nZPosition < pTestSprite->m_nZPosition)) {
+						pTestSprite->m_pZPrev = pSprite->m_pZPrev;
+						pTestSprite->m_pZNext = pSprite;
+						pSprite->m_pZPrev = pTestSprite;
+						if (pTestSprite->m_pZPrev != nullptr)
+							pTestSprite->m_pZPrev->m_pZNext = pTestSprite;
 						break;
 					} else
-						pSprite = (*pSprite).m_pZPrev;  // shift left in chain and set to test again
+						pSprite = pSprite->m_pZPrev;  // shift left in chain and set to test again
 				} else                                  // need to head rightward
-					if ((*pTestSprite).m_nZPosition >= (*pSprite).m_nZPosition) {
-						if (((*pSprite).m_pZNext == nullptr) ||    // put it to the right of us (we overlap it)
-						        ((*(*pSprite).m_pZNext).m_nZPosition >= (*pTestSprite).m_nZPosition)) {
-							(*pTestSprite).m_pZNext = (*pSprite).m_pZNext;
-							(*pTestSprite).m_pZPrev = pSprite;
-							(*pSprite).m_pZNext = pTestSprite;
-							if ((*pTestSprite).m_pZNext != nullptr)
-								(*(*pTestSprite).m_pZNext).m_pZPrev = pTestSprite;
+					if (pTestSprite->m_nZPosition >= pSprite->m_nZPosition) {
+						if ((pSprite->m_pZNext == nullptr) ||    // put it to the right of us (we overlap it)
+						        (pSprite->m_pZNext->m_nZPosition >= pTestSprite->m_nZPosition)) {
+							pTestSprite->m_pZNext = pSprite->m_pZNext;
+							pTestSprite->m_pZPrev = pSprite;
+							pSprite->m_pZNext = pTestSprite;
+							if (pTestSprite->m_pZNext != nullptr)
+								pTestSprite->m_pZNext->m_pZPrev = pTestSprite;
 							break;
 						} else
-							pSprite = (*pSprite).m_pZNext;  // shift right in chain and set to test again
+							pSprite = pSprite->m_pZNext;  // shift right in chain and set to test again
 					}
 			}
 			pTestSprite = m_pSpriteChain;               // need to check all sprites again since the
 		}                                           // ... the bounding rectangle has expanded and
 		else                                            // ... may now intercept additional sprites
-			pTestSprite = (*pTestSprite).m_pNext;       // set to test against the next sprite
+			pTestSprite = pTestSprite->m_pNext;       // set to test against the next sprite
 	}
 
-	while ((*pSprite).m_pZPrev != nullptr)                 // find the head of the z order chain so that
-		pSprite = (*pSprite).m_pZPrev;                  // ... we can begin background reconstruction
+	while (pSprite->m_pZPrev != nullptr)                 // find the head of the z order chain so that
+		pSprite = pSprite->m_pZPrev;                  // ... we can begin background reconstruction
 
 	pZHead = pSprite;                                   // save head of z order chain
 
-	if (((*pZHead).m_nId == m_nId) &&                   // if we are the head of the z order chain
+	if ((pZHead->m_nId == m_nId) &&                   // if we are the head of the z order chain
 	        (m_nZOrder == SPRITE_TOPMOST) &&                // ... and we are a top-most type of sprite
 	        !m_bHaveBackdrop) {                             // ... and we're painting direct to the screen
-		pTestSprite = (*pZHead).m_pZNext;               // ... then we only need to handle this sprite
+		pTestSprite = pZHead->m_pZNext;               // ... then we only need to handle this sprite
 		while (pTestSprite != nullptr) {                   // so set to not paint others in z order chain
-			(*pTestSprite).m_bPaintOverlap = false;
-			pTestSprite = (*pTestSprite).m_pZNext;
+			pTestSprite->m_bPaintOverlap = false;
+			pTestSprite = pTestSprite->m_pZNext;
 		}
 		if (m_nCelCount <= 1)                           // if we're not a cel strip, then set a
 			bDoingTopMost = true;                       // ... special flag indicating just our sprite
@@ -1710,7 +1710,7 @@ bool CSprite::ReconstructBackground(CDC *pDC, CRect *myRect) {
 	pBitmap = new CBitmap();                            // create a bitmap to contain our work area
 	if (pBitmap == nullptr)
 		return false;
-	if (!(*pBitmap).CreateCompatibleBitmap(pDC, dx, dy)) {
+	if (!pBitmap->CreateCompatibleBitmap(pDC, dx, dy)) {
 		delete pBitmap;
 		return false;
 	}
@@ -1719,8 +1719,8 @@ bool CSprite::ReconstructBackground(CDC *pDC, CRect *myRect) {
 		if (m_pPalette != nullptr) {                       // ... work area and map in the palette
 			pPalOldWork = workDC.SelectPalette(m_pPalette, false);
 			workDC.RealizePalette();
-			pPalOld = (*pDC).SelectPalette(m_pPalette, false);
-			(*pDC).RealizePalette();
+			pPalOld = pDC->SelectPalette(m_pPalette, false);
+			pDC->RealizePalette();
 		}
 		pBitmapOld = workDC.SelectObject(pBitmap);      // map our bitmap into the work area
 		if (pBitmapOld != nullptr) {                       // now need to create the original background
@@ -1741,11 +1741,11 @@ bool CSprite::ReconstructBackground(CDC *pDC, CRect *myRect) {
 				if (!bSuccess)
 					goto punt;
 				while (true) {
-					pTestSprite = (*pSprite).m_pZNext;  // now update z order relative positions
+					pTestSprite = pSprite->m_pZNext;  // now update z order relative positions
 					if (pTestSprite == nullptr)            // ... of every sprite in the z order chain
 						break;                          // ... to ensure/maintain increasing ordering
-					if ((*pSprite).m_nZOrder == (*pTestSprite).m_nZOrder)
-						(*pTestSprite).m_nZPosition = (*pSprite).m_nZPosition + 1;
+					if (pSprite->m_nZOrder == pTestSprite->m_nZOrder)
+						pTestSprite->m_nZPosition = pSprite->m_nZPosition + 1;
 					pSprite = pTestSprite;
 				}
 			} else {                                    // no backdrop, so first grab the screen
@@ -1754,74 +1754,74 @@ bool CSprite::ReconstructBackground(CDC *pDC, CRect *myRect) {
 				bSuccess = (*pDC).BitBlt(viewOrigin.x, viewOrigin.y, dx, dy, &workDC, 0, 0, SRCCOPY);
 				#endif
 				while (true) {                          // now restore the saved background from each
-					if ((*pSprite).m_bPaintOverlap && (*pSprite).m_bRetainBackground) {
-						bSuccess = (*pSprite).SetupBackground(pDC); // ... sprite in the z order chain
+					if (pSprite->m_bPaintOverlap && pSprite->m_bRetainBackground) {
+						bSuccess = pSprite->SetupBackground(pDC); // ... sprite in the z order chain
 						if (bSuccess) {
-							if ((*pSprite).m_bMasked && // if just doing the single topmost sprite, then
+							if (pSprite->m_bMasked && // if just doing the single topmost sprite, then
 							        bDoingTopMost &&        // ... replace its image area with its background
-							        (*pSprite).SetupMask(pDC)) {    // .this is extra work but compensated by ignoring all others
-								bSuccess = workDC.BitBlt((*pSprite).m_cPosition.x - unionRect.left,  // mask away where sprite image is located
-								                         (*pSprite).m_cPosition.y - unionRect.top,
-								                         (*pSprite).m_cSize.cx,
-								                         (*pSprite).m_cSize.cy,
-								                         (*pSprite).m_pMaskDC,
-								                         (*pSprite).m_cImageRect.left,
-								                         (*pSprite).m_cImageRect.top,
+							        pSprite->SetupMask(pDC)) {    // .this is extra work but compensated by ignoring all others
+								bSuccess = workDC.BitBlt(pSprite->m_cPosition.x - unionRect.left,  // mask away where sprite image is located
+								                         pSprite->m_cPosition.y - unionRect.top,
+								                         pSprite->m_cSize.cx,
+								                         pSprite->m_cSize.cy,
+								                         pSprite->m_pMaskDC,
+								                         pSprite->m_cImageRect.left,
+								                         pSprite->m_cImageRect.top,
 								                         SRCAND);
 								#if SPRITE_DEBUG
 								bSuccess = (*pDC).BitBlt(viewOrigin.x, viewOrigin.y, dx, dy, &workDC, 0, 0, SRCCOPY);
 								bSuccess = (*pDC).BitBlt(viewOrigin.x, viewOrigin.y, (*pSprite).m_cSize.cx, (*pSprite).m_cSize.cy, (*pSprite).m_pMaskDC, 0, 0, SRCCOPY);
 								#endif
-								bSuccess = (*(*pSprite).m_pMaskDC).BitBlt(    // invert the image mask
-								               (*pSprite).m_cImageRect.left,
-								               (*pSprite).m_cImageRect.top,
-								               (*pSprite).m_cSize.cx,
-								               (*pSprite).m_cSize.cy,
-								               (*pSprite).m_pMaskDC,
-								               (*pSprite).m_cImageRect.left,
-								               (*pSprite).m_cImageRect.top,
+								bSuccess = pSprite->m_pMaskDC->BitBlt(    // invert the image mask
+								               pSprite->m_cImageRect.left,
+								               pSprite->m_cImageRect.top,
+								               pSprite->m_cSize.cx,
+								               pSprite->m_cSize.cy,
+								               pSprite->m_pMaskDC,
+								               pSprite->m_cImageRect.left,
+								               pSprite->m_cImageRect.top,
 								               NOTSRCCOPY);
 								#if SPRITE_DEBUG
 								bSuccess = (*pDC).BitBlt(viewOrigin.x, viewOrigin.y, (*pSprite).m_cSize.cx, (*pSprite).m_cSize.cy, (*pSprite).m_pMaskDC, 0, 0, SRCCOPY);
 								#endif
-								bSuccess = (*(*pSprite).m_pBackgroundDC).BitBlt(0, 0,   // mask away area of saved background that
-								           (*pSprite).m_cSize.cx,         // ... is NOT spanned by the sprite image
-								           (*pSprite).m_cSize.cy,
-								           (*pSprite).m_pMaskDC,
-								           (*pSprite).m_cImageRect.left,
-								           (*pSprite).m_cImageRect.top,
-								           SRCAND);
+								bSuccess = pSprite->m_pBackgroundDC->BitBlt(0, 0,   // mask away area of saved background that
+								                                           pSprite->m_cSize.cx,         // ... is NOT spanned by the sprite image
+								                                           pSprite->m_cSize.cy,
+								                                           pSprite->m_pMaskDC,
+								                                           pSprite->m_cImageRect.left,
+								                                           pSprite->m_cImageRect.top,
+								                                           SRCAND);
 								#if SPRITE_DEBUG
 								bSuccess = (*pDC).BitBlt(viewOrigin.x, viewOrigin.y, (*pSprite).m_cSize.cx, (*pSprite).m_cSize.cy, (*pSprite).m_pBackgroundDC, 0, 0, SRCCOPY);
 								#endif
-								bSuccess = (*(*pSprite).m_pMaskDC).BitBlt(
-								               (*pSprite).m_cImageRect.left,  // put the mask back the way it was
-								               (*pSprite).m_cImageRect.top,
-								               (*pSprite).m_cSize.cx,
-								               (*pSprite).m_cSize.cy,
-								               (*pSprite).m_pMaskDC,
-								               (*pSprite).m_cImageRect.left,
-								               (*pSprite).m_cImageRect.top,
+								bSuccess = pSprite->m_pMaskDC->BitBlt(
+								               pSprite->m_cImageRect.left,  // put the mask back the way it was
+								               pSprite->m_cImageRect.top,
+								               pSprite->m_cSize.cx,
+								               pSprite->m_cSize.cy,
+								               pSprite->m_pMaskDC,
+								               pSprite->m_cImageRect.left,
+								               pSprite->m_cImageRect.top,
 								               NOTSRCCOPY);
 								#if SPRITE_DEBUG
 								bSuccess = (*pDC).BitBlt(viewOrigin.x, viewOrigin.y, (*pSprite).m_cSize.cx, (*pSprite).m_cSize.cy, (*pSprite).m_pMaskDC, 0, 0, SRCCOPY);
 								#endif
-								bSuccess = workDC.BitBlt((*pSprite).m_cPosition.x - unionRect.left, // paint the remaining background into cleared area
-								                         (*pSprite).m_cPosition.y - unionRect.top,  // i.e. we only updated the pixels where the image
-								                         (*pSprite).m_cSize.cx,                     // ... was actually located, leaving all else untouched
-								                         (*pSprite).m_cSize.cy,
-								                         (*pSprite).m_pBackgroundDC,
+								bSuccess = workDC.BitBlt(pSprite->m_cPosition.x - unionRect.left, // paint the remaining background into cleared area
+								                         pSprite->m_cPosition.y - unionRect.top,  // i.e. we only updated the pixels where the image
+								                         pSprite->m_cSize.cx,                     // ... was actually located, leaving all else untouched
+								                         pSprite->m_cSize.cy,
+								                         pSprite->m_pBackgroundDC,
 								                         0,
 								                         0,
 								                         SRCPAINT);
 							} else                              // just splat sprite's background to work area
-								bSuccess = workDC.BitBlt((*pSprite).m_cPosition.x - unionRect.left,
-								                         (*pSprite).m_cPosition.y - unionRect.top,
-								                         (*pSprite).m_cSize.cx,
-								                         (*pSprite).m_cSize.cy,
-								                         (*pSprite).m_pBackgroundDC, 0, 0, SRCCOPY);
-							if (!(*pSprite).m_bRetainContexts)  // release contexts if not optimizing
-								(*pSprite).ReleaseMaskContext();
+								bSuccess = workDC.BitBlt(pSprite->m_cPosition.x - unionRect.left,
+								                         pSprite->m_cPosition.y - unionRect.top,
+								                         pSprite->m_cSize.cx,
+								                         pSprite->m_cSize.cy,
+								                         pSprite->m_pBackgroundDC, 0, 0, SRCCOPY);
+							if (!pSprite->m_bRetainContexts)  // release contexts if not optimizing
+								pSprite->ReleaseMaskContext();
 							#if SPRITE_DEBUG
 							bSuccess = (*pDC).BitBlt(viewOrigin.x, viewOrigin.y, dx, dy, &workDC, 0, 0, SRCCOPY);
 							#endif
@@ -1830,37 +1830,37 @@ bool CSprite::ReconstructBackground(CDC *pDC, CRect *myRect) {
 							goto punt;
 					}
 
-					if ((*pSprite).m_pZNext == nullptr) {          // once we have restored all backgrounds
+					if (pSprite->m_pZNext == nullptr) {          // once we have restored all backgrounds
 						if ((m_nZOrder == SPRITE_TOPMOST) &&    // ... then place us at the head of the
-						        (m_nId != (*pZHead).m_nId)) {       // ... z order chain if we are to be topmost
-							if ((*pSprite).m_nId == m_nId)      // maintain pointer to last in z order
+						        (m_nId != pZHead->m_nId)) {       // ... z order chain if we are to be topmost
+							if (pSprite->m_nId == m_nId)      // maintain pointer to last in z order
 								pSprite = m_pZPrev;             // ... backing up one if it is us
 							pTestSprite = m_pZPrev;             // ... since we're moving to the head
-							(*pTestSprite).m_pZNext = m_pZNext;
+							pTestSprite->m_pZNext = m_pZNext;
 							if (m_pZNext != nullptr)
-								(*m_pZNext).m_pZPrev = pTestSprite;
+								m_pZNext->m_pZPrev = pTestSprite;
 							m_pZNext = pZHead;
 							m_pZPrev = nullptr;
-							(*pZHead).m_pZPrev = this;
+							pZHead->m_pZPrev = this;
 							pZHead = this;
 							m_nZPosition = m_nZOrder;
 						}
 						break;
 					}
 
-					pSprite = (*pSprite).m_pZNext;
+					pSprite = pSprite->m_pZNext;
 				}
 
 				pTestSprite = pZHead;                           // update z order relative positions
-				while ((*pTestSprite).m_pZNext != nullptr) {       // ... to ensure increasing ordering
-					if ((*pTestSprite).m_nZOrder == (*(*pTestSprite).m_pZNext).m_nZOrder)
-						(*(*pTestSprite).m_pZNext).m_nZPosition = (*pTestSprite).m_nZPosition + 1;
-					pTestSprite = (*pTestSprite).m_pZNext;
+				while (pTestSprite->m_pZNext != nullptr) {       // ... to ensure increasing ordering
+					if (pTestSprite->m_nZOrder == pTestSprite->m_pZNext->m_nZOrder)
+						pTestSprite->m_pZNext->m_nZPosition = pTestSprite->m_nZPosition + 1;
+					pTestSprite = pTestSprite->m_pZNext;
 				}
 			}
 
 			while (true) {                                      // now repaint the images of the sprites
-				if (m_nId == (*pSprite).m_nId) {                // ... onto the work area
+				if (m_nId == pSprite->m_nId) {                // ... onto the work area
 					if (myRect == nullptr)                         // no image, just erasing our sprite
 						bSuccess = true;
 					else {
@@ -1871,12 +1871,12 @@ bool CSprite::ReconstructBackground(CDC *pDC, CRect *myRect) {
 									        !SetupBackground(pDC))
 										goto punt;
 								}
-								bSuccess = (*m_pBackgroundDC).BitBlt(0, 0,
+								bSuccess = m_pBackgroundDC->BitBlt(0, 0,
 								                                     m_cSize.cx,
 								                                     m_cSize.cy,
 								                                     &workDC,
-								                                     (*myRect).left - unionRect.left,
-								                                     (*myRect).top - unionRect.top,
+								                                     myRect->left - unionRect.left,
+								                                     myRect->top - unionRect.top,
 								                                     SRCCOPY);
 								if (!m_bRetainContexts || m_bDuplicated)
 									ReleaseBackgroundContext();
@@ -1885,51 +1885,51 @@ bool CSprite::ReconstructBackground(CDC *pDC, CRect *myRect) {
 							}
 							m_bPaintOverlap = true;
 						}
-						cPoint.x = (*myRect).left - unionRect.left; // set the destination for where our
-						cPoint.y = (*myRect).top - unionRect.top;   // ... sprite will be painted
+						cPoint.x = myRect->left - unionRect.left; // set the destination for where our
+						cPoint.y = myRect->top - unionRect.top;   // ... sprite will be painted
 						goto paint_sprite;
 					}
 				} else {                                        // save what the background looks like
-					if (!m_bHaveBackdrop && (*pSprite).m_bRetainBackground &&
-					        (*pSprite).m_bPaintOverlap) {
-						bSuccess = (*(*pSprite).m_pBackgroundDC).BitBlt(0, 0,
-						           (*pSprite).m_cSize.cx,
-						           (*pSprite).m_cSize.cy,
-						           &workDC,
-						           (*pSprite).m_cPosition.x - unionRect.left,
-						           (*pSprite).m_cPosition.y - unionRect.top,
-						           SRCCOPY);
-						if (!(*pSprite).m_bRetainContexts || (*pSprite).m_bDuplicated)
-							(*pSprite).ReleaseBackgroundContext();
+					if (!m_bHaveBackdrop && pSprite->m_bRetainBackground &&
+					        pSprite->m_bPaintOverlap) {
+						bSuccess = pSprite->m_pBackgroundDC->BitBlt(0, 0,
+						                                           pSprite->m_cSize.cx,
+						                                           pSprite->m_cSize.cy,
+						                                           &workDC,
+						                                           pSprite->m_cPosition.x - unionRect.left,
+						                                           pSprite->m_cPosition.y - unionRect.top,
+						                                           SRCCOPY);
+						if (!pSprite->m_bRetainContexts || pSprite->m_bDuplicated)
+							pSprite->ReleaseBackgroundContext();
 						if (!bSuccess)
 							goto punt;
 					}
-					cPoint.x = (*pSprite).m_cPosition.x - unionRect.left;   // set the destination for sprite
-					cPoint.y = (*pSprite).m_cPosition.y - unionRect.top;
+					cPoint.x = pSprite->m_cPosition.x - unionRect.left;   // set the destination for sprite
+					cPoint.y = pSprite->m_cPosition.y - unionRect.top;
 paint_sprite:
-					if ((*pSprite).m_bPaintOverlap) {
-						bSuccess = (!(*pSprite).m_bMasked || (*pSprite).SetupMask(pDC)) &&  // setup image and mask contexts
-						           (*pSprite).SetupImage(pDC);
+					if (pSprite->m_bPaintOverlap) {
+						bSuccess = (!pSprite->m_bMasked || pSprite->SetupMask(pDC)) &&  // setup image and mask contexts
+						           pSprite->SetupImage(pDC);
 						if (bSuccess) {
-							if ((*pSprite).m_bMasked) {                             // need to do a masked transfer ...
+							if (pSprite->m_bMasked) {                             // need to do a masked transfer ...
 								workDC.BitBlt(cPoint.x,                      // ... mask away where image will go
 								                     cPoint.y,
-								                     (*pSprite).m_cSize.cx,
-								                     (*pSprite).m_cSize.cy,
-								                     (*pSprite).m_pMaskDC,
-								                     (*pSprite).m_cImageRect.left,
-								                     (*pSprite).m_cImageRect.top,
+								                     pSprite->m_cSize.cx,
+								                     pSprite->m_cSize.cy,
+								                     pSprite->m_pMaskDC,
+								                     pSprite->m_cImageRect.left,
+								                     pSprite->m_cImageRect.top,
 								                     SRCAND);
 								#if SPRITE_DEBUG
 								bSuccess = (*pDC).BitBlt(viewOrigin.x, viewOrigin.y, dx, dy, &workDC, 0, 0, SRCCOPY);
 								#endif
 								workDC.BitBlt(cPoint.x,                      // ... paint image into cleared area
 								                     cPoint.y,
-								                     (*pSprite).m_cSize.cx,
-								                     (*pSprite).m_cSize.cy,
-								                     (*pSprite).m_pImageDC,
-								                     (*pSprite).m_cImageRect.left,
-								                     (*pSprite).m_cImageRect.top,
+								                     pSprite->m_cSize.cx,
+								                     pSprite->m_cSize.cy,
+								                     pSprite->m_pImageDC,
+								                     pSprite->m_cImageRect.left,
+								                     pSprite->m_cImageRect.top,
 								                     SRCPAINT);
 								#if SPRITE_DEBUG
 								bSuccess = (*pDC).BitBlt(viewOrigin.x, viewOrigin.y, dx, dy, &workDC, 0, 0, SRCCOPY);
@@ -1937,32 +1937,32 @@ paint_sprite:
 							} else {
 								workDC.BitBlt(cPoint.x,                      // just paint the image
 								                     cPoint.y,
-								                     (*pSprite).m_cSize.cx,
-								                     (*pSprite).m_cSize.cy,
-								                     (*pSprite).m_pImageDC,
-								                     (*pSprite).m_cImageRect.left,
-								                     (*pSprite).m_cImageRect.top,
+								                     pSprite->m_cSize.cx,
+								                     pSprite->m_cSize.cy,
+								                     pSprite->m_pImageDC,
+								                     pSprite->m_cImageRect.left,
+								                     pSprite->m_cImageRect.top,
 								                     SRCCOPY);
 								#if SPRITE_DEBUG
 								bSuccess = (*pDC).BitBlt(viewOrigin.x, viewOrigin.y, dx, dy, &workDC, 0, 0, SRCCOPY);
 								#endif
 							}
-							if (!(*pSprite).m_bRetainContexts) {                // release contexts if not optimizing
-								(*pSprite).ReleaseImageContext();
-								if ((*pSprite).m_bMasked)
-									(*pSprite).ReleaseMaskContext();
+							if (!pSprite->m_bRetainContexts) {                // release contexts if not optimizing
+								pSprite->ReleaseImageContext();
+								if (pSprite->m_bMasked)
+									pSprite->ReleaseMaskContext();
 							}
 						}
 					}
 				}
 				if (!bSuccess)
 					goto punt;
-				if ((*pSprite).m_pZPrev == nullptr)                // see if done with image painting
+				if (pSprite->m_pZPrev == nullptr)                // see if done with image painting
 					break;
-				pSprite = (*pSprite).m_pZPrev;
+				pSprite = pSprite->m_pZPrev;
 			}
 
-			(*pDC).BitBlt(baseRect.left,                  // paint only the part of the work area
+			pDC->BitBlt(baseRect.left,                  // paint only the part of the work area
 			                    baseRect.top,                   // ... spanned by our sprites source
 			                    baseRect.right - baseRect.left, // ... and destination locations to
 			                    baseRect.bottom - baseRect.top, // ... the screen; i.e. doing the whole
@@ -1974,10 +1974,10 @@ paint_sprite:
 			workDC.SelectObject(pBitmapOld);     // tear down the work area's bitmap, palette
 			if (m_pPalette != nullptr) {                           // ... and device context, as well as the
 				workDC.SelectPalette(pPalOldWork, false); // ... destination's palette
-				(*pDC).SelectPalette(pPalOld, false);
+				pDC->SelectPalette(pPalOld, false);
 			}
 			workDC.DeleteDC();
-			(*pBitmap).DeleteObject();
+			pBitmap->DeleteObject();
 			delete pBitmap;
 			return true;
 		}
@@ -1992,11 +1992,11 @@ punt:
 	if (workDC.m_hDC != nullptr)                           // ... release the context
 		workDC.DeleteDC();
 
-	(*pBitmap).DeleteObject();                          // ... delete the bitmap
+	pBitmap->DeleteObject();                          // ... delete the bitmap
 	delete pBitmap;
 
 	if (pPalOld != nullptr)                                // map out the palette from the output context
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	return false;
 }
@@ -2024,9 +2024,9 @@ bool CSprite::EraseSprites(CDC *pDC) {
 	pSprite = m_pSpriteChain;
 
 	while (pSprite != nullptr) {
-		if (!(*pSprite).EraseSprite(pDC))
+		if (!pSprite->EraseSprite(pDC))
 			return false;
-		pSprite = (*pSprite).m_pNext;
+		pSprite = pSprite->m_pNext;
 	}
 
 	return true;
@@ -2085,16 +2085,16 @@ bool CSprite::TestInterception(CDC *pDC, CSprite * pTestSprite, CPoint *pPoint) 
 	        testRect,                                   // sprite retangle to be tested against
 	        overlapRect;                                // area of overlap between rectangles
 
-	if (!m_bIntercepts || !(*pTestSprite).m_bIntercepts)    // punt if no interception allowed
+	if (!m_bIntercepts || !pTestSprite->m_bIntercepts)    // punt if no interception allowed
 		return false;
 
 	myRect = m_cRect;                                   // acquire the rectangle for base sprite
 
-	if (m_nId != (*pTestSprite).m_nId) {                // be sure to not test against ourself
-		testRect = (*pTestSprite).m_cRect;              // get bounding rectangle to test against
+	if (m_nId != pTestSprite->m_nId) {                // be sure to not test against ourself
+		testRect = pTestSprite->m_cRect;              // get bounding rectangle to test against
 		if (overlapRect.IntersectRect(&myRect, &testRect)) { // use simple rectangle screening first
 			if (!m_bMasked ||                           // ... and if that succeeds, see if we
-			        !(*pTestSprite).m_bMasked ||            // ... and if that succeeds, see if we
+			        !pTestSprite->m_bMasked ||            // ... and if that succeeds, see if we
 			        SpritesOverlap(pDC, pTestSprite, pPoint))   // ... have image masks that overlap
 				return true;                          // got a simple or complex overlap
 		}
@@ -2135,13 +2135,13 @@ CSprite *CSprite::Interception(CRect *newRect, CSprite * pTestSprite) {
 	myRect = *newRect;                                  // acquire the rectangle for base sprite
 
 	while (pSprite != nullptr) {                           // thumb through the sprite chain
-		if ((m_nId != (*pSprite).m_nId) &&              // be sure to not test against ourself
-		        (*pSprite).m_bIntercepts) {                 // ... and only test against overlapping sprites
-			testRect = (*pSprite).m_cRect;              // sprites touch if their rectangles intersect
+		if ((m_nId != pSprite->m_nId) &&              // be sure to not test against ourself
+		        pSprite->m_bIntercepts) {                 // ... and only test against overlapping sprites
+			testRect = pSprite->m_cRect;              // sprites touch if their rectangles intersect
 			if (overlapRect.IntersectRect(&myRect, &testRect))  // does our sprite overlap another?
 				return (pSprite);                       // ... if so return a pointer to it
 		}
-		pSprite = (*pSprite).m_pNext;
+		pSprite = pSprite->m_pNext;
 	}                  // fetch next sprite in chain for testing
 
 	return nullptr;
@@ -2175,7 +2175,7 @@ CSprite *CSprite::Interception(CDC *pDC, CSprite * pTestSprite) {
 	while (pSprite != nullptr) {                           // thumb through the entire sprite collection
 		if (TestInterception(pDC, pSprite, nullptr))       // ... testing against each sprite in turn
 			return (pSprite);                           // found an interception
-		pSprite = (*pSprite).m_pNext;
+		pSprite = pSprite->m_pNext;
 	}                  // fetch next sprite in chain for testing
 
 	return nullptr;
@@ -2216,13 +2216,13 @@ bool CSprite::SpritesOverlap(CDC * pDC, CSprite * pSprite, CPoint *pPoint) {
 	BITMAP  cBitmapData;
 	int     bx, by, bdx, bdy;
 
-	if (!m_bVisible || !(*pSprite).m_bVisible)          // punt if not visible
+	if (!m_bVisible || !pSprite->m_bVisible)          // punt if not visible
 		return false;
 
 	if (pDC == nullptr)                                    // punt if no output context
 		return false;
 
-	unionRect.UnionRect(m_cRect, (*pSprite).m_cRect);   // calculate the smallest enclosing rectangle that
+	unionRect.UnionRect(m_cRect, pSprite->m_cRect);   // calculate the smallest enclosing rectangle that
 	dx = unionRect.right - unionRect.left;              // ... contains the bitmap area where the sprite was
 	dy = unionRect.bottom - unionRect.top;              // ... and the bitmap area where it will be next
 
@@ -2239,12 +2239,12 @@ bool CSprite::SpritesOverlap(CDC * pDC, CSprite * pSprite, CPoint *pPoint) {
 
 	if ((cDC1 != nullptr) &&                               // verify we got the objects we asked for
 	        (cDC2 != nullptr) &&
-	        (*cDC1).CreateCompatibleDC(pDC) &&              // create the actual device contexts
-	        (*cDC2).CreateCompatibleDC(pDC) &&
-	        (*pBitmap1).CreateBitmap(dx, dy, 1, 1, chPixels) && // create the actual bitmaps
-	        (*pBitmap2).CreateBitmap(dx, dy, 1, 1, chPixels)) {
-		pBitmap1Old = (*cDC1).SelectObject(pBitmap1);   // map the bitmaps into the contexts
-		pBitmap2Old = (*cDC2).SelectObject(pBitmap2);
+	        cDC1->CreateCompatibleDC(pDC) &&              // create the actual device contexts
+	        cDC2->CreateCompatibleDC(pDC) &&
+	        pBitmap1->CreateBitmap(dx, dy, 1, 1, chPixels) && // create the actual bitmaps
+	        pBitmap2->CreateBitmap(dx, dy, 1, 1, chPixels)) {
+		pBitmap1Old = cDC1->SelectObject(pBitmap1);   // map the bitmaps into the contexts
+		pBitmap2Old = cDC2->SelectObject(pBitmap2);
 		if ((pBitmap1Old != nullptr) &&
 		        (pBitmap2Old != nullptr)) {
 			bx = m_cPosition.x - unionRect.left;        // get positioning information for sprite 1
@@ -2253,35 +2253,35 @@ bool CSprite::SpritesOverlap(CDC * pDC, CSprite * pSprite, CPoint *pPoint) {
 			bdy = m_cSize.cy;
 			bSuccess = SetupMask(pDC);
 			if (bSuccess) {
-				(*cDC1).BitBlt(bx, by, bdx, bdy, m_pMaskDC, m_cImageRect.left, m_cImageRect.top, NOTSRCCOPY); // get sprite 1's mask
+				cDC1->BitBlt(bx, by, bdx, bdy, m_pMaskDC, m_cImageRect.left, m_cImageRect.top, NOTSRCCOPY); // get sprite 1's mask
 				if (!m_bRetainContexts)
 					ReleaseMaskContext();
-				bx = (*pSprite).m_cPosition.x - unionRect.left;     // get positioning information for sprite 2
-				by = (*pSprite).m_cPosition.y - unionRect.top;
-				bdx = (*pSprite).m_cSize.cx;
-				bdy = (*pSprite).m_cSize.cy;
-				bSuccess = (*pSprite).SetupMask(pDC);
+				bx = pSprite->m_cPosition.x - unionRect.left;     // get positioning information for sprite 2
+				by = pSprite->m_cPosition.y - unionRect.top;
+				bdx = pSprite->m_cSize.cx;
+				bdy = pSprite->m_cSize.cy;
+				bSuccess = pSprite->SetupMask(pDC);
 				if (bSuccess) {
-					(*cDC2).BitBlt(bx, by, bdx, bdy, (*pSprite).m_pMaskDC, (*pSprite).m_cImageRect.left, (*pSprite).m_cImageRect.top, NOTSRCCOPY); // get sprite 2's mask
-					if (!(*pSprite).m_bRetainContexts)
-						(*pSprite).ReleaseMaskContext();
-					(*cDC1).BitBlt(0, 0, dx, dy, cDC2, 0, 0, SRCAND); // logically AND the masks together
-					(*cDC1).SelectObject(pBitmap1Old);            // ... leaving bits set where they overlap
+					cDC2->BitBlt(bx, by, bdx, bdy, pSprite->m_pMaskDC, pSprite->m_cImageRect.left, pSprite->m_cImageRect.top, NOTSRCCOPY); // get sprite 2's mask
+					if (!pSprite->m_bRetainContexts)
+						pSprite->ReleaseMaskContext();
+					cDC1->BitBlt(0, 0, dx, dy, cDC2, 0, 0, SRCAND); // logically AND the masks together
+					cDC1->SelectObject(pBitmap1Old);            // ... leaving bits set where they overlap
 					pBitmap1Old = nullptr;
-					(*pBitmap1).GetBitmapBits(dwN, chPixels); // fetch the image we created
-					(*pBitmap1).GetObject(sizeof(BITMAP), &cBitmapData); // .. get the scanline length
+					pBitmap1->GetBitmapBits(dwN, chPixels); // fetch the image we created
+					pBitmap1->GetObject(sizeof(BITMAP), &cBitmapData); // .. get the scanline length
 					bSuccess = false;
 					for (i = 0; i < cBitmapData.bmHeight; i++) {        // ... and look for a byte that is nonzero
 						for (j = 0; j < cBitmapData.bmWidthBytes; j++) {// ... in which case we have an image overlap
 							if (chPixels[(i * cBitmapData.bmWidthBytes) + j] != 0) {
 								bSuccess = true;
 								if (pPoint != nullptr) {                   // estimate point of intersection
-									(*pPoint).x = j - (m_cPosition.x - unionRect.left);
-									(*pPoint).y = i - (m_cPosition.y - unionRect.top);
-									if ((*pPoint).x < 0)
-										(*pPoint).x = 0;
-									if ((*pPoint).y < 0)
-										(*pPoint).y = 0;
+									pPoint->x = j - (m_cPosition.x - unionRect.left);
+									pPoint->y = i - (m_cPosition.y - unionRect.top);
+									if (pPoint->x < 0)
+										pPoint->x = 0;
+									if (pPoint->y < 0)
+										pPoint->y = 0;
 								}
 								break;
 							}
@@ -2295,25 +2295,25 @@ bool CSprite::SpritesOverlap(CDC * pDC, CSprite * pSprite, CPoint *pPoint) {
 	free(chPixels);                                 // free up the work area's bitmap
 
 	if (pBitmap1Old != nullptr)                            // map out the bitmaps we used
-		(*cDC1).SelectObject(pBitmap1Old);
+		cDC1->SelectObject(pBitmap1Old);
 	if (pBitmap2Old != nullptr)
-		(*cDC2).SelectObject(pBitmap2Old);
+		cDC2->SelectObject(pBitmap2Old);
 
 	if (pBitmap1 != nullptr) {                             // delete the bitmap resources and objects
-		(*pBitmap1).DeleteObject();
+		pBitmap1->DeleteObject();
 		delete pBitmap1;
 	}
 	if (pBitmap2 != nullptr) {
-		(*pBitmap2).DeleteObject();
+		pBitmap2->DeleteObject();
 		delete pBitmap2;
 	}
 
 	if (cDC1 != nullptr) {                                 // release the contexts and delete the objects
-		(*cDC1).DeleteDC();
+		cDC1->DeleteDC();
 		delete cDC1;
 	}
 	if (cDC2 != nullptr) {
-		(*cDC2).DeleteDC();
+		cDC2->DeleteDC();
 		delete cDC2;
 	}
 
@@ -2364,12 +2364,12 @@ CSprite *CSprite::Touched(CPoint myPoint, CSprite *pSprite) {
 	CRect   testRect;                                   // sprite area to be tested
 
 	while (pSprite != nullptr) {                           // thumb through the entire sprite collection
-		if ((*pSprite).m_bIntercepts) {                 // ... ignoring sprites that don't intercept
-			testRect = (*pSprite).m_cRect;
+		if (pSprite->m_bIntercepts) {                 // ... ignoring sprites that don't intercept
+			testRect = pSprite->m_cRect;
 			if (testRect.PtInRect(myPoint))             // See if the point is in the sprite's rectangle
 				return (pSprite);                       // ... and if so, return a pointer to it
 		}
-		pSprite = (*pSprite).m_pNext;
+		pSprite = pSprite->m_pNext;
 	}                  // fetch next sprite for testing
 
 	return nullptr;
@@ -2431,40 +2431,40 @@ bool CSprite::CropImage(CDC *pDC, CRect *pRect) {
 	if (m_pImage != nullptr) {
 		if (SetupImage(pDC)) {                      // blacken image section to crop it
 			myBrush.CreateStockObject(BLACK_BRUSH);
-			(*m_pImageDC).FillRect(&myRect, &myBrush);
+			m_pImageDC->FillRect(&myRect, &myBrush);
 			if (!m_bMasked || (m_pMask == nullptr))
 				bSuccess = true;
 			else {
 				bSuccess = SetupMask(pDC);          // whiten mask section to crop it
 				myBrush.CreateStockObject(WHITE_BRUSH);
-				(*m_pMaskDC).FillRect(&myRect, &myBrush);
+				m_pMaskDC->FillRect(&myRect, &myBrush);
 			}
 			if (bSuccess && m_bHaveBackdrop) {
 				if (GetBackdropDC(pDC) == nullptr)
 					bSuccess = false;
 				else {
-					bSuccess = (*pDC).BitBlt(
-					               m_cRect.left + (*pRect).left,
-					               m_cRect.top + (*pRect).top,
-					               (*pRect).right - (*pRect).left,
-					               (*pRect).bottom - (*pRect).top,
+					bSuccess = pDC->BitBlt(
+					               m_cRect.left + pRect->left,
+					               m_cRect.top + pRect->top,
+					               pRect->right - pRect->left,
+					               pRect->bottom - pRect->top,
 					               m_pBackdropDC,
-					               m_cRect.left + (*pRect).left,
-					               m_cRect.top + (*pRect).top,
+					               m_cRect.left + pRect->left,
+					               m_cRect.top + pRect->top,
 					               SRCCOPY);
 					ReleaseBackdropDC();
 				}
 			} else if (bSuccess && (m_pBackground != nullptr)) {
 				bSuccess = SetupBackground(pDC);    // update background with cropped area
 				if (bSuccess) {
-					bSuccess = (*pDC).BitBlt(
-					               m_cRect.left + (*pRect).left,
-					               m_cRect.top + (*pRect).top,
-					               (*pRect).right - (*pRect).left,
-					               (*pRect).bottom - (*pRect).top,
+					bSuccess = pDC->BitBlt(
+					               m_cRect.left + pRect->left,
+					               m_cRect.top + pRect->top,
+					               pRect->right - pRect->left,
+					               pRect->bottom - pRect->top,
 					               m_pBackgroundDC,
-					               (*pRect).left,
-					               (*pRect).top,
+					               pRect->left,
+					               pRect->top,
 					               SRCCOPY);
 					ReleaseBackgroundContext();
 				}
@@ -2524,10 +2524,10 @@ bool CSprite::CreateMask(CDC *pDC) {
 	if ((m_pMask != nullptr) &&                            // verify that worked
 	        SetupImage(pDC) &&                              // setup the image bitmap and context
 	        CreateMaskContext(pDC)) {                       // create a context for the mask
-		if ((*m_pMask).CreateBitmap(mySize.cx, mySize.cy, 1, 1, nullptr)) { // create mask bitmap
-			m_pMaskOld = (*m_pMaskDC).SelectObject(m_pMask);    // map bitmap into context
+		if (m_pMask->CreateBitmap(mySize.cx, mySize.cy, 1, 1, nullptr)) { // create mask bitmap
+			m_pMaskOld = m_pMaskDC->SelectObject(m_pMask);    // map bitmap into context
 			if (m_pMaskOld) {
-				(*m_pMaskDC).BitBlt(0,            // copy in the image, doing an inversion
+				m_pMaskDC->BitBlt(0,            // copy in the image, doing an inversion
 				                          0,              // ... so that we can mask out the sprite's
 				                          mySize.cx,      // ... transparent area
 				                          mySize.cy,
@@ -2535,7 +2535,7 @@ bool CSprite::CreateMask(CDC *pDC) {
 				                          0,
 				                          0,
 				                          NOTSRCCOPY);
-				(*m_pImageDC).BitBlt(0,           // remove transparent area from sprite image
+				m_pImageDC->BitBlt(0,           // remove transparent area from sprite image
 				                           0,
 				                           mySize.cx,
 				                           mySize.cy,
@@ -2543,7 +2543,7 @@ bool CSprite::CreateMask(CDC *pDC) {
 				                           0,
 				                           0,
 				                           SRCAND);
-				(*m_pMaskDC).BitBlt(0,            // invert mask again so it can be used later
+				m_pMaskDC->BitBlt(0,            // invert mask again so it can be used later
 				                          0,              // ... to mask away the sprite image area
 				                          mySize.cx,      // ... from the background for each new
 				                          mySize.cy,      // ... destination
@@ -2599,7 +2599,7 @@ bool CSprite::CreateBackground(CDC *pDC) {
 	if (pDC != nullptr) {                                  // create an object to hold things
 		m_pBackground = new CBitmap();
 		if (m_pBackground != nullptr) {                    // create the background bitmap
-			if ((*m_pBackground).CreateCompatibleBitmap(pDC, m_cSize.cx, m_cSize.cy))
+			if (m_pBackground->CreateCompatibleBitmap(pDC, m_cSize.cx, m_cSize.cy))
 				return true;
 			delete m_pBackground;                       // tear things down if we failed
 			m_pBackground = nullptr;
@@ -2639,7 +2639,7 @@ bool CSprite::SetupImage(CDC * pDC) {
 
 		if (CreateImageContext(pDC)) {                  // create a context for the image
 			if (m_pImageOld == nullptr)                    // ... then map in the bitmap
-				m_pImageOld = (*m_pImageDC).SelectObject(m_pImage);
+				m_pImageOld = m_pImageDC->SelectObject(m_pImage);
 			if (m_pImageOld != nullptr)
 				return true;
 		}
@@ -2681,7 +2681,7 @@ bool CSprite::SetupBackground(CDC * pDC) {
 
 		if (CreateBackgroundContext(pDC)) {             // create a context for
 			if (m_pBackgroundOld == nullptr)               // ... and map in the bitmap
-				m_pBackgroundOld = (*m_pBackgroundDC).SelectObject(m_pBackground);
+				m_pBackgroundOld = m_pBackgroundDC->SelectObject(m_pBackground);
 			if (m_pBackgroundOld != nullptr)
 				return true;
 		}
@@ -2724,7 +2724,7 @@ bool CSprite::SetupMask(CDC * pDC) {
 		if (CreateMaskContext(pDC) &&                   // create a context for the mask
 		        CreateMask(pDC)) {                          // create the mask bitmap and content
 			if (m_pMaskOld == nullptr)                     // map bitmap into context
-				m_pMaskOld = (*m_pMaskDC).SelectObject(m_pMask);
+				m_pMaskOld = m_pMaskDC->SelectObject(m_pMask);
 			if (m_pMaskOld != nullptr)
 				return true;
 		}
@@ -2758,12 +2758,12 @@ bool CSprite::CreateImageContext(CDC * pDC) {
 	if (pDC != nullptr) {                                  // verify output context
 		if (m_pImageDC == nullptr) {                       // if we don't already have
 			m_pImageDC = new CDC();                     // ... a context for the image
-			if (!(*m_pImageDC).CreateCompatibleDC(pDC)) // ... we create one now
+			if (!m_pImageDC->CreateCompatibleDC(pDC)) // ... we create one now
 				goto Error;
 		}
 		if ((m_pPalette != nullptr) && (m_pPalImageOld == nullptr)) { // map in palette if present
-			m_pPalImageOld = (*m_pImageDC).SelectPalette(m_pPalette, false);
-			(*m_pImageDC).RealizePalette();
+			m_pPalImageOld = m_pImageDC->SelectPalette(m_pPalette, false);
+			m_pImageDC->RealizePalette();
 		}
 		return true;
 	}
@@ -2797,12 +2797,12 @@ bool CSprite::CreateBackgroundContext(CDC * pDC) {
 	if (pDC != nullptr) {                                  // verify the output context
 		if (m_pBackgroundDC == nullptr) {                  // if we don't have a context
 			m_pBackgroundDC = new CDC();                // ... then we create one now
-			if (!(*m_pBackgroundDC).CreateCompatibleDC(pDC))
+			if (!m_pBackgroundDC->CreateCompatibleDC(pDC))
 				goto Error;
 		}
 		if ((m_pPalette != nullptr) && (m_pPalBackOld == nullptr)) {  // map in palette if present
-			m_pPalBackOld = (*m_pBackgroundDC).SelectPalette(m_pPalette, false);
-			(*m_pBackgroundDC).RealizePalette();
+			m_pPalBackOld = m_pBackgroundDC->SelectPalette(m_pPalette, false);
+			m_pBackgroundDC->RealizePalette();
 		}
 		return true;
 	}
@@ -2839,7 +2839,7 @@ bool CSprite::CreateMaskContext(CDC * pDC) {
 			return true;
 		m_pMaskDC = new CDC();                          // create an object for the context
 		if ((m_pMaskDC != nullptr) &&                      // ... then create the context itself
-		        (*m_pMaskDC).CreateCompatibleDC(pDC))
+		        m_pMaskDC->CreateCompatibleDC(pDC))
 			return true;
 		ReleaseMaskContext();
 	}                          // release the context if we failed
@@ -2866,10 +2866,10 @@ void CSprite::ReleaseImageContext() {
 
 	if (m_pImageDC != nullptr) {                           // if there is an image device context
 		if (m_pImageOld != nullptr)                        // ... map out existing bitmap
-			(*m_pImageDC).SelectObject(m_pImageOld);
+			m_pImageDC->SelectObject(m_pImageOld);
 		if (m_pPalImageOld != nullptr)                     // ... map out the palette
-			(*m_pImageDC).SelectPalette(m_pPalImageOld, false);
-		(*m_pImageDC).DeleteDC();                       // ... release the context
+			m_pImageDC->SelectPalette(m_pPalImageOld, false);
+		m_pImageDC->DeleteDC();                       // ... release the context
 		delete m_pImageDC;                              // ... then delete the device context
 
 		m_pImageOld = nullptr;
@@ -2897,14 +2897,14 @@ void CSprite::ReleaseBackgroundContext() {
 
 	if (m_pBackgroundDC != nullptr) {                      // if there is a background device context
 		if (m_pBackgroundOld != nullptr) {                 // ... map out existing bitmap
-			(*m_pBackgroundDC).SelectObject(m_pBackgroundOld);
+			m_pBackgroundDC->SelectObject(m_pBackgroundOld);
 			m_pBackgroundOld = nullptr;
 		}
 		if (m_pPalBackOld != nullptr) {                    // ... map out the palette
-			(*m_pBackgroundDC).SelectPalette(m_pPalBackOld, false);
+			m_pBackgroundDC->SelectPalette(m_pPalBackOld, false);
 			m_pPalBackOld = nullptr;
 		}
-		(*m_pBackgroundDC).DeleteDC();                  // ... release the context
+		m_pBackgroundDC->DeleteDC();                  // ... release the context
 		delete m_pBackgroundDC;
 		m_pBackgroundDC = nullptr;
 	}                        // ... then delete the device context
@@ -2930,8 +2930,8 @@ void CSprite::ReleaseMaskContext() {
 	if (m_bMasked &&
 	        (m_pMaskDC != nullptr)) {                          // if there is a mask device context
 		if (m_pMaskOld != nullptr)                         // ... map out existing bitmap
-			(*m_pMaskDC).SelectObject(m_pMaskOld);
-		(*m_pMaskDC).DeleteDC();                        // ... release the context
+			m_pMaskDC->SelectObject(m_pMaskOld);
+		m_pMaskDC->DeleteDC();                        // ... release the context
 		delete m_pMaskDC;                               // ... then delete the device context
 
 		m_pMaskOld = nullptr;
@@ -2960,7 +2960,7 @@ void CSprite::ClearImage() {
 		ReleaseImageContext();                          // release the imnage context
 
 		if (m_pImage != nullptr) {                         // destroy the image bitmap object
-			(*m_pImage).DeleteObject();                 // ... if present
+			m_pImage->DeleteObject();                 // ... if present
 			delete m_pImage;
 		}
 	}
@@ -2990,8 +2990,8 @@ void CSprite::ClearBackgrounds() {
 	pSprite = m_pSpriteChain;
 
 	while (pSprite != nullptr) {
-		(*pSprite).ClearBackground();
-		pSprite = (*pSprite).m_pNext;
+		pSprite->ClearBackground();
+		pSprite = pSprite->m_pNext;
 	}
 }
 
@@ -3019,7 +3019,7 @@ void CSprite::ClearBackground() {
 	ReleaseBackgroundContext();                         // release the background context
 
 	if (m_pBackground != nullptr) {                        // destroy the backgrond bitmap object
-		(*m_pBackground).DeleteObject();                // ... if present
+		m_pBackground->DeleteObject();                // ... if present
 		delete m_pBackground;
 		m_pBackground = nullptr;
 	}
@@ -3067,7 +3067,7 @@ void CSprite::ClearMask() {
 		ReleaseMaskContext();                           // release mask context
 
 		if (m_pMask != nullptr) {                          // destroy the Mask bitmap resource and object
-			(*m_pMask).DeleteObject();                  // ... if present
+			m_pMask->DeleteObject();                  // ... if present
 			delete m_pMask;
 		}
 	}
@@ -3091,7 +3091,7 @@ void CSprite::ClearMask() {
 
 void CSprite::ClearPalette() {
 	if ((m_pPalette != nullptr) && !m_bSharedPalette) {            // explicitly delete the palette resource
-		(*m_pPalette).DeleteObject();                           // ... if it is not shared by other sprites
+		m_pPalette->DeleteObject();                           // ... if it is not shared by other sprites
 		delete m_pPalette;
 	}
 
@@ -3118,26 +3118,26 @@ CDC *CSprite::GetBackdropDC(CDC *pDC) {
 		return (m_pBackdropDC);
 
 	m_pBackdropDC = new CDC();
-	if (!(*m_pBackdropDC).CreateCompatibleDC(pDC)) {
+	if (!m_pBackdropDC->CreateCompatibleDC(pDC)) {
 		delete m_pBackdropDC;
 		m_pBackdropDC = nullptr;
 		return nullptr;
 	}
 
 	if (m_pBackdropPalette != nullptr) {                       // map in the palette if present
-		m_pBackdropPalOld = (*m_pBackdropDC).SelectPalette(m_pBackdropPalette, false);
+		m_pBackdropPalOld = m_pBackdropDC->SelectPalette(m_pBackdropPalette, false);
 		if (m_pBackdropPalOld == nullptr) {                     // punt if not successful
 			delete m_pBackdropDC;
 			m_pBackdropDC = nullptr;
 			return nullptr;
 		}
-		(*m_pBackdropDC).RealizePalette();            // make the system use the palette
+		m_pBackdropDC->RealizePalette();            // make the system use the palette
 	}
 
-	m_pBackdropOld = (*m_pBackdropDC).SelectObject(m_pBackdrop);    // map in our bitmap
+	m_pBackdropOld = m_pBackdropDC->SelectObject(m_pBackdrop);    // map in our bitmap
 	if (m_pBackdropOld == nullptr) {
 		if (m_pBackdropPalOld != nullptr) {                    // map out palette on failure
-			(*m_pBackdropDC).SelectPalette(m_pBackdropPalOld, false);
+			m_pBackdropDC->SelectPalette(m_pBackdropPalOld, false);
 			m_pBackdropPalOld = nullptr;
 			delete m_pBackdropDC;
 			m_pBackdropDC = nullptr;
@@ -3163,12 +3163,12 @@ CDC *CSprite::GetBackdropDC(CDC *pDC) {
 
 void CSprite::ReleaseBackdropDC() {
 	if (m_pBackdropOld != nullptr) {                       // map back the previous bitmap
-		(*m_pBackdropDC).SelectObject(m_pBackdropOld);
+		m_pBackdropDC->SelectObject(m_pBackdropOld);
 		m_pBackdropOld = nullptr;
 	}
 
 	if (m_pBackdropPalOld != nullptr) {                    // map back the previous palette
-		(*m_pBackdropDC).SelectPalette(m_pBackdropPalOld, false);
+		m_pBackdropDC->SelectPalette(m_pBackdropPalOld, false);
 		m_pBackdropPalOld = nullptr;
 	}
 

--- a/engines/bagel/hodjnpodj/hnplibs/text.cpp
+++ b/engines/bagel/hodjnpodj/hnplibs/text.cpp
@@ -93,11 +93,11 @@ CText::~CText() {
 	ReleaseContexts();
 
 	if (m_pWork != nullptr) {
-		(*m_pWork).DeleteObject();
+		m_pWork->DeleteObject();
 		delete m_pWork;
 	}
 	if (m_pBackground != nullptr) {
-		(*m_pBackground).DeleteObject();
+		m_pBackground->DeleteObject();
 		delete m_pBackground;
 	}
 }
@@ -174,8 +174,8 @@ bool CText::SetupText(CDC *pDC, CPalette *pPalette, CRect *pRect, int nJustify) 
 	m_nJustify = nJustify;
 
 	if (m_pPalette != nullptr) {
-		pPalOld = (*pDC).SelectPalette(m_pPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(m_pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	if (!m_bFontLoaded) {                       // load the font if we have not
@@ -189,16 +189,16 @@ bool CText::SetupText(CDC *pDC, CPalette *pPalette, CRect *pRect, int nJustify) 
 
 	m_pWork = new CBitmap();                    // create a bitmap to serve as our
 	if ((m_pWork == nullptr) ||                    // ... work area as we output text
-	        !(*m_pWork).CreateCompatibleBitmap(pDC, m_cSize.cx, m_cSize.cy))
+	        !m_pWork->CreateCompatibleBitmap(pDC, m_cSize.cx, m_cSize.cy))
 		return false;
 
 	m_pBackground = new CBitmap();              // create a bitmap to hold the
 	if ((m_pBackground == nullptr) ||              // ... background we overwrite
-	        !(*m_pBackground).CreateCompatibleBitmap(pDC, m_cSize.cx, m_cSize.cy))
+	        !m_pBackground->CreateCompatibleBitmap(pDC, m_cSize.cx, m_cSize.cy))
 		return false;
 
 	if (m_pPalette != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	return true;                              // return status
 }
@@ -225,13 +225,13 @@ bool CText::RestoreBackground(CDC *pDC) {
 	CPalette *pPalOld = nullptr;
 
 	if (m_pPalette != nullptr) {
-		pPalOld = (*pDC).SelectPalette(m_pPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(m_pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	if ((m_pBackground != nullptr) &&
 	        SetupContexts(pDC)) {
-		bSuccess = (*pDC).BitBlt(                   // simply splat the background art
+		bSuccess = pDC->BitBlt(                   // simply splat the background art
 		               m_cRect.left,           // ... back where it came from
 		               m_cRect.top,
 		               m_cSize.cx,
@@ -244,7 +244,7 @@ bool CText::RestoreBackground(CDC *pDC) {
 	}
 
 	if (m_pPalette != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	return bSuccess;
 }
@@ -341,15 +341,15 @@ bool CText::DisplayText(CDC *pDC, const char *pszText, const int nSize, const in
 	CPalette *pPalOld = nullptr;
 
 	if (m_pPalette != nullptr) {
-		pPalOld = (*pDC).SelectPalette(m_pPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(m_pPalette, false);
+		pDC->RealizePalette();
 	}
 
 	if (!SetupContexts(pDC))                        // setup the device contexts and map in
 		return false;                             // ... the various bitmaps
 
 	if (!m_bHaveBackground) {
-		(*m_pBackgroundDC).BitBlt(           // grab what the background looks like
+		m_pBackgroundDC->BitBlt(           // grab what the background looks like
 		    0,                      // ... putting it in the work area
 		    0,
 		    m_cSize.cx,
@@ -363,17 +363,17 @@ bool CText::DisplayText(CDC *pDC, const char *pszText, const int nSize, const in
 
 	// Create an instance of the specified font
 	m_pFont = new CFont();
-	(*m_pFont).CreateFont(nSize, 0, 0, 0, nWeight,
+	m_pFont->CreateFont(nSize, 0, 0, 0, nWeight,
 		0, 0, 0, 0, OUT_RASTER_PRECIS, 0,
 		PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
 
-	pFontOld = (*m_pWorkDC).SelectObject(m_pFont);  // select it into our context
-	(*m_pWorkDC).GetTextMetrics(&fontMetrics);      // get some info about the font
-	(*m_pWorkDC).SetBkMode(TRANSPARENT);            // make the text overlay transparently
+	pFontOld = m_pWorkDC->SelectObject(m_pFont);  // select it into our context
+	m_pWorkDC->GetTextMetrics(&fontMetrics);      // get some info about the font
+	m_pWorkDC->SetBkMode(TRANSPARENT);            // make the text overlay transparently
 
-	textInfo = (*m_pWorkDC).GetTextExtent(pszText, strlen(pszText));  // get the area spanned by the text
+	textInfo = m_pWorkDC->GetTextExtent(pszText, strlen(pszText));  // get the area spanned by the text
 
-	(*m_pWorkDC).BitBlt(                     // copy the saved background to the work area
+	m_pWorkDC->BitBlt(                     // copy the saved background to the work area
 	    0,
 	    0,
 	    m_cSize.cx,
@@ -399,8 +399,8 @@ bool CText::DisplayText(CDC *pDC, const char *pszText, const int nSize, const in
 	m_cPosition.y = MAX<int>(m_cPosition.y, 0);
 
 	if (bShadowed) {
-		(*m_pWorkDC).SetTextColor(m_cShadowColor);      // set the color of the shadow
-		(*m_pWorkDC).TabbedTextOut(                     // zap the shadow to the work area
+		m_pWorkDC->SetTextColor(m_cShadowColor);      // set the color of the shadow
+		m_pWorkDC->TabbedTextOut(                     // zap the shadow to the work area
 		    m_cPosition.x + m_nShadow_DX,
 		    m_cPosition.y + m_nShadow_DY,
 		    (const char *)pszText,
@@ -408,20 +408,20 @@ bool CText::DisplayText(CDC *pDC, const char *pszText, const int nSize, const in
 		    1, &m_nTabStop, 0);
 	}
 
-	(*m_pWorkDC).SetTextColor(m_cTextColor);            // set the color of the text
-	(*m_pWorkDC).TabbedTextOut(                         // zap the text to the work area
+	m_pWorkDC->SetTextColor(m_cTextColor);            // set the color of the text
+	m_pWorkDC->TabbedTextOut(                         // zap the text to the work area
 	    m_cPosition.x,
 	    m_cPosition.y,
 	    (const char *)pszText,
 	    strlen(pszText),
 	    1, &m_nTabStop, 0);
 
-	(*m_pWorkDC).SelectObject(pFontOld);         // map out the font
+	m_pWorkDC->SelectObject(pFontOld);         // map out the font
 
 	delete m_pFont;                                     // release the font instance
 	m_pFont = nullptr;
 
-	(*pDC).BitBlt(                               // copy the result to the destination context
+	pDC->BitBlt(                               // copy the result to the destination context
 	    m_cRect.left,
 	    m_cRect.top,
 	    m_cSize.cx,
@@ -434,7 +434,7 @@ bool CText::DisplayText(CDC *pDC, const char *pszText, const int nSize, const in
 	ReleaseContexts();
 
 	if (m_pPalette != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	return true;
 }
@@ -461,13 +461,13 @@ bool CText::SetupContexts(CDC *pDC) {
 	if (m_pWorkDC == nullptr) {
 		m_pWorkDC = new CDC();
 		if ((m_pWorkDC == nullptr) ||
-		        !(*m_pWorkDC).CreateCompatibleDC(pDC))
+		        !m_pWorkDC->CreateCompatibleDC(pDC))
 			return false;
 		if (m_pPalette != nullptr) {
-			m_pPalWorkOld = (*m_pWorkDC).SelectPalette(m_pPalette, false);
-			(*m_pWorkDC).RealizePalette();
+			m_pPalWorkOld = m_pWorkDC->SelectPalette(m_pPalette, false);
+			m_pWorkDC->RealizePalette();
 		}
-		m_pWorkOld = (*m_pWorkDC).SelectObject(m_pWork);
+		m_pWorkOld = m_pWorkDC->SelectObject(m_pWork);
 		if (m_pWorkOld == nullptr)
 			return false;
 	}
@@ -475,13 +475,13 @@ bool CText::SetupContexts(CDC *pDC) {
 	if (m_pBackgroundDC == nullptr) {
 		m_pBackgroundDC = new CDC();
 		if ((m_pBackgroundDC == nullptr) ||
-		        !(*m_pBackgroundDC).CreateCompatibleDC(pDC))
+		        !m_pBackgroundDC->CreateCompatibleDC(pDC))
 			return false;
 		if (m_pPalette != nullptr) {
-			m_pPalBackOld = (*m_pBackgroundDC).SelectPalette(m_pPalette, false);
-			(*m_pBackgroundDC).RealizePalette();
+			m_pPalBackOld = m_pBackgroundDC->SelectPalette(m_pPalette, false);
+			m_pBackgroundDC->RealizePalette();
 		}
-		m_pBackgroundOld = (*m_pBackgroundDC).SelectObject(m_pBackground);
+		m_pBackgroundOld = m_pBackgroundDC->SelectObject(m_pBackground);
 		if (m_pBackgroundOld == nullptr)
 			return false;
 	}
@@ -505,30 +505,30 @@ bool CText::SetupContexts(CDC *pDC) {
 
 void CText::ReleaseContexts() {
 	if (m_pWorkOld != nullptr) {
-		(*m_pWorkDC).SelectObject(m_pWorkOld);
+		m_pWorkDC->SelectObject(m_pWorkOld);
 		m_pWorkOld = nullptr;
 	}
 	if (m_pBackgroundOld != nullptr) {
-		(*m_pBackgroundDC).SelectObject(m_pBackgroundOld);
+		m_pBackgroundDC->SelectObject(m_pBackgroundOld);
 		m_pBackgroundOld = nullptr;
 	}
 
 	if (m_pPalWorkOld != nullptr) {
-		(*m_pWorkDC).SelectPalette(m_pPalWorkOld, false);
+		m_pWorkDC->SelectPalette(m_pPalWorkOld, false);
 		m_pPalWorkOld = nullptr;
 	}
 	if (m_pPalBackOld != nullptr) {
-		(*m_pBackgroundDC).SelectPalette(m_pPalBackOld, false);
+		m_pBackgroundDC->SelectPalette(m_pPalBackOld, false);
 		m_pPalBackOld = nullptr;
 	}
 
 	if (m_pWorkDC != nullptr) {
-		(*m_pWorkDC).DeleteDC();
+		m_pWorkDC->DeleteDC();
 		delete m_pWorkDC;
 		m_pWorkDC = nullptr;
 	}
 	if (m_pBackgroundDC != nullptr) {
-		(*m_pBackgroundDC).DeleteDC();
+		m_pBackgroundDC->DeleteDC();
 		delete m_pBackgroundDC;
 		m_pBackgroundDC = nullptr;
 	}

--- a/engines/bagel/hodjnpodj/life/game.cpp
+++ b/engines/bagel/hodjnpodj/life/game.cpp
@@ -131,10 +131,10 @@ CMainWindow::CMainWindow(HWND hParentWnd, LPGAMESTRUCT lpGameInfo) {
 	* game art work.                                                    *
 	********************************************************************/
 	pDibDoc = new CDibDoc();
-	bAssertCheck = (*pDibDoc).OpenDocument(SPLASHSPEC);
+	bAssertCheck = pDibDoc->OpenDocument(SPLASHSPEC);
 	ASSERT(bAssertCheck);
 
-	pGamePalette = (*pDibDoc).DetachPalette();
+	pGamePalette = pDibDoc->DetachPalette();
 	ASSERT(pGamePalette);
 	delete pDibDoc;
 
@@ -239,30 +239,30 @@ CMainWindow::CMainWindow(HWND hParentWnd, LPGAMESTRUCT lpGameInfo) {
 	                   EVOLVE_BUTTON_HEIGHT + EVOLVE_BUTTON_OFFSET_Y);
 	pEvolveButton = new CColorButton();
 	if (pEvolveButton != nullptr) {
-		(void)(*pEvolveButton).Create("Evolve", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | BS_OWNERDRAW,
+		(void)pEvolveButton->Create("Evolve", BS_PUSHBUTTON | WS_CHILD | WS_VISIBLE | BS_OWNERDRAW,
 		                        EvolveRect, this, IDC_EVOLVE);
-		(*pEvolveButton).SetPalette(pGamePalette);
+		pEvolveButton->SetPalette(pGamePalette);
 	}
 
 	/***********************************
 	* Initialize Sprite Scroll Button. *
 	***********************************/
 	pScrollSprite = new CSprite;
-	(*pScrollSprite).SharePalette(pGamePalette);
-	bAssertCheck = (*pScrollSprite).LoadSprite(pDC, SCROLL_BUTTON);
+	pScrollSprite->SharePalette(pGamePalette);
+	bAssertCheck = pScrollSprite->LoadSprite(pDC, SCROLL_BUTTON);
 	ASSERT(bAssertCheck);
-	(*pScrollSprite).SetMasked(true);
-	(*pScrollSprite).SetMobile(true);
+	pScrollSprite->SetMasked(true);
+	pScrollSprite->SetMobile(true);
 
 	/******************************
 	* Initialize Sprite Calendar  *
 	******************************/
 	pCalendarSprite = new CSprite;
-	(*pCalendarSprite).SharePalette(pGamePalette);
-	bAssertCheck = (*pCalendarSprite).LoadSprite(pDC, CALENDAR_BMP);
+	pCalendarSprite->SharePalette(pGamePalette);
+	bAssertCheck = pCalendarSprite->LoadSprite(pDC, CALENDAR_BMP);
 	ASSERT(bAssertCheck);
-	(*pCalendarSprite).SetMasked(true);
-	(*pCalendarSprite).SetMobile(false);
+	pCalendarSprite->SetMasked(true);
+	pCalendarSprite->SetMobile(false);
 
 	ReleaseDC(pDC);
 
@@ -416,13 +416,13 @@ void CMainWindow::NewGame() {
 	        row,
 	        col;
 
-	if ((*m_cLife).m_bIsEvolving == true) {      // Evolve timer on?
+	if (m_cLife->m_bIsEvolving == true) {      // Evolve timer on?
 		KillTimer(EVOLVE_TIMER_ID);             // yes - turn it off.
-		(*m_cLife).m_bIsEvolving = false;
+		m_cLife->m_bIsEvolving = false;
 	} // end if
 
 	pDC = GetDC();
-	(*m_cLife).NewGame(pDC);
+	m_cLife->NewGame(pDC);
 
 	if (bPrePlaceColonies) {                                     // want ten colonies preplaced?
 		// Randomly place 10 of their villages for them!
@@ -435,7 +435,7 @@ void CMainWindow::NewGame() {
 			col = (point.x - BOARD_START_COL) / (BOARD_SPACING_TIMES_TWO + CURLY_X);
 
 			if (!m_cLife->pColony->islife(row, col)) {                // life at this cell already?
-				(*m_cLife).change_board(
+				m_cLife->change_board(
 				    0,                                  // nFlags is not used by change_board
 				    point,
 				    pDC,
@@ -479,7 +479,7 @@ void CMainWindow::NewGame() {
  *
  ****************************************************************/
 void CMainWindow::GamePause() {
-	if ((*m_cLife).m_bIsEvolving == true) {      // Evolve timer on?
+	if (m_cLife->m_bIsEvolving == true) {      // Evolve timer on?
 		KillTimer(EVOLVE_TIMER_ID);             // yes - turn it off.
 	} // end if
 }
@@ -510,7 +510,7 @@ void CMainWindow::GamePause() {
  *
  ****************************************************************/
 void CMainWindow::GameResume() {
-	if ((*m_cLife).m_bIsEvolving == true) {
+	if (m_cLife->m_bIsEvolving == true) {
 		RefreshStats();
 		SetTimer(EVOLVE_TIMER_ID, EVOLVE_INTERVAL, nullptr);
 	}
@@ -553,7 +553,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 		GamePause();
 
 		pDC = GetDC();
-		bAssertCheck = (*pScrollSprite).EraseSprite(pDC);
+		bAssertCheck = pScrollSprite->EraseSprite(pDC);
 		ReleaseDC(pDC);
 		ASSERT(bAssertCheck);
 
@@ -601,7 +601,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 		// show the command scroll
 		pDC = GetDC();
-		bAssertCheck = (*pScrollSprite).PaintSprite(pDC, SCROLL_BUTTON_X, SCROLL_BUTTON_Y);
+		bAssertCheck = pScrollSprite->PaintSprite(pDC, SCROLL_BUTTON_X, SCROLL_BUTTON_Y);
 		ReleaseDC(pDC);
 		ASSERT(bAssertCheck);
 		GameResume();
@@ -612,23 +612,23 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 		//}
 
 	} else if (wParam == IDC_EVOLVE) {                           // Evolve button was clicked
-		if ((*m_cLife).m_bIsEvolving == true) {                  // currently evolving?
+		if (m_cLife->m_bIsEvolving == true) {                  // currently evolving?
 			if (m_lpGameStruct->bPlayingMetagame == false) {     // playing meta game?
-				(*m_cLife).m_bIsEvolving = false;               // no - can turn evolve off, then
+				m_cLife->m_bIsEvolving = false;               // no - can turn evolve off, then
 				KillTimer(EVOLVE_TIMER_ID);
 				SetDlgItemText(IDC_EVOLVE, "Evolve");            // so give them the Suspend option
 			}
 		} else {
-			(*m_cLife).m_bIsEvolving = true;                    // no - turn it on
+			m_cLife->m_bIsEvolving = true;                    // no - turn it on
 			nCountDown = nSpeed * MONTHS;
 			if (m_lpGameStruct->bPlayingMetagame == false) {     // not playing metagame
 				SetDlgItemText(IDC_EVOLVE, "Suspend");       // so give them the Suspend option
 			} else {                                            // Only works once in metagame,
-				(*pEvolveButton).EnableWindow(false);            //...so disable evolve button
+				pEvolveButton->EnableWindow(false);            //...so disable evolve button
 			}
 
 			pDC = GetDC();                                      // Update visual calendars
-			(*m_cLife).ResetMonths(pDC);
+			m_cLife->ResetMonths(pDC);
 			ReleaseDC(pDC);
 
 			RefreshStats();
@@ -757,7 +757,7 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	CDC     *pDC;
 	CRect   cTestRect;
 
-	cTestRect = (*pScrollSprite).GetRect();
+	cTestRect = pScrollSprite->GetRect();
 
 	if (cTestRect.PtInRect(point) == true) {
 		SendMessage(WM_COMMAND, IDC_COMMAND, BN_CLICKED);
@@ -768,7 +768,7 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 		NewGame();          // no - new game ok
 	} else {
 		pDC = GetDC();
-		(*m_cLife).change_board(
+		m_cLife->change_board(
 		    nFlags,
 		    point,
 		    pDC,
@@ -809,7 +809,7 @@ void CMainWindow::OnLButtonDblClk(unsigned int nFlags, CPoint point) {
 	CRect   cTestRect;
 	CDC     *pDC;
 
-	cTestRect = (*pScrollSprite).GetRect();
+	cTestRect = pScrollSprite->GetRect();
 
 	if (cTestRect.PtInRect(point)) {
 		SendMessage(WM_COMMAND, IDC_COMMAND, BN_CLICKED);
@@ -819,7 +819,7 @@ void CMainWindow::OnLButtonDblClk(unsigned int nFlags, CPoint point) {
 		NewGame();
 	} else {
 		pDC = GetDC();
-		(*m_cLife).change_board(
+		m_cLife->change_board(
 		    nFlags,
 		    point,
 		    pDC,
@@ -865,7 +865,7 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 		if (
 		    !nLifeCounter &&
 		    bIsInfiniteLife != true &&
-		    !(*m_cLife).ColonyPlaced() &&
+		    !m_cLife->ColonyPlaced() &&
 		    m_lpGameStruct->bPlayingMetagame == false
 		) {
 			KillTimer(EVOLVE_TIMER_ID);
@@ -883,7 +883,7 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 			    "No villages left."
 			);
 
-			(*m_cLife).m_bIsEvolving = false;
+			m_cLife->m_bIsEvolving = false;
 
 			if (m_lpGameStruct->bSoundEffectsEnabled != false) {
 				sndPlaySound(nullptr, SND_SYNC);
@@ -895,7 +895,7 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 
 		// Have we evolved proper number of turns or
 		//  is evolution infinite?
-		if ((*m_cLife).m_nYears != nTurnCounter ||
+		if (m_cLife->m_nYears != nTurnCounter ||
 		        bIsInfiniteTurns) {
 			// No - evolve again
 			//  has timer run down to zero?
@@ -904,7 +904,7 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 				KillTimer(EVOLVE_TIMER_ID);
 				pDC = GetDC();
 
-				(*m_cLife).evolution(pDC);
+				m_cLife->evolution(pDC);
 
 				// Restart timer and display it
 				nCountDown = nSpeed * MONTHS;
@@ -925,14 +925,14 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 
 				// Update visual calendar
 				pDC = GetDC();
-				(*m_cLife).DisplayMonth(nCountDown, pDC);
+				m_cLife->DisplayMonth(nCountDown, pDC);
 				ReleaseDC(pDC);
 			}
 		} else {  // Yes -- shut this thing down
 			KillTimer(EVOLVE_TIMER_ID);
-			(*m_cLife).m_bIsEvolving = false;
+			m_cLife->m_bIsEvolving = false;
 			char buf[64];
-			Common::sprintf_s(buf, "Score:  %ld", (long)(*m_cLife).m_dScore);
+			Common::sprintf_s(buf, "Score:  %ld", (long)m_cLife->m_dScore);
 			if (m_lpGameStruct->bSoundEffectsEnabled != false)
 				sndPlaySound(WAV_GAMEOVER, SND_SYNC);   // When first starts up so
 			//  that u get to see the screen
@@ -944,7 +944,7 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 			);
 
 			if (m_lpGameStruct->bPlayingMetagame != false) {
-				m_lpGameStruct->lScore = (long)(*m_cLife).m_dScore;
+				m_lpGameStruct->lScore = (long)m_cLife->m_dScore;
 				PostMessage(WM_CLOSE, 0, 0);
 			} else {
 				PostMessage(WM_COMMAND, IDC_OPTIONS_NEWGAME, BN_CLICKED);
@@ -1094,7 +1094,7 @@ void CMainWindow::SplashScreen() {
 		rcDIB.top = rcDIB.left = 0;
 		rcDIB.right = cxDIB;
 		rcDIB.bottom = cyDIB;
-		PaintDIB((*pDC).m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
+		PaintDIB(pDC->m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
 		if (pScrollSprite != nullptr)
 			pScrollSprite->PaintSprite(pDC, SCROLL_BUTTON_X, SCROLL_BUTTON_Y);
 		if (pCalendarSprite != nullptr)
@@ -1103,10 +1103,10 @@ void CMainWindow::SplashScreen() {
 
 	pSprite = CSprite::GetSpriteChain();
 	while (pSprite) {
-		(*pSprite).ClearBackground();
-		bCheck = (*pSprite).RefreshSprite(pDC);
+		pSprite->ClearBackground();
+		bCheck = pSprite->RefreshSprite(pDC);
 		ASSERT(bCheck);
-		pSprite = (*pSprite).GetNextSprite();
+		pSprite = pSprite->GetNextSprite();
 	}
 
 	// Refresh visual calendar
@@ -1165,11 +1165,11 @@ void CMainWindow::DisplayStats() {
 	                  CURRENT_RIGHT_COL,
 	                  CURRENT_RIGHT_ROW);
 
-	if (((*m_cLife).pColonyPlaced = new CText()) != nullptr) {
+	if ((m_cLife->pColonyPlaced = new CText()) != nullptr) {
 		bAssertCheck = m_cLife->pColonyPlaced->SetupText(pDC, pGamePalette, &statsRect, JUSTIFY_LEFT);
 		ASSERT(bAssertCheck);   // initialize the text objext
 
-		Common::sprintf_s(buf, "Current Villages: %d", (*m_cLife).ColonyPlaced());
+		Common::sprintf_s(buf, "Current Villages: %d", m_cLife->ColonyPlaced());
 		bAssertCheck = m_cLife->pColonyPlaced->DisplayString(pDC, buf, STATS_FONT_SIZE, FW_BOLD, STATS_COLOR);
 		ASSERT(bAssertCheck);   // paint the text
 	}
@@ -1180,11 +1180,11 @@ void CMainWindow::DisplayStats() {
 	                  SCORE_RIGHT_COL,
 	                  SCORE_RIGHT_ROW);
 
-	if (((*m_cLife).pScore = new CText()) != nullptr) {
+	if ((m_cLife->pScore = new CText()) != nullptr) {
 		bAssertCheck = m_cLife->pScore->SetupText(pDC, pGamePalette, &statsRect, JUSTIFY_LEFT);
 		ASSERT(bAssertCheck);   // initialize the text objext
 
-		Common::sprintf_s(buf, "Score: %.1f", (*m_cLife).m_dScore);
+		Common::sprintf_s(buf, "Score: %.1f", m_cLife->m_dScore);
 		bAssertCheck = m_cLife->pScore->DisplayString(pDC, buf, STATS_FONT_SIZE, FW_BOLD, STATS_COLOR);
 		ASSERT(bAssertCheck);   // paint the text
 	}
@@ -1195,11 +1195,11 @@ void CMainWindow::DisplayStats() {
 	                  ROUND_RIGHT_COL,
 	                  ROUND_RIGHT_ROW);
 
-	if (((*m_cLife).pYears = new CText()) != nullptr) {
+	if ((m_cLife->pYears = new CText()) != nullptr) {
 		bAssertCheck = m_cLife->pYears->SetupText(pDC, pGamePalette, &statsRect);
 		ASSERT(bAssertCheck);   // initialize the text objext
 
-		Common::sprintf_s(buf, "%d", (*m_cLife).m_nYears);
+		Common::sprintf_s(buf, "%d", m_cLife->m_nYears);
 		bAssertCheck = m_cLife->pYears->DisplayString(pDC, buf, STATS_FONT_SIZE, FW_BOLD, STATS_COLOR);
 		ASSERT(bAssertCheck);   // paint the text
 	}
@@ -1209,7 +1209,7 @@ void CMainWindow::DisplayStats() {
 	                  ROUND_TEXT1_RIGHT_COL,
 	                  ROUND_TEXT1_RIGHT_ROW);
 
-	if (((*m_cLife).pYearsText1 = new CText()) != nullptr) {
+	if ((m_cLife->pYearsText1 = new CText()) != nullptr) {
 		bAssertCheck = m_cLife->pYearsText1->SetupText(pDC, pGamePalette, &statsRect);
 		ASSERT(bAssertCheck);   // initialize the text objext
 
@@ -1223,7 +1223,7 @@ void CMainWindow::DisplayStats() {
 	                  ROUND_TEXT2_RIGHT_COL,
 	                  ROUND_TEXT2_RIGHT_ROW);
 
-	if (((*m_cLife).pYearsText2 = new CText()) != nullptr) {
+	if ((m_cLife->pYearsText2 = new CText()) != nullptr) {
 		bAssertCheck = m_cLife->pYearsText2->SetupText(pDC, pGamePalette, &statsRect);
 		ASSERT(bAssertCheck);   // initialize the text objext
 
@@ -1238,7 +1238,7 @@ void CMainWindow::DisplayStats() {
 	                  VILLAGE_RIGHT_COL,
 	                  VILLAGE_RIGHT_ROW);
 
-	if (((*m_cLife).pColonyStat = new CText()) != nullptr) {
+	if ((m_cLife->pColonyStat = new CText()) != nullptr) {
 		bAssertCheck = m_cLife->pColonyStat->SetupText(pDC, pGamePalette, &statsRect);
 		ASSERT(bAssertCheck);   // initialize the text objext
 
@@ -1252,7 +1252,7 @@ void CMainWindow::DisplayStats() {
 	                  VILLAGE_TEXT1_RIGHT_COL,
 	                  VILLAGE_TEXT1_RIGHT_ROW);
 
-	if (((*m_cLife).pColonyStatText1 = new CText()) != nullptr) {
+	if ((m_cLife->pColonyStatText1 = new CText()) != nullptr) {
 		bAssertCheck = m_cLife->pColonyStatText1->SetupText(pDC, pGamePalette, &statsRect);
 		ASSERT(bAssertCheck);   // initialize the text objext
 
@@ -1262,7 +1262,7 @@ void CMainWindow::DisplayStats() {
 	}
 
 	// Update visual calendar
-	(*m_cLife).DisplayMonth(nCountDown, pDC);
+	m_cLife->DisplayMonth(nCountDown, pDC);
 
 	ReleaseDC(pDC);
 }
@@ -1301,18 +1301,18 @@ void CMainWindow::RefreshStats() {
 	pDC = GetDC();
 
 	// Colony placed count box
-	Common::sprintf_s(buf, "Current Villages: %d", (*m_cLife).ColonyPlaced());
+	Common::sprintf_s(buf, "Current Villages: %d", m_cLife->ColonyPlaced());
 	bAssertCheck = m_cLife->pColonyPlaced->DisplayString(pDC, buf, STATS_FONT_SIZE, FW_BOLD, STATS_COLOR);
 	ASSERT(bAssertCheck);   // paint the text
 
 	// Score box
-	Common::sprintf_s(buf, "Score: %.1f", (*m_cLife).m_dScore);
+	Common::sprintf_s(buf, "Score: %.1f", m_cLife->m_dScore);
 	bAssertCheck = m_cLife->pScore->DisplayString(pDC, buf, STATS_FONT_SIZE, FW_BOLD, STATS_COLOR);
 	ASSERT(bAssertCheck);   // paint the text
 
 	// Round box
 	if (bIsInfiniteTurns != true) {
-		Common::sprintf_s(buf, "%d", (*m_cLife).m_nYears);
+		Common::sprintf_s(buf, "%d", m_cLife->m_nYears);
 
 		bAssertCheck = m_cLife->pYears->DisplayString(pDC, buf, STATS_FONT_SIZE, FW_BOLD, STATS_COLOR);
 		ASSERT(bAssertCheck);   // paint the text
@@ -1360,7 +1360,7 @@ void CMainWindow::RefreshStats() {
 
 
 	// Update visual calendar
-	(*m_cLife).DisplayMonth(nCountDown, pDC);
+	m_cLife->DisplayMonth(nCountDown, pDC);
 
 	ReleaseDC(pDC);
 }

--- a/engines/bagel/hodjnpodj/life/life.cpp
+++ b/engines/bagel/hodjnpodj/life/life.cpp
@@ -102,13 +102,13 @@ CLife::CLife(CDC *pDC) {
 
 	for (i = 0 ; i < VILLAGES ; i++) {
 		pBaseSprite[i] = new CSprite();
-		(*pBaseSprite[i]).SharePalette(pGamePalette);
-		bCheck = (*pBaseSprite[i]).LoadSprite(pDC, curly[i]);
+		pBaseSprite[i]->SharePalette(pGamePalette);
+		bCheck = pBaseSprite[i]->LoadSprite(pDC, curly[i]);
 		ASSERT(bCheck);
 
-		(*pBaseSprite[i]).SetMobile(true);
-		(*pBaseSprite[i]).SetMasked(true);
-		(*pBaseSprite[i]).SetOptimizeSpeed(true);
+		pBaseSprite[i]->SetMobile(true);
+		pBaseSprite[i]->SetMasked(true);
+		pBaseSprite[i]->SetOptimizeSpeed(true);
 	}
 
 	for (i = 0 ; i < MONTHS ; i++) {
@@ -223,7 +223,7 @@ void CLife::change_board(unsigned int nFlags, CPoint point, CDC *pDC, bool bPlay
 	row = (point.y - BOARD_START_ROW) / (BOARD_SPACING_TIMES_TWO + CURLY_Y);
 	col = (point.x - BOARD_START_COL) / (BOARD_SPACING_TIMES_TWO + CURLY_X);
 
-	if (!(*pColony).islife(row, col)) { //life at this cell now?
+	if (!pColony->islife(row, col)) { //life at this cell now?
 		// No - so do we have colonies left to place?
 		if (!nLifeCounter && !bIsInfiniteLife) {
 			// No - so indicate this to user
@@ -241,7 +241,7 @@ void CLife::change_board(unsigned int nFlags, CPoint point, CDC *pDC, bool bPlay
 	} // end if
 
 	// flip it on/off
-	(*pColony).flip(row, col);
+	pColony->flip(row, col);
 
 	// Update colony placed count on the board
 	gMainWnd->RefreshStats();
@@ -252,7 +252,7 @@ void CLife::change_board(unsigned int nFlags, CPoint point, CDC *pDC, bool bPlay
 
 	pSprite = CSprite::GetSpriteChain();
 	// User want to turn life off?
-	if ((*pColony).islife(row, col)) {
+	if (pColony->islife(row, col)) {
 		if (bIsInfiniteLife != true) {
 			//decrement colony counter if not infinite
 			nLifeCounter--;
@@ -261,12 +261,12 @@ void CLife::change_board(unsigned int nFlags, CPoint point, CDC *pDC, bool bPlay
 			ASSERT(bAssertCheck);   // paint the text
 		}
 		i = brand() % VILLAGES;
-		pSprite = (*pBaseSprite[i]).DuplicateSprite(pDC);
-		mySize = (*pSprite).GetSize();
-		(*pSprite).LinkSprite();
+		pSprite = pBaseSprite[i]->DuplicateSprite(pDC);
+		mySize = pSprite->GetSize();
+		pSprite->LinkSprite();
 
 		// paint the sprite in its new location
-		(*pSprite).PaintSprite(pDC,
+		pSprite->PaintSprite(pDC,
 		                       sprite_loc.x,  // finding center of cell
 		                       sprite_loc.y);
 
@@ -284,8 +284,8 @@ void CLife::change_board(unsigned int nFlags, CPoint point, CDC *pDC, bool bPlay
 
 		pSprite = CSprite::Touched(sprite_loc);
 		if (pSprite != nullptr) { // See if the point is in the sprite's rectangle
-			(*pSprite).RefreshBackground(pDC);      // ... simply repaint background
-			(*pSprite).UnlinkSprite(); // ... and if so, unlink it from chain
+			pSprite->RefreshBackground(pDC);      // ... simply repaint background
+			pSprite->UnlinkSprite(); // ... and if so, unlink it from chain
 			delete pSprite;
 		}
 	}
@@ -323,21 +323,21 @@ void CLife::evolution(CDC *pDC) {
 	CPoint sprite_loc;                  // center location of sprite on board
 	int i;                              // used to gen random village
 	int row, col;                           // indexs help find board cell
-	colony colonyCopy((*pColony).row(), (*pColony).col());
+	colony colonyCopy(pColony->row(), pColony->col());
 
 	// make copy of original pColony for later ref
 	colonyCopy = (*pColony);
 	// Update stats
 	if (m_nYears == 0) //just starting evolution?
-		m_nCumLife = (*pColony).m_nColony_count;
+		m_nCumLife = pColony->m_nColony_count;
 	else
-		m_nCumLife += (*pColony).m_nColony_count;
+		m_nCumLife += pColony->m_nColony_count;
 
 	m_nYears++;
 	m_dScore = ((double) m_nCumLife) / ((double) m_nYears);
 
 	//Evolve internal board
-	(*pColony).evolve(colonyCopy);
+	pColony->evolve(colonyCopy);
 
 	// update score
 	if (m_nCumLife > LARGE && bIsInfiniteTurns) { // This prevents int overflow
@@ -351,28 +351,28 @@ void CLife::evolution(CDC *pDC) {
 
 	//Update visual board
 	if (colonyCopy != (*pColony))
-		for (row = 0; row < (*pColony).row(); row++)
-			for (col = 0; col < (*pColony).col(); col++) {
+		for (row = 0; row < pColony->row(); row++)
+			for (col = 0; col < pColony->col(); col++) {
 				pSprite = CSprite::GetSpriteChain();
 
 				// Any change for this particular cell?
-				if (colonyCopy.islife(row, col) == (*pColony).islife(row, col))
+				if (colonyCopy.islife(row, col) == pColony->islife(row, col))
 					continue;  // no change -- loop
 
-				if ((*pColony).islife(row, col)) { //Need to put a sprite there?
+				if (pColony->islife(row, col)) { //Need to put a sprite there?
 					// Yes, paint new sprite in cell
 					i = brand() % VILLAGES;
-					pSprite = (*pBaseSprite[i]).DuplicateSprite(pDC);
-					mySize = (*pSprite).GetSize();
+					pSprite = pBaseSprite[i]->DuplicateSprite(pDC);
+					mySize = pSprite->GetSize();
 					//set it up to be centered
 
 					sprite_loc.y = BOARD_START_ROW + (CURLY_Y + BOARD_SPACING_TIMES_TWO) * row;
 					sprite_loc.x = BOARD_START_COL + (CURLY_X + BOARD_SPACING_TIMES_TWO) * col;
 
-					(*pSprite).LinkSprite();
+					pSprite->LinkSprite();
 
 					// paint the sprite in its new location
-					(*pSprite).PaintSprite(pDC,
+					pSprite->PaintSprite(pDC,
 					                       sprite_loc.x,  // finding center of cell
 					                       sprite_loc.y);
 				} else {
@@ -383,8 +383,8 @@ void CLife::evolution(CDC *pDC) {
 
 					pSprite = CSprite::Touched(sprite_loc);
 					if (pSprite != nullptr) { // See if the point is in the sprite's rectangle
-						(*pSprite).RefreshBackground(pDC);      // ... simply repaint background
-						(*pSprite).UnlinkSprite(); // ... and if so, unlink it from chain
+						pSprite->RefreshBackground(pDC);      // ... simply repaint background
+						pSprite->UnlinkSprite(); // ... and if so, unlink it from chain
 						delete pSprite;
 					}
 				}
@@ -417,7 +417,7 @@ void CLife::evolution(CDC *pDC) {
  *
  ****************************************************************/
 void CLife::NewGame(CDC *pDC) {
-	colony  pColonyCopy((*pColony).row(), (*pColony).col());
+	colony  pColonyCopy(pColony->row(), pColony->col());
 
 	// Reset internal grid
 	(*pColony)      = pColonyCopy;

--- a/engines/bagel/hodjnpodj/life/life.h
+++ b/engines/bagel/hodjnpodj/life/life.h
@@ -62,7 +62,7 @@ public:
 	void    DisplayMonth(int nMonth, CDC *pDC);
 	void    ResetMonths(CDC *pDC);
 	int     ColonyPlaced() {
-		return (*pColony).m_nColony_count;
+		return pColony->m_nColony_count;
 	}
 
 public:

--- a/engines/bagel/hodjnpodj/life/usercfg.cpp
+++ b/engines/bagel/hodjnpodj/life/usercfg.cpp
@@ -136,7 +136,7 @@ bool CUserCfgDlg::OnInitDialog() {
 	);
 
 	if ((m_pVillages = new CText) != nullptr) {
-		bAssertCheck = (*m_pVillages).SetupText(pDC, pGamePalette, &statsRect, JUSTIFY_LEFT);
+		bAssertCheck = m_pVillages->SetupText(pDC, pGamePalette, &statsRect, JUSTIFY_LEFT);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	} // end if
 
@@ -154,7 +154,7 @@ bool CUserCfgDlg::OnInitDialog() {
 	);
 
 	if ((m_pSpeed = new CText) != nullptr) {
-		bAssertCheck = (*m_pSpeed).SetupText(pDC, pGamePalette, &statsRect, JUSTIFY_LEFT);
+		bAssertCheck = m_pSpeed->SetupText(pDC, pGamePalette, &statsRect, JUSTIFY_LEFT);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	} // end if
 
@@ -172,7 +172,7 @@ bool CUserCfgDlg::OnInitDialog() {
 	);
 
 	if ((m_pRounds = new CText) != nullptr) {
-		bAssertCheck = (*m_pRounds).SetupText(pDC, pGamePalette, &statsRect, JUSTIFY_LEFT);
+		bAssertCheck = m_pRounds->SetupText(pDC, pGamePalette, &statsRect, JUSTIFY_LEFT);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	} // end if
 
@@ -186,19 +186,19 @@ bool CUserCfgDlg::OnInitDialog() {
 	* Set up color buttons. *
 	************************/
 	if ((m_pPrePlaceButton = new CCheckButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*m_pPrePlaceButton).SetPalette(pGamePalette);                      // set the palette to use
-		(*m_pPrePlaceButton).SetControl(IDC_PREPLACE, this);            // tie to the dialog control
+		m_pPrePlaceButton->SetPalette(pGamePalette);                      // set the palette to use
+		m_pPrePlaceButton->SetControl(IDC_PREPLACE, this);            // tie to the dialog control
 	}
 	((CWnd *)this)->CheckDlgButton(IDC_PREPLACE, bPrePlaceColonies);             // Set the frame option box
 
 	if ((m_pOKButton = new CColorButton) != nullptr) {     // build a color OK button
-		(*m_pOKButton).SetPalette(pGamePalette);        // set the palette to use
-		(*m_pOKButton).SetControl(IDOK, this);          // tie to the dialog control
+		m_pOKButton->SetPalette(pGamePalette);        // set the palette to use
+		m_pOKButton->SetControl(IDOK, this);          // tie to the dialog control
 	} // end if
 
 	if ((m_pCancelButton = new CColorButton) != nullptr) { // build a color CANCEL button
-		(*m_pCancelButton).SetPalette(pGamePalette);
-		(*m_pCancelButton).SetControl(IDCANCEL, this);
+		m_pCancelButton->SetPalette(pGamePalette);
+		m_pCancelButton->SetControl(IDCANCEL, this);
 	} // end if
 
 	return true;  // return true  unless you set the focus to a control
@@ -248,7 +248,7 @@ void CUserCfgDlg::OnHScroll(unsigned int nSBCode, unsigned int nPos, CScrollBar*
 		if (nSpeedTemp != nOldSpeed) {                       //To prevent "flicker"
 			Common::sprintf_s(msg, "Speed: %s", mSpeedTable[nSpeedTemp].c_str());   //  only redraw if
 			//  m_nSpeedTemp has changed
-			bAssertCheck = (*m_pSpeed).DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
+			bAssertCheck = m_pSpeed->DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
 			ASSERT(bAssertCheck);
 
 			pScrollBar->SetScrollPos(nSpeedTemp, true);
@@ -293,7 +293,7 @@ void CUserCfgDlg::OnHScroll(unsigned int nSBCode, unsigned int nPos, CScrollBar*
 			else
 				Common::sprintf_s(msg, "Villages: %d", m_nLife[nLifeTemp]);
 
-			bAssertCheck = (*m_pVillages).DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
+			bAssertCheck = m_pVillages->DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
 			ASSERT(bAssertCheck);   // paint the text
 
 			pScrollBar->SetScrollPos(nLifeTemp, true);
@@ -338,7 +338,7 @@ void CUserCfgDlg::OnHScroll(unsigned int nSBCode, unsigned int nPos, CScrollBar*
 			else
 				Common::sprintf_s(msg, "Years: %d", m_nTurns[nTurnCounterTemp]);
 
-			bAssertCheck = (*m_pRounds).DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
+			bAssertCheck = m_pRounds->DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
 			ASSERT(bAssertCheck);   // paint the text
 
 			pScrollBar->SetScrollPos(nTurnCounterTemp, true);
@@ -432,14 +432,14 @@ void CUserCfgDlg::OnPaint() {
 	else
 		Common::sprintf_s(msg, "Villages: %d", m_nLife[nLifeTemp]);
 
-	bAssertCheck = (*m_pVillages).DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
+	bAssertCheck = m_pVillages->DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
 	ASSERT(bAssertCheck);
 
 
 	// Display Speed stats
 	Common::sprintf_s(msg, "Speed: %s", mSpeedTable[nSpeedTemp].c_str());
 
-	bAssertCheck = (*m_pSpeed).DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
+	bAssertCheck = m_pSpeed->DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
 	ASSERT(bAssertCheck);   // paint the text
 
 	// set up the rounds stat display box
@@ -448,7 +448,7 @@ void CUserCfgDlg::OnPaint() {
 	else
 		Common::sprintf_s(msg, "Years: %d", m_nTurns[nTurnCounterTemp]);
 
-	bAssertCheck = (*m_pRounds).DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
+	bAssertCheck = m_pRounds->DisplayString(pDC, msg, FONT_SIZE, FW_BOLD, OPTIONS_COLOR);
 	ASSERT(bAssertCheck);   // paint the text
 
 	ReleaseDC(pDC);

--- a/engines/bagel/hodjnpodj/mankala/mnk.cpp
+++ b/engines/bagel/hodjnpodj/mankala/mnk.cpp
@@ -156,7 +156,7 @@ CMnkWindow::CMnkWindow() {
 		return;
 	}      // ... and verify we got it
 
-	if (!(*xpDibDoc).OpenDocument("art\\MANKALA.BMP")) {
+	if (!xpDibDoc->OpenDocument("art\\MANKALA.BMP")) {
 		MFC::SetCursor(hOldCursor);
 		MFC::MessageBox(nullptr, "Cannot Open Background Bitmap. Please Check for file path and/or system resources. Terminating Game", "Open Error", MB_ICONEXCLAMATION | MB_OK) ;
 		delete xpDibDoc;
@@ -165,7 +165,7 @@ CMnkWindow::CMnkWindow() {
 	}
 
 	// next load in the actual DIB based artwork for screen
-	if (!(CMnkWindow::m_xpGamePalette = (*xpDibDoc).DetachPalette())) {
+	if (!(CMnkWindow::m_xpGamePalette = xpDibDoc->DetachPalette())) {
 		// grab its palette and save it for later use
 		MFC::SetCursor(hOldCursor);
 		MFC::MessageBox(nullptr, "Cannot acquire a non nullptr Palette. Game Terminated", "Palette Error", MB_OK | MB_ICONEXCLAMATION);
@@ -363,7 +363,7 @@ bool CMnkWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 		case IDC_SCROLL:
 			if (!m_bInMenu) {
 				OptionsDialog() ;     //bring up main menu.
-				(*this).SetFocus() ; // Reset focus back to the main window
+				(this)->SetFocus() ; // Reset focus back to the main window
 			}                           //end if !m_bInMenu
 			break ;                // ... to force a repaint
 		default :

--- a/engines/bagel/hodjnpodj/mankala/mnkopt.cpp
+++ b/engines/bagel/hodjnpodj/mankala/mnkopt.cpp
@@ -158,12 +158,12 @@ bool CMnkUsr::OnInitDialog() {
 	mLevelTable[4] =  "Invincible";         /*nish added 08/04/94*/
 	statRect.SetRect(LEFT_SIDE, 25, LEFT_SIDE + 100, 40);
 	if ((m_pShellText = new CText()) != nullptr) {
-		(*m_pShellText).SetupText(pDC, m_xpGamePalette, &statRect, JUSTIFY_LEFT);
+		m_pShellText->SetupText(pDC, m_xpGamePalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	statRect.SetRect(LEFT_SIDE, 65, LEFT_SIDE + 185, 80);
 	if ((m_pStrengthText = new CText()) != nullptr) {
-		(*m_pStrengthText).SetupText(pDC, m_xpGamePalette, &statRect, JUSTIFY_LEFT);
+		m_pStrengthText->SetupText(pDC, m_xpGamePalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	m_xpUScrShell = (CScrollBar *)GetDlgItem(IDC_USCRSHELL) ;
@@ -175,13 +175,13 @@ bool CMnkUsr::OnInitDialog() {
 	m_xpUScrStrength->SetScrollPos(m_iUStrength) ;
 
 	if ((pOKButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pOKButton).SetPalette(m_pPalette);                        // set the palette to use
-		(*pOKButton).SetControl(IDOK, this);            // tie to the dialog control
+		pOKButton->SetPalette(m_pPalette);                        // set the palette to use
+		pOKButton->SetControl(IDOK, this);            // tie to the dialog control
 	}
 
 	if ((pCancelButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pCancelButton).SetPalette(m_pPalette);                        // set the palette to use
-		(*pCancelButton).SetControl(IDCANCEL, this);            // tie to the dialog control
+		pCancelButton->SetPalette(m_pPalette);                        // set the palette to use
+		pCancelButton->SetControl(IDCANCEL, this);            // tie to the dialog control
 	}
 
 
@@ -327,14 +327,14 @@ void CMnkUsr::UpdateScrollbars() {
 	m_iUShells = m_xpUScrShell->GetScrollPos();
 	if (OldValue != m_iUShells) {
 		Common::sprintf_s(msg, "Shells per Pit: %d", m_iUShells);
-		(*m_pShellText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+		m_pShellText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 	}
 
 	OldValue = m_iUStrength;
 	m_iUStrength = m_xpUScrStrength->GetScrollPos();
 	if (OldValue != m_iUStrength) {
 		Common::sprintf_s(msg, "Crab's Ability: %s", mLevelTable[m_iUStrength - 1].c_str());
-		(*m_pStrengthText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+		m_pStrengthText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 	}
 
 	ReleaseDC(pDC);
@@ -351,10 +351,10 @@ void CMnkUsr::OnPaint() {
 	pDC = GetDC();
 
 	Common::sprintf_s(msg, "Shells per Pit: %d", m_iUShells);
-	(*m_pShellText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+	m_pShellText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 
 	Common::sprintf_s(msg, "Crab's Ability: %s", mLevelTable[m_iUStrength - 1].c_str());
-	(*m_pStrengthText).DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
+	m_pStrengthText->DisplayString(pDC, msg, 14, FW_BOLD, OPTIONS_COLOR);
 
 	ReleaseDC(pDC);
 

--- a/engines/bagel/hodjnpodj/mankala/mnkui.cpp
+++ b/engines/bagel/hodjnpodj/mankala/mnkui.cpp
@@ -928,7 +928,7 @@ bool CMnkWindow::FreePitResources(bool bDelete)
 		{
 			m_xpFreeStoneChain = xpcNextStone->m_xpcNext ;
 			// unlink it from stone sprite chain
-			(*(CSprite *)xpcNextStone).UnlinkSprite();                          // ... unlinking it
+			((CSprite *)xpcNextStone)->UnlinkSprite();                          // ... unlinking it
 			// unlink it from sprite chain
 			delete xpcNextStone ;       // delete stone sprite
 		}

--- a/engines/bagel/hodjnpodj/mazedoom/mod.cpp
+++ b/engines/bagel/hodjnpodj/mazedoom/mod.cpp
@@ -185,8 +185,8 @@ CMainWindow::CMainWindow() {
 	CDibDoc *pSourceDoc;                // Get the game palette
 	pSourceDoc = new CDibDoc();
 	ASSERT(pSourceDoc != nullptr);
-	(*pSourceDoc).OpenDocument(MAINSCREEN);
-	pGamePalette = (*pSourceDoc).DetachPalette();       // Acquire the shared palette for our game from the art
+	pSourceDoc->OpenDocument(MAINSCREEN);
+	pGamePalette = pSourceDoc->DetachPalette();       // Acquire the shared palette for our game from the art
 	delete pSourceDoc;
 
 	pDC->SelectPalette(pGamePalette, false);            // select the game palette
@@ -201,9 +201,9 @@ CMainWindow::CMainWindow() {
 	tmpRect.SetRect(SCROLL_BUTTON_X, SCROLL_BUTTON_Y,
 	                SCROLL_BUTTON_X + SCROLL_BUTTON_DX - 1,
 	                SCROLL_BUTTON_Y + SCROLL_BUTTON_DY - 1);
-	_success = (*m_pScrollButton).Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, tmpRect, this, IDC_SCROLL);
+	_success = m_pScrollButton->Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, tmpRect, this, IDC_SCROLL);
 	ASSERT(_success);
-	_success = (*m_pScrollButton).LoadBitmaps(SCROLLUP, SCROLLDOWN, 0, 0);
+	_success = m_pScrollButton->LoadBitmaps(SCROLLUP, SCROLLDOWN, 0, 0);
 	ASSERT(_success);
 	m_bIgnoreScrollClick = false;
 
@@ -245,11 +245,11 @@ CMainWindow::CMainWindow() {
 	}
 
 	_playerSprite = new CSprite;
-	(*_playerSprite).SharePalette(pGamePalette);
-	_success = (*_playerSprite).LoadResourceCels(pDC, IDB_HODJ_LEFT + m_nPlayerID, NUM_CELS);
+	_playerSprite->SharePalette(pGamePalette);
+	_success = _playerSprite->LoadResourceCels(pDC, IDB_HODJ_LEFT + m_nPlayerID, NUM_CELS);
 	ASSERT(_success);
-	(*_playerSprite).SetMasked(true);
-	(*_playerSprite).SetMobile(true);
+	_playerSprite->SetMasked(true);
+	_playerSprite->SetMobile(true);
 
 	_localeBitmap = FetchResourceBitmap(pDC, nullptr, "IDB_LOCALE_BMP");
 	ASSERT(_localeBitmap != nullptr);
@@ -259,7 +259,7 @@ CMainWindow::CMainWindow() {
 	tmpRect.SetRect(TIME_LOCATION_X, TIME_LOCATION_Y,
 	                TIME_LOCATION_X + TIME_WIDTH, TIME_LOCATION_Y + TIME_HEIGHT);
 	if ((m_pTimeText = new CText()) != nullptr) {
-		(*m_pTimeText).SetupText(pDC, pGamePalette, &tmpRect, JUSTIFY_CENTER);
+		m_pTimeText->SetupText(pDC, pGamePalette, &tmpRect, JUSTIFY_CENTER);
 	}
 
 	ReleaseDC(pDC);
@@ -297,7 +297,7 @@ CMainWindow::CMainWindow() {
 	if (pGameInfo->bMusicEnabled) {
 		_gameSound = new CSound(this, GAME_THEME, SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 		if (_gameSound != nullptr) {
-			(*_gameSound).midiLoopPlaySegment(3000, 32980, 0, FMT_MILLISEC);
+			_gameSound->midiLoopPlaySegment(3000, 32980, 0, FMT_MILLISEC);
 		} // end if pGameSound
 	}
 
@@ -338,7 +338,7 @@ void CMainWindow::SplashScreen() {
 	pDC = GetDC();
 
 	myDoc.OpenDocument(MAINSCREEN);
-	pPalOld = (*pDC).SelectPalette(pGamePalette, false);                            // Select Game Palette
+	pPalOld = pDC->SelectPalette(pGamePalette, false);                            // Select Game Palette
 	pDC->RealizePalette();                              // Realize the palette to prevent palette shifting
 
 	hDIB = myDoc.GetHDIB();
@@ -352,10 +352,10 @@ void CMainWindow::SplashScreen() {
 		rcDIB.top = rcDIB.left = 0;
 		rcDIB.right = cxDIB;
 		rcDIB.bottom = cyDIB;
-		PaintDIB((*pDC).m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
+		PaintDIB(pDC->m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
 		pDC->BitBlt(SIDE_BORDER, TOP_BORDER, ART_WIDTH, ART_HEIGHT, pMazeDC, 0, SQ_SIZE_Y / 2, SRCCOPY);    // Draw Maze
 		if ((_playerSprite != nullptr) && _playing)
-			(*_playerSprite).PaintSprite(pDC, (_playerPos.x * SQ_SIZE_X) + SIDE_BORDER,
+			_playerSprite->PaintSprite(pDC, (_playerPos.x * SQ_SIZE_X) + SIDE_BORDER,
 			                             (_playerPos.y * SQ_SIZE_Y) + TOP_BORDER - SQ_SIZE_Y / 2); // Update PLAYER
 	}
 
@@ -366,13 +366,13 @@ void CMainWindow::SplashScreen() {
 		else {
 			Common::sprintf_s(msg, "Time Left: %02d:%02d", _minutes, _seconds);
 		}
-		(*m_pTimeText).DisplayString(pDC, msg, 16, FW_SEMIBOLD, OPTIONS_COLOR);
+		m_pTimeText->DisplayString(pDC, msg, 16, FW_SEMIBOLD, OPTIONS_COLOR);
 	} else {
 		if (_localeBitmap != nullptr)
 			PaintBitmap(pDC, pGamePalette, _localeBitmap, TIME_LOCATION_X, TIME_LOCATION_Y);
 	}
 
-	(*pDC).SelectPalette(pPalOld, false);                                           // Select back old palette
+	pDC->SelectPalette(pPalOld, false);                                           // Select back old palette
 	ReleaseDC(pDC);
 }
 
@@ -409,11 +409,11 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 			KillTimer(GAME_TIMER);
 			CSound::waitWaveSounds();
 			m_bIgnoreScrollClick = true;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 
 			RulesDlg.DoModal();
 			m_bIgnoreScrollClick = false;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 			if (!_gameOver)
 				SetTimer(GAME_TIMER, CLICK_TIME, nullptr);                     // Reset ticker
 			break;
@@ -421,12 +421,12 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 		case IDC_SCROLL:
 			KillTimer(GAME_TIMER);
 			if (m_bIgnoreScrollClick) {
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 				break;
 			}
 
 			m_bIgnoreScrollClick = true;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 			SendDlgItemMessage(IDC_SCROLL, BM_SETSTATE, true, 0L);
 
 			CSound::waitWaveSounds();
@@ -434,14 +434,14 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 			switch (COptionsWind.DoModal()) {
 
 			case IDC_OPTIONS_NEWGAME:                           // Selected New Game
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				m_bIgnoreScrollClick = false;
 				if (!pGameInfo->bPlayingMetagame)
 					NewGame();
 				break;
 
 			case IDC_OPTIONS_RETURN:
-				(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				m_bIgnoreScrollClick = false;
 				if (!_gameOver)
 					SetTimer(GAME_TIMER, CLICK_TIME, nullptr);     // Reset ticker
@@ -471,13 +471,13 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 			}
 
 			m_bIgnoreScrollClick = false;
-			(*m_pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+			m_pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 			break;
 		} //end switch(wParam)
 		ReleaseDC(pDC);
 	} // end if
 
-	(*this).SetFocus();                     // Reset focus back to the main window
+	(this)->SetFocus();                     // Reset focus back to the main window
 	return true;
 }
 
@@ -660,7 +660,7 @@ void CMainWindow::OnSysKeyDown(unsigned int nChar, unsigned int nRepCnt, unsigne
 
 void CMainWindow::OnKeyDown(unsigned int nChar, unsigned int nRepCnt, unsigned int nFlags) {
 	CPoint  NewPosition;
-	NewPosition = (*_playerSprite).GetPosition();
+	NewPosition = _playerSprite->GetPosition();
 
 	switch (nChar) {
 	case VK_F1:                                             // F1 key is hit
@@ -762,7 +762,7 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 		else {
 			Common::sprintf_s(msg, "Time Left: %02d:%02d", _minutes, _seconds);
 		}
-		(*m_pTimeText).DisplayString(pDC, msg, 16, FW_SEMIBOLD, OPTIONS_COLOR);
+		m_pTimeText->DisplayString(pDC, msg, 16, FW_SEMIBOLD, OPTIONS_COLOR);
 
 		if (_minutes == 0 && _seconds == 0) {           // No time left on the clock!!
 			KillTimer(nIDEvent);                        // Stop the Display timer
@@ -771,7 +771,7 @@ void CMainWindow::OnTimer(uintptr nIDEvent) {
 			if (pGameInfo->bSoundEffectsEnabled) {
 				pEffect = new CSound((CWnd *)this, LOSE_SOUND,
 				                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-				(*pEffect).play();                                                      //...play the narration
+				pEffect->play();                                                      //...play the narration
 			}
 			MSG lpmsg;
 			while (PeekMessage(&lpmsg, m_hWnd, WM_MOUSEFIRST, WM_MOUSELAST, PM_REMOVE)) ;
@@ -834,7 +834,7 @@ void CMainWindow::NewGame() {
 	_difficulty = tempDifficulty;                 //...new Difficulty
 
 	if (_playerSprite != nullptr)                      // Refresh PLAYER
-		(*_playerSprite).EraseSprite(pDC);          // Erase PlayerSprite
+		_playerSprite->EraseSprite(pDC);          // Erase PlayerSprite
 
 	if (_time != 0) {                             // If we've got a time limit
 		_minutes = _time / 60;                    //...get the minutes and seconds
@@ -850,7 +850,7 @@ void CMainWindow::NewGame() {
 	PaintMaze(pMazeDC);                             // paint that sucker to the offscreen bitmap
 	pDC->BitBlt(SIDE_BORDER, TOP_BORDER, ART_WIDTH, ART_HEIGHT, pMazeDC, 0, SQ_SIZE_Y / 2, SRCCOPY);    // Draw Maze
 	if (_playerSprite != nullptr)
-		(*_playerSprite).PaintSprite(pDC, (_playerPos.x * SQ_SIZE_X) + SIDE_BORDER,
+		_playerSprite->PaintSprite(pDC, (_playerPos.x * SQ_SIZE_X) + SIDE_BORDER,
 		                             (_playerPos.y * SQ_SIZE_Y) + TOP_BORDER - SQ_SIZE_Y / 2); // Display PLAYER
 	_playing = true;                                // Game is started
 	_gameOver = false;
@@ -861,7 +861,7 @@ void CMainWindow::NewGame() {
 	else {
 		Common::sprintf_s(msg, "Time Left: %02d:%02d", _minutes, _seconds);
 	}
-	(*m_pTimeText).DisplayString(pDC, msg, 16, FW_SEMIBOLD, OPTIONS_COLOR);
+	m_pTimeText->DisplayString(pDC, msg, 16, FW_SEMIBOLD, OPTIONS_COLOR);
 
 	SetTimer(GAME_TIMER, CLICK_TIME, nullptr);         // Reset ticker
 
@@ -942,10 +942,10 @@ void CMainWindow::MovePlayer(CPoint point) {
 	}
 
 	if ((Step.x != 0) || (Step.y != 0)) {       // If the click is not in the Player's Tile
-		_success = (*_playerSprite).LoadResourceCels(pDC, nBmpID, NUM_CELS);
+		_success = _playerSprite->LoadResourceCels(pDC, nBmpID, NUM_CELS);
 		ASSERT(_success);
 		if (_playerSprite != nullptr)                                              // Refresh PLAYER
-			(*_playerSprite).PaintSprite(pDC, (_playerPos.x * SQ_SIZE_X) + SIDE_BORDER,
+			_playerSprite->PaintSprite(pDC, (_playerPos.x * SQ_SIZE_X) + SIDE_BORDER,
 			                             (_playerPos.y * SQ_SIZE_Y) + TOP_BORDER - SQ_SIZE_Y / 2);  //...in new direction
 
 		while (!bCollision) {
@@ -963,13 +963,13 @@ void CMainWindow::MovePlayer(CPoint point) {
 					x += Step.x * i * (SQ_SIZE_X / 4);                          //...per tile moved
 					y += Step.y * i * (SQ_SIZE_Y / 4);
 					if (_playerSprite != nullptr)
-						(*_playerSprite).PaintSprite(pDC, x, y);                // Update PLAYER
+						_playerSprite->PaintSprite(pDC, x, y);                // Update PLAYER
 				} // end for
 
 				_playerPos.x = NewPosition.x;
 				_playerPos.y = NewPosition.y;
 				if (_playerSprite != nullptr)                                      // Refresh PLAYER
-					(*_playerSprite).PaintSprite(pDC, (_playerPos.x * SQ_SIZE_X) + SIDE_BORDER,
+					_playerSprite->PaintSprite(pDC, (_playerPos.x * SQ_SIZE_X) + SIDE_BORDER,
 						(_playerPos.y * SQ_SIZE_Y) + TOP_BORDER - SQ_SIZE_Y / 2);  //...in new direction
 				app->pause();
 			} // end if
@@ -980,12 +980,12 @@ void CMainWindow::MovePlayer(CPoint point) {
 				if (pGameInfo->bSoundEffectsEnabled) {
 					pEffect = new CSound((CWnd *)this, HIT_SOUND,
 					                     SOUND_WAVE | SOUND_AUTODELETE); //| SOUND_ASYNCH ...Wave file, to delete itself
-					(*pEffect).play();                                                      //...play the narration
+					pEffect->play();                                                      //...play the narration
 				}
 				_mazeTile[NewPosition.x][NewPosition.y].m_bHidden = false;
 
 				if (_playerSprite != nullptr)                                      // Refresh PLAYER
-					(*_playerSprite).EraseSprite(pDC);                          // Erase PlayerSprite
+					_playerSprite->EraseSprite(pDC);                          // Erase PlayerSprite
 				PaintBitmap(pDC, pGamePalette, _wallBitmap,                     // Paint wall on screen
 				            _mazeTile[NewPosition.x][NewPosition.y].m_nStart.x + SIDE_BORDER,
 				            _mazeTile[NewPosition.x][NewPosition.y].m_nStart.y + TOP_BORDER - SQ_SIZE_Y / 2);
@@ -995,7 +995,7 @@ void CMainWindow::MovePlayer(CPoint point) {
 				            _mazeTile[NewPosition.x][NewPosition.y].m_nStart.y);
 				AddEdges(pMazeDC, NewPosition.x, NewPosition.y, 0, 0);
 				if (_playerSprite != nullptr)                                      // Refresh PLAYER
-					(*_playerSprite).PaintSprite(pDC, (_playerPos.x * SQ_SIZE_X) + SIDE_BORDER,
+					_playerSprite->PaintSprite(pDC, (_playerPos.x * SQ_SIZE_X) + SIDE_BORDER,
 					                             (_playerPos.y * SQ_SIZE_Y) + TOP_BORDER - SQ_SIZE_Y / 2);  //...in new direction
 				bCollision = true;
 			}
@@ -1007,7 +1007,7 @@ void CMainWindow::MovePlayer(CPoint point) {
 				_playerPos.x = _mazeTile[NewPosition.x][NewPosition.y].m_nDest.x;
 				_playerPos.y = _mazeTile[NewPosition.x][NewPosition.y].m_nDest.y;
 				if (_playerSprite != nullptr)
-					(*_playerSprite).EraseSprite(pDC);                      // Erase PlayerSprite
+					_playerSprite->EraseSprite(pDC);                      // Erase PlayerSprite
 				PaintBitmap(pDC, pGamePalette,                              // Paint trap on screen
 				            _trapBitmap[_mazeTile[NewPosition.x][NewPosition.y].m_nTrap],
 				            _mazeTile[NewPosition.x][NewPosition.y].m_nStart.x + SIDE_BORDER,
@@ -1016,14 +1016,14 @@ void CMainWindow::MovePlayer(CPoint point) {
 				if (pGameInfo->bSoundEffectsEnabled) {
 					pEffect = new CSound((CWnd *)this, TRAP_SOUND,
 					                     SOUND_WAVE | SOUND_AUTODELETE); //| SOUND_ASYNCH ...Wave file, to delete itself
-					(*pEffect).play();                                                      //...play the narration
+					pEffect->play();                                                      //...play the narration
 				}
 				PaintBitmap(pMazeDC, pGamePalette,                          // Paint trap in Maze Bitmap
 				            _trapBitmap[_mazeTile[NewPosition.x][NewPosition.y].m_nTrap],
 				            _mazeTile[NewPosition.x][NewPosition.y].m_nStart.x,
 				            _mazeTile[NewPosition.x][NewPosition.y].m_nStart.y);
 				if (_playerSprite != nullptr)
-					(*_playerSprite).PaintSprite(pDC, (_playerPos.x * SQ_SIZE_X) + SIDE_BORDER,
+					_playerSprite->PaintSprite(pDC, (_playerPos.x * SQ_SIZE_X) + SIDE_BORDER,
 					                             (_playerPos.y * SQ_SIZE_Y) + TOP_BORDER - SQ_SIZE_Y / 2); // Update PLAYER
 				bCollision = true;
 			}
@@ -1041,7 +1041,7 @@ void CMainWindow::MovePlayer(CPoint point) {
 				if (pGameInfo->bSoundEffectsEnabled) {
 					pEffect = new CSound((CWnd *)this, WIN_SOUND,
 					                     SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-					(*pEffect).play();                                                      //...play the narration
+					pEffect->play();                                                      //...play the narration
 				}
 				MSG lpmsg;
 				while (PeekMessage(&lpmsg, m_hWnd, WM_MOUSEFIRST, WM_MOUSELAST, PM_REMOVE)) ;
@@ -1109,19 +1109,19 @@ void CMainWindow::GetNewCursor() {
 	Delta.y = _playerPos.y - Hit.y;
 
 	if ((_playerPos.x == Hit.x) && (_playerPos.y == Hit.y)) {     // Directly over player
-		hNewCursor = (*pMyApp).LoadCursor(IDC_MOD_NOARROW);
+		hNewCursor = pMyApp->LoadCursor(IDC_MOD_NOARROW);
 	}
 
 	else if (ABS(Delta.x) >= ABS(Delta.y)) {                        // Moving horizontally:
 		if (Delta.x <= 0)                                           // To the RIGHT
-			hNewCursor = (*pMyApp).LoadCursor(IDC_MOD_RTARROW);
+			hNewCursor = pMyApp->LoadCursor(IDC_MOD_RTARROW);
 		else if (Delta.x > 0)                                       // To the LEFT
-			hNewCursor = (*pMyApp).LoadCursor(IDC_MOD_LFARROW);
+			hNewCursor = pMyApp->LoadCursor(IDC_MOD_LFARROW);
 	} else if (ABS(Delta.y) > ABS(Delta.x)) {
 		if (Delta.y >= 0)                                           // Going UPward
-			hNewCursor = (*pMyApp).LoadCursor(IDC_MOD_UPARROW);
+			hNewCursor = pMyApp->LoadCursor(IDC_MOD_UPARROW);
 		else if (Delta.y < 0)                                       // Going DOWNward
-			hNewCursor = (*pMyApp).LoadCursor(IDC_MOD_DNARROW);
+			hNewCursor = pMyApp->LoadCursor(IDC_MOD_DNARROW);
 	}
 
 //    if (hNewCursor != nullptr);
@@ -1805,7 +1805,7 @@ void CMainWindow::OnClose() {
 	pDC = GetDC();
 	myRect.SetRect(0, 0, GAME_WIDTH, GAME_HEIGHT);
 	myBrush.CreateStockObject(BLACK_BRUSH);
-	(*pDC).FillRect(&myRect, &myBrush);
+	pDC->FillRect(&myRect, &myBrush);
 	ReleaseDC(pDC);
 
 	SetCursor(LoadCursor(nullptr, IDC_ARROW));            // Refresh cursor object to arrow

--- a/engines/bagel/hodjnpodj/mazedoom/optndlg.cpp
+++ b/engines/bagel/hodjnpodj/mazedoom/optndlg.cpp
@@ -124,17 +124,17 @@ bool COptnDlg::OnInitDialog() {
 
 	statRect.SetRect(LEFT_SIDE, 25, LEFT_SIDE + 70, 40);
 	if ((m_pTimeLeft = new CText()) != nullptr) {
-		(*m_pTimeLeft).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pTimeLeft->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	statRect.SetRect(LEFT_SIDE, 45, LEFT_SIDE + 80, 70);
 	if ((m_pDiffTitleText = new CText()) != nullptr) {
-		(*m_pDiffTitleText).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pDiffTitleText->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	statRect.SetRect(LEFT_SIDE, 65, LEFT_SIDE + 170, 80);
 	if ((m_pDifficultyText = new CText()) != nullptr) {
-		(*m_pDifficultyText).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pDifficultyText->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	m_ScrollDifficulty.SetScrollRange(MIN_DIFFICULTY, MAX_DIFFICULTY, 0);       //...last element is Max - 1
@@ -142,7 +142,7 @@ bool COptnDlg::OnInitDialog() {
 
 	statRect.SetRect(LEFT_SIDE, 115, LEFT_SIDE + 100, 130);
 	if ((m_pTimerText = new CText()) != nullptr) {
-		(*m_pTimerText).SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
+		m_pTimerText->SetupText(pDC, pSubOptionsPalette, &statRect, JUSTIFY_LEFT);
 	}
 
 	m_ScrollTime.SetScrollRange(TIMER_MIN, TIMER_MAX - 1, 0);
@@ -155,13 +155,13 @@ bool COptnDlg::OnInitDialog() {
 	ReleaseDC(pDC);
 
 	if ((pOKButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pOKButton).SetPalette(pSubOptionsPalette);                        // set the palette to use
-		(*pOKButton).SetControl(IDOK, this);            // tie to the dialog control
+		pOKButton->SetPalette(pSubOptionsPalette);                        // set the palette to use
+		pOKButton->SetControl(IDOK, this);            // tie to the dialog control
 	}
 
 	if ((pCancelButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pCancelButton).SetPalette(pSubOptionsPalette);                        // set the palette to use
-		(*pCancelButton).SetControl(IDCANCEL, this);            // tie to the dialog control
+		pCancelButton->SetPalette(pSubOptionsPalette);                        // set the palette to use
+		pCancelButton->SetControl(IDCANCEL, this);            // tie to the dialog control
 	}
 
 	return true;  // return true  unless you set the focus to a control
@@ -211,7 +211,7 @@ void COptnDlg::OnHScroll(unsigned int nSBCode, unsigned int nPos, CScrollBar* pS
 	if (NewPos > pMax) NewPos = pMax;
 
 	if (NewPos != OldPos) {                              //To prevent "flicker"
-		(*pScrollBar).SetScrollPos(NewPos, true);        //...only update when
+		pScrollBar->SetScrollPos(NewPos, true);        //...only update when
 	}                                                   //...changed
 
 	UpdateScrollbars();
@@ -264,14 +264,14 @@ void COptnDlg::UpdateScrollbars() {
 
 			Common::sprintf_s(msg, "Time Limit: %02d:%02d", m_nMins, m_nSecs);
 		}
-		(*m_pTimerText).DisplayString(pDC, msg, 14, TEXT_BOLD, RGB(0, 0, 0));
+		m_pTimerText->DisplayString(pDC, msg, 14, TEXT_BOLD, RGB(0, 0, 0));
 	}
 
 	OldValue = _difficulty;
 	_difficulty = m_ScrollDifficulty.GetScrollPos();
 	if (OldValue != _difficulty) {
 		Common::sprintf_s(msg, "%s", mDifficultyTable[_difficulty - 1].c_str());
-		(*m_pDifficultyText).DisplayString(pDC, msg, 14, TEXT_BOLD, RGB(0, 0, 0));
+		m_pDifficultyText->DisplayString(pDC, msg, 14, TEXT_BOLD, RGB(0, 0, 0));
 	}
 
 	ReleaseDC(pDC);
@@ -299,13 +299,13 @@ void COptnDlg::OnPaint() {
 	pDC = GetDC();
 
 	Common::sprintf_s(msg, "Time: %02d:%02d", _minutes, _seconds);
-	(*m_pTimeLeft).DisplayString(pDC, msg, 14, TEXT_BOLD, RGB(0, 0, 0));
+	m_pTimeLeft->DisplayString(pDC, msg, 14, TEXT_BOLD, RGB(0, 0, 0));
 
 	Common::sprintf_s(msg, "Level:");
-	(*m_pDiffTitleText).DisplayString(pDC, msg, 14, TEXT_BOLD, RGB(0, 0, 0));
+	m_pDiffTitleText->DisplayString(pDC, msg, 14, TEXT_BOLD, RGB(0, 0, 0));
 
 	Common::sprintf_s(msg, "%s", mDifficultyTable[_difficulty - 1].c_str());
-	(*m_pDifficultyText).DisplayString(pDC, msg, 14, TEXT_BOLD, RGB(0, 0, 0));
+	m_pDifficultyText->DisplayString(pDC, msg, 14, TEXT_BOLD, RGB(0, 0, 0));
 
 	if (_time == m_nTimeScale[TIMER_MAX - 1])
 		Common::sprintf_s(msg, "Time Limit: None");
@@ -315,7 +315,7 @@ void COptnDlg::OnPaint() {
 
 		Common::sprintf_s(msg, "Time Limit: %02d:%02d", m_nMins, m_nSecs);
 	}
-	(*m_pTimerText).DisplayString(pDC, msg, 14, TEXT_BOLD, RGB(0, 0, 0));
+	m_pTimerText->DisplayString(pDC, msg, 14, TEXT_BOLD, RGB(0, 0, 0));
 
 	ReleaseDC(pDC);
 

--- a/engines/bagel/hodjnpodj/metagame/bgen/backpack.cpp
+++ b/engines/bagel/hodjnpodj/metagame/bgen/backpack.cpp
@@ -133,33 +133,33 @@ LRESULT BackpackHookProc(int code, WPARAM wParam, LPARAM lParam) {
 				nFirstSlot -= (nItemsPerRow * nItemsPerColumn);
 				if (nFirstSlot < 0)
 					nFirstSlot = 0;
-				pDC = (*pBackpackDialog).GetDC();
+				pDC = pBackpackDialog->GetDC();
 			}
 			break;
 		case VK_DOWN:                               // go to next page of text
 		case VK_NUMPAD2:
 		case VK_NEXT:
-			if (nFirstSlot + (nItemsPerRow * nItemsPerColumn) < (*pInventory).ItemCount()) {
+			if (nFirstSlot + (nItemsPerRow * nItemsPerColumn) < pInventory->ItemCount()) {
 				nFirstSlot += (nItemsPerRow * nItemsPerColumn);
-				pDC = (*pBackpackDialog).GetDC();
+				pDC = pBackpackDialog->GetDC();
 			}
 			break;
 		case VK_HOME:                               // go to first page of text
 			if (nFirstSlot != 0) {
 				nFirstSlot = 0;
-				pDC = (*pBackpackDialog).GetDC();
+				pDC = pBackpackDialog->GetDC();
 			}
 			break;
 		case VK_END:                                // go to last page of text
-			nFirstSlot = (*pInventory).ItemCount() - (nItemsPerRow * nItemsPerColumn);
+			nFirstSlot = pInventory->ItemCount() - (nItemsPerRow * nItemsPerColumn);
 			if (nFirstSlot < 0)
 				nFirstSlot = 0;
-			pDC = (*pBackpackDialog).GetDC();
+			pDC = pBackpackDialog->GetDC();
 		}
 
 	if (pDC != nullptr) {                                  // update the inventory page if required
 		CBackpack::UpdatePage(pDC);
-		(*pBackpackDialog).ReleaseDC(pDC);
+		pBackpackDialog->ReleaseDC(pDC);
 		return true;
 	}
 
@@ -231,11 +231,11 @@ void CBackpack::OnDestroy() {
 		RemoveKeyboardHook();
 
 	if (pWorkOld != nullptr) {
-		(*pWorkDC).SelectObject(pWorkOld);
+		pWorkDC->SelectObject(pWorkOld);
 		pWorkOld = nullptr;
 	}
 	if (pWorkPalOld != nullptr) {
-		(*pWorkDC).SelectPalette(pWorkPalOld, false);
+		pWorkDC->SelectPalette(pWorkPalOld, false);
 		pWorkPalOld = nullptr;
 	}
 	if (pWork != nullptr) {
@@ -255,9 +255,9 @@ void CBackpack::OnDestroy() {
 	if (pBackgroundBitmap != nullptr) {
 		delete pBackgroundBitmap;
 		pBackgroundBitmap = nullptr;
-		bUpdateNeeded = (*pParentWnd).GetUpdateRect(nullptr, false);
+		bUpdateNeeded = pParentWnd->GetUpdateRect(nullptr, false);
 		if (bUpdateNeeded)
-			(*pParentWnd).ValidateRect(nullptr);
+			pParentWnd->ValidateRect(nullptr);
 	}
 
 	if (pTitleText != nullptr) {
@@ -286,7 +286,7 @@ bool CBackpack::OnInitDialog() {
 		m_pParentWnd = ((CWnd *)this)->GetParent();            // ... as passed to us or inquired about
 	assert(m_pParentWnd);
 
-	(*m_pParentWnd).GetWindowRect(&myRect);
+	m_pParentWnd->GetWindowRect(&myRect);
 	x = myRect.left + (((myRect.right - myRect.left) - BACKPACK_DX) >> 1);
 	y = myRect.top + (((myRect.bottom - myRect.top) - BACKPACK_DY) >> 1);
 	BackpackRect.SetRect(0, 0, BACKPACK_DX, BACKPACK_DY);
@@ -294,20 +294,20 @@ bool CBackpack::OnInitDialog() {
 
 	pButton = GetDlgItem((int)GetDefID());                     // get the window for the okay button
 	ASSERT(pButton != nullptr);                                    // ... and verify we have it
-	(*pButton).GetWindowRect(&myRect);                          // get the button's position and size
+	pButton->GetWindowRect(&myRect);                          // get the button's position and size
 
 	dx = myRect.right - myRect.left;                            // calculate where to place the button
 	x = (BackpackRect.right - dx) >> 1;                         // ... centered at the bottom edge
 	dy = myRect.bottom - myRect.top;
 	y = BackpackRect.bottom - dy - BUTTON_DY;
 
-	(*pButton).MoveWindow(x, y, dx, dy);                        // reposition the button
+	pButton->MoveWindow(x, y, dx, dy);                        // reposition the button
 	OkayRect.SetRect(x, y, x + dx, y + dy);
 
 	pOKButton = new CColorButton();                   // build a color QUIT button to let us exit
 	ASSERT(pOKButton != nullptr);
-	(*pOKButton).SetPalette(pBackgroundPalette);        // set the palette to use
-	bSuccess = (*pOKButton).SetControl((int)GetDefID(), this); // tie to the dialog control
+	pOKButton->SetPalette(pBackgroundPalette);        // set the palette to use
+	bSuccess = pOKButton->SetControl((int)GetDefID(), this); // tie to the dialog control
 	ASSERT(bSuccess);
 
 	ScrollTopRect.SetRect(0, 0, BACKPACK_DX, BACKPACK_CURL_DY); // setup rectangles for scrolling areas
@@ -359,26 +359,26 @@ void CBackpack::UpdateBackpack(CDC *pDC) {
 
 	ShowWaitCursor();                                             // put up the hourglass cursor
 
-	pPalOld = (*pDC).SelectPalette(pBackgroundPalette, false);      // setup the proper palette
-	(*pDC).RealizePalette();
+	pPalOld = pDC->SelectPalette(pBackgroundPalette, false);      // setup the proper palette
+	pDC->RealizePalette();
 
 	if (pWorkDC == nullptr) {                                      // if we don't have a work area
 		RefreshBackground();                                    // ... then update the screen directly
 		PaintMaskedBitmap(pDC, pBackgroundPalette, pBackpackBitmap, 0, 0, BACKPACK_DX, BACKPACK_DY);
 		UpdateContent(pDC);
 		if (pTitleText != nullptr)
-			(*pTitleText).DisplayString(pDC, (*pInventory).GetTitle(), 32, TEXT_HEAVY, BACKPACK_TEXT_COLOR);
+			pTitleText->DisplayString(pDC, pInventory->GetTitle(), 32, TEXT_HEAVY, BACKPACK_TEXT_COLOR);
 	} else {
 		if (pBackgroundBitmap != nullptr)                                                      // ... otherwise revise work area
 			PaintBitmap(pWorkDC, pBackgroundPalette, pBackgroundBitmap, 0, 0, BACKPACK_DX, BACKPACK_DY);
 		PaintMaskedBitmap(pWorkDC, pBackgroundPalette, pBackpackBitmap, 0, 0, BACKPACK_DX, BACKPACK_DY);
 		UpdateContent(pWorkDC);                                 // ... then zap it to the screen
 		if (pTitleText != nullptr)
-			(*pTitleText).DisplayString(pWorkDC, (*pInventory).GetTitle(), 32, TEXT_HEAVY, BACKPACK_TEXT_COLOR);
-		(*pDC).BitBlt(0, 0, BACKPACK_DX, BACKPACK_DY, pWorkDC, 0, 0, SRCCOPY);
+			pTitleText->DisplayString(pWorkDC, pInventory->GetTitle(), 32, TEXT_HEAVY, BACKPACK_TEXT_COLOR);
+		pDC->BitBlt(0, 0, BACKPACK_DX, BACKPACK_DY, pWorkDC, 0, 0, SRCCOPY);
 	}
 
-	(*pDC).SelectPalette(pPalOld, false);                       // reset the palette
+	pDC->SelectPalette(pPalOld, false);                       // reset the palette
 
 	DoArrowCursor();                                            // return to an arrow cursor
 }
@@ -388,14 +388,14 @@ void CBackpack::UpdatePage(CDC *pDC) {
 	CPalette *pPalOld;
 
 	if (pWorkDC == nullptr)                                        // update everything if no work area
-		(*pBackpackDialog).InvalidateRect(nullptr, false);
+		pBackpackDialog->InvalidateRect(nullptr, false);
 	else {                                                      // otherwise just update central area
 		ShowWaitCursor();                                         // put up the hourglass cursor
-		pPalOld = (*pDC).SelectPalette(pBackgroundPalette, false); // setup the proper palette
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pBackgroundPalette, false); // setup the proper palette
+		pDC->RealizePalette();
 		PaintMaskedBitmap(pWorkDC, pBackgroundPalette, pBackpackBitmap, 0, 0, BACKPACK_DX, BACKPACK_DY);
 		UpdateContent(pWorkDC);                                 // zap it to the screen
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 			0,
 			BACKPACK_BORDER_DY + BACKPACK_TITLEZONE_DY,
 			BACKPACK_DX,
@@ -404,7 +404,7 @@ void CBackpack::UpdatePage(CDC *pDC) {
 			0,
 			BACKPACK_BORDER_DY + BACKPACK_TITLEZONE_DY,
 			SRCCOPY);
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 			BACKPACK_DX - TEXT_MORE_DX,
 			BACKPACK_DY - BACKPACK_CURL_DY,
 			TEXT_MORE_DX,
@@ -413,7 +413,7 @@ void CBackpack::UpdatePage(CDC *pDC) {
 			BACKPACK_DX - TEXT_MORE_DX,
 			BACKPACK_DY - BACKPACK_CURL_DY,
 			SRCCOPY);
-		(*pDC).SelectPalette(pPalOld, false);                   // reset the palette
+		pDC->SelectPalette(pPalOld, false);                   // reset the palette
 		DoArrowCursor();
 	}                                                           // return to an arrow cursor
 }
@@ -427,7 +427,7 @@ void CBackpack::UpdateContent(CDC *pDC) {
 	TEXTMETRIC  fontMetrics;
 	int     i, x, y, dx, dy;
 
-	if ((*pInventory).ItemCount() <= 0)
+	if (pInventory->ItemCount() <= 0)
 		return;
 
 	nBackpack_DX = BACKPACK_DX - (BACKPACK_BORDER_DX << 1);     // calculate the horizontal space we have available
@@ -450,36 +450,36 @@ void CBackpack::UpdateContent(CDC *pDC) {
 		nItemsPerColumn -= 1;
 	}
 
-	pItem = (*pInventory).FetchItem(nFirstSlot);                // get first item on this page
+	pItem = pInventory->FetchItem(nFirstSlot);                // get first item on this page
 	for (i = 0; (i < (nItemsPerRow * nItemsPerColumn)) && (pItem != nullptr); i++) {                           // will thumb through all of them
 		x = (i % nItemsPerRow);                                 // calculate its horizontal position
 		x *= (BACKPACK_BITMAP_DX + nItem_DDX);                      // ... allowing proper spacing between items
 		y = (i / nItemsPerRow);                                 // calculate its vertical position
 		y *= (BACKPACK_BITMAP_DY + nItem_DDY);                      // ... allowing proper spacing between items
 		UpdateItem(pDC, pItem, x + BACKPACK_BORDER_DX, y + BACKPACK_BORDER_DY + BACKPACK_TITLEZONE_DY);     // now show the item
-		pItem = (*pItem).GetNext();
+		pItem = pItem->GetNext();
 	}
 
 	if (pBackpackBitmap != nullptr) {
-		pFontOld = (*pDC).SelectObject(pFont);                  // select it into our context
-		(*pDC).SetBkMode(TRANSPARENT);                              // make the text overlay transparently
-		(*pDC).GetTextMetrics(&fontMetrics);                        // show whether there are more notes
+		pFontOld = pDC->SelectObject(pFont);                  // select it into our context
+		pDC->SetBkMode(TRANSPARENT);                              // make the text overlay transparently
+		pDC->GetTextMetrics(&fontMetrics);                        // show whether there are more notes
 		x = BACKPACK_DX - TEXT_MORE_DX;                             // ... that can be scrolled through
 		y = BACKPACK_DY -
 			BACKPACK_CURL_DY +
 			((BACKPACK_CURL_DY - fontMetrics.tmHeight) >> 1) -
 			TEXT_MORE_DY;
-		textInfo = (*pDC).GetTextExtent(MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+		textInfo = pDC->GetTextExtent(MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 		dx = textInfo.cx;
 		dy = fontMetrics.tmHeight;
 		if (pItem == nullptr) {
 			myRect.SetRect(x, y, x + dx, y + dy);
 			BltBitmap(pDC, pBackgroundPalette, pBackpackBitmap, &myRect, &myRect, SRCCOPY);
 		} else {
-			(*pDC).SetTextColor(BACKPACK_MORE_COLOR);
-			(*pDC).TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+			pDC->SetTextColor(BACKPACK_MORE_COLOR);
+			pDC->TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 		}
-		(*pDC).SelectObject(pFontOld);                            // map out the font
+		pDC->SelectObject(pFontOld);                            // map out the font
 	}
 }
 
@@ -488,20 +488,20 @@ void CBackpack::UpdateItem(CDC *pDC, CItem *pItem, int nX, int nY) {
 	CFont *pFontOld = nullptr;               // font that was mapped to the context
 	char    chBuffer[32];
 
-	PaintMaskedDIB(pDC, pBackgroundPalette, (*pItem).GetArtSpec(), nX, nY, BACKPACK_BITMAP_DX, BACKPACK_BITMAP_DY);
+	PaintMaskedDIB(pDC, pBackgroundPalette, pItem->GetArtSpec(), nX, nY, BACKPACK_BITMAP_DX, BACKPACK_BITMAP_DY);
 
-	if (((*pItem).m_nQuantity == 0) ||
-		((*pItem).m_nQuantity > 1)) {
-		Common::sprintf_s(chBuffer, "%ld", (*pItem).m_nQuantity);
-		pFontOld = (*pDC).SelectObject(pFont);                  // select it into our context
-		(*pDC).SetBkMode(TRANSPARENT);                          // make the text overlay transparently
-		(*pDC).SetTextColor(BACKPACK_BLURB_COLOR);              // set the color of the text
-		(*pDC).TextOut(                             // zap the text to the work area
+	if ((pItem->m_nQuantity == 0) ||
+		(pItem->m_nQuantity > 1)) {
+		Common::sprintf_s(chBuffer, "%ld", pItem->m_nQuantity);
+		pFontOld = pDC->SelectObject(pFont);                  // select it into our context
+		pDC->SetBkMode(TRANSPARENT);                          // make the text overlay transparently
+		pDC->SetTextColor(BACKPACK_BLURB_COLOR);              // set the color of the text
+		pDC->TextOut(                             // zap the text to the work area
 			nX,
 			nY,
 			(const char *)chBuffer,
 			strlen(chBuffer));
-		(*pDC).SelectObject(pFontOld);                     // map out the font
+		pDC->SelectObject(pFontOld);                     // map out the font
 	}
 }
 
@@ -515,7 +515,7 @@ void CBackpack::ClearDialogImage() {
 	if (pBackgroundBitmap != nullptr) {
 		delete pOKButton;
 		pOKButton = nullptr;
-		(*pBackpackDialog).ValidateRect(nullptr);
+		pBackpackDialog->ValidateRect(nullptr);
 		RefreshBackground();
 	}
 }
@@ -525,9 +525,9 @@ void CBackpack::RefreshBackground() {
 	CDC *pDC;
 
 	if (pBackgroundBitmap != nullptr) {
-		pDC = (*pBackpackDialog).GetDC();                       // get a context for our window
+		pDC = pBackpackDialog->GetDC();                       // get a context for our window
 		PaintBitmap(pDC, pBackgroundPalette, pBackgroundBitmap, 0, 0, BACKPACK_DX, BACKPACK_DY);
-		(*pBackpackDialog).ReleaseDC(pDC);                      // release the context
+		pBackpackDialog->ReleaseDC(pDC);                      // release the context
 	}
 }
 
@@ -554,7 +554,7 @@ int CBackpack::OnCreate(LPCREATESTRUCT lpCreateStruct) {
 	AddFontResource("msserif.fon");
 	pFont = new CFont();
 	ASSERT(pFont != nullptr);
-	bSuccess = (*pFont).CreateFont(BACKPACK_FONT_SIZE, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, OUT_RASTER_PRECIS, 0, PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
+	bSuccess = pFont->CreateFont(BACKPACK_FONT_SIZE, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, OUT_RASTER_PRECIS, 0, PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
 	ASSERT(bSuccess);
 
 	if (CDialog::OnCreate(lpCreateStruct) == -1)
@@ -575,19 +575,19 @@ bool CBackpack::CreateWorkAreas(CDC *pDC) {
 
 	pBackgroundBitmap = FetchScreenBitmap(pDC, pBackgroundPalette, 0, 0, BACKPACK_DX, BACKPACK_DY);
 
-	(*pDC).SelectPalette(pBackgroundPalette, false);
-	(*pDC).RealizePalette();
+	pDC->SelectPalette(pBackgroundPalette, false);
+	pDC->RealizePalette();
 
 	if ((GetFreeSpace(0) >= (unsigned long)1000000) &&
 		(GlobalCompact((unsigned long)500000) >= (unsigned long)450000)) {
 		pWork = new CBitmap();
-		if ((*pWork).CreateCompatibleBitmap(pDC, BACKPACK_DX, BACKPACK_DY)) {
+		if (pWork->CreateCompatibleBitmap(pDC, BACKPACK_DX, BACKPACK_DY)) {
 			pWorkDC = new CDC();
 			if ((pWorkDC != nullptr) &&
-				(*pWorkDC).CreateCompatibleDC(pDC)) {
-				pWorkPalOld = (*pWorkDC).SelectPalette(pBackgroundPalette, false);
-				(*pWorkDC).RealizePalette();
-				pWorkOld = (*pWorkDC).SelectObject(pWork);
+				pWorkDC->CreateCompatibleDC(pDC)) {
+				pWorkPalOld = pWorkDC->SelectPalette(pBackgroundPalette, false);
+				pWorkDC->RealizePalette();
+				pWorkOld = pWorkDC->SelectObject(pWork);
 				if (pWorkOld != nullptr)
 					bSuccess = true;
 			}
@@ -600,7 +600,7 @@ bool CBackpack::CreateWorkAreas(CDC *pDC) {
 
 	if (!bSuccess) {
 		if (pWorkPalOld != nullptr) {
-			(*pWorkDC).SelectPalette(pWorkPalOld, false);
+			pWorkDC->SelectPalette(pWorkPalOld, false);
 			pWorkPalOld = nullptr;
 		}
 		if (pWork != nullptr) {
@@ -612,7 +612,7 @@ bool CBackpack::CreateWorkAreas(CDC *pDC) {
 		bSuccess = true;
 	}
 
-	(*pDC).SelectPalette(pWorkPalOld, false);
+	pDC->SelectPalette(pWorkPalOld, false);
 
 	myRect.SetRect(BACKPACK_TEXTZONE_DX,
 		BACKPACK_BORDER_DY + BACKPACK_TITLEZONE_DDY,
@@ -638,30 +638,30 @@ void CBackpack::OnMouseMove(unsigned int nFlags, CPoint point) {
 	pMyApp = AfxGetApp();
 
 	if (OkayRect.PtInRect(point))                   // use standard arrow in buttons
-		hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+		hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 	else if (ScrollTopRect.PtInRect(point)) {           // set cursor to scolling up okay or invalid
 		if (nFirstSlot == 0)                        // ... depending on current slot for page
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_INVALID);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_INVALID);
 		else
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_ARROWUP);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_ARROWUP);
 	} else if (ScrollBotRect.PtInRect(point)) {         // set cursor to scrolling down okay or invalid
-		if (nFirstSlot + (nItemsPerRow * nItemsPerColumn) >= (*pInventory).ItemCount())
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_INVALID);
+		if (nFirstSlot + (nItemsPerRow * nItemsPerColumn) >= pInventory->ItemCount())
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_INVALID);
 		else
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_ARROWDN);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_ARROWDN);
 	} else {                                        // see if cursor is on an inventory item
 		i = SelectedItem(point);                    // ... and if so, then show the text blurb
 		if ((i >= 0) &&                             // ... for it at the base of the scroll
-			((i + nFirstSlot) < (*pInventory).ItemCount())) {
-			pItem = (*pInventory).FetchItem(i + nFirstSlot);
+			((i + nFirstSlot) < pInventory->ItemCount())) {
+			pItem = pInventory->FetchItem(i + nFirstSlot);
 			if (pItem != nullptr) {
-				if ((*pItem).m_nActionCode == ITEM_ACTION_NOTEBOOK)
-					hNewCursor = (*pMyApp).LoadCursor(IDC_NOTEBOOK_BOOK);
-				else if ((*pItem).GetSoundSpec() != nullptr) {
-					hNewCursor = (*pMyApp).LoadCursor(IDC_NOTEBOOK_SOUND);
-					(*pItem).m_nActionCode = ITEM_ACTION_SOUND;
+				if (pItem->m_nActionCode == ITEM_ACTION_NOTEBOOK)
+					hNewCursor = pMyApp->LoadCursor(IDC_NOTEBOOK_BOOK);
+				else if (pItem->GetSoundSpec() != nullptr) {
+					hNewCursor = pMyApp->LoadCursor(IDC_NOTEBOOK_SOUND);
+					pItem->m_nActionCode = ITEM_ACTION_SOUND;
 				} else
-					hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+					hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 				pDC = GetDC();
 				if (pItemText == nullptr) {
 					testRect.SetRect(BACKPACK_TEXTZONE_DX,
@@ -671,17 +671,17 @@ void CBackpack::OnMouseMove(unsigned int nFlags, CPoint point) {
 					pItemText = new CText(pDC, pBackgroundPalette, &testRect, JUSTIFY_CENTER);
 				}
 				if (pItemText != nullptr)
-					(*pItemText).DisplayString(pDC, (*pItem).GetDescription(), 24, TEXT_BOLD, BACKPACK_TEXT_COLOR);
+					pItemText->DisplayString(pDC, pItem->GetDescription(), 24, TEXT_BOLD, BACKPACK_TEXT_COLOR);
 				ReleaseDC(pDC);
 			}
 		}
 	}
 
 	if (hNewCursor == nullptr) {                       // use default cursor if not specified
-		hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+		hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 		if (pItemText != nullptr) {
 			pDC = GetDC();
-			(*pItemText).RestoreBackground(pDC);    // clear any extant item text
+			pItemText->RestoreBackground(pDC);    // clear any extant item text
 			delete pItemText;
 			pItemText = nullptr;
 			ReleaseDC(pDC);
@@ -714,36 +714,36 @@ void CBackpack::OnLButtonDown(unsigned int nFlags, CPoint point) {
 		pDC = GetDC();
 	} else                                          // if click is in lower curl, then
 		if (ScrollBotRect.PtInRect(point) &&            // ... scroll down if not show last item
-			(nFirstSlot + (nItemsPerRow * nItemsPerColumn) < (*pInventory).ItemCount())) {
+			(nFirstSlot + (nItemsPerRow * nItemsPerColumn) < pInventory->ItemCount())) {
 			nFirstSlot += (nItemsPerRow * nItemsPerColumn);
 			pDC = GetDC();
 		} else {                                        // see if cursor is on an inventory item
 			i = SelectedItem(point);                    // ... and if so, then show then dispatch
 			if ((i >= 0) &&                             // ... on its action code
-				((i + nFirstSlot) < (*pInventory).ItemCount())) {
-				pItem = (*pInventory).FetchItem(i + nFirstSlot);
+				((i + nFirstSlot) < pInventory->ItemCount())) {
+				pItem = pInventory->FetchItem(i + nFirstSlot);
 				if (pItem != nullptr) {
-					CNotebook   NotebookDlg(this, pBackgroundPalette, (*pItem).GetFirstNote(), nullptr);
-					switch ((*pItem).GetActionCode()) {
+					CNotebook   NotebookDlg(this, pBackgroundPalette, pItem->GetFirstNote(), nullptr);
+					switch (pItem->GetActionCode()) {
 					case ITEM_ACTION_NOTEBOOK:      // open the notebook
-						pItem = (*pInventory).FindItem(MG_OBJ_HODJ_NOTEBOOK);
+						pItem = pInventory->FindItem(MG_OBJ_HODJ_NOTEBOOK);
 						if (pItem == nullptr)
-							pItem = (*pInventory).FindItem(MG_OBJ_PODJ_NOTEBOOK);
+							pItem = pInventory->FindItem(MG_OBJ_PODJ_NOTEBOOK);
 						if (pItem != nullptr) {
 							pButton = GetDlgItem((int)GetDefID()); // get the window for the okay button
 							ASSERT(pButton != nullptr);                // ... and verify we have it
-							(*pButton).EnableWindow(false);  // disable & enable across note entries
+							pButton->EnableWindow(false);  // disable & enable across note entries
 							NotebookDlg.DoModal();   // invoke the notebook dialog box
-							(*pButton).EnableWindow(true);
+							pButton->EnableWindow(true);
 							pControl = GetDlgItem((int)GetDefID());
 							GotoDlgCtrl(pControl);
 							bActiveWindow = true;
 						}
 						break;
 					case ITEM_ACTION_SOUND:
-						pSound = new CSound(this, (*pItem).GetSoundSpec(), SOUND_WAVE | SOUND_QUEUE | SOUND_AUTODELETE);
-						(*pSound).setDrivePath(lpMetaGameStruct->m_chCDPath);
-						(*pSound).play();
+						pSound = new CSound(this, pItem->GetSoundSpec(), SOUND_WAVE | SOUND_QUEUE | SOUND_AUTODELETE);
+						pSound->setDrivePath(lpMetaGameStruct->m_chCDPath);
+						pSound->play();
 						break;
 					}
 				}
@@ -785,7 +785,7 @@ int CBackpack::SelectedItem(CPoint point) {
 
 
 bool CBackpack::OnSetCursor(CWnd *pWnd, unsigned int /*nHitTest*/, unsigned int /*message*/) {
-	if ((*pWnd).m_hWnd == (*this).m_hWnd)
+	if (pWnd->m_hWnd == (this)->m_hWnd)
 		return true;
 	else
 		return false;
@@ -797,7 +797,7 @@ void CBackpack::ShowWaitCursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).BeginWaitCursor();
+	pMyApp->BeginWaitCursor();
 }
 
 
@@ -806,7 +806,7 @@ void CBackpack::DoArrowCursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).EndWaitCursor();
+	pMyApp->EndWaitCursor();
 }
 
 } // namespace Gtl

--- a/engines/bagel/hodjnpodj/metagame/bgen/c1btndlg.cpp
+++ b/engines/bagel/hodjnpodj/metagame/bgen/c1btndlg.cpp
@@ -141,7 +141,7 @@ bool C1ButtonDialog::OnInitDialog() {
 	);
 
 	if ((m_cTextMessage1 = new CText()) != nullptr) {
-		bAssertCheck = (*m_cTextMessage1).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+		bAssertCheck = m_cTextMessage1->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	}
 
@@ -153,7 +153,7 @@ bool C1ButtonDialog::OnInitDialog() {
 	                 );
 
 	if ((m_cTextMessage2 = new CText()) != nullptr) {
-		bAssertCheck = (*m_cTextMessage2).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+		bAssertCheck = m_cTextMessage2->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	}
 
@@ -172,9 +172,9 @@ bool C1ButtonDialog::OnInitDialog() {
 	ReleaseDC(pDC);
 
 	if ((m_pButton1 = new CColorButton) != nullptr) {            // build the first color button
-		(*m_pButton1).SetPalette(m_pPalette);                 // set the palette to use
-		(*m_pButton1).SetControl(IDOK, this);                 // tie to the dialog control
-		(*m_pButton1).SetWindowText(m_pszButton1Text);
+		m_pButton1->SetPalette(m_pPalette);                 // set the palette to use
+		m_pButton1->SetControl(IDOK, this);                 // tie to the dialog control
+		m_pButton1->SetWindowText(m_pszButton1Text);
 	}
 
 	return true;  // return true  unless you set the focus to a control
@@ -191,17 +191,17 @@ void C1ButtonDialog::OnPaint() {
 	pDC = GetDC();
 
 	if (m_pszMessage1 != nullptr) {
-		bAssertCheck = (*m_cTextMessage1).DisplayString(pDC, m_pszMessage1, 21, FW_BOLD, TEXT_COLOR);
+		bAssertCheck = m_cTextMessage1->DisplayString(pDC, m_pszMessage1, 21, FW_BOLD, TEXT_COLOR);
 		ASSERT(bAssertCheck);
 	}
 
 	if (m_pszMessage2 != nullptr) {
-		bAssertCheck = (*m_cTextMessage2).DisplayString(pDC, m_pszMessage2, 21, FW_BOLD, TEXT_COLOR);
+		bAssertCheck = m_cTextMessage2->DisplayString(pDC, m_pszMessage2, 21, FW_BOLD, TEXT_COLOR);
 		ASSERT(bAssertCheck);
 	}
 
 	if (m_pszMessage3 != nullptr) {
-		bAssertCheck = (*m_cTextMessage3).DisplayString(pDC, m_pszMessage3, 21, FW_BOLD, TEXT_COLOR);
+		bAssertCheck = m_cTextMessage3->DisplayString(pDC, m_pszMessage3, 21, FW_BOLD, TEXT_COLOR);
 		ASSERT(bAssertCheck);
 	}
 

--- a/engines/bagel/hodjnpodj/metagame/bgen/c2btndlg.cpp
+++ b/engines/bagel/hodjnpodj/metagame/bgen/c2btndlg.cpp
@@ -147,7 +147,7 @@ bool C2ButtonDialog::OnInitDialog() {
 	);
 
 	if ((m_cTextMessage1 = new CText()) != nullptr) {
-		bAssertCheck = (*m_cTextMessage1).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+		bAssertCheck = m_cTextMessage1->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	}
 
@@ -159,7 +159,7 @@ bool C2ButtonDialog::OnInitDialog() {
 	                 );
 
 	if ((m_cTextMessage2 = new CText()) != nullptr) {
-		bAssertCheck = (*m_cTextMessage2).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+		bAssertCheck = m_cTextMessage2->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	}
 
@@ -178,14 +178,14 @@ bool C2ButtonDialog::OnInitDialog() {
 	ReleaseDC(pDC);
 
 	if ((m_pButton1 = new CColorButton) != nullptr) {            // build the first color button
-		(*m_pButton1).SetPalette(m_pPalette);                 // set the palette to use
-		(*m_pButton1).SetControl(IDOK, this);                 // tie to the dialog control
-		(*m_pButton1).SetWindowText(m_pszButton1Text);
+		m_pButton1->SetPalette(m_pPalette);                 // set the palette to use
+		m_pButton1->SetControl(IDOK, this);                 // tie to the dialog control
+		m_pButton1->SetWindowText(m_pszButton1Text);
 	}
 	if ((m_pButton2 = new CColorButton) != nullptr) {             // build the second color button
-		(*m_pButton2).SetPalette(m_pPalette);                  // set the palette to use
-		(*m_pButton2).SetControl(IDCANCEL, this);              // tie to the dialog control
-		(*m_pButton2).SetWindowText(m_pszButton2Text);
+		m_pButton2->SetPalette(m_pPalette);                  // set the palette to use
+		m_pButton2->SetControl(IDCANCEL, this);              // tie to the dialog control
+		m_pButton2->SetWindowText(m_pszButton2Text);
 	}
 
 	return true;  // return true  unless you set the focus to a control

--- a/engines/bagel/hodjnpodj/metagame/bgen/invent.cpp
+++ b/engines/bagel/hodjnpodj/metagame/bgen/invent.cpp
@@ -71,7 +71,7 @@ CInventory::~CInventory() {
 		pItem = m_pEquipment;                       // ... one item at a time
 		if (pItem == nullptr)
 			break;
-		m_pEquipment = (*pItem).m_pNext;            // make next item be first
+		m_pEquipment = pItem->m_pNext;            // make next item be first
 		delete pItem;
 	}
 	m_pEquipment = nullptr;
@@ -94,13 +94,13 @@ CInventory::~CInventory() {
 void CInventory::AddItem(CItem *pItem) {
 	CItem   *pTemp;
 
-	if (((*pItem).m_pPrev != nullptr) ||               // don't relink a linked item
-	        ((*pItem).m_pNext != nullptr))
+	if ((pItem->m_pPrev != nullptr) ||               // don't relink a linked item
+	        (pItem->m_pNext != nullptr))
 		return;
 
-	pTemp = FindItem((*pItem).m_nID);               // see if it is already in the list
+	pTemp = FindItem(pItem->m_nID);               // see if it is already in the list
 	if (pTemp != nullptr) {                            // ... and if so, just bump the quantity
-		(*pTemp).m_nQuantity += (*pItem).m_nQuantity;   // ... of the existing item and
+		pTemp->m_nQuantity += pItem->m_nQuantity;   // ... of the existing item and
 		delete pItem;                               // ... then purge the item given us
 		return;
 	}
@@ -109,10 +109,10 @@ void CInventory::AddItem(CItem *pItem) {
 		m_pEquipment = pItem;                       // ... if no existing items
 	else {
 		pTemp = m_pEquipment;                       // otherwise hunt for the last item
-		while ((*pTemp).m_pNext != nullptr)            // ... and insert it as the new last one
-			pTemp = (*pTemp).m_pNext;
-		(*pTemp).m_pNext = pItem;
-		(*pItem).m_pPrev = pTemp;
+		while (pTemp->m_pNext != nullptr)            // ... and insert it as the new last one
+			pTemp = pTemp->m_pNext;
+		pTemp->m_pNext = pItem;
+		pItem->m_pPrev = pTemp;
 	}
 
 	m_nItemCount += 1;                              // increment item count accordingly
@@ -139,10 +139,10 @@ void CInventory::AddItem(int nID, long nQuantity) {
 	pItem = FindItem(nID);                          // see if we already have it
 	if (pItem == nullptr) {                            // if not, then create it
 		pItem = new CItem(nID);                     // ... initialize its values
-		(*pItem).m_nQuantity = nQuantity;           // ... and link it into the list
+		pItem->m_nQuantity = nQuantity;           // ... and link it into the list
 		AddItem(pItem);
 	} else
-		(*pItem).m_nQuantity += nQuantity;          // just bump the quantity field
+		pItem->m_nQuantity += nQuantity;          // just bump the quantity field
 }
 
 
@@ -162,23 +162,23 @@ void CInventory::AddItem(int nID, long nQuantity) {
 void CInventory::RemoveItem(CItem *pItem) {
 	CItem   *pTemp;
 
-	if (((*pItem).m_pPrev == nullptr) &&               // don't unlink a lone item
-	        ((*pItem).m_pNext == nullptr) &&
+	if ((pItem->m_pPrev == nullptr) &&               // don't unlink a lone item
+	        (pItem->m_pNext == nullptr) &&
 	        (m_pEquipment != pItem))
 		return;
 
-	if ((*pItem).m_pPrev == nullptr) {                 // handle being first item in list
-		m_pEquipment = (*pItem).m_pNext;            // ... next item becomes new head
+	if (pItem->m_pPrev == nullptr) {                 // handle being first item in list
+		m_pEquipment = pItem->m_pNext;            // ... next item becomes new head
 		if (m_pEquipment != nullptr)                   // ... if we weren't the only item
-			(*m_pEquipment).m_pPrev = nullptr;         // ... then clear head's previous pointer
+			m_pEquipment->m_pPrev = nullptr;         // ... then clear head's previous pointer
 	} else {                                        // handle being not head of list
-		pTemp = (*pItem).m_pPrev;                   // ... make previous item point to after us
-		(*pTemp).m_pNext = (*pItem).m_pNext;
-		if ((*pTemp).m_pNext != nullptr)               // ... if something was after us, then
-			(*(*pTemp).m_pNext).m_pPrev = pTemp;    // ... have it point to what's previous
+		pTemp = pItem->m_pPrev;                   // ... make previous item point to after us
+		pTemp->m_pNext = pItem->m_pNext;
+		if (pTemp->m_pNext != nullptr)               // ... if something was after us, then
+			pTemp->m_pNext->m_pPrev = pTemp;    // ... have it point to what's previous
 	}
 
-	(*pItem).m_pNext = (*pItem).m_pPrev = nullptr;
+	pItem->m_pNext = pItem->m_pPrev = nullptr;
 	m_nItemCount -= 1;                              // decrement item count accordingly
 }
 
@@ -219,12 +219,12 @@ void CInventory::DiscardItem(CItem *pItem) {
  ************************************************************************/
 
 void CInventory::DiscardItem(CItem *pItem, long nQuantity) {
-	(*pItem).m_nQuantity -= nQuantity;              // debit the requested quantity
+	pItem->m_nQuantity -= nQuantity;              // debit the requested quantity
 
-	if ((*pItem).m_nID == MG_OBJ_CROWN) {           // special case handling for crowns
-		if ((*pItem).m_nQuantity < 0)               // ... can have zero count
-			(*pItem).m_nQuantity = 0;
-	} else if ((*pItem).m_nQuantity <= 0)               // else if we exhausted the supply
+	if (pItem->m_nID == MG_OBJ_CROWN) {           // special case handling for crowns
+		if (pItem->m_nQuantity < 0)               // ... can have zero count
+			pItem->m_nQuantity = 0;
+	} else if (pItem->m_nQuantity <= 0)               // else if we exhausted the supply
 		DiscardItem(pItem);                         // ... then purge the item
 }
 
@@ -302,7 +302,7 @@ CItem *CInventory::FetchItem(int nIdx) {
 	for (i = 0; pItem != nullptr; i++) {               // scan through the list
 		if (nIdx == i)                              // ... looking for item
 			break;
-		pItem = (*pItem).m_pNext;
+		pItem = pItem->m_pNext;
 	}
 
 	return pItem;                                   // return what we found
@@ -328,9 +328,9 @@ CItem *CInventory::FindItem(int nID) {
 
 	pItem = m_pEquipment;                           // get head of equipment list
 	while (pItem != nullptr) {                         // scan through the list
-		if (nID == (*pItem).m_nID)                  // ... looking for a match
+		if (nID == pItem->m_nID)                  // ... looking for a match
 			break;
-		pItem = (*pItem).m_pNext;
+		pItem = pItem->m_pNext;
 	}
 
 	return pItem;                                   // return what we found

--- a/engines/bagel/hodjnpodj/metagame/bgen/item.cpp
+++ b/engines/bagel/hodjnpodj/metagame/bgen/item.cpp
@@ -268,7 +268,7 @@ CItem::~CItem() {
 
 	while (m_pNotes != nullptr) {                      // remove all associated notes
 		pNote = m_pNotes;
-		m_pNotes = (*pNote).m_pNext;
+		m_pNotes = pNote->m_pNext;
 		delete pNote;
 	}
 }
@@ -332,9 +332,9 @@ bool CItem::AddNote(int nID, int nClue, int nRepeat, int nPerson, int nPlace) {
 
 	pNote = new CNote(nID, nClue, nRepeat, nPerson, nPlace);    // create the note object
 	if (pNote != nullptr) {                            // ... and add it to the list
-		(*pNote).m_pNext = m_pNotes;                // make head of list follow us
+		pNote->m_pNext = m_pNotes;                // make head of list follow us
 		if (m_pNotes != nullptr)                       // have list point back at us
-			(*m_pNotes).m_pPrev = pNote;
+			m_pNotes->m_pPrev = pNote;
 		m_pNotes = pNote;                           // make us be new head of list
 		bSuccess = true;
 	}
@@ -361,9 +361,9 @@ bool CItem::AddNote(CNote *pNote) {
 	bool    bSuccess = false;
 
 	if (pNote != nullptr) {                            // ... and add it to the list
-		(*pNote).m_pNext = m_pNotes;                // make head of list follow us
+		pNote->m_pNext = m_pNotes;                // make head of list follow us
 		if (m_pNotes != nullptr)                       // have list point back at us
-			(*m_pNotes).m_pPrev = pNote;
+			m_pNotes->m_pPrev = pNote;
 		m_pNotes = pNote;                           // make us be new head of list
 		bSuccess = true;
 	}

--- a/engines/bagel/hodjnpodj/metagame/bgen/notebook.cpp
+++ b/engines/bagel/hodjnpodj/metagame/bgen/notebook.cpp
@@ -138,9 +138,9 @@ LRESULT NotebookHookProc(int code, WPARAM wParam, LPARAM lParam) {
 		case VK_PRIOR:                              // go to previous note
 			if ((pKeyNote == nullptr) &&
 				(pNoteList != nullptr) &&
-				((*pNoteList).m_pPrev != nullptr)) {   // ... scroll up if not at first item
-				pNoteList = (*pNoteList).m_pPrev;
-				pDC = (*pNotebookDialog).GetDC();
+				(pNoteList->m_pPrev != nullptr)) {   // ... scroll up if not at first item
+				pNoteList = pNoteList->m_pPrev;
+				pDC = pNotebookDialog->GetDC();
 			}
 			break;
 		case VK_DOWN:                               // go to next note
@@ -148,33 +148,33 @@ LRESULT NotebookHookProc(int code, WPARAM wParam, LPARAM lParam) {
 		case VK_NEXT:
 			if ((pKeyNote == nullptr) &&
 				(pNoteList != nullptr) &&
-				((*pNoteList).m_pNext != nullptr)) {
-				pNoteList = (*pNoteList).m_pNext;
-				pDC = (*pNotebookDialog).GetDC();
+				(pNoteList->m_pNext != nullptr)) {
+				pNoteList = pNoteList->m_pNext;
+				pDC = pNotebookDialog->GetDC();
 			}
 			break;
 		case VK_HOME:                               // go to first note
 			if ((pKeyNote == nullptr) &&
 				(pNoteList != nullptr) &&
-				((*pNoteList).m_pPrev != nullptr)) {   // ... scroll up if not at first item
-				while ((*pNoteList).m_pPrev != nullptr)
-					pNoteList = (*pNoteList).m_pPrev;
-				pDC = (*pNotebookDialog).GetDC();
+				(pNoteList->m_pPrev != nullptr)) {   // ... scroll up if not at first item
+				while (pNoteList->m_pPrev != nullptr)
+					pNoteList = pNoteList->m_pPrev;
+				pDC = pNotebookDialog->GetDC();
 			}
 			break;
 		case VK_END:                                // go to last note
 			if ((pKeyNote == nullptr) &&
 				(pNoteList != nullptr) &&
-				((*pNoteList).m_pNext != nullptr)) {
-				while ((*pNoteList).m_pNext != nullptr)
-					pNoteList = (*pNoteList).m_pNext;
-				pDC = (*pNotebookDialog).GetDC();
+				(pNoteList->m_pNext != nullptr)) {
+				while (pNoteList->m_pNext != nullptr)
+					pNoteList = pNoteList->m_pNext;
+				pDC = pNotebookDialog->GetDC();
 			}
 		}
 
 	if (pDC != nullptr) {                                  // update the inventory page if required
 		CNotebook::UpdateNote(pDC);
-		(*pNotebookDialog).ReleaseDC(pDC);
+		pNotebookDialog->ReleaseDC(pDC);
 		return true;
 	}
 
@@ -250,11 +250,11 @@ void CNotebook::OnDestroy() {
 		RemoveKeyboardHook();
 
 	if (pWorkOld != nullptr) {                         // release the various contexts, palettes
-		(*pWorkDC).SelectObject(pWorkOld);    // ... and bitmaps that we used
+		pWorkDC->SelectObject(pWorkOld);    // ... and bitmaps that we used
 		pWorkOld = nullptr;
 	}
 	if (pWorkPalOld != nullptr) {
-		(*pWorkDC).SelectPalette(pWorkPalOld, false);
+		pWorkDC->SelectPalette(pWorkPalOld, false);
 		pWorkPalOld = nullptr;
 	}
 	if (pWork != nullptr) {
@@ -274,9 +274,9 @@ void CNotebook::OnDestroy() {
 	if (pBackgroundBitmap != nullptr) {                // if we had a background to refresh
 		delete pBackgroundBitmap;                   // ... then validate the parent window
 		pBackgroundBitmap = nullptr;
-		bUpdateNeeded = (*pParentWnd).GetUpdateRect(nullptr, false);
+		bUpdateNeeded = pParentWnd->GetUpdateRect(nullptr, false);
 		if (bUpdateNeeded)
-			(*pParentWnd).ValidateRect(nullptr);
+			pParentWnd->ValidateRect(nullptr);
 	}
 
 	/*
@@ -306,7 +306,7 @@ bool CNotebook::OnInitDialog() {
 	if (pParentWnd == nullptr)                                     // get our parent window
 		pParentWnd = ((CWnd *)this)->GetParent();              // ... as passed to us or inquired about
 
-	(*pParentWnd).GetWindowRect(&myRect);
+	pParentWnd->GetWindowRect(&myRect);
 
 	x = myRect.left + (((myRect.right - myRect.left) - NOTEBOOK_DX) >> 1);
 	y = myRect.top + (((myRect.bottom - myRect.top) - NOTEBOOK_DY) >> 1);
@@ -316,20 +316,20 @@ bool CNotebook::OnInitDialog() {
 
 	pButton = GetDlgItem((int)GetDefID());                     // get the window for the okay button
 	ASSERT(pButton != nullptr);                                    // ... and verify we have it
-	(*pButton).GetWindowRect(&myRect);                          // get the button's position and size
+	pButton->GetWindowRect(&myRect);                          // get the button's position and size
 
 	dx = myRect.right - myRect.left;                            // calculate where to place the button
 	x = (NOTEBOOK_DX - dx) >> 1;                                // ... centered at the bottom edge
 	dy = myRect.bottom - myRect.top;
 	y = NOTEBOOK_DY - dy - NOTE_BUTTON_DY;
 
-	(*pButton).MoveWindow(x, y, dx, dy);                        // reposition the button
+	pButton->MoveWindow(x, y, dx, dy);                        // reposition the button
 	OkayRect.SetRect(x, y, x + dx, y + dy);
 
 	pOKButton = new CColorButton();                               // build a color OKAY button to let us exit
 	ASSERT(pOKButton != nullptr);
-	(*pOKButton).SetPalette(pBackgroundPalette);                // set the palette to use
-	bSuccess = (*pOKButton).SetControl((int)GetDefID(), this); // tie to the dialog control
+	pOKButton->SetPalette(pBackgroundPalette);                // set the palette to use
+	bSuccess = pOKButton->SetControl((int)GetDefID(), this); // tie to the dialog control
 	ASSERT(bSuccess);
 
 	ScrollTopRect.SetRect(0, 0, NOTEBOOK_DX, NOTEBOOK_CURL_DY); // setup rectangles for scrolling areas
@@ -383,8 +383,8 @@ void CNotebook::UpdateNotebook(CDC *pDC) {
 
 	ShowWaitCursor();                                             // put up the hourglass cursor
 
-	pPalOld = (*pDC).SelectPalette(pBackgroundPalette, false);  // setup the proper palette
-	(*pDC).RealizePalette();
+	pPalOld = pDC->SelectPalette(pBackgroundPalette, false);  // setup the proper palette
+	pDC->RealizePalette();
 
 	if (pWorkDC == nullptr) {                                      // if we don't have a work area
 		RefreshBackground();                                    // ... then update the screen directly
@@ -399,10 +399,10 @@ void CNotebook::UpdateNotebook(CDC *pDC) {
 		UpdateContent(pWorkDC);                                 // ... then zap it to the screen
 		//		if (pTitleText != nullptr)
 		//			(*pTitleText).DisplayString(pWorkDC, "Log Entries", FONT_SIZE, TEXT_HEAVY, RGB(128,0,128));
-		(*pDC).BitBlt(0, 0, NOTEBOOK_DX, NOTEBOOK_DY, pWorkDC, 0, 0, SRCCOPY);
+		pDC->BitBlt(0, 0, NOTEBOOK_DX, NOTEBOOK_DY, pWorkDC, 0, 0, SRCCOPY);
 	}
 
-	(*pDC).SelectPalette(pPalOld, false);                       // reset the palette
+	pDC->SelectPalette(pPalOld, false);                       // reset the palette
 
 	DoArrowCursor();                                            // return to an arrow cursor
 }
@@ -412,14 +412,14 @@ void CNotebook::UpdateNote(CDC *pDC) {
 	CPalette *pPalOld;
 
 	if (pWorkDC == nullptr)                                        // update everything if no work area
-		(*pNotebookDialog).InvalidateRect(nullptr, false);
+		pNotebookDialog->InvalidateRect(nullptr, false);
 	else {                                                      // otherwise just update central area
 		ShowWaitCursor();                                         // put up the hourglass cursor
-		pPalOld = (*pDC).SelectPalette(pBackgroundPalette, false); // setup the proper palette
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pBackgroundPalette, false); // setup the proper palette
+		pDC->RealizePalette();
 		PaintMaskedBitmap(pWorkDC, pBackgroundPalette, pNotebookBitmap, 0, 0, NOTEBOOK_DX, NOTEBOOK_DY);
 		UpdateContent(pWorkDC);                                 // zap it to the screen
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 			0,
 			NOTEBOOK_CURL_DY,
 			NOTEBOOK_DX,
@@ -428,7 +428,7 @@ void CNotebook::UpdateNote(CDC *pDC) {
 			0,
 			NOTEBOOK_CURL_DY,
 			SRCCOPY);
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 			NOTEBOOK_DX - TEXT_MORE_DX,
 			NOTEBOOK_DY - NOTEBOOK_CURL_DY,
 			TEXT_MORE_DX,
@@ -437,7 +437,7 @@ void CNotebook::UpdateNote(CDC *pDC) {
 			NOTEBOOK_DX - TEXT_MORE_DX,
 			NOTEBOOK_DY - NOTEBOOK_CURL_DY,
 			SRCCOPY);
-		(*pDC).SelectPalette(pPalOld, false);                   // reset the palette
+		pDC->SelectPalette(pPalOld, false);                   // reset the palette
 		DoArrowCursor();
 	}                                                           // return to an arrow cursor
 }
@@ -461,7 +461,7 @@ void CNotebook::UpdateContent(CDC *pDC) {
 				NOTE_TEXT_DX + NOTE_TEXT_DDX,
 				NOTE_TEXT_DY + NOTE_TEXT_DDY);
 			pText = new CText(pDC, pBackgroundPalette, &myRect, JUSTIFY_CENTER);
-			(*pText).DisplayString(pDC, "The log is empty ...", FONT_SIZE, TEXT_BOLD, RGB(128, 0, 128));
+			pText->DisplayString(pDC, "The log is empty ...", FONT_SIZE, TEXT_BOLD, RGB(128, 0, 128));
 			delete pText;
 			return;
 		} else
@@ -469,10 +469,10 @@ void CNotebook::UpdateContent(CDC *pDC) {
 	} else
 		pNote = pNoteList;                                      // show the one note list points to
 
-	lpsPersonSoundSpec = (*pNote).GetPersonSoundSpec();
-	lpsPlaceSoundSpec = (*pNote).GetPlaceSoundSpec();
+	lpsPersonSoundSpec = pNote->GetPersonSoundSpec();
+	lpsPlaceSoundSpec = pNote->GetPlaceSoundSpec();
 
-	pFileSpec = (*pNote).GetPersonArtSpec();
+	pFileSpec = pNote->GetPersonArtSpec();
 	if (pFileSpec != nullptr)
 		PaintMaskedDIB(pDC, pBackgroundPalette, pFileSpec,
 			NOTE_PERSON_DX, NOTE_PERSON_DY, NOTE_BITMAP_DX, NOTE_BITMAP_DY);
@@ -481,7 +481,7 @@ void CNotebook::UpdateContent(CDC *pDC) {
 		ShowClue(pNote);
 	}
 
-	pFileSpec = (*pNote).GetPlaceArtSpec();
+	pFileSpec = pNote->GetPlaceArtSpec();
 	if (pFileSpec != nullptr)
 		PaintMaskedDIB(pDC, pBackgroundPalette, pFileSpec,
 			NOTE_PLACE_DX, NOTE_PLACE_DY, NOTE_BITMAP_DX, NOTE_BITMAP_DY);
@@ -490,20 +490,20 @@ void CNotebook::UpdateContent(CDC *pDC) {
 		ShowClue(pNote);
 	}
 
-	pFileSpec = (*pNote).GetClueArtSpec();
+	pFileSpec = pNote->GetClueArtSpec();
 	if (pFileSpec != nullptr) {
-		if ((*pNote).GetRepeatCount() <= NOTE_BITMAPS_PER_LINE) {   // shrink the bitmaps a little if
+		if (pNote->GetRepeatCount() <= NOTE_BITMAPS_PER_LINE) {   // shrink the bitmaps a little if
 			nDeltaX = NOTE_BITMAP_DX;                               // ... the number of repetitions
 			nDeltaY = NOTE_BITMAP_DY;                               // ... would force them off the page
 		} else {
 			nDeltaX = NOTE_SMALL_BITMAP_DX;
 			nDeltaY = NOTE_SMALL_BITMAP_DY;
 		}
-		dx = ((*pNote).GetRepeatCount() * nDeltaX) + (((*pNote).GetRepeatCount() - 1) * (NOTE_BITMAP_DDX / (*pNote).GetRepeatCount()));
+		dx = (pNote->GetRepeatCount() * nDeltaX) + ((pNote->GetRepeatCount() - 1) * (NOTE_BITMAP_DDX / pNote->GetRepeatCount()));
 		x = ((NOTEBOOK_DX - (NOTEBOOK_BORDER_DX << 1)) - dx) >> 1;  // establish left most position
-		for (i = 0; i < (*pNote).GetRepeatCount(); i++)             // loop till all icons displayed
+		for (i = 0; i < pNote->GetRepeatCount(); i++)             // loop till all icons displayed
 			PaintMaskedDIB(pDC, pBackgroundPalette, pFileSpec,
-				x + (i * (nDeltaX + (NOTE_BITMAP_DDX / (*pNote).GetRepeatCount()))) + NOTEBOOK_BORDER_DX,
+				x + (i * (nDeltaX + (NOTE_BITMAP_DDX / pNote->GetRepeatCount()))) + NOTEBOOK_BORDER_DX,
 				NOTE_ICON_DY,
 				nDeltaX,
 				nDeltaY);
@@ -512,13 +512,13 @@ void CNotebook::UpdateContent(CDC *pDC) {
 		ShowClue(pNote);
 	}
 
-	pFontOld = (*pDC).SelectObject(pNoteFont);                  // select it into our context
-	(*pDC).SetBkMode(TRANSPARENT);                              // make the text overlay transparently
-	(*pDC).SetTextColor(NOTE_TEXT_COLOR);                       // set the color of the text
+	pFontOld = pDC->SelectObject(pNoteFont);                  // select it into our context
+	pDC->SetBkMode(TRANSPARENT);                              // make the text overlay transparently
+	pDC->SetTextColor(NOTE_TEXT_COLOR);                       // set the color of the text
 
-	if ((*pNote).GetDescription() != nullptr) {
-		textInfo = (*pDC).GetTextExtent((*pNote).GetDescription(), strlen((*pNote).GetDescription())); // get the area spanned by the text
-		dy = textInfo.cy * (strlen((*pNote).GetDescription()) / NOTE_TEXT_CHARSPERLINE);
+	if (pNote->GetDescription() != nullptr) {
+		textInfo = pDC->GetTextExtent(pNote->GetDescription(), strlen(pNote->GetDescription())); // get the area spanned by the text
+		dy = textInfo.cy * (strlen(pNote->GetDescription()) / NOTE_TEXT_CHARSPERLINE);
 		if (dy < NOTE_TEXT_DDY)                                     // use the estimated number of lines
 			myRect.SetRect(NOTE_TEXT_DX,                            // ... of text to see if we can fit into
 				NOTE_TEXT_DY + ((NOTE_TEXT_DDY - dy) >> 1),  // ... a smaller rectangle, and thus
@@ -529,8 +529,8 @@ void CNotebook::UpdateContent(CDC *pDC) {
 				NOTE_TEXT_DY,
 				NOTE_TEXT_DX + NOTE_TEXT_DDX,
 				NOTE_TEXT_DY + NOTE_TEXT_DDY);
-		(*pDC).DrawText(                              // zap the text to the work area
-			(const char *)(*pNote).GetDescription(),
+		pDC->DrawText(                              // zap the text to the work area
+			(const char *)pNote->GetDescription(),
 			-1,
 			&myRect,
 			DT_CENTER | DT_WORDBREAK);
@@ -540,33 +540,33 @@ void CNotebook::UpdateContent(CDC *pDC) {
 	}
 
 	if (pNotebookBitmap != nullptr) {
-		(*pDC).GetTextMetrics(&fontMetrics);                        // show whether there are more notes
+		pDC->GetTextMetrics(&fontMetrics);                        // show whether there are more notes
 		x = NOTEBOOK_DX - TEXT_MORE_DX;                             // ... that can be scrolled through
 		y = NOTEBOOK_DY -
 			NOTEBOOK_CURL_DY +
 			((NOTEBOOK_CURL_DY - fontMetrics.tmHeight) >> 1) -
 			TEXT_MORE_DY;
-		textInfo = (*pDC).GetTextExtent(MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+		textInfo = pDC->GetTextExtent(MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 		dx = textInfo.cx;
 		dy = fontMetrics.tmHeight;
 
-		if ((*pNote).m_pNext == nullptr) {
+		if (pNote->m_pNext == nullptr) {
 			myRect.SetRect(x, y, x + dx, y + dy);
 			BltBitmap(pDC, pBackgroundPalette, pNotebookBitmap, &myRect, &myRect, SRCCOPY);
 		} else {
-			(*pDC).SetTextColor(NOTE_MORE_COLOR);
-			(*pDC).TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+			pDC->SetTextColor(NOTE_MORE_COLOR);
+			pDC->TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 		}
 	}
 
-	(*pDC).SelectObject(pFontOld);                            // map out the font
+	pDC->SelectObject(pFontOld);                            // map out the font
 }
 
 
 void CNotebook::ShowClue(CNote *pNote) {
 	char    blurb[128];
 
-	Common::sprintf_s(blurb, "Id=%d  Clue=%d  Person=%d  Place=%d", (*pNote).GetID(), (*pNote).GetClueID(), (*pNote).GetPersonID(), (*pNote).GetPlaceID());
+	Common::sprintf_s(blurb, "Id=%d  Clue=%d  Person=%d  Place=%d", pNote->GetID(), pNote->GetClueID(), pNote->GetPersonID(), pNote->GetPlaceID());
 	MessageBox(nullptr, blurb, "Internal Problem", MB_ICONINFORMATION);
 }
 
@@ -580,7 +580,7 @@ void CNotebook::ClearDialogImage() {
 	if (pBackgroundBitmap != nullptr) {                            // release the dialog button
 		delete pOKButton;                                       // ... validate our window to avoid refresh
 		pOKButton = nullptr;                                       // ... and restore the background
-		(*pNotebookDialog).ValidateRect(nullptr);
+		pNotebookDialog->ValidateRect(nullptr);
 		RefreshBackground();
 	}
 }
@@ -590,9 +590,9 @@ void CNotebook::RefreshBackground() {
 	CDC *pDC;
 
 	if (pBackgroundBitmap != nullptr) {
-		pDC = (*pNotebookDialog).GetDC();                       // get a context for our window
+		pDC = pNotebookDialog->GetDC();                       // get a context for our window
 		PaintBitmap(pDC, pBackgroundPalette, pBackgroundBitmap, 0, 0, NOTEBOOK_DX, NOTEBOOK_DY);
-		(*pNotebookDialog).ReleaseDC(pDC);                      // release the context
+		pNotebookDialog->ReleaseDC(pDC);                      // release the context
 	}
 }
 
@@ -619,7 +619,7 @@ int CNotebook::OnCreate(LPCREATESTRUCT lpCreateStruct) {
 	AddFontResource("msserif.fon");                       // create the text font we'll use
 	pNoteFont = new CFont();
 	ASSERT(pNoteFont != nullptr);
-	bSuccess = (*pNoteFont).CreateFont(NOTE_FONT_SIZE, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, OUT_RASTER_PRECIS, 0, PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
+	bSuccess = pNoteFont->CreateFont(NOTE_FONT_SIZE, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, OUT_RASTER_PRECIS, 0, PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
 	ASSERT(bSuccess);
 
 	if (CDialog::OnCreate(lpCreateStruct) == -1)
@@ -644,19 +644,19 @@ bool CNotebook::CreateWorkAreas(CDC *pDC) {
 	else
 		pBackgroundBitmap = nullptr;
 
-	(*pDC).SelectPalette(pBackgroundPalette, false); // create an offscreen bitmap that
-	(*pDC).RealizePalette();                           // ... we can use to construct note
+	pDC->SelectPalette(pBackgroundPalette, false); // create an offscreen bitmap that
+	pDC->RealizePalette();                           // ... we can use to construct note
 	// ... entries to avoid flashes
 	if ((GetFreeSpace(0) >= (unsigned long)1000000) &&
 		(GlobalCompact((unsigned long)500000) >= (unsigned long)450000)) {
 		pWork = new CBitmap();                                   // will paint directly if not successful
-		if ((*pWork).CreateCompatibleBitmap(pDC, NOTEBOOK_DX, NOTEBOOK_DY)) {
+		if (pWork->CreateCompatibleBitmap(pDC, NOTEBOOK_DX, NOTEBOOK_DY)) {
 			pWorkDC = new CDC();
 			if ((pWorkDC != nullptr) &&
-				(*pWorkDC).CreateCompatibleDC(pDC)) {
-				pWorkPalOld = (*pWorkDC).SelectPalette(pBackgroundPalette, false);
-				(*pWorkDC).RealizePalette();
-				pWorkOld = (*pWorkDC).SelectObject(pWork);
+				pWorkDC->CreateCompatibleDC(pDC)) {
+				pWorkPalOld = pWorkDC->SelectPalette(pBackgroundPalette, false);
+				pWorkDC->RealizePalette();
+				pWorkOld = pWorkDC->SelectObject(pWork);
 				if (pWorkOld != nullptr)
 					bSuccess = true;
 			}
@@ -667,11 +667,11 @@ bool CNotebook::CreateWorkAreas(CDC *pDC) {
 		bSuccess = true;
 	}
 
-	(*pDC).SelectPalette(pWorkPalOld, false);
+	pDC->SelectPalette(pWorkPalOld, false);
 
 	if (!bSuccess) {                                        // not successful, so tear down
 		if (pWorkPalOld != nullptr) {                          // ... the work area
-			(*pWorkDC).SelectPalette(pWorkPalOld, false);
+			pWorkDC->SelectPalette(pWorkPalOld, false);
 			pWorkPalOld = nullptr;
 		}
 		if (pWork != nullptr) {
@@ -704,30 +704,30 @@ void CNotebook::OnMouseMove(unsigned int nFlags, CPoint point) {
 	pMyApp = AfxGetApp();
 
 	if (OkayRect.PtInRect(point))                   // use standard arrow in buttons
-		hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+		hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 	else if (ScrollTopRect.PtInRect(point)) {           // set cursor to scolling up okay or invalid
 		if ((pKeyNote != nullptr) ||                   // ... depending on note status
 			((pNoteList != nullptr) &&
-				((*pNoteList).m_pPrev == nullptr)))
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_INVALID);
+				(pNoteList->m_pPrev == nullptr)))
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_INVALID);
 		else
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_ARROWUP);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_ARROWUP);
 	} else if (ScrollBotRect.PtInRect(point)) {         // set cursor to scrolling down okay or invalid
 		if ((pKeyNote != nullptr) ||                   // ... depending on note status
 			((pNoteList != nullptr) &&
-				((*pNoteList).m_pNext == nullptr)))
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_INVALID);
+				(pNoteList->m_pNext == nullptr)))
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_INVALID);
 		else
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_ARROWDN);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_ARROWDN);
 	} else if (PersonRect.PtInRect(point) &&
 		(lpsPersonSoundSpec != nullptr))
-		hNewCursor = (*pMyApp).LoadCursor(IDC_NOTEBOOK_SOUND);
+		hNewCursor = pMyApp->LoadCursor(IDC_NOTEBOOK_SOUND);
 	else if (PlaceRect.PtInRect(point) &&
 		(lpsPlaceSoundSpec != nullptr))
-		hNewCursor = (*pMyApp).LoadCursor(IDC_NOTEBOOK_SOUND);
+		hNewCursor = pMyApp->LoadCursor(IDC_NOTEBOOK_SOUND);
 
 	if (hNewCursor == nullptr)                         // use default cursor if not specified
-		hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+		hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 
 	ASSERT(hNewCursor != nullptr);                     // force the cursor change
 	MFC::SetCursor(hNewCursor);
@@ -746,8 +746,8 @@ void CNotebook::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	if (ScrollTopRect.PtInRect(point) &&            // if click is in upper curl, then
 		(pKeyNote == nullptr) &&
 		(pNoteList != nullptr) &&
-		((*pNoteList).m_pPrev != nullptr)) {            // ... scroll up if not at first item
-		pNoteList = (*pNoteList).m_pPrev;
+		(pNoteList->m_pPrev != nullptr)) {            // ... scroll up if not at first item
+		pNoteList = pNoteList->m_pPrev;
 		pDC = GetDC();
 	}
 	// if click is in lower curl, then
@@ -755,20 +755,20 @@ void CNotebook::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	else if (ScrollBotRect.PtInRect(point) &&
 		(pKeyNote == nullptr) &&
 		(pNoteList != nullptr) &&
-		((*pNoteList).m_pNext != nullptr)) {
-		pNoteList = (*pNoteList).m_pNext;
+		(pNoteList->m_pNext != nullptr)) {
+		pNoteList = pNoteList->m_pNext;
 		pDC = GetDC();
 	} else if (PersonRect.PtInRect(point)) {            // play the person sound file
 		if (lpsPersonSoundSpec != nullptr) {
 			pSound = new CSound(this, lpsPersonSoundSpec, SOUND_WAVE | SOUND_QUEUE | SOUND_AUTODELETE);
-			(*pSound).setDrivePath(lpMetaGameStruct->m_chCDPath);
-			(*pSound).play();
+			pSound->setDrivePath(lpMetaGameStruct->m_chCDPath);
+			pSound->play();
 		}
 	} else if (PlaceRect.PtInRect(point)) {             // play the place sound file
 		if (lpsPlaceSoundSpec != nullptr) {
 			pSound = new CSound(this, lpsPlaceSoundSpec, SOUND_WAVE | SOUND_QUEUE | SOUND_AUTODELETE);
-			(*pSound).setDrivePath(lpMetaGameStruct->m_chCDPath);
-			(*pSound).play();
+			pSound->setDrivePath(lpMetaGameStruct->m_chCDPath);
+			pSound->play();
 		}
 	}
 
@@ -784,7 +784,7 @@ void CNotebook::OnLButtonDown(unsigned int nFlags, CPoint point) {
 
 
 bool CNotebook::OnSetCursor(CWnd *pWnd, unsigned int /*nHitTest*/, unsigned int /*message*/) {
-	if ((*pWnd).m_hWnd == (*this).m_hWnd)
+	if (pWnd->m_hWnd == (this)->m_hWnd)
 		return true;
 	else
 		return false;
@@ -796,7 +796,7 @@ void CNotebook::ShowWaitCursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).BeginWaitCursor();
+	pMyApp->BeginWaitCursor();
 }
 
 
@@ -805,7 +805,7 @@ void CNotebook::DoArrowCursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).EndWaitCursor();
+	pMyApp->EndWaitCursor();
 }
 
 } // namespace Gtl

--- a/engines/bagel/hodjnpodj/metagame/demo/hodjpodj_demo.cpp
+++ b/engines/bagel/hodjnpodj/metagame/demo/hodjpodj_demo.cpp
@@ -140,14 +140,14 @@ void CHodjPodjDemoWindow::blackScreen() {
 	pDC->FillRect(&MainRect, &Brush);
 
 	if (pGamePalette != nullptr) {                                  // map in color palette to be used
-		pPalOld = (*pDC).SelectPalette(pGamePalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pGamePalette, false);
+		pDC->RealizePalette();
 	}
 
 	pDC->FillRect(&MainRect, &Brush);
 
 	if (pPalOld != nullptr)                                 // relinquish the resources we built
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	ReleaseDC(pDC);
 }
@@ -179,13 +179,13 @@ void CHodjPodjDemoWindow::playMovie(const int nMovieId, const char *pszMovie, bo
 void CHodjPodjDemoWindow::startBackgroundMidi() {
 	if (pBackgroundMidi == nullptr) {
 		pBackgroundMidi = new CSound(this, LOGO_MIDI, SOUND_MIDI | SOUND_LOOP /* | SOUND_DONT_LOOP_TO_END */);
-		(*pBackgroundMidi).play();
+		pBackgroundMidi->play();
 	}
 }
 
 void CHodjPodjDemoWindow::stopBackgroundMidi() {
 	if (pBackgroundMidi != nullptr) {
-		(*pBackgroundMidi).stop();
+		pBackgroundMidi->stop();
 		delete pBackgroundMidi;
 		pBackgroundMidi = nullptr;
 	}

--- a/engines/bagel/hodjnpodj/metagame/frame/hodjpodj.cpp
+++ b/engines/bagel/hodjnpodj/metagame/frame/hodjpodj.cpp
@@ -358,11 +358,11 @@ bool CHodjPodjWindow::CheckConfig(CDC *pDC) {
 
 	bLowMemory = CheckLowMemory();
 
-	nDevCaps = (*pDC).GetDeviceCaps(BITSPIXEL);
+	nDevCaps = pDC->GetDeviceCaps(BITSPIXEL);
 	if (nDevCaps < 8) {
 		error("Please set your display to 256 colors before playing this game");
 	} else {
-		nDevCaps = (*pDC).GetDeviceCaps(RASTERCAPS);
+		nDevCaps = pDC->GetDeviceCaps(RASTERCAPS);
 		if (!(nDevCaps & RC_PALETTE))
 			error("It is recommended that your display be set to 256 colors before playing");
 	}
@@ -570,7 +570,7 @@ bool CHodjPodjWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 		pWnd = (CWnd *)lParam;
 		if (pWnd != nullptr) {
-			(*pWnd).SendMessage(WM_CLOSE, 0, 0L);
+			pWnd->SendMessage(WM_CLOSE, 0, 0L);
 			delete pWnd;
 		}
 
@@ -713,7 +713,7 @@ void CHodjPodjWindow::OnMouseMove(unsigned int nFlags, CPoint point) {
 
 	pMyApp = AfxGetApp();
 
-	hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+	hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 
 	//if (hNewCursor != nullptr);
 	SetCursor(hNewCursor);
@@ -784,14 +784,14 @@ void CHodjPodjWindow::BlackScreen() {
 	pDC->FillRect(&MainRect, &Brush);
 
 	if (pGamePalette != nullptr) {                                  // map in color palette to be used
-		pPalOld = (*pDC).SelectPalette(pGamePalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pGamePalette, false);
+		pDC->RealizePalette();
 	}
 
 	pDC->FillRect(&MainRect, &Brush);
 
 	if (pPalOld != nullptr)                                 // relinquish the resources we built
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	ReleaseDC(pDC);
 }
@@ -1603,12 +1603,12 @@ void CHodjPodjWindow::OnParentNotify(unsigned int msg, LPARAM lParam) {
 	switch (msg) {
 	case WM_DESTROY:
 		if (bReturnToMeta && (lpMetaGame != nullptr)) {
-			bSoundEffectsEnabled = (*lpMetaGame).m_stGameStruct.bSoundEffectsEnabled;
-			bMusicEnabled = (*lpMetaGame).m_stGameStruct.bMusicEnabled;
-			bScrollingEnabled = (*lpMetaGame).m_bScrolling;
+			bSoundEffectsEnabled = lpMetaGame->m_stGameStruct.bSoundEffectsEnabled;
+			bMusicEnabled = lpMetaGame->m_stGameStruct.bMusicEnabled;
+			bScrollingEnabled = lpMetaGame->m_bScrolling;
 		} else if (bReturnToGrandTour && (lpGrandTour != nullptr)) {
-			bSoundEffectsEnabled = (*lpGrandTour).stMiniGame.bSoundEffectsEnabled;
-			bMusicEnabled = (*lpGrandTour).stMiniGame.bMusicEnabled;
+			bSoundEffectsEnabled = lpGrandTour->stMiniGame.bSoundEffectsEnabled;
+			bMusicEnabled = lpGrandTour->stMiniGame.bMusicEnabled;
 		}
 
 		nGameReturn = lParam;
@@ -1726,14 +1726,14 @@ void CHodjPodjWindow::StartBackgroundMidi() {
 	if (bMusicEnabled && (pBackgroundMidi == nullptr)) {
 		PositionAtHomePath();
 		pBackgroundMidi = new CSound(this, LOGO_MIDI, SOUND_MIDI | SOUND_LOOP /* | SOUND_DONT_LOOP_TO_END */);
-		(*pBackgroundMidi).play();
+		pBackgroundMidi->play();
 	}
 }
 
 
 void CHodjPodjWindow::StopBackgroundMidi() {
 	if (pBackgroundMidi != nullptr) {
-		(*pBackgroundMidi).stop();
+		pBackgroundMidi->stop();
 		delete pBackgroundMidi;
 		pBackgroundMidi = nullptr;
 	}
@@ -1892,7 +1892,7 @@ void InitBFCInfo(CBfcMgr *pBfcMgr) {
 
 			pPlayer->m_pInventory->AddItem(k == 0 ? MG_OBJ_HODJ_NOTEBOOK : MG_OBJ_PODJ_NOTEBOOK, 1);
 			pItem = pPlayer->m_pInventory->FindItem(k == 0 ? MG_OBJ_HODJ_NOTEBOOK : MG_OBJ_PODJ_NOTEBOOK);
-			(*pItem).SetActionCode(ITEM_ACTION_NOTEBOOK);
+			pItem->SetActionCode(ITEM_ACTION_NOTEBOOK);
 			pPlayer->m_pInventory->AddItem(MG_OBJ_CROWN, 20);
 		}
 

--- a/engines/bagel/hodjnpodj/metagame/grand_tour/grand_tour.cpp
+++ b/engines/bagel/hodjnpodj/metagame/grand_tour/grand_tour.cpp
@@ -335,7 +335,7 @@ CMainGTWindow::CMainGTWindow(HWND hCallingWnd, LPGRANDTRSTRUCT  pgtGrandTourStru
 		if (nNewRank > -1) {
 			pScoresResetButton->EnableWindow(false);
 			pScoresLeaveButton->EnableWindow(false);
-			(*this).SetFocus();
+			(this)->SetFocus();
 		}
 		//  else {
 		//      pScoresLeaveButton->SetFocus();
@@ -539,7 +539,7 @@ CMainGTWindow::CMainGTWindow(HWND hCallingWnd, LPGRANDTRSTRUCT  pgtGrandTourStru
 
 		}
 	}
-	(*this).SetFocus();
+	(this)->SetFocus();
 
 	EndWaitCursor();
 }
@@ -818,7 +818,7 @@ void CMainGTWindow::SplashScreen() {
 
 			pDC->TextOut(ScoresLeaveRect.left, nTop + 300, "Press Enter When Done.", 22);
 
-			(*this).SetFocus();                         // Reset focus back to the main window
+			(this)->SetFocus();                         // Reset focus back to the main window
 
 		} else {
 			rgbOldColorRef = pDC->SetTextColor(RGB(0, 0, 255));
@@ -1081,7 +1081,7 @@ bool CMainGTWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 		}
 	}
 
-	(*this).SetFocus();                         // Reset focus back to the main window
+	(this)->SetFocus();                         // Reset focus back to the main window
 	return true;
 }
 
@@ -1188,7 +1188,7 @@ void CMainGTWindow::OnChar(unsigned int nChar, unsigned int nRepCnt, unsigned in
 								pText = new CText();
 								cTextRect.SetRect(SCROLL_LEFT + 69, SCROLL_TOP + (nNewRank * 20) + 90, SCROLL_LEFT + 349, SCROLL_TOP + (nNewRank * 20) + 110);
 								pText->SetupText(pDC, pGamePalette, &cTextRect, JUSTIFY_LEFT);
-								(*this).SetFocus();
+								(this)->SetFocus();
 								break;
 							}
 						}

--- a/engines/bagel/hodjnpodj/metagame/gtl/citemdlg.cpp
+++ b/engines/bagel/hodjnpodj/metagame/gtl/citemdlg.cpp
@@ -108,7 +108,7 @@ bool CItemDialog::OnInitDialog() {
 	                 nText_row_offset + nTextHeight);
 
 	if ((m_pTextMessage = new CText()) != nullptr) {
-		bSuccess = (*m_pTextMessage).SetupText(pDC, m_pPalette, &textRect, JUSTIFY_CENTER);
+		bSuccess = m_pTextMessage->SetupText(pDC, m_pPalette, &textRect, JUSTIFY_CENTER);
 		ASSERT(bSuccess);   // Initialize the text objext
 	}
 
@@ -121,7 +121,7 @@ bool CItemDialog::OnInitDialog() {
 	);
 
 	if ((m_pTextDescription = new CText()) != nullptr) {
-		bSuccess = (*m_pTextDescription).SetupText(pDC, m_pPalette, &textRect, JUSTIFY_CENTER);
+		bSuccess = m_pTextDescription->SetupText(pDC, m_pPalette, &textRect, JUSTIFY_CENTER);
 		ASSERT(bSuccess);   // Initialize the text objext
 	}
 
@@ -130,8 +130,8 @@ bool CItemDialog::OnInitDialog() {
 	// build a color OK button to let us exit
 	m_pOKButton = new CColorButton();
 	ASSERT(m_pOKButton != nullptr);
-	(*m_pOKButton).SetPalette(m_pPalette);
-	bSuccess = (*m_pOKButton).SetControl((int) GetDefID(), this); // Tie to the dialog control
+	m_pOKButton->SetPalette(m_pPalette);
+	bSuccess = m_pOKButton->SetControl((int) GetDefID(), this); // Tie to the dialog control
 	ASSERT(bSuccess);
 
 	return true;
@@ -156,18 +156,18 @@ void CItemDialog::OnPaint() {
 	pDC = GetDC();
 
 	Common::sprintf_s(buf, "%s %s", m_bHodj ? "Hodj" : "Podj", m_bGain ? "gains" : "loses");
-	bSuccess = (*m_pTextMessage).DisplayString(pDC, buf, 20, FW_BOLD, TEXT_COLOR);
+	bSuccess = m_pTextMessage->DisplayString(pDC, buf, 20, FW_BOLD, TEXT_COLOR);
 	ASSERT(bSuccess);
 
-	Common::sprintf_s(buf, "%s", (*m_pItem).GetDescription((*m_pItem).GetID(), m_lAmount));
+	Common::sprintf_s(buf, "%s", m_pItem->GetDescription(m_pItem->GetID(), m_lAmount));
 	while (buf[i] != 0) i++;
 	if (i > 20)
-		bSuccess = (*m_pTextDescription).DisplayString(pDC, buf, 13, FW_BOLD, ITEMDLG_TEXT_COLOR);
+		bSuccess = m_pTextDescription->DisplayString(pDC, buf, 13, FW_BOLD, ITEMDLG_TEXT_COLOR);
 	else
-		bSuccess = (*m_pTextDescription).DisplayString(pDC, buf, 16, FW_BOLD, ITEMDLG_TEXT_COLOR);
+		bSuccess = m_pTextDescription->DisplayString(pDC, buf, 16, FW_BOLD, ITEMDLG_TEXT_COLOR);
 	ASSERT(bSuccess);
 
-	PaintMaskedDIB(pDC, m_pPalette, (*m_pItem).GetArtSpec(),
+	PaintMaskedDIB(pDC, m_pPalette, m_pItem->GetArtSpec(),
 	    (ITEMDLG_DX - ITEMDLG_BITMAP_DX / 2), (ITEMDLG_DY - ITEMDLG_BITMAP_DY),
 	    ITEMDLG_BITMAP_DX, ITEMDLG_BITMAP_DY);
 

--- a/engines/bagel/hodjnpodj/metagame/gtl/cmapdlg.cpp
+++ b/engines/bagel/hodjnpodj/metagame/gtl/cmapdlg.cpp
@@ -100,7 +100,7 @@ bool CMapDialog::OnInitDialog() {
 	                 nText_row_offset + nTextHeight);
 
 	if ((m_pTextMessage = new CText()) != nullptr) {
-		bSuccess = (*m_pTextMessage).SetupText(pDC, m_pPalette, &textRect, JUSTIFY_CENTER);
+		bSuccess = m_pTextMessage->SetupText(pDC, m_pPalette, &textRect, JUSTIFY_CENTER);
 		ASSERT(bSuccess);   // initialize the text objext
 	}
 
@@ -108,8 +108,8 @@ bool CMapDialog::OnInitDialog() {
 
 	m_pOKButton = new CColorButton();                   // build a color QUIT button to let us exit
 	ASSERT(m_pOKButton != nullptr);
-	(*m_pOKButton).SetPalette(m_pPalette);                       // set the palette to use
-	bSuccess = (*m_pOKButton).SetControl((int) GetDefID(), this); // tie to the dialog control
+	m_pOKButton->SetPalette(m_pPalette);                       // set the palette to use
+	bSuccess = m_pOKButton->SetControl((int) GetDefID(), this); // tie to the dialog control
 	ASSERT(bSuccess);
 
 	return true;  // return true  unless you set the focus to a control
@@ -126,7 +126,7 @@ void CMapDialog::OnPaint() {
 	pDC = GetDC();
 
 	Common::strcpy_s(buf, "");
-	bSuccess = (*m_pTextMessage).DisplayString(pDC, buf, 20, FW_BOLD, TEXT_COLOR);
+	bSuccess = m_pTextMessage->DisplayString(pDC, buf, 20, FW_BOLD, TEXT_COLOR);
 	ASSERT(bSuccess);
 
 	m_ptZoomHodj.x = (int)(((long)m_HodjLoc.x * ZOOMMAP_WIDTH) / BIGMAP_WIDTH);

--- a/engines/bagel/hodjnpodj/metagame/gtl/cturndlg.cpp
+++ b/engines/bagel/hodjnpodj/metagame/gtl/cturndlg.cpp
@@ -100,7 +100,7 @@ bool CTurnDialog::OnInitDialog() {
 	                 nText_row_offset + nTextHeight);
 
 	if ((m_pTextMessage = new CText()) != nullptr) {
-		bSuccess = (*m_pTextMessage).SetupText(pDC, m_pPalette, &textRect, JUSTIFY_CENTER);
+		bSuccess = m_pTextMessage->SetupText(pDC, m_pPalette, &textRect, JUSTIFY_CENTER);
 		ASSERT(bSuccess);   // initialize the text objext
 	}
 
@@ -108,8 +108,8 @@ bool CTurnDialog::OnInitDialog() {
 
 	m_pOKButton = new CColorButton();                   // build a color QUIT button to let us exit
 	ASSERT(m_pOKButton != nullptr);
-	(*m_pOKButton).SetPalette(m_pPalette);        // set the palette to use
-	bSuccess = (*m_pOKButton).SetControl((int) GetDefID(), this); // tie to the dialog control
+	m_pOKButton->SetPalette(m_pPalette);        // set the palette to use
+	bSuccess = m_pOKButton->SetControl((int) GetDefID(), this); // tie to the dialog control
 	ASSERT(bSuccess);
 
 	return true;  // return true  unless you set the focus to a control
@@ -134,7 +134,7 @@ void CTurnDialog::OnPaint() {
 		Common::sprintf_s(artBuf, "%s", m_bGain ? "art\\wingame.bmp" : "art\\losegame.bmp");
 	}
 
-	bSuccess = (*m_pTextMessage).DisplayString(pDC, msgBuf, 20, FW_BOLD, TEXT_COLOR);
+	bSuccess = m_pTextMessage->DisplayString(pDC, msgBuf, 20, FW_BOLD, TEXT_COLOR);
 	ASSERT(bSuccess);
 
 	PaintMaskedDIB(pDC, m_pPalette, artBuf,

--- a/engines/bagel/hodjnpodj/metagame/gtl/encount.cpp
+++ b/engines/bagel/hodjnpodj/metagame/gtl/encount.cpp
@@ -611,16 +611,16 @@ int DoEncounter(CWnd *pWnd, CPalette *pPalette, bool bHodj, CInventory *pInvento
 			nRandom = brand() % RAND_FACTOR;
 			if (nTestProb >= nRandom) {                                        // If we are in the probability percentage...
 				// check ItemCount(), set Item flag
-				pItem = (*pInventory).FindItem(MG_OBJ_MISH);                    // See if they have mish or mosh
+				pItem = pInventory->FindItem(MG_OBJ_MISH);                    // See if they have mish or mosh
 				if (pItem != nullptr)                                              // don't count crowns and notebook
-					nItems = (*pInventory).ItemCount() - INVENT_MIN_ITEM_COUNT - ENC_MISHMOSH; // and Mish & Mosh
+					nItems = pInventory->ItemCount() - INVENT_MIN_ITEM_COUNT - ENC_MISHMOSH; // and Mish & Mosh
 				else
-					nItems = (*pInventory).ItemCount() - INVENT_MIN_ITEM_COUNT;     // don't count crowns and notebook
-				pItem = (*pInventory).FindItem(MG_OBJ_CROWN);               // get money item obj, set Money int to am't
+					nItems = pInventory->ItemCount() - INVENT_MIN_ITEM_COUNT;     // don't count crowns and notebook
+				pItem = pInventory->FindItem(MG_OBJ_CROWN);               // get money item obj, set Money int to am't
 				if (pItem == nullptr)
 					lCrowns = 0;
 				else
-					lCrowns = (int)(*pItem).GetQuantity();
+					lCrowns = (int)pItem->GetQuantity();
 
 				// players crowns in his inventory is bogus if this fails
 				assert(lCrowns >= 0);
@@ -663,9 +663,9 @@ int DoEncounter(CWnd *pWnd, CPalette *pPalette, bool bHodj, CInventory *pInvento
 							if (lCrowns < 0)                                        // If we end up with negative
 								lCrowns = 0;                                        //...crowns, make it zero
 
-							pItem = (*pInventory).FindItem(MG_OBJ_CROWN);           // get money item obj
+							pItem = pInventory->FindItem(MG_OBJ_CROWN);           // get money item obj
 							if (pItem != nullptr)                                      //...if successful
-								(*pItem).SetQuantity(lCrowns);                      //...set Money int to am't
+								pItem->SetQuantity(lCrowns);                      //...set Money int to am't
 							CItemDialog ItemDlg(pWnd, pPalette, pItem, bHodj, (nRandFactor > 0) ? true : false, nChangeAmount);
 							i++;                                                    // skip the one we just read in
 						} else if (Encounters[nID].m_Actions[i] == MG_ACT_OBJECT) { // Trap effects the inventory
@@ -678,34 +678,34 @@ int DoEncounter(CWnd *pWnd, CPalette *pPalette, bool bHodj, CInventory *pInvento
 									pTryOne = pPawn;
 									pTryTwo = pGeneral;
 								}
-								if ((*pTryOne).ItemCount() > 0) {                   // If the first one has items
-									nItems = (*pTryOne).ItemCount();                // How many items
-									pItem = (*pTryOne).FetchItem(brand() % nItems);  // Get one and
-									(*pTryOne).RemoveItem(pItem);                   //...remove it to pItem
+								if (pTryOne->ItemCount() > 0) {                   // If the first one has items
+									nItems = pTryOne->ItemCount();                // How many items
+									pItem = pTryOne->FetchItem(brand() % nItems);  // Get one and
+									pTryOne->RemoveItem(pItem);                   //...remove it to pItem
 								} else {                                            // Otherwise, get the first
-									nItems = (*pTryTwo).ItemCount();                // How many items
-									pItem = (*pTryTwo).FetchItem(brand() % nItems);  // Get one and
-									(*pTryTwo).RemoveItem(pItem);                   //...and remove _it_ to pItem
+									nItems = pTryTwo->ItemCount();                // How many items
+									pItem = pTryTwo->FetchItem(brand() % nItems);  // Get one and
+									pTryTwo->RemoveItem(pItem);                   //...and remove _it_ to pItem
 								}
-								(*pInventory).AddItem(pItem);                       // And put pItem in the player's
+								pInventory->AddItem(pItem);                       // And put pItem in the player's
 								CItemDialog ItemDlg(pWnd, pPalette, pItem, bHodj, true, 1);
 							}                                                       //...backpack Inventory
 							else {                                                  // Otherwise, he loses an item
-								nItems = (*pInventory).ItemCount() - INVENT_MIN_ITEM_COUNT;     // don't count crowns and notebook
+								nItems = pInventory->ItemCount() - INVENT_MIN_ITEM_COUNT;     // don't count crowns and notebook
 								bDone = false;
 								while (!bDone) {
 									assert(nItems != 0);
-									pItem = (*pInventory).FetchItem(INVENT_MIN_ITEM_COUNT + brand() % nItems);   // Get one
+									pItem = pInventory->FetchItem(INVENT_MIN_ITEM_COUNT + brand() % nItems);   // Get one
 									if ((pItem != nullptr) &&                          //...make sure it's valid
 									        ((pItem->GetID() != MG_OBJ_MISH) &&
 									         (pItem->GetID() != MG_OBJ_MOSH))) {
 
-										(*pInventory).RemoveItem(pItem);            // Remove it from the backpack
+										pInventory->RemoveItem(pItem);            // Remove it from the backpack
 										nPick = brand() % 2;                         //...get a random destination
 										if (nPick == 0)
-											(*pGeneral).AddItem(pItem);             //...and put it there
+											pGeneral->AddItem(pItem);             //...and put it there
 										else
-											(*pPawn).AddItem(pItem);
+											pPawn->AddItem(pItem);
 										CItemDialog ItemDlg(pWnd, pPalette, pItem, bHodj, false, 1);
 										bDone = true;
 									} // end if
@@ -872,8 +872,8 @@ bool PlayEncounter(CWnd *pWnd, int nID) {
 	if (pNarration == nullptr)
 		return false;
 
-	(*pNarration).setDrivePath(lpMetaGameStruct->m_chCDPath);
-	(*pNarration).play();                                           //...play the narration
+	pNarration->setDrivePath(lpMetaGameStruct->m_chCDPath);
+	pNarration->play();                                           //...play the narration
 	if (nID < MG_TRAP_COUNT)                                            // For Booby Traps:
 		CSound::waitWaveSounds();
 

--- a/engines/bagel/hodjnpodj/metagame/gtl/gtlmve.cpp
+++ b/engines/bagel/hodjnpodj/metagame/gtl/gtlmve.cpp
@@ -3270,7 +3270,7 @@ bool CGtlData::DetermineGameEligibility(CXodj *xpXodj, int iGameCode, bool bExec
 			CDC *pDC = nullptr;
 			if ((pDC = gpMyView->GetDC()) != nullptr) {
 				m_cBgbMgr.m_xpBsuSet->PrepareDc(pDC, true);
-				nDevCaps = (*pDC).GetDeviceCaps(RASTERCAPS);
+				nDevCaps = pDC->GetDeviceCaps(RASTERCAPS);
 				m_cBgbMgr.m_xpBsuSet->PrepareDc(pDC, false);
 				gpMyView->ReleaseDC(pDC);
 				if (!(nDevCaps & RC_PALETTE)) {

--- a/engines/bagel/hodjnpodj/metagame/gtl/gtlview.cpp
+++ b/engines/bagel/hodjnpodj/metagame/gtl/gtlview.cpp
@@ -512,7 +512,7 @@ void CGtlView::OnTimer(uintptr nEventID) {
 
 
 bool CGtlView::OnSetCursor(CWnd *pWnd, unsigned int /*nHitTest*/, unsigned int /*message*/) {
-	if ((*pWnd).m_hWnd == (*this).m_hWnd)
+	if (pWnd->m_hWnd == (this)->m_hWnd)
 		return true;
 	else
 		return false;

--- a/engines/bagel/hodjnpodj/metagame/gtl/pawn.cpp
+++ b/engines/bagel/hodjnpodj/metagame/gtl/pawn.cpp
@@ -140,33 +140,33 @@ LRESULT PawnHookProc(int code, WPARAM wParam, LPARAM lParam) {
 				nFirstSlot -= (nItemsPerRow * nItemsPerColumn);
 				if (nFirstSlot < 0)
 					nFirstSlot = 0;
-				pDC = (*pPawnDialog).GetDC();
+				pDC = pPawnDialog->GetDC();
 			}
 			break;
 		case VK_DOWN:                               // go to next page of text
 		case VK_NUMPAD2:
 		case VK_NEXT:
-			if (nFirstSlot + (nItemsPerRow * nItemsPerColumn) < (*pInventory).ItemCount()) {
+			if (nFirstSlot + (nItemsPerRow * nItemsPerColumn) < pInventory->ItemCount()) {
 				nFirstSlot += (nItemsPerRow * nItemsPerColumn);
-				pDC = (*pPawnDialog).GetDC();
+				pDC = pPawnDialog->GetDC();
 			}
 			break;
 		case VK_HOME:                               // go to first page of text
 			if (nFirstSlot != 0) {
 				nFirstSlot = 0;
-				pDC = (*pPawnDialog).GetDC();
+				pDC = pPawnDialog->GetDC();
 			}
 			break;
 		case VK_END:                                // go to last page of text
-			nFirstSlot = (*pInventory).ItemCount() - (nItemsPerRow * nItemsPerColumn);
+			nFirstSlot = pInventory->ItemCount() - (nItemsPerRow * nItemsPerColumn);
 			if (nFirstSlot < 0)
 				nFirstSlot = 0;
-			pDC = (*pPawnDialog).GetDC();
+			pDC = pPawnDialog->GetDC();
 		}
 
 	if (pDC != nullptr) {                                  // update the inventory page if required
 		CPawnShop::UpdatePage(pDC);
-		(*pPawnDialog).ReleaseDC(pDC);
+		pPawnDialog->ReleaseDC(pDC);
 		return true;
 	}
 
@@ -239,11 +239,11 @@ void CPawnShop::OnDestroy() {
 		RemoveKeyboardHook();
 
 	if (pWorkOld != nullptr) {
-		(*pWorkDC).SelectObject(pWorkOld);
+		pWorkDC->SelectObject(pWorkOld);
 		pWorkOld = nullptr;
 	}
 	if (pWorkPalOld != nullptr) {
-		(*pWorkDC).SelectPalette(pWorkPalOld, false);
+		pWorkDC->SelectPalette(pWorkPalOld, false);
 		pWorkPalOld = nullptr;
 	}
 	if (pWork != nullptr) {
@@ -263,9 +263,9 @@ void CPawnShop::OnDestroy() {
 	if (pBackgroundBitmap != nullptr) {
 		delete pBackgroundBitmap;
 		pBackgroundBitmap = nullptr;
-		bUpdateNeeded = (*pParentWnd).GetUpdateRect(nullptr, false);
+		bUpdateNeeded = pParentWnd->GetUpdateRect(nullptr, false);
 		if (bUpdateNeeded)
-			(*pParentWnd).ValidateRect(nullptr);
+			pParentWnd->ValidateRect(nullptr);
 	}
 
 	if (pItemText != nullptr) {
@@ -298,7 +298,7 @@ bool CPawnShop::OnInitDialog() {
 		m_pParentWnd = ((CWnd *) this)->GetParent();            // ... as passed to us or inquired about
 	assert(m_pParentWnd);
 
-	(*m_pParentWnd).GetWindowRect(&myRect);
+	m_pParentWnd->GetWindowRect(&myRect);
 	x = myRect.left + (((myRect.right - myRect.left) - PAWN_DX) >> 1);
 	y = myRect.top + (((myRect.bottom - myRect.top) - PAWN_DY) >> 1);
 	PawnRect.SetRect(0, 0, PAWN_DX, PAWN_DY);
@@ -306,20 +306,20 @@ bool CPawnShop::OnInitDialog() {
 
 	pButton = GetDlgItem((int) GetDefID());                     // get the window for the okay button
 	ASSERT(pButton != nullptr);                                    // ... and verify we have it
-	(*pButton).GetWindowRect(&myRect);                          // get the button's position and size
+	pButton->GetWindowRect(&myRect);                          // get the button's position and size
 
 	dx = myRect.right - myRect.left;                            // calculate where to place the button
 	x = (PawnRect.right - dx) >> 1;                             // ... centered at the bottom edge
 	dy = myRect.bottom - myRect.top;
 	y = PawnRect.bottom - dy - BUTTON_DY;
 
-	(*pButton).MoveWindow(x, y, dx, dy);                        // reposition the button
+	pButton->MoveWindow(x, y, dx, dy);                        // reposition the button
 	OkayRect.SetRect(x, y, x + dx, y + dy);
 
 	pOKButton = new CColorButton();                               // build a color OKAY button to let us exit
 	ASSERT(pOKButton != nullptr);
-	(*pOKButton).SetPalette(pBackgroundPalette);                // set the palette to use
-	bSuccess = (*pOKButton).SetControl((int) GetDefID(), this); // tie to the dialog control
+	pOKButton->SetPalette(pBackgroundPalette);                // set the palette to use
+	bSuccess = pOKButton->SetControl((int) GetDefID(), this); // tie to the dialog control
 	ASSERT(bSuccess);
 
 	ScrollTopRect.SetRect(0, 0, PAWN_DX, PAWN_CURL_DY); // setup rectangles for scrolling areas
@@ -330,7 +330,7 @@ bool CPawnShop::OnInitDialog() {
 	bFirstTime = true;
 	nFirstSlot = 0;
 
-	if ((*pInventory).FindItem(MG_OBJ_HODJ_NOTEBOOK) != nullptr)   // see who is playing
+	if (pInventory->FindItem(MG_OBJ_HODJ_NOTEBOOK) != nullptr)   // see who is playing
 		bPlayingHodj = true;
 	else
 		bPlayingHodj = false;
@@ -376,26 +376,26 @@ void CPawnShop::UpdatePawn(CDC *pDC) {
 
 	ShowWaitCursor();                                             // put up the hourglass cursor
 
-	pPalOld = (*pDC).SelectPalette(pBackgroundPalette, false);      // setup the proper palette
-	(*pDC).RealizePalette();
+	pPalOld = pDC->SelectPalette(pBackgroundPalette, false);      // setup the proper palette
+	pDC->RealizePalette();
 
 	if (pWorkDC == nullptr) {                                      // if we don't have a work area
 		RefreshBackground();                                    // ... then update the screen directly
 		PaintMaskedBitmap(pDC, pBackgroundPalette, pPawnBitmap, 0, 0, PAWN_DX, PAWN_DY);
 		UpdateContent(pDC);
 		if (pTitleText != nullptr)
-			(*pTitleText).DisplayString(pDC, "Pawn Shop", 32, TEXT_HEAVY, PAWN_TEXT_COLOR);
+			pTitleText->DisplayString(pDC, "Pawn Shop", 32, TEXT_HEAVY, PAWN_TEXT_COLOR);
 	} else {
 		if (pBackgroundBitmap != nullptr)                                                      // ... otherwise revise work area
 			PaintBitmap(pWorkDC, pBackgroundPalette, pBackgroundBitmap, 0, 0, PAWN_DX, PAWN_DY);
 		PaintMaskedBitmap(pWorkDC, pBackgroundPalette, pPawnBitmap, 0, 0, PAWN_DX, PAWN_DY);
 		UpdateContent(pWorkDC);                                 // ... then zap it to the screen
 		if (pTitleText != nullptr)
-			(*pTitleText).DisplayString(pWorkDC, "Pawn Shop", 32, TEXT_HEAVY, PAWN_TEXT_COLOR);
-		(*pDC).BitBlt(0, 0, PAWN_DX, PAWN_DY, pWorkDC, 0, 0, SRCCOPY);
+			pTitleText->DisplayString(pWorkDC, "Pawn Shop", 32, TEXT_HEAVY, PAWN_TEXT_COLOR);
+		pDC->BitBlt(0, 0, PAWN_DX, PAWN_DY, pWorkDC, 0, 0, SRCCOPY);
 	}
 
-	(*pDC).SelectPalette(pPalOld, false);                       // reset the palette
+	pDC->SelectPalette(pPalOld, false);                       // reset the palette
 
 	DoArrowCursor();                                            // return to an arrow cursor
 }
@@ -405,16 +405,16 @@ void CPawnShop::UpdatePage(CDC *pDC) {
 	CPalette    *pPalOld;
 
 	if (pWorkDC == nullptr)                                        // update everything if no work area
-		(*pPawnDialog).InvalidateRect(nullptr, false);
+		pPawnDialog->InvalidateRect(nullptr, false);
 	else {                                                      // otherwise just update central area
 		ShowWaitCursor();                                         // put up the hourglass cursor
-		pPalOld = (*pDC).SelectPalette(pBackgroundPalette, false); // setup the proper palette
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pBackgroundPalette, false); // setup the proper palette
+		pDC->RealizePalette();
 		if (pBackgroundBitmap != nullptr)
 			PaintBitmap(pWorkDC, pBackgroundPalette, pBackgroundBitmap, 0, 0, PAWN_DX, PAWN_DY);
 		PaintMaskedBitmap(pWorkDC, pBackgroundPalette, pPawnBitmap, 0, 0, PAWN_DX, PAWN_DY);
 		UpdateContent(pWorkDC);                                 // zap it to the screen
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 		    0,
 		    PAWN_BORDER_DY + PAWN_TITLEZONE_DY,
 		    PAWN_DX,
@@ -423,7 +423,7 @@ void CPawnShop::UpdatePage(CDC *pDC) {
 		    0,
 		    PAWN_BORDER_DY + PAWN_TITLEZONE_DY,
 		    SRCCOPY);
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 		    PAWN_DX - TEXT_MORE_DX,
 		    PAWN_DY - PAWN_CURL_DY,
 		    TEXT_MORE_DX,
@@ -432,7 +432,7 @@ void CPawnShop::UpdatePage(CDC *pDC) {
 		    PAWN_DX - TEXT_MORE_DX,
 		    PAWN_DY - PAWN_CURL_DY,
 		    SRCCOPY);
-		(*pDC).SelectPalette(pPalOld, false);                   // reset the palette
+		pDC->SelectPalette(pPalOld, false);                   // reset the palette
 		DoArrowCursor();
 	}                                                           // return to an arrow cursor
 }
@@ -446,7 +446,7 @@ void CPawnShop::UpdateContent(CDC *pDC) {
 	CSize   textInfo;                                               // font info about the text to be displayed
 	TEXTMETRIC  fontMetrics;
 
-	if ((*pInventory).ItemCount() <= 0)
+	if (pInventory->ItemCount() <= 0)
 		return;
 
 	nPawn_DX = PAWN_DX - (PAWN_BORDER_DX << 1);             // calculate the horizontal space we have available
@@ -467,26 +467,26 @@ void CPawnShop::UpdateContent(CDC *pDC) {
 		nItemsPerColumn -= 1;
 	}
 
-	pItem = (*pInventory).FetchItem(nFirstSlot);                // get first item on this page
+	pItem = pInventory->FetchItem(nFirstSlot);                // get first item on this page
 	for (i = 0; (i < (nItemsPerRow * nItemsPerColumn)) && (pItem != nullptr); i++) {                           // will thumb through all of them
 		x = (i % nItemsPerRow);                                 // calculate its horizontal position
 		x *= (PAWN_BITMAP_DX + nItem_DDX);                      // ... allowing proper spacing between items
 		y = (i / nItemsPerRow);                                 // calculate its vertical position
 		y *= (PAWN_BITMAP_DY + nItem_DDY);                      // ... allowing proper spacing between items
 		UpdateItem(pDC, pItem, x + PAWN_BORDER_DX, y + PAWN_BORDER_DY + PAWN_TITLEZONE_DY);     // now show the item
-		pItem = (*pItem).GetNext();
+		pItem = pItem->GetNext();
 	}
 
 	if (pPawnBitmap != nullptr) {
-		pFontOld = (*pDC).SelectObject(pFont);                  // select it into our context
-		(*pDC).SetBkMode(TRANSPARENT);                              // make the text overlay transparently
-		(*pDC).GetTextMetrics(&fontMetrics);                        // show whether there are more notes
+		pFontOld = pDC->SelectObject(pFont);                  // select it into our context
+		pDC->SetBkMode(TRANSPARENT);                              // make the text overlay transparently
+		pDC->GetTextMetrics(&fontMetrics);                        // show whether there are more notes
 		x = PAWN_DX - TEXT_MORE_DX;                             // ... that can be scrolled through
 		y = PAWN_DY -
 		    PAWN_CURL_DY +
 		    ((PAWN_CURL_DY - fontMetrics.tmHeight) >> 1) -
 		    TEXT_MORE_DY;
-		textInfo = (*pDC).GetTextExtent(MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+		textInfo = pDC->GetTextExtent(MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 		dx = textInfo.cx;
 		dy = fontMetrics.tmHeight;
 
@@ -494,10 +494,10 @@ void CPawnShop::UpdateContent(CDC *pDC) {
 			myRect.SetRect(x, y, x + dx, y + dy);
 			BltBitmap(pDC, pBackgroundPalette, pPawnBitmap, &myRect, &myRect, SRCCOPY);
 		} else {
-			(*pDC).SetTextColor(PAWN_MORE_COLOR);
-			(*pDC).TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+			pDC->SetTextColor(PAWN_MORE_COLOR);
+			pDC->TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 		}
-		(*pDC).SelectObject(pFontOld);                            // map out the font
+		pDC->SelectObject(pFontOld);                            // map out the font
 	}
 }
 
@@ -506,20 +506,20 @@ void CPawnShop::UpdateItem(CDC *pDC, CItem *pItem, int nX, int nY) {
 	CFont   *pFontOld = nullptr;               // font that was mapped to the context
 	char    chBuffer[32];
 
-	PaintMaskedDIB(pDC, pBackgroundPalette, (*pItem).GetArtSpec(), nX, nY, PAWN_BITMAP_DX, PAWN_BITMAP_DY);
+	PaintMaskedDIB(pDC, pBackgroundPalette, pItem->GetArtSpec(), nX, nY, PAWN_BITMAP_DX, PAWN_BITMAP_DY);
 
-	if (((*pItem).m_nQuantity == 0) ||
-	        ((*pItem).m_nQuantity > 1)) {
-		Common::sprintf_s(chBuffer, "%ld", (*pItem).m_nQuantity);
-		pFontOld = (*pDC).SelectObject(pFont);                  // select it into our context
-		(*pDC).SetBkMode(TRANSPARENT);                          // make the text overlay transparently
-		(*pDC).SetTextColor(PAWN_BLURB_COLOR);                      // set the color of the text
-		(*pDC).TextOut(                             // zap the text to the work area
+	if ((pItem->m_nQuantity == 0) ||
+	        (pItem->m_nQuantity > 1)) {
+		Common::sprintf_s(chBuffer, "%ld", pItem->m_nQuantity);
+		pFontOld = pDC->SelectObject(pFont);                  // select it into our context
+		pDC->SetBkMode(TRANSPARENT);                          // make the text overlay transparently
+		pDC->SetTextColor(PAWN_BLURB_COLOR);                      // set the color of the text
+		pDC->TextOut(                             // zap the text to the work area
 		    nX,
 		    nY,
 		    (const char *) chBuffer,
 		    strlen(chBuffer));
-		(*pDC).SelectObject(pFontOld);                     // map out the font
+		pDC->SelectObject(pFontOld);                     // map out the font
 	}
 }
 
@@ -528,20 +528,20 @@ void CPawnShop::UpdateCrowns(CDC *pDC) {
 	CItem   *pItem;
 	char    chBuffer[128];
 
-	pItem = (*pInventory).FindItem(MG_OBJ_CROWN);
+	pItem = pInventory->FindItem(MG_OBJ_CROWN);
 	if ((pItem == nullptr) ||
-	        ((*pItem).GetQuantity() < 1)) {
+	        (pItem->GetQuantity() < 1)) {
 		if (bPlayingHodj)
 			Common::strcpy_s(chBuffer, "Hodj has no Crowns");
 		else
 			Common::strcpy_s(chBuffer, "Podj has no Crowns");
 	} else {
 		if (bPlayingHodj)
-			Common::sprintf_s(chBuffer, "Hodj has %ld Crowns", (*pItem).GetQuantity());
+			Common::sprintf_s(chBuffer, "Hodj has %ld Crowns", pItem->GetQuantity());
 		else
-			Common::sprintf_s(chBuffer, "Podj has %ld Crowns", (*pItem).GetQuantity());
+			Common::sprintf_s(chBuffer, "Podj has %ld Crowns", pItem->GetQuantity());
 	}
-	(*pItemCost).DisplayString(pDC, chBuffer, FONT_SIZE, TEXT_BOLD, PAWN_TEXT_COLOR);
+	pItemCost->DisplayString(pDC, chBuffer, FONT_SIZE, TEXT_BOLD, PAWN_TEXT_COLOR);
 }
 
 
@@ -554,7 +554,7 @@ void CPawnShop::ClearDialogImage() {
 	if (pBackgroundBitmap != nullptr) {
 		delete pOKButton;
 		pOKButton = nullptr;
-		(*pPawnDialog).ValidateRect(nullptr);
+		pPawnDialog->ValidateRect(nullptr);
 		RefreshBackground();
 	}
 }
@@ -564,9 +564,9 @@ void CPawnShop::RefreshBackground() {
 	CDC *pDC;
 
 	if (pBackgroundBitmap != nullptr) {
-		pDC = (*pPawnDialog).GetDC();                       // get a context for our window
+		pDC = pPawnDialog->GetDC();                       // get a context for our window
 		PaintBitmap(pDC, pBackgroundPalette, pBackgroundBitmap, 0, 0, PAWN_DX, PAWN_DY);
-		(*pPawnDialog).ReleaseDC(pDC);                      // release the context
+		pPawnDialog->ReleaseDC(pDC);                      // release the context
 	}
 }
 
@@ -593,7 +593,7 @@ int CPawnShop::OnCreate(LPCREATESTRUCT lpCreateStruct) {
 	AddFontResource("msserif.fon");
 	pFont = new CFont();
 	ASSERT(pFont != nullptr);
-	bSuccess = (*pFont).CreateFont(-14, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, OUT_RASTER_PRECIS, 0, PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
+	bSuccess = pFont->CreateFont(-14, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, OUT_RASTER_PRECIS, 0, PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
 	ASSERT(bSuccess);
 
 	if (CDialog::OnCreate(lpCreateStruct) == -1)
@@ -618,19 +618,19 @@ bool CPawnShop::CreateWorkAreas(CDC *pDC) {
 	else
 		pBackgroundBitmap = nullptr;
 
-	(*pDC).SelectPalette(pBackgroundPalette, false);
-	(*pDC).RealizePalette();
+	pDC->SelectPalette(pBackgroundPalette, false);
+	pDC->RealizePalette();
 
 	if ((GetFreeSpace(0) >= (unsigned long) 1000000) &&
 	        (GlobalCompact((unsigned long) 500000) >= (unsigned long) 450000)) {
 		pWork = new CBitmap();
-		if ((*pWork).CreateCompatibleBitmap(pDC, PAWN_DX, PAWN_DY)) {
+		if (pWork->CreateCompatibleBitmap(pDC, PAWN_DX, PAWN_DY)) {
 			pWorkDC = new CDC();
 			if ((pWorkDC != nullptr) &&
-			        (*pWorkDC).CreateCompatibleDC(pDC)) {
-				pWorkPalOld = (*pWorkDC).SelectPalette(pBackgroundPalette, false);
-				(*pWorkDC).RealizePalette();
-				pWorkOld = (*pWorkDC).SelectObject(pWork);
+			        pWorkDC->CreateCompatibleDC(pDC)) {
+				pWorkPalOld = pWorkDC->SelectPalette(pBackgroundPalette, false);
+				pWorkDC->RealizePalette();
+				pWorkOld = pWorkDC->SelectObject(pWork);
 				if (pWorkOld != nullptr)
 					bSuccess = true;
 			}
@@ -643,7 +643,7 @@ bool CPawnShop::CreateWorkAreas(CDC *pDC) {
 
 	if (!bSuccess) {
 		if (pWorkPalOld != nullptr) {
-			(*pWorkDC).SelectPalette(pWorkPalOld, false);
+			pWorkDC->SelectPalette(pWorkPalOld, false);
 			pWorkPalOld = nullptr;
 		}
 		if (pWork != nullptr) {
@@ -655,7 +655,7 @@ bool CPawnShop::CreateWorkAreas(CDC *pDC) {
 		bSuccess = true;
 	}
 
-	(*pDC).SelectPalette(pWorkPalOld, false);
+	pDC->SelectPalette(pWorkPalOld, false);
 
 	myRect.SetRect(PAWN_TEXTZONE_DX,
 	               PAWN_BORDER_DY + PAWN_TITLEZONE_DDY,
@@ -694,30 +694,30 @@ void CPawnShop::OnMouseMove(unsigned int nFlags, CPoint point) {
 	pMyApp = AfxGetApp();
 
 	if (OkayRect.PtInRect(point))                   // use standard arrow in buttons
-		hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+		hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 	else if (ScrollTopRect.PtInRect(point)) {           // set cursor to scolling up okay or invalid
 		if (nFirstSlot == 0)                        // ... depending on current slot for page
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_INVALID);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_INVALID);
 		else
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_ARROWUP);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_ARROWUP);
 	} else if (ScrollBotRect.PtInRect(point)) {         // set cursor to scrolling down okay or invalid
-		if (nFirstSlot + (nItemsPerRow * nItemsPerColumn) >= (*pInventory).ItemCount())
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_INVALID);
+		if (nFirstSlot + (nItemsPerRow * nItemsPerColumn) >= pInventory->ItemCount())
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_INVALID);
 		else
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_ARROWDN);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_ARROWDN);
 	} else {                                        // see if cursor is on an inventory item
 		i = SelectedItem(point);                    // ... and if so, then show the text blurb
 		if ((i >= 0) &&                             // ... for it at the base of the scroll
-		        ((i + nFirstSlot) < (*pInventory).ItemCount())) {
-			pItem = (*pInventory).FetchItem(i + nFirstSlot);
+		        ((i + nFirstSlot) < pInventory->ItemCount())) {
+			pItem = pInventory->FetchItem(i + nFirstSlot);
 			if (pItem != nullptr) {
-				hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+				hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 				pDC = GetDC();
-				nPrice = (*pItem).GetValue();
+				nPrice = pItem->GetValue();
 				if (nPrice == 0)
 					Common::strcpy_s(chBuffer, "That can't be sold here");
 				else {
-					if ((*pItem).GetQuantity() == 1) {
+					if (pItem->GetQuantity() == 1) {
 						if (nPrice == 1)
 							Common::strcpy_s(chBuffer, "It can be sold for 1 Crown");
 						else
@@ -726,19 +726,19 @@ void CPawnShop::OnMouseMove(unsigned int nFlags, CPoint point) {
 						Common::sprintf_s(chBuffer, "One can be sold for 1 Crown");
 					else
 						Common::sprintf_s(chBuffer, "One can be sold for %d Crowns", nPrice);
-					hNewCursor = (*pMyApp).LoadCursor(IDC_PAWN_DOLLAR);
+					hNewCursor = pMyApp->LoadCursor(IDC_PAWN_DOLLAR);
 				}
-				(*pItemText).DisplayString(pDC, (*pItem).GetDescription(), FONT_SIZE, TEXT_BOLD, PAWN_TEXT_COLOR);
-				(*pItemCost).DisplayString(pDC, chBuffer, FONT_SIZE, TEXT_BOLD, PAWN_TEXT_COLOR);
+				pItemText->DisplayString(pDC, pItem->GetDescription(), FONT_SIZE, TEXT_BOLD, PAWN_TEXT_COLOR);
+				pItemCost->DisplayString(pDC, chBuffer, FONT_SIZE, TEXT_BOLD, PAWN_TEXT_COLOR);
 				ReleaseDC(pDC);
 			}
 		}
 	}
 
 	if (hNewCursor == nullptr) {                       // use default cursor if not specified
-		hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+		hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 		pDC = GetDC();
-		(*pItemText).DisplayString(pDC, "", FONT_SIZE, TEXT_BOLD, PAWN_TEXT_COLOR);
+		pItemText->DisplayString(pDC, "", FONT_SIZE, TEXT_BOLD, PAWN_TEXT_COLOR);
 		UpdateCrowns(pDC);
 		ReleaseDC(pDC);
 	}
@@ -768,30 +768,30 @@ void CPawnShop::OnLButtonDown(unsigned int nFlags, CPoint point) {
 		bNeedsUpdate = true;
 	} else                                          // if click is in lower curl, then
 		if (ScrollBotRect.PtInRect(point) &&            // ... scroll down if not show last item
-		        (nFirstSlot + (nItemsPerRow * nItemsPerColumn) < (*pInventory).ItemCount())) {
+		        (nFirstSlot + (nItemsPerRow * nItemsPerColumn) < pInventory->ItemCount())) {
 			nFirstSlot += (nItemsPerRow * nItemsPerColumn);
 			bNeedsUpdate = true;
 		} else {                                        // see if cursor is on an inventory item
 			i = SelectedItem(point);                    // ... and if so, then show then dispatch
 			if ((i >= 0) &&                             // ... on its action code
-			        ((i + nFirstSlot) < (*pInventory).ItemCount())) {
-				pItem = (*pInventory).FetchItem(i + nFirstSlot);
+			        ((i + nFirstSlot) < pInventory->ItemCount())) {
+				pItem = pInventory->FetchItem(i + nFirstSlot);
 				if ((pItem != nullptr) &&
-				        ((*pItem).GetValue() > 0)) {
+				        (pItem->GetValue() > 0)) {
 					pSound = new CSound(this, (bPlayingHodj ? "sound\\gsps7.wav" : "sound\\gsps8.wav"), SOUND_WAVE | SOUND_QUEUE | SOUND_AUTODELETE);
-					(*pSound).setDrivePath(lpMetaGameStruct->m_chCDPath);
-					(*pSound).play();
+					pSound->setDrivePath(lpMetaGameStruct->m_chCDPath);
+					pSound->play();
 					pDC = GetDC();
-					(*pInventory).AddItem(MG_OBJ_CROWN, (*pItem).GetValue());
-					if ((*pItem).GetQuantity() > 1) {
-						(*pInventory).DiscardItem(pItem, 1);
-						(*pGeneralStore).AddItem((*pItem).GetID(), 1);
+					pInventory->AddItem(MG_OBJ_CROWN, pItem->GetValue());
+					if (pItem->GetQuantity() > 1) {
+						pInventory->DiscardItem(pItem, 1);
+						pGeneralStore->AddItem(pItem->GetID(), 1);
 					} else {
-						(*pInventory).RemoveItem(pItem);
-						(*pGeneralStore).AddItem(pItem);
+						pInventory->RemoveItem(pItem);
+						pGeneralStore->AddItem(pItem);
 					}
-					(*pItemText).DisplayString(pDC, "Thank you!!!", FONT_SIZE, TEXT_BOLD, PAWN_BLURB_COLOR);
-					(*pItemCost).RestoreBackground(pDC);
+					pItemText->DisplayString(pDC, "Thank you!!!", FONT_SIZE, TEXT_BOLD, PAWN_BLURB_COLOR);
+					pItemCost->RestoreBackground(pDC);
 					ReleaseDC(pDC);
 					bNeedsUpdate = true;
 				}
@@ -834,7 +834,7 @@ int CPawnShop::SelectedItem(CPoint point) {
 
 
 bool CPawnShop::OnSetCursor(CWnd *pWnd, unsigned int /*nHitTest*/, unsigned int /*message*/) {
-	if ((*pWnd).m_hWnd == (*this).m_hWnd)
+	if (pWnd->m_hWnd == (this)->m_hWnd)
 		return true;
 	else
 		return false;
@@ -846,7 +846,7 @@ void CPawnShop::ShowWaitCursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).BeginWaitCursor();
+	pMyApp->BeginWaitCursor();
 }
 
 
@@ -855,7 +855,7 @@ void CPawnShop::DoArrowCursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).EndWaitCursor();
+	pMyApp->EndWaitCursor();
 }
 
 } // namespace Gtl

--- a/engines/bagel/hodjnpodj/metagame/gtl/rules.cpp
+++ b/engines/bagel/hodjnpodj/metagame/gtl/rules.cpp
@@ -192,21 +192,21 @@ LRESULT PrefHookProc(int code, WPARAM wParam, LPARAM lParam) {
 		case VK_NUMPAD8:                            // ... deal with all the rest
 		case VK_PRIOR:                              // go to previous page of text
 			if (nHelpPage > 0)
-				(*pRulesDialog).UpdateScroll(nHelpPage - 1);
+				pRulesDialog->UpdateScroll(nHelpPage - 1);
 			return true;
 		case VK_DOWN:                               // go to next page of text
 		case VK_NUMPAD2:
 		case VK_NEXT:
 			if (!bHelpEOF)
-				(*pRulesDialog).UpdateScroll(nHelpPage + 1);
+				pRulesDialog->UpdateScroll(nHelpPage + 1);
 			return true;
 		case VK_HOME:                               // go to first page of text
 			if (nHelpPage > 0)
-				(*pRulesDialog).UpdateScroll(0);
+				pRulesDialog->UpdateScroll(0);
 			return true;
 		case VK_END:                                // go to last page of text
 			while (!bHelpEOF) {
-				(*pRulesDialog).UpdateScroll(nHelpPage + 1);
+				pRulesDialog->UpdateScroll(nHelpPage + 1);
 			}
 			return true;
 		}
@@ -273,7 +273,7 @@ void CRules::OnDestroy() {
 	CWinApp *pMyApp;
 
 	pMyApp = AfxGetApp();
-	hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+	hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 	//if (hNewCursor != nullptr);
 	MFC::SetCursor(hNewCursor);
 
@@ -285,13 +285,13 @@ void CRules::OnDestroy() {
 
 	delete pFont;                                   // release the font file
 
-	(*pHelpFile).Close();                           // close and release the rules file
+	pHelpFile->Close();                           // close and release the rules file
 	delete pHelpFile;
 
 	if (pBackgroundBitmap != nullptr) {
-		bUpdateNeeded = (*pParentWnd).GetUpdateRect(nullptr, false);
+		bUpdateNeeded = pParentWnd->GetUpdateRect(nullptr, false);
 		if (bUpdateNeeded)
-			(*pParentWnd).ValidateRect(nullptr);
+			pParentWnd->ValidateRect(nullptr);
 	}
 
 	if (!bBruteForce) {
@@ -320,28 +320,28 @@ bool CRules::OnInitDialog() {
 	if (pParentWnd == nullptr)                         // get our parent window
 		pParentWnd = ((CWnd *) this)->GetParent();  // ... as passed to us or inquired about
 
-	(*pParentWnd).GetWindowRect(&myRect);
+	pParentWnd->GetWindowRect(&myRect);
 	x = myRect.left + (((myRect.right - myRect.left) - ScrollRect.right) >> 1);
 	y = myRect.top + (((myRect.bottom - myRect.top) - ScrollRect.bottom) >> 1);
 	MoveWindow(x, y, ScrollRect.right, ScrollRect.bottom);      // center the dialog box on the parent
 
 	pButton = GetDlgItem((int) GetDefID());         // get the window for the okay button
 	ASSERT(pButton != nullptr);                        // ... and verify we have it
-	(*pButton).GetWindowRect(&myRect);              // get the button's position and size
+	pButton->GetWindowRect(&myRect);              // get the button's position and size
 
 	dx = myRect.right - myRect.left;                // calculate where to place the button
 	x = (ScrollRect.right - dx) >> 1;               // ... centered at the bottom edge
 	dy = myRect.bottom - myRect.top;
 	y = ScrollRect.bottom - dy - BUTTON_DY;
 
-	(*pButton).MoveWindow(x, y, dx, dy);            // reposition the button
+	pButton->MoveWindow(x, y, dx, dy);            // reposition the button
 	OkayRect.SetRect(x, y, x + dx, y + dy);
 
 	#if COLOR_BUTTONS
 	pOKButton = new CColorButton();                   // build a color QUIT button to let us exit
 	ASSERT(pOKButton != nullptr);
-	(*pOKButton).SetPalette(pScrollPalette);        // set the palette to use
-	bSuccess = (*pOKButton).SetControl((int) GetDefID(), this); // tie to the dialog control
+	pOKButton->SetPalette(pScrollPalette);        // set the palette to use
+	bSuccess = pOKButton->SetControl((int) GetDefID(), this); // tie to the dialog control
 	ASSERT(bSuccess);
 	#endif
 
@@ -393,7 +393,7 @@ void CRules::OnPaint() {
 		ReleaseCompatibleContext(pScrollTopMaskDC, pScrollTopMask, pScrollTopMaskOld, pScrollTopMaskPalOld);
 		ReleaseCompatibleContext(pScrollBotMaskDC, pScrollBotMask, pScrollBotMaskOld, pScrollBotMaskPalOld);
 		if (pNarrative != nullptr)
-			(*pNarrative).play();                   // play the narration
+			pNarrative->play();                   // play the narration
 	} else if (bBruteForce) {                           // need to paint directly to screen
 		pDibDoc = LoadScrollDIB(SCROLL_SPEC, nullptr);
 		if (pDibDoc != nullptr) {
@@ -442,11 +442,11 @@ void CRules::RefreshBackground() {
 	pDC = GetDC();                                  // get a context for our window
 
 	if (pScrollPalette != nullptr) {                   // map in our palette
-		pPalOld = (*pDC).SelectPalette(pScrollPalette, false);
-		(*pDC).RealizePalette();              // .. and make the system use it
+		pPalOld = pDC->SelectPalette(pScrollPalette, false);
+		pDC->RealizePalette();              // .. and make the system use it
 	}
 
-	(*pDC).BitBlt(        // repaint the background as it was
+	pDC->BitBlt(        // repaint the background as it was
 	    0,
 	    0,
 	    ScrollRect.right,
@@ -457,7 +457,7 @@ void CRules::RefreshBackground() {
 	    SRCCOPY);
 
 	if (pScrollPalette != nullptr)                     // map out our palette
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	ReleaseDC(pDC);                                 // release the context
 }
@@ -491,7 +491,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		return;
 	}
 
-	(*pBackgroundDC).BitBlt(      // save the entire background
+	pBackgroundDC->BitBlt(      // save the entire background
 	    0, 0,
 	    ScrollRect.right,
 	    ScrollRect.bottom,
@@ -499,7 +499,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    SRCCOPY);
 
-	(*pScrollDC).BitBlt(       // copy background to scroll context
+	pScrollDC->BitBlt(       // copy background to scroll context
 	    0, 0,                           // ... so we can construct the scroll
 	    ScrollRect.right,               // ... on top of it in a masked manner
 	    ScrollRect.bottom,
@@ -511,7 +511,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 
 	ScrollTopCurlRect = ScrollTopRect;              // record where we're putting the top curl
 
-	(*pScrollDC).BitBlt(       // mask out where the top curl goes
+	pScrollDC->BitBlt(       // mask out where the top curl goes
 	    0, 0,
 	    ScrollTopRect.right,
 	    ScrollTopRect.bottom,
@@ -519,7 +519,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    SRCAND);
 
-	(*pScrollTopMaskDC).BitBlt(     // invert the top curl mask
+	pScrollTopMaskDC->BitBlt(     // invert the top curl mask
 	    0, 0,
 	    ScrollTopRect.right,
 	    ScrollTopRect.bottom,
@@ -527,7 +527,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    DSTINVERT);
 
-	(*pScrollTopDC).BitBlt(      // remove transparent area from top curl
+	pScrollTopDC->BitBlt(      // remove transparent area from top curl
 	    0, 0,
 	    ScrollTopRect.right,
 	    ScrollTopRect.bottom,
@@ -535,7 +535,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    SRCAND);
 
-	(*pScrollTopMaskDC).BitBlt(     // restore top curl mask
+	pScrollTopMaskDC->BitBlt(     // restore top curl mask
 	    0, 0,
 	    ScrollTopRect.right,
 	    ScrollTopRect.bottom,
@@ -543,7 +543,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    DSTINVERT);
 
-	(*pScrollDC).BitBlt(       // paint top curl into the scroll
+	pScrollDC->BitBlt(       // paint top curl into the scroll
 	    0, 0,
 	    ScrollTopRect.right,
 	    ScrollTopRect.bottom,
@@ -557,7 +557,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	dstRect.top += ScrollTopRect.bottom;            // ... mid section strip of the scroll
 	dstRect.bottom += ScrollTopRect.bottom;
 
-	(*pScrollMidMaskDC).BitBlt(     // invert the mid section mask
+	pScrollMidMaskDC->BitBlt(     // invert the mid section mask
 	    0, 0,
 	    ScrollMidRect.right,
 	    ScrollMidRect.bottom,
@@ -565,7 +565,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    DSTINVERT);
 
-	(*pScrollMidDC).BitBlt(      // mask out transparent part of mid section
+	pScrollMidDC->BitBlt(      // mask out transparent part of mid section
 	    0, 0,
 	    ScrollMidRect.right,
 	    ScrollMidRect.bottom,
@@ -573,7 +573,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    SRCAND);
 
-	(*pScrollMidMaskDC).BitBlt(     // reset the mid section mask
+	pScrollMidMaskDC->BitBlt(     // reset the mid section mask
 	    0, 0,
 	    ScrollMidRect.right,
 	    ScrollMidRect.bottom,
@@ -582,7 +582,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    DSTINVERT);
 
 	for (i = 0; i < SCROLL_PIECES; i++) {           // build the scroll's mid section srip-wise
-		(*pScrollDC).BitBlt(
+		pScrollDC->BitBlt(
 		    dstRect.left,               // mask out where the image will go
 		    dstRect.top + ScrollMidRect.bottom * i,
 		    ScrollMidRect.right,
@@ -591,7 +591,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    0, 0,
 		    SRCAND);
 
-		(*pScrollDC).BitBlt(      // paint in the mid section image
+		pScrollDC->BitBlt(      // paint in the mid section image
 		    dstRect.left,
 		    dstRect.top + ScrollMidRect.bottom * i,
 		    ScrollMidRect.right,
@@ -607,7 +607,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	dstRect.bottom = dstRect.top + ScrollBotRect.bottom;
 	ScrollBotCurlRect = dstRect;
 
-	(*pScrollDC).BitBlt(       // mask out where the bottom curl image goes
+	pScrollDC->BitBlt(       // mask out where the bottom curl image goes
 	    dstRect.left,
 	    dstRect.top,
 	    ScrollBotRect.right,
@@ -616,7 +616,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    SRCAND);
 
-	(*pScrollBotMaskDC).BitBlt(     // invert the bottom curl mask
+	pScrollBotMaskDC->BitBlt(     // invert the bottom curl mask
 	    0, 0,
 	    ScrollBotRect.right,
 	    ScrollBotRect.bottom,
@@ -624,7 +624,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    DSTINVERT);
 
-	(*pScrollBotDC).BitBlt(      // mask out transparent part of curl
+	pScrollBotDC->BitBlt(      // mask out transparent part of curl
 	    0, 0,
 	    ScrollBotRect.right,
 	    ScrollBotRect.bottom,
@@ -632,7 +632,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    SRCAND);
 
-	(*pScrollBotMaskDC).BitBlt(     // reset the mask
+	pScrollBotMaskDC->BitBlt(     // reset the mask
 	    0, 0,
 	    ScrollBotRect.right,
 	    ScrollBotRect.bottom,
@@ -640,7 +640,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 	    0, 0,
 	    DSTINVERT);
 
-	(*pScrollDC).BitBlt(       // paint in the bottom curl
+	pScrollDC->BitBlt(       // paint in the bottom curl
 	    dstRect.left,
 	    dstRect.top,
 	    ScrollBotRect.right,
@@ -674,7 +674,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 
 		dst2Rect = dstRect;
 
-		(*pWorkDC).BitBlt(      // splat in the background for top curl
+		pWorkDC->BitBlt(      // splat in the background for top curl
 		    0, 0,
 		    ScrollTopRect.right,
 		    ScrollTopRect.bottom,
@@ -683,7 +683,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    dst2Rect.top,
 		    SRCCOPY);
 
-		(*pWorkDC).BitBlt(      // mask out where the top curl goes
+		pWorkDC->BitBlt(      // mask out where the top curl goes
 		    0, 0,
 		    ScrollTopRect.right,
 		    ScrollTopRect.bottom,
@@ -691,7 +691,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    0, 0,
 		    SRCAND);
 
-		(*pWorkDC).BitBlt(      // insert the top curl background
+		pWorkDC->BitBlt(      // insert the top curl background
 		    0, 0,
 		    ScrollTopRect.right,
 		    ScrollTopRect.bottom,
@@ -700,7 +700,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    SRCPAINT);
 
 		if (i == 0) {                               // if first time, just paint curl to display
-			(*pDC).BitBlt(
+			pDC->BitBlt(
 			    dst2Rect.left,
 			    dst2Rect.top,
 			    ScrollTopRect.right,
@@ -709,7 +709,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 			    0, 0,
 			    SRCCOPY);
 		} else {
-			(*pWorkDC).BitBlt(     // ... otherwise paint in a new piece of
+			pWorkDC->BitBlt(     // ... otherwise paint in a new piece of
 			    dst2Rect.left,          // ... the middle section
 			    ScrollTopRect.bottom,
 			    dst2Rect.right,
@@ -718,7 +718,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 			    dst2Rect.left,
 			    dst2Rect.top + ScrollTopRect.bottom,
 			    SRCCOPY);
-			(*pDC).BitBlt(      // ... then paint it and the curl, thus
+			pDC->BitBlt(      // ... then paint it and the curl, thus
 			    dst2Rect.left,          // ... causing the top to seemingly unfurl
 			    dst2Rect.top,           // ... by one more strip
 			    ScrollTopRect.right,
@@ -732,7 +732,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		dst2Rect.bottom = dstRect.bottom;
 
 		if ((i == 0) || ((i == 1) && (h == 1))) {   // if first time or doing last iteration
-			(*pWorkDC).BitBlt(                // ... just paint in the bottom curl
+			pWorkDC->BitBlt(                // ... just paint in the bottom curl
 			    0, 0,
 			    dst2Rect.right,
 			    scroll_delta,
@@ -741,7 +741,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 			    dst2Rect.top,
 			    SRCCOPY);
 		} else {                                    //
-			(*pWorkDC).BitBlt(
+			pWorkDC->BitBlt(
 			    0, 0,
 			    dst2Rect.right,
 			    scroll_delta,
@@ -751,7 +751,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 			    SRCCOPY);
 		}
 
-		(*pWorkDC).BitBlt(
+		pWorkDC->BitBlt(
 		    0,
 		    scroll_delta,
 		    ScrollBotRect.right,
@@ -761,7 +761,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    dst2Rect.top + scroll_delta,
 		    SRCCOPY);
 
-		(*pWorkDC).BitBlt(
+		pWorkDC->BitBlt(
 		    0,
 		    scroll_delta,
 		    ScrollBotRect.right,
@@ -770,7 +770,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    0, 0,
 		    SRCAND);
 
-		(*pWorkDC).BitBlt(
+		pWorkDC->BitBlt(
 		    0,
 		    scroll_delta,
 		    ScrollBotRect.right,
@@ -779,7 +779,7 @@ void CRules::UnfurlScroll(CDC *pDC) {
 		    0, 0,
 		    SRCPAINT);
 
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 		    ScrollBotRect.left,
 		    dst2Rect.top,
 		    ScrollBotRect.right,
@@ -823,8 +823,8 @@ void CRules::UpdateScroll(int nPage) {
 	pDC = GetDC();
 
 	if (pScrollPalette != nullptr) {                   // map in our palette
-		pPalOld = (*pDC).SelectPalette(pScrollPalette, false);
-		(*pDC).RealizePalette();              // .. and make the system use it
+		pPalOld = pDC->SelectPalette(pScrollPalette, false);
+		pDC->RealizePalette();              // .. and make the system use it
 	}
 
 	dstRect = ScrollMidRect;                        // setup initial destination for blts
@@ -832,7 +832,7 @@ void CRules::UpdateScroll(int nPage) {
 	dstRect.bottom += ScrollTopRect.bottom;
 
 	for (i = 0; i < SCROLL_PIECES; i++) {           // repaint the scroll midsection artwork
-		(*pScrollDC).BitBlt(      // ... mask out where artwork goes
+		pScrollDC->BitBlt(      // ... mask out where artwork goes
 		    dstRect.left,
 		    dstRect.top + ScrollMidRect.bottom * i,
 		    ScrollMidRect.right,
@@ -841,7 +841,7 @@ void CRules::UpdateScroll(int nPage) {
 		    0, 0,
 		    SRCAND);
 
-		(*pScrollDC).BitBlt(      // ... paint in the scroll artwork
+		pScrollDC->BitBlt(      // ... paint in the scroll artwork
 		    dstRect.left,
 		    dstRect.top + ScrollMidRect.bottom * i,
 		    ScrollMidRect.right,
@@ -853,7 +853,7 @@ void CRules::UpdateScroll(int nPage) {
 
 	WritePage(pScrollDC, nPage);                    // construct the new page of text
 
-	(*pDC).BitBlt(        // paint the result to the sceen
+	pDC->BitBlt(        // paint the result to the sceen
 	    TEXT_LEFT_MARGIN,
 	    ScrollTopRect.bottom + TEXT_TOP_MARGIN,
 	    TEXT_WIDTH,
@@ -866,7 +866,7 @@ void CRules::UpdateScroll(int nPage) {
 	UpdateMore(pDC);                                // update the "more" indicator
 
 	if (pScrollPalette != nullptr)                     // map out our palette
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	ReleaseDC(pDC);
 }
@@ -885,23 +885,23 @@ void CRules::WritePage(CDC *pDC, int nPage) {
 	nHelpPage = nPage;
 	bEOF = bHelpEOF = false;
 
-	(*pHelpFile).SeekToBegin();
+	pHelpFile->SeekToBegin();
 
 	if ((nHelpPage == 0) && (nPage == 0)) {
-		dwHelpPagePosition[nHelpPage] = (*pHelpFile).GetPosition();
+		dwHelpPagePosition[nHelpPage] = pHelpFile->GetPosition();
 		bEOL = dwHelpPageEOL[nHelpPage] = true;
 	} else {
-		(*pHelpFile).Seek(dwHelpPagePosition[nPage], CFile::begin);
+		pHelpFile->Seek(dwHelpPagePosition[nPage], CFile::begin);
 		bEOL = dwHelpPageEOL[nHelpPage];
 	}
 
 	dwHelpPagePosition[nHelpPage + 1] = dwHelpPagePosition[nHelpPage];
 
-	pFontOld = (*pDC).SelectObject(pFont);
+	pFontOld = pDC->SelectObject(pFont);
 
-	(*pDC).GetTextMetrics(&fontMetrics);
+	pDC->GetTextMetrics(&fontMetrics);
 
-	(*pDC).SetBkMode(TRANSPARENT);
+	pDC->SetBkMode(TRANSPARENT);
 
 	i = 0;
 	n = 1;
@@ -914,7 +914,7 @@ try_again:
 			if (bEOF)
 				break;
 			dwHelpPagePosition[nHelpPage + 1] += i + nCropped;
-			nCount = (*pHelpFile).Read(&chInBuf, TEXT_BUFFER_SIZE);
+			nCount = pHelpFile->Read(&chInBuf, TEXT_BUFFER_SIZE);
 			if (nCount < TEXT_BUFFER_SIZE)
 				bEOF = true;
 			i = 0;
@@ -945,7 +945,7 @@ try_again:
 					break;
 				dwHelpPagePosition[nHelpPage + 1] += i + nCropped;
 				strncpy(&chInBuf[0], &chInBuf[i], n);
-				nCount = (*pHelpFile).Read(&chInBuf[n], TEXT_BUFFER_SIZE - n);
+				nCount = pHelpFile->Read(&chInBuf[n], TEXT_BUFFER_SIZE - n);
 				nCount += n;
 				if (nCount < TEXT_BUFFER_SIZE)
 					bEOF = true;
@@ -977,7 +977,7 @@ crop_byte:
 				break;
 			}
 
-			textInfo = (*pDC).GetTextExtent(&chInBuf[i], n);
+			textInfo = pDC->GetTextExtent(&chInBuf[i], n);
 			if (textInfo.cx > TEXT_WIDTH - TEXT_LEFT_MARGIN) {
 				if ((chInBuf[i + n - 1] != ' ') &&
 				        (chInBuf[i + n - 1] != '\t'))
@@ -991,7 +991,7 @@ crop_byte:
 			n += 1;
 		}
 //		(*pDC).TextOut(x,y,(const char *) &chInBuf[i],n);
-		(*pDC).TabbedTextOut(x, y, (const char *) &chInBuf[i], n, 1, &tabstop, 0);
+		pDC->TabbedTextOut(x, y, (const char *) &chInBuf[i], n, 1, &tabstop, 0);
 		if (chInBuf[i + n] == '\r')
 			i += 2;
 		else if (chInBuf[i + n] == TEXT_NEWLINE)
@@ -1003,7 +1003,7 @@ crop_byte:
 			break;
 	}
 
-	(*pDC).SelectObject(pFontOld);
+	pDC->SelectObject(pFontOld);
 
 	dwHelpPagePosition[nPage + 1] += i + nCropped;
 	dwHelpPageEOL[nPage + 1] = bEOL;
@@ -1012,7 +1012,7 @@ crop_byte:
 		if (i >= (int) nCount) {
 			if (bEOF)
 				break;
-			nCount = (*pHelpFile).Read(&chInBuf, TEXT_BUFFER_SIZE);
+			nCount = pHelpFile->Read(&chInBuf, TEXT_BUFFER_SIZE);
 			if (nCount < TEXT_BUFFER_SIZE)
 				bEOF = true;
 			i = 0;
@@ -1032,7 +1032,7 @@ crop_byte:
 	if (bEOF && (i >= (int) nCount))
 		bHelpEOF = true;
 
-	(*pDC).SelectObject(pFontOld);
+	pDC->SelectObject(pFontOld);
 
 }
 
@@ -1043,21 +1043,21 @@ void CRules::UpdateMore(CDC *pDC) {
 	TEXTMETRIC  fontMetrics;
 	CSize       textInfo;
 
-	pFontOld = (*pDC).SelectObject(pFont);
+	pFontOld = pDC->SelectObject(pFont);
 
-	(*pDC).GetTextMetrics(&fontMetrics);
+	pDC->GetTextMetrics(&fontMetrics);
 
-	(*pDC).SetBkMode(TRANSPARENT);
+	pDC->SetBkMode(TRANSPARENT);
 
 	x = ScrollRect.right - TEXT_MORE_DX;
 	y = ((ScrollTopRect.bottom - fontMetrics.tmHeight) >> 1) +
 	    TEXT_MORE_DY - 3;
-	textInfo = (*pDC).GetTextExtent(MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+	textInfo = pDC->GetTextExtent(MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 	dx = textInfo.cx;
 	dy = fontMetrics.tmHeight;
 
 	if (nHelpPage == 0)
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 		    x,
 		    y,
 		    dx,
@@ -1067,7 +1067,7 @@ void CRules::UpdateMore(CDC *pDC) {
 		    y,
 		    SRCCOPY);
 	else
-		(*pDC).TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+		pDC->TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 
 	y = ScrollRect.bottom -
 	    ScrollBotRect.bottom +
@@ -1075,7 +1075,7 @@ void CRules::UpdateMore(CDC *pDC) {
 	    TEXT_MORE_DY;
 
 	if (bHelpEOF)
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 		    x,
 		    y,
 		    dx,
@@ -1085,9 +1085,9 @@ void CRules::UpdateMore(CDC *pDC) {
 		    y,
 		    SRCCOPY);
 	else
-		(*pDC).TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+		pDC->TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 
-	(*pDC).SelectObject(pFontOld);
+	pDC->SelectObject(pFontOld);
 }
 
 
@@ -1113,16 +1113,16 @@ int CRules::OnCreate(LPCREATESTRUCT lpCreateStruct) {
 
 	pHelpFile = new CFile();
 	ASSERT(pHelpFile != nullptr);
-	bSuccess = (*pHelpFile).Open(chPathName, CFile::modeRead | CFile::typeBinary, nullptr);
+	bSuccess = pHelpFile->Open(chPathName, CFile::modeRead | CFile::typeBinary, nullptr);
 	ASSERT(bSuccess);
 	if (!bSuccess)
 		return -1;
-	nHelpFileSize = (*pHelpFile).GetLength();
+	nHelpFileSize = pHelpFile->GetLength();
 
 	AddFontResource("msserif.fon");
 	pFont = new CFont();
 	ASSERT(pFont != nullptr);
-	bSuccess = (*pFont).CreateFont(16, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, OUT_RASTER_PRECIS, 0, PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
+	bSuccess = pFont->CreateFont(16, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, OUT_RASTER_PRECIS, 0, PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
 	ASSERT(bSuccess);
 
 	if ((GetFreeSpace(0) >= (unsigned long) 1000000) &&
@@ -1200,7 +1200,7 @@ bool CRules::CreateWorkAreas(CDC *pDC) {
 	pScrollBitmap = new CBitmap();
 	if (pScrollBitmap == nullptr)
 		return false;
-	bSuccess = (*pScrollBitmap).CreateCompatibleBitmap(pDC, ScrollRect.right, ScrollRect.bottom);
+	bSuccess = pScrollBitmap->CreateCompatibleBitmap(pDC, ScrollRect.right, ScrollRect.bottom);
 	if (!bSuccess)
 		return false;
 	pScrollDC = SetupCompatibleContext(pDC, pScrollBitmap, pScrollBitmapOld, pScrollPalette, pScrollPalOld);
@@ -1210,7 +1210,7 @@ bool CRules::CreateWorkAreas(CDC *pDC) {
 	pBackgroundBitmap = new CBitmap();
 	if (pBackgroundBitmap == nullptr)
 		return false;
-	bSuccess = (*pBackgroundBitmap).CreateCompatibleBitmap(pDC, ScrollRect.right, ScrollRect.bottom);
+	bSuccess = pBackgroundBitmap->CreateCompatibleBitmap(pDC, ScrollRect.right, ScrollRect.bottom);
 	if (!bSuccess)
 		return false;
 	pBackgroundDC = SetupCompatibleContext(pDC, pBackgroundBitmap, pBackgroundBitmapOld, pScrollPalette, pBackgroundPalOld);
@@ -1224,7 +1224,7 @@ bool CRules::CreateWorkAreas(CDC *pDC) {
 	pWorkBitmap = new CBitmap();
 	if (pWorkBitmap == nullptr)
 		return false;
-	bSuccess = (*pWorkBitmap).CreateCompatibleBitmap(pDC, WorkRect.right, WorkRect.bottom);
+	bSuccess = pWorkBitmap->CreateCompatibleBitmap(pDC, WorkRect.right, WorkRect.bottom);
 	if (!bSuccess)
 		return false;
 	pWorkDC = SetupCompatibleContext(pDC, pWorkBitmap, pWorkBitmapOld, pScrollPalette, pWorkPalOld);
@@ -1253,18 +1253,18 @@ bool CRules::CreateWorkAreas(CDC *pDC) {
 CDC *CRules::SetupMask(CDC *pDC, CDC *pBitmapDC, CBitmap *pMask, CBitmap * &pMaskOld, CRect *pRect) {
 	CDC *pNewDC = nullptr;
 
-	(*pMask).CreateBitmap((*pRect).right, (*pRect).bottom, 1, 1, nullptr);
+	pMask->CreateBitmap(pRect->right, pRect->bottom, 1, 1, nullptr);
 
 	pNewDC = new CDC();
 
 	if ((pNewDC != nullptr) &&
-	        (*pNewDC).CreateCompatibleDC(pDC)) {
-		pMaskOld = (*pNewDC).SelectObject(pMask);
+	        pNewDC->CreateCompatibleDC(pDC)) {
+		pMaskOld = pNewDC->SelectObject(pMask);
 		if (pMaskOld != nullptr) {
-			(*pNewDC).BitBlt(
+			pNewDC->BitBlt(
 			    0, 0,
-			    (*pRect).right,
-			    (*pRect).bottom,
+			    pRect->right,
+			    pRect->bottom,
 			    pBitmapDC,
 			    0, 0,
 			    SRCCOPY);
@@ -1283,13 +1283,13 @@ CDC *CRules::SetupCompatibleContext(CDC *pDC, CBitmap *pBitmap, CBitmap * &pBitm
 
 	if ((pDC != nullptr) &&
 	        (pNewDC != nullptr) &&
-	        (*pNewDC).CreateCompatibleDC(pDC)) {
+	        pNewDC->CreateCompatibleDC(pDC)) {
 		if (pPalette)
-			pPalOld = (*pNewDC).SelectPalette(pPalette, false);
+			pPalOld = pNewDC->SelectPalette(pPalette, false);
 		else
 			pPalOld = nullptr;
-		(*pNewDC).RealizePalette();
-		pBitmapOld = (*pNewDC).SelectObject(pBitmap);
+		pNewDC->RealizePalette();
+		pBitmapOld = pNewDC->SelectObject(pBitmap);
 		if (pBitmapOld != nullptr)
 			return (pNewDC);
 	}
@@ -1301,23 +1301,23 @@ CDC *CRules::SetupCompatibleContext(CDC *pDC, CBitmap *pBitmap, CBitmap * &pBitm
 
 void CRules::ReleaseCompatibleContext(CDC *&pDC, CBitmap * &pBitmap, CBitmap *pBitmapOld, CPalette *pPalOld) {
 	if (pBitmapOld != nullptr) {
-		(*pDC).SelectObject(pBitmapOld);
+		pDC->SelectObject(pBitmapOld);
 		pBitmapOld = nullptr;
 	}
 
 	if (pPalOld != nullptr) {
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 		pPalOld = nullptr;
 	}
 
 	if (pBitmap != nullptr) {
-		(*pBitmap).DeleteObject();
+		pBitmap->DeleteObject();
 		delete pBitmap;
 		pBitmap = nullptr;
 	}
 
 	if (pDC != nullptr) {
-		(*pDC).DeleteDC();
+		pDC->DeleteDC();
 		delete pDC;
 		pDC = nullptr;
 	}
@@ -1333,9 +1333,9 @@ CDibDoc *CRules::LoadScrollDIB(const char *pszPathName, CRect *pRect) {
 	pDibDoc = new CDibDoc();
 	ASSERT(pDibDoc != nullptr);
 
-	bSuccess = (*pDibDoc).OpenDocument(pszPathName);
+	bSuccess = pDibDoc->OpenDocument(pszPathName);
 	ASSERT(bSuccess);
-	hDIB = (*pDibDoc).GetHDIB();
+	hDIB = pDibDoc->GetHDIB();
 	ASSERT(hDIB != nullptr);
 	
 	dxDIB = (int) DIBWidth(hDIB);
@@ -1343,7 +1343,7 @@ CDibDoc *CRules::LoadScrollDIB(const char *pszPathName, CRect *pRect) {
 	
 
 	if (pRect != nullptr)
-		(*pRect).SetRect(0, 0, dxDIB, dyDIB);
+		pRect->SetRect(0, 0, dxDIB, dyDIB);
 
 	return (pDibDoc);
 }
@@ -1355,7 +1355,7 @@ bool CRules::PaintScrollDIB(CDC *pDC, CDibDoc *pDibDoc) {
 	int         dxDIB, dyDIB;
 	CRect       myRect;
 
-	hDIB = (*pDibDoc).GetHDIB();
+	hDIB = pDibDoc->GetHDIB();
 	ASSERT(hDIB != nullptr);
 	
 	dxDIB = (int) DIBWidth(hDIB);
@@ -1364,7 +1364,7 @@ bool CRules::PaintScrollDIB(CDC *pDC, CDibDoc *pDibDoc) {
 
 	myRect.SetRect(0, 0, dxDIB, dyDIB);
 
-	bSuccess = PaintDIB((*pDC).m_hDC, myRect, hDIB, myRect, pScrollPalette);
+	bSuccess = PaintDIB(pDC->m_hDC, myRect, hDIB, myRect, pScrollPalette);
 
 	return bSuccess;
 }
@@ -1374,7 +1374,7 @@ CBitmap *CRules::CreateScrollBitmap(CDC *pDC, CDibDoc *pDibDoc, CPalette *pPalet
 	HDIB        hDIB;
 	CBitmap     *pBitmap = nullptr;
 
-	hDIB = (*pDibDoc).GetHDIB();
+	hDIB = pDibDoc->GetHDIB();
 	ASSERT(hDIB != nullptr);
 
 	pBitmap = ConvertDIB(pDC, hDIB, pPalette);
@@ -1408,19 +1408,19 @@ void CRules::OnMouseMove(unsigned int nFlags, CPoint point) {
 	pMyApp = AfxGetApp();
 
 	if (OkayRect.PtInRect(point))
-		hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+		hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 	else if (ScrollTopCurlRect.PtInRect(point)) {
 		if (nHelpPage == 0)
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_INVALID);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_INVALID);
 		else
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_ARROWUP);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_ARROWUP);
 	} else if (ScrollBotCurlRect.PtInRect(point)) {
 		if (bHelpEOF)
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_INVALID);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_INVALID);
 		else
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_ARROWDN);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_ARROWDN);
 	} else
-		hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+		hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 
 	//if (hNewCursor != nullptr);
 	MFC::SetCursor(hNewCursor);
@@ -1430,7 +1430,7 @@ void CRules::OnMouseMove(unsigned int nFlags, CPoint point) {
 
 
 bool CRules::OnSetCursor(CWnd *pWnd, unsigned int nHitTest, unsigned int message) {
-	if ((*pWnd).m_hWnd == (*this).m_hWnd)
+	if (pWnd->m_hWnd == (this)->m_hWnd)
 		return true;
 	else
 		return false;
@@ -1442,7 +1442,7 @@ void CRules::ShowWaitCursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).BeginWaitCursor();
+	pMyApp->BeginWaitCursor();
 }
 
 
@@ -1451,7 +1451,7 @@ void CRules::DoArrowCursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).EndWaitCursor();
+	pMyApp->EndWaitCursor();
 }
 
 } // namespace Gtl

--- a/engines/bagel/hodjnpodj/metagame/gtl/spinner.cpp
+++ b/engines/bagel/hodjnpodj/metagame/gtl/spinner.cpp
@@ -177,9 +177,9 @@ bool CSpinner::Initialize(CWnd *pWnd, CDC *pDC, int nX, int nY, bool bHodj) {
 	m_pSprite = new CSprite();                      // load the sprite image
 	if ((m_pDC != nullptr) &&
 	        (m_pSprite != nullptr)) {
-		bSuccess = (*m_pSprite).LoadSprite(m_pDC, SPINNER_SPEC);
+		bSuccess = m_pSprite->LoadSprite(m_pDC, SPINNER_SPEC);
 		if (bSuccess)
-			(*m_pSprite).SetMasked(true);
+			m_pSprite->SetMasked(true);
 		else {
 			delete m_pSprite;                       // failed so release it
 			m_pSprite = nullptr;
@@ -314,7 +314,7 @@ bool CSpinner::Show(int nX, int nY) {
 	m_nX = nX;
 	m_nY = nY;
 
-	bSuccess = (*m_pSprite).PaintSprite(m_pDC, nX, nY);
+	bSuccess = m_pSprite->PaintSprite(m_pDC, nX, nY);
 
 	if (bSuccess)
 		m_bVisible = true;
@@ -342,7 +342,7 @@ bool CSpinner::Hide() {
 		return false;
 
 	if (m_bVisible) {                                   // if visible ...
-		bSuccess = (*m_pSprite).EraseSprite(m_pDC);     // ... just erase the sprite
+		bSuccess = m_pSprite->EraseSprite(m_pDC);     // ... just erase the sprite
 		if (bSuccess)
 			m_bVisible = false;                         // ... and mark spinner as invisible
 	} else
@@ -381,8 +381,8 @@ int CSpinner::Spin() {
 	CSound::waitWaveSounds();
 
 	pSound = new CSound();                              // create the spinner sound
-	(*pSound).initialize(m_pWnd, SPINNER_SOUND, SOUND_WAVE | SOUND_QUEUE | SOUND_BUFFERED | SOUND_ASYNCH | SOUND_NOTIFY | SOUND_LOOP);
-	(*pSound).play();                                   // start the spinner sound
+	pSound->initialize(m_pWnd, SPINNER_SOUND, SOUND_WAVE | SOUND_QUEUE | SOUND_BUFFERED | SOUND_ASYNCH | SOUND_NOTIFY | SOUND_LOOP);
+	pSound->play();                                   // start the spinner sound
 
 	if (!m_bVisible) {                                  // make it visible
 		bSuccess = Show(m_nX, m_nY);
@@ -415,7 +415,7 @@ int CSpinner::Spin() {
 
 	app->pause();
 
-	(*pSound).stop();
+	pSound->stop();
 	delete pSound;
 	pSound = nullptr;
 

--- a/engines/bagel/hodjnpodj/metagame/gtl/store.cpp
+++ b/engines/bagel/hodjnpodj/metagame/gtl/store.cpp
@@ -142,33 +142,33 @@ LRESULT StoreHookProc(int code, WPARAM wParam, LPARAM lParam) {
 				nFirstSlot -= (nItemsPerRow * nItemsPerColumn);
 				if (nFirstSlot < 0)
 					nFirstSlot = 0;
-				pDC = (*pStoreDialog).GetDC();
+				pDC = pStoreDialog->GetDC();
 			}
 			break;
 		case VK_DOWN:                               // go to next page of text
 		case VK_NUMPAD2:
 		case VK_NEXT:
-			if (nFirstSlot + (nItemsPerRow * nItemsPerColumn) < (*pGeneralStore).ItemCount()) {
+			if (nFirstSlot + (nItemsPerRow * nItemsPerColumn) < pGeneralStore->ItemCount()) {
 				nFirstSlot += (nItemsPerRow * nItemsPerColumn);
-				pDC = (*pStoreDialog).GetDC();
+				pDC = pStoreDialog->GetDC();
 			}
 			break;
 		case VK_HOME:                               // go to first page of text
 			if (nFirstSlot != 0) {
 				nFirstSlot = 0;
-				pDC = (*pStoreDialog).GetDC();
+				pDC = pStoreDialog->GetDC();
 			}
 			break;
 		case VK_END:                                // go to last page of text
-			nFirstSlot = (*pGeneralStore).ItemCount() - (nItemsPerRow * nItemsPerColumn);
+			nFirstSlot = pGeneralStore->ItemCount() - (nItemsPerRow * nItemsPerColumn);
 			if (nFirstSlot < 0)
 				nFirstSlot = 0;
-			pDC = (*pStoreDialog).GetDC();
+			pDC = pStoreDialog->GetDC();
 		}
 
 	if (pDC != nullptr) {                                  // update the inventory page if required
 		CGeneralStore::UpdatePage(pDC);
-		(*pStoreDialog).ReleaseDC(pDC);
+		pStoreDialog->ReleaseDC(pDC);
 		return true;
 	}
 
@@ -240,11 +240,11 @@ void CGeneralStore::OnDestroy() {
 		RemoveKeyboardHook();
 
 	if (pWorkOld != nullptr) {
-		(*pWorkDC).SelectObject(pWorkOld);
+		pWorkDC->SelectObject(pWorkOld);
 		pWorkOld = nullptr;
 	}
 	if (pWorkPalOld != nullptr) {
-		(*pWorkDC).SelectPalette(pWorkPalOld, false);
+		pWorkDC->SelectPalette(pWorkPalOld, false);
 		pWorkPalOld = nullptr;
 	}
 	if (pWork != nullptr) {
@@ -264,9 +264,9 @@ void CGeneralStore::OnDestroy() {
 	if (pBackgroundBitmap != nullptr) {
 		delete pBackgroundBitmap;
 		pBackgroundBitmap = nullptr;
-		bUpdateNeeded = (*pParentWnd).GetUpdateRect(nullptr, false);
+		bUpdateNeeded = pParentWnd->GetUpdateRect(nullptr, false);
 		if (bUpdateNeeded)
-			(*pParentWnd).ValidateRect(nullptr);
+			pParentWnd->ValidateRect(nullptr);
 	}
 
 	if (pItemText != nullptr) {
@@ -299,7 +299,7 @@ bool CGeneralStore::OnInitDialog() {
 		m_pParentWnd = ((CWnd *) this)->GetParent();            // ... as passed to us or inquired about
 	assert(m_pParentWnd);
 
-	(*m_pParentWnd).GetWindowRect(&myRect);
+	m_pParentWnd->GetWindowRect(&myRect);
 	x = myRect.left + (((myRect.right - myRect.left) - STORE_DX) >> 1);
 	y = myRect.top + (((myRect.bottom - myRect.top) - STORE_DY) >> 1);
 	StoreRect.SetRect(0, 0, STORE_DX, STORE_DY);
@@ -307,20 +307,20 @@ bool CGeneralStore::OnInitDialog() {
 
 	pButton = GetDlgItem((int) GetDefID());                     // get the window for the okay button
 	ASSERT(pButton != nullptr);                                    // ... and verify we have it
-	(*pButton).GetWindowRect(&myRect);                          // get the button's position and size
+	pButton->GetWindowRect(&myRect);                          // get the button's position and size
 
 	dx = myRect.right - myRect.left;                            // calculate where to place the button
 	x = (StoreRect.right - dx) >> 1;                            // ... centered at the bottom edge
 	dy = myRect.bottom - myRect.top;
 	y = StoreRect.bottom - dy - BUTTON_DY;
 
-	(*pButton).MoveWindow(x, y, dx, dy);                        // reposition the button
+	pButton->MoveWindow(x, y, dx, dy);                        // reposition the button
 	OkayRect.SetRect(x, y, x + dx, y + dy);
 
 	pOKButton = new CColorButton();                               // build a color QUIT button to let us exit
 	ASSERT(pOKButton != nullptr);
-	(*pOKButton).SetPalette(pBackgroundPalette);                // set the palette to use
-	bSuccess = (*pOKButton).SetControl((int) GetDefID(), this); // tie to the dialog control
+	pOKButton->SetPalette(pBackgroundPalette);                // set the palette to use
+	bSuccess = pOKButton->SetControl((int) GetDefID(), this); // tie to the dialog control
 	ASSERT(bSuccess);
 
 	ScrollTopRect.SetRect(0, 0, STORE_DX, STORE_CURL_DY);       // setup rectangles for scrolling areas
@@ -331,7 +331,7 @@ bool CGeneralStore::OnInitDialog() {
 	bFirstTime = true;
 	nFirstSlot = 0;
 
-	if ((*pInventory).FindItem(MG_OBJ_HODJ_NOTEBOOK) != nullptr)   // see who is playing
+	if (pInventory->FindItem(MG_OBJ_HODJ_NOTEBOOK) != nullptr)   // see who is playing
 		bPlayingHodj = true;
 	else
 		bPlayingHodj = false;
@@ -377,26 +377,26 @@ void CGeneralStore::UpdateStore(CDC *pDC) {
 
 	ShowWaitCursor();                                             // put up the hourglass cursor
 
-	pPalOld = (*pDC).SelectPalette(pBackgroundPalette, false);      // setup the proper palette
-	(*pDC).RealizePalette();
+	pPalOld = pDC->SelectPalette(pBackgroundPalette, false);      // setup the proper palette
+	pDC->RealizePalette();
 
 	if (pWorkDC == nullptr) {                                      // if we don't have a work area
 		RefreshBackground();                                    // ... then update the screen directly
 		PaintMaskedBitmap(pDC, pBackgroundPalette, pStoreBitmap, 0, 0, STORE_DX, STORE_DY);
 		UpdateContent(pDC);
 		if (pTitleText != nullptr)
-			(*pTitleText).DisplayString(pDC, (*pGeneralStore).GetTitle(), 32, TEXT_HEAVY, STORE_TEXT_COLOR);
+			pTitleText->DisplayString(pDC, pGeneralStore->GetTitle(), 32, TEXT_HEAVY, STORE_TEXT_COLOR);
 	} else {
 		if (pBackgroundBitmap != nullptr)                                                      // ... otherwise revise work area
 			PaintBitmap(pWorkDC, pBackgroundPalette, pBackgroundBitmap, 0, 0, STORE_DX, STORE_DY);
 		PaintMaskedBitmap(pWorkDC, pBackgroundPalette, pStoreBitmap, 0, 0, STORE_DX, STORE_DY);
 		UpdateContent(pWorkDC);                                 // ... then zap it to the screen
 		if (pTitleText != nullptr)
-			(*pTitleText).DisplayString(pWorkDC, (*pGeneralStore).GetTitle(), 32, TEXT_HEAVY, STORE_TEXT_COLOR);
-		(*pDC).BitBlt(0, 0, STORE_DX, STORE_DY, pWorkDC, 0, 0, SRCCOPY);
+			pTitleText->DisplayString(pWorkDC, pGeneralStore->GetTitle(), 32, TEXT_HEAVY, STORE_TEXT_COLOR);
+		pDC->BitBlt(0, 0, STORE_DX, STORE_DY, pWorkDC, 0, 0, SRCCOPY);
 	}
 
-	(*pDC).SelectPalette(pPalOld, false);                       // reset the palette
+	pDC->SelectPalette(pPalOld, false);                       // reset the palette
 
 	DoArrowCursor();                                            // return to an arrow cursor
 }
@@ -406,16 +406,16 @@ void CGeneralStore::UpdatePage(CDC *pDC) {
 	CPalette    *pPalOld;
 
 	if (pWorkDC == nullptr)                                        // update everything if no work area
-		(*pStoreDialog).InvalidateRect(nullptr, false);
+		pStoreDialog->InvalidateRect(nullptr, false);
 	else {                                                      // otherwise just update central area
 		ShowWaitCursor();                                         // put up the hourglass cursor
-		pPalOld = (*pDC).SelectPalette(pBackgroundPalette, false); // setup the proper palette
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pBackgroundPalette, false); // setup the proper palette
+		pDC->RealizePalette();
 		if (pBackgroundBitmap != nullptr)
 			PaintBitmap(pWorkDC, pBackgroundPalette, pBackgroundBitmap, 0, 0, STORE_DX, STORE_DY);
 		PaintMaskedBitmap(pWorkDC, pBackgroundPalette, pStoreBitmap, 0, 0, STORE_DX, STORE_DY);
 		UpdateContent(pWorkDC);                                 // zap it to the screen
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 		    0,
 		    STORE_BORDER_DY + STORE_TITLEZONE_DY,
 		    STORE_DX,
@@ -424,7 +424,7 @@ void CGeneralStore::UpdatePage(CDC *pDC) {
 		    0,
 		    STORE_BORDER_DY + STORE_TITLEZONE_DY,
 		    SRCCOPY);
-		(*pDC).BitBlt(
+		pDC->BitBlt(
 		    STORE_DX - TEXT_MORE_DX,
 		    STORE_DY - STORE_CURL_DY,
 		    TEXT_MORE_DX,
@@ -433,7 +433,7 @@ void CGeneralStore::UpdatePage(CDC *pDC) {
 		    STORE_DX - TEXT_MORE_DX,
 		    STORE_DY - STORE_CURL_DY,
 		    SRCCOPY);
-		(*pDC).SelectPalette(pPalOld, false);                   // reset the palette
+		pDC->SelectPalette(pPalOld, false);                   // reset the palette
 		DoArrowCursor();
 	}                                                           // return to an arrow cursor
 }
@@ -447,7 +447,7 @@ void CGeneralStore::UpdateContent(CDC *pDC) {
 	CSize   textInfo;                                               // font info about the text to be displayed
 	TEXTMETRIC  fontMetrics;
 
-	if ((*pGeneralStore).ItemCount() <= 0)
+	if (pGeneralStore->ItemCount() <= 0)
 		return;
 
 	nStore_DX = STORE_DX - (STORE_BORDER_DX << 1);              // calculate the horizontal space we have available
@@ -468,26 +468,26 @@ void CGeneralStore::UpdateContent(CDC *pDC) {
 		nItemsPerColumn -= 1;
 	}
 
-	pItem = (*pGeneralStore).FetchItem(nFirstSlot);                // get first item on this page
+	pItem = pGeneralStore->FetchItem(nFirstSlot);                // get first item on this page
 	for (i = 0; (i < (nItemsPerRow * nItemsPerColumn)) && (pItem != nullptr); i++) {                           // will thumb through all of them
 		x = (i % nItemsPerRow);                                 // calculate its horizontal position
 		x *= (STORE_BITMAP_DX + nItem_DDX);                      // ... allowing proper spacing between items
 		y = (i / nItemsPerRow);                                 // calculate its vertical position
 		y *= (STORE_BITMAP_DY + nItem_DDY);                      // ... allowing proper spacing between items
 		UpdateItem(pDC, pItem, x + STORE_BORDER_DX, y + STORE_BORDER_DY + STORE_TITLEZONE_DY);  // now show the item
-		pItem = (*pItem).GetNext();
+		pItem = pItem->GetNext();
 	}
 
 	if (pStoreBitmap != nullptr) {
-		pFontOld = (*pDC).SelectObject(pFont);                  // select it into our context
-		(*pDC).SetBkMode(TRANSPARENT);                              // make the text overlay transparently
-		(*pDC).GetTextMetrics(&fontMetrics);                        // show whether there are more notes
+		pFontOld = pDC->SelectObject(pFont);                  // select it into our context
+		pDC->SetBkMode(TRANSPARENT);                              // make the text overlay transparently
+		pDC->GetTextMetrics(&fontMetrics);                        // show whether there are more notes
 		x = STORE_DX - TEXT_MORE_DX;                                // ... that can be scrolled through
 		y = STORE_DY -
 		    STORE_CURL_DY +
 		    ((STORE_CURL_DY - fontMetrics.tmHeight) >> 1) -
 		    TEXT_MORE_DY;
-		textInfo = (*pDC).GetTextExtent(MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+		textInfo = pDC->GetTextExtent(MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 		dx = textInfo.cx;
 		dy = fontMetrics.tmHeight;
 
@@ -495,10 +495,10 @@ void CGeneralStore::UpdateContent(CDC *pDC) {
 			myRect.SetRect(x, y, x + dx, y + dy);
 			BltBitmap(pDC, pBackgroundPalette, pStoreBitmap, &myRect, &myRect, SRCCOPY);
 		} else {
-			(*pDC).SetTextColor(STORE_MORE_COLOR);
-			(*pDC).TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
+			pDC->SetTextColor(STORE_MORE_COLOR);
+			pDC->TextOut(x, y, MORE_TEXT_BLURB, MORE_TEXT_LENGTH);
 		}
-		(*pDC).SelectObject(pFontOld);                            // map out the font
+		pDC->SelectObject(pFontOld);                            // map out the font
 	}
 }
 
@@ -507,7 +507,7 @@ void CGeneralStore::UpdateItem(CDC *pDC, CItem *pItem, int nX, int nY) {
 	bool bSuccess = true;
 	const char *pArtSpec;
 
-	pArtSpec = (*pItem).GetArtSpec();
+	pArtSpec = pItem->GetArtSpec();
 	if (pArtSpec != nullptr)
 		bSuccess = PaintMaskedDIB(pDC, pBackgroundPalette, pArtSpec, nX, nY, STORE_BITMAP_DX, STORE_BITMAP_DY);
 
@@ -519,20 +519,20 @@ void CGeneralStore::UpdateCrowns(CDC *pDC) {
 	CItem   *pItem;
 	char    chBuffer[128];
 
-	pItem = (*pInventory).FindItem(MG_OBJ_CROWN);
+	pItem = pInventory->FindItem(MG_OBJ_CROWN);
 	if ((pItem == nullptr) ||
-	        ((*pItem).GetQuantity() < 1)) {
+	        (pItem->GetQuantity() < 1)) {
 		if (bPlayingHodj)
 			Common::strcpy_s(chBuffer, "Hodj has no Crowns");
 		else
 			Common::strcpy_s(chBuffer, "Podj has no Crowns");
 	} else {
 		if (bPlayingHodj)
-			Common::sprintf_s(chBuffer, "Hodj has %ld Crowns", (*pItem).GetQuantity());
+			Common::sprintf_s(chBuffer, "Hodj has %ld Crowns", pItem->GetQuantity());
 		else
-			Common::sprintf_s(chBuffer, "Podj has %ld Crowns", (*pItem).GetQuantity());
+			Common::sprintf_s(chBuffer, "Podj has %ld Crowns", pItem->GetQuantity());
 	}
-	(*pItemCost).DisplayString(pDC, chBuffer, FONT_SIZE, TEXT_BOLD, STORE_TEXT_COLOR);
+	pItemCost->DisplayString(pDC, chBuffer, FONT_SIZE, TEXT_BOLD, STORE_TEXT_COLOR);
 }
 
 
@@ -545,7 +545,7 @@ void CGeneralStore::ClearDialogImage() {
 	if (pBackgroundBitmap != nullptr) {
 		delete pOKButton;
 		pOKButton = nullptr;
-		(*pStoreDialog).ValidateRect(nullptr);
+		pStoreDialog->ValidateRect(nullptr);
 		RefreshBackground();
 	}
 }
@@ -555,9 +555,9 @@ void CGeneralStore::RefreshBackground() {
 	CDC *pDC;
 
 	if (pBackgroundBitmap != nullptr) {
-		pDC = (*pStoreDialog).GetDC();                      // get a context for our window
+		pDC = pStoreDialog->GetDC();                      // get a context for our window
 		PaintBitmap(pDC, pBackgroundPalette, pBackgroundBitmap, 0, 0, STORE_DX, STORE_DY);
-		(*pStoreDialog).ReleaseDC(pDC);                     // release the context
+		pStoreDialog->ReleaseDC(pDC);                     // release the context
 	}
 }
 
@@ -584,7 +584,7 @@ int CGeneralStore::OnCreate(LPCREATESTRUCT lpCreateStruct) {
 	AddFontResource("msserif.fon");
 	pFont = new CFont();
 	ASSERT(pFont != nullptr);
-	bSuccess = (*pFont).CreateFont(-14, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, OUT_RASTER_PRECIS, 0, PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
+	bSuccess = pFont->CreateFont(-14, 0, 0, 0, FW_BOLD, 0, 0, 0, 0, OUT_RASTER_PRECIS, 0, PROOF_QUALITY, FF_ROMAN, "MS Sans Serif");
 	ASSERT(bSuccess);
 
 	if (CDialog::OnCreate(lpCreateStruct) == -1)
@@ -609,19 +609,19 @@ bool CGeneralStore::CreateWorkAreas(CDC *pDC) {
 	else
 		pBackgroundBitmap = nullptr;
 
-	(*pDC).SelectPalette(pBackgroundPalette, false);
-	(*pDC).RealizePalette();
+	pDC->SelectPalette(pBackgroundPalette, false);
+	pDC->RealizePalette();
 
 	if ((GetFreeSpace(0) >= (unsigned long) 1000000) &&
 	        (GlobalCompact((unsigned long) 500000) >= (unsigned long) 450000)) {
 		pWork = new CBitmap();
-		if ((*pWork).CreateCompatibleBitmap(pDC, STORE_DX, STORE_DY)) {
+		if (pWork->CreateCompatibleBitmap(pDC, STORE_DX, STORE_DY)) {
 			pWorkDC = new CDC();
 			if ((pWorkDC != nullptr) &&
-			        (*pWorkDC).CreateCompatibleDC(pDC)) {
-				pWorkPalOld = (*pWorkDC).SelectPalette(pBackgroundPalette, false);
-				(*pWorkDC).RealizePalette();
-				pWorkOld = (*pWorkDC).SelectObject(pWork);
+			        pWorkDC->CreateCompatibleDC(pDC)) {
+				pWorkPalOld = pWorkDC->SelectPalette(pBackgroundPalette, false);
+				pWorkDC->RealizePalette();
+				pWorkOld = pWorkDC->SelectObject(pWork);
 				if (pWorkOld != nullptr)
 					bSuccess = true;
 			}
@@ -634,7 +634,7 @@ bool CGeneralStore::CreateWorkAreas(CDC *pDC) {
 
 	if (!bSuccess) {
 		if (pWorkPalOld != nullptr) {
-			(*pWorkDC).SelectPalette(pWorkPalOld, false);
+			pWorkDC->SelectPalette(pWorkPalOld, false);
 			pWorkPalOld = nullptr;
 		}
 		if (pWork != nullptr) {
@@ -646,7 +646,7 @@ bool CGeneralStore::CreateWorkAreas(CDC *pDC) {
 		bSuccess = true;
 	}
 
-	(*pDC).SelectPalette(pWorkPalOld, false);
+	pDC->SelectPalette(pWorkPalOld, false);
 
 	myRect.SetRect(STORE_TEXTZONE_DX,
 	               STORE_BORDER_DY + STORE_TITLEZONE_DDY,
@@ -685,26 +685,26 @@ void CGeneralStore::OnMouseMove(unsigned int nFlags, CPoint point) {
 	pMyApp = AfxGetApp();
 
 	if (OkayRect.PtInRect(point))                   // use standard arrow in buttons
-		hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+		hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 	else if (ScrollTopRect.PtInRect(point)) {           // set cursor to scolling up okay or invalid
 		if (nFirstSlot == 0)                        // ... depending on current slot for page
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_INVALID);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_INVALID);
 		else
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_ARROWUP);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_ARROWUP);
 	} else if (ScrollBotRect.PtInRect(point)) {         // set cursor to scrolling down okay or invalid
-		if (nFirstSlot + (nItemsPerRow * nItemsPerColumn) >= (*pGeneralStore).ItemCount())
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_INVALID);
+		if (nFirstSlot + (nItemsPerRow * nItemsPerColumn) >= pGeneralStore->ItemCount())
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_INVALID);
 		else
-			hNewCursor = (*pMyApp).LoadCursor(IDC_RULES_ARROWDN);
+			hNewCursor = pMyApp->LoadCursor(IDC_RULES_ARROWDN);
 	} else {                                        // see if cursor is on an inventory item
 		i = SelectedItem(point);                    // ... and if so, then show the text blurb
 		if ((i >= 0) &&                             // ... for it at the base of the scroll
-		        ((i + nFirstSlot) < (*pGeneralStore).ItemCount())) {
-			pItem = (*pGeneralStore).FetchItem(i + nFirstSlot);
+		        ((i + nFirstSlot) < pGeneralStore->ItemCount())) {
+			pItem = pGeneralStore->FetchItem(i + nFirstSlot);
 			if (pItem != nullptr) {
 				pDC = GetDC();
-				nPrice = (*pItem).GetValue();
-				if ((*pItem).GetQuantity() == 1) {
+				nPrice = pItem->GetValue();
+				if (pItem->GetQuantity() == 1) {
 					if (nPrice == 1)
 						Common::strcpy_s(chBuffer, "It can be bought for 1 Crown");
 					else
@@ -713,19 +713,19 @@ void CGeneralStore::OnMouseMove(unsigned int nFlags, CPoint point) {
 					Common::strcpy_s(chBuffer, "One can be bought for 1 Crown");
 				else
 					Common::sprintf_s(chBuffer, "One can be bought for %d Crowns", nPrice);
-				(*pItemText).DisplayString(pDC, (*pItem).GetDescription(), FONT_SIZE, TEXT_BOLD, STORE_TEXT_COLOR);
-				(*pItemCost).DisplayString(pDC, chBuffer, FONT_SIZE, TEXT_BOLD, STORE_TEXT_COLOR);
+				pItemText->DisplayString(pDC, pItem->GetDescription(), FONT_SIZE, TEXT_BOLD, STORE_TEXT_COLOR);
+				pItemCost->DisplayString(pDC, chBuffer, FONT_SIZE, TEXT_BOLD, STORE_TEXT_COLOR);
 				ReleaseDC(pDC);
-				hNewCursor = (*pMyApp).LoadCursor(IDC_STORE_DOLLAR);
+				hNewCursor = pMyApp->LoadCursor(IDC_STORE_DOLLAR);
 			}
 		}
 	}
 
 	if (hNewCursor == nullptr) {                       // use default cursor if not specified
-		hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+		hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 		pDC = GetDC();
-		(*pItemText).DisplayString(pDC, "", FONT_SIZE, TEXT_BOLD, STORE_TEXT_COLOR);
-		(*pItemText).RestoreBackground(pDC);        // clear any extant item text
+		pItemText->DisplayString(pDC, "", FONT_SIZE, TEXT_BOLD, STORE_TEXT_COLOR);
+		pItemText->RestoreBackground(pDC);        // clear any extant item text
 		UpdateCrowns(pDC);                          // clear any extant item text
 		ReleaseDC(pDC);
 	}
@@ -757,46 +757,46 @@ void CGeneralStore::OnLButtonDown(unsigned int nFlags, CPoint point) {
 		bUpdateNeeded = true;
 	} else                                          // if click is in lower curl, then
 		if (ScrollBotRect.PtInRect(point) &&            // ... scroll down if not show last item
-		        (nFirstSlot + (nItemsPerRow * nItemsPerColumn) < (*pGeneralStore).ItemCount())) {
+		        (nFirstSlot + (nItemsPerRow * nItemsPerColumn) < pGeneralStore->ItemCount())) {
 			nFirstSlot += (nItemsPerRow * nItemsPerColumn);
 			bUpdateNeeded = true;
 		} else {                                        // see if cursor is on an inventory item
 			i = SelectedItem(point);                    // ... and if so, then show then dispatch
 			if ((i >= 0) &&                             // ... on its action code
-			        ((i + nFirstSlot) < (*pGeneralStore).ItemCount())) {
-				pItem = (*pGeneralStore).FetchItem(i + nFirstSlot);
+			        ((i + nFirstSlot) < pGeneralStore->ItemCount())) {
+				pItem = pGeneralStore->FetchItem(i + nFirstSlot);
 				if (pItem != nullptr) {
 					pDC = GetDC();
-					nPrice = (*pItem).GetValue();
-					pCrowns = (*pInventory).FindItem(MG_OBJ_CROWN);
+					nPrice = pItem->GetValue();
+					pCrowns = pInventory->FindItem(MG_OBJ_CROWN);
 					if ((pCrowns == nullptr) ||
-					        ((*pCrowns).GetQuantity() < nPrice)) {
-						(*pItemText).DisplayString(pDC, "Not have enough crowns to buy that!", FONT_SIZE, TEXT_BOLD, STORE_BLURB_COLOR);
+					        (pCrowns->GetQuantity() < nPrice)) {
+						pItemText->DisplayString(pDC, "Not have enough crowns to buy that!", FONT_SIZE, TEXT_BOLD, STORE_BLURB_COLOR);
 						pSound = new CSound(this, (bPlayingHodj ? "sound\\gsps5.wav" : "sound\\gsps6.wav"), SOUND_WAVE | SOUND_QUEUE | SOUND_AUTODELETE);
-						(*pSound).setDrivePath(lpMetaGameStruct->m_chCDPath);
-						(*pSound).play();
+						pSound->setDrivePath(lpMetaGameStruct->m_chCDPath);
+						pSound->play();
 					} else {
-						(*pItemText).DisplayString(pDC, "Thanks for the purchase!", FONT_SIZE, TEXT_BOLD, STORE_BLURB_COLOR);
+						pItemText->DisplayString(pDC, "Thanks for the purchase!", FONT_SIZE, TEXT_BOLD, STORE_BLURB_COLOR);
 						if (brand() & 1)
 							pSound = new CSound(this, (bPlayingHodj ? "sound\\gsps1.wav" : "sound\\gsps2.wav"), SOUND_WAVE | SOUND_QUEUE | SOUND_AUTODELETE);
 						else
 							pSound = new CSound(this, (bPlayingHodj ? "sound\\gsps3.wav" : "sound\\gsps4.wav"), SOUND_WAVE | SOUND_QUEUE | SOUND_AUTODELETE);
-						(*pSound).setDrivePath(lpMetaGameStruct->m_chCDPath);
-						(*pSound).play();
-						(*pInventory).DiscardItem(pCrowns, nPrice);
-						if ((*pItem).GetQuantity() > 1) {
-							(*pGeneralStore).DiscardItem(pItem, 1);
-							(*pInventory).AddItem((*pItem).GetID(), 1);
+						pSound->setDrivePath(lpMetaGameStruct->m_chCDPath);
+						pSound->play();
+						pInventory->DiscardItem(pCrowns, nPrice);
+						if (pItem->GetQuantity() > 1) {
+							pGeneralStore->DiscardItem(pItem, 1);
+							pInventory->AddItem(pItem->GetID(), 1);
 						} else {
-							(*pGeneralStore).RemoveItem(pItem);
-							(*pInventory).AddItem(pItem);
+							pGeneralStore->RemoveItem(pItem);
+							pInventory->AddItem(pItem);
 							bUpdateNeeded = true;
 						}
 
 
 
 					}
-					(*pItemCost).RestoreBackground(pDC);    // clear any extant item cost
+					pItemCost->RestoreBackground(pDC);    // clear any extant item cost
 					ReleaseDC(pDC);
 				}
 			}
@@ -838,7 +838,7 @@ int CGeneralStore::SelectedItem(CPoint point) {
 
 
 bool CGeneralStore::OnSetCursor(CWnd *pWnd, unsigned int /*nHitTest*/, unsigned int /*message*/) {
-	if ((*pWnd).m_hWnd == (*this).m_hWnd)
+	if (pWnd->m_hWnd == (this)->m_hWnd)
 		return true;
 	else
 		return false;
@@ -850,7 +850,7 @@ void CGeneralStore::ShowWaitCursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).BeginWaitCursor();
+	pMyApp->BeginWaitCursor();
 }
 
 
@@ -859,7 +859,7 @@ void CGeneralStore::DoArrowCursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).EndWaitCursor();
+	pMyApp->EndWaitCursor();
 }
 
 } // namespace Gtl

--- a/engines/bagel/hodjnpodj/metagame/saves/savegame.cpp
+++ b/engines/bagel/hodjnpodj/metagame/saves/savegame.cpp
@@ -494,7 +494,7 @@ ERROR_CODE ConvertFromSGI(CBfcMgr *pBfcMgr, SAVEGAME_INFO *pSaveGameInfo) {
 		}
 
 		pItem = pPlayer->m_pInventory->FindItem(i == 0 ? MG_OBJ_HODJ_NOTEBOOK : MG_OBJ_PODJ_NOTEBOOK);
-		(*pItem).SetActionCode(ITEM_ACTION_NOTEBOOK);
+		pItem->SetActionCode(ITEM_ACTION_NOTEBOOK);
 
 		for (j = 0; j < NUMBER_OF_CLUES; j++) {
 

--- a/engines/bagel/hodjnpodj/metagame/zoom/zoommap.cpp
+++ b/engines/bagel/hodjnpodj/metagame/zoom/zoommap.cpp
@@ -458,7 +458,7 @@ bool CMainZoomWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 			break;
 		}
 	}
-	(*this).SetFocus();                         // Reset focus back to the main window
+	(this)->SetFocus();                         // Reset focus back to the main window
 	return true;
 }
 

--- a/engines/bagel/hodjnpodj/packrat/packrat.cpp
+++ b/engines/bagel/hodjnpodj/packrat/packrat.cpp
@@ -752,7 +752,7 @@ CMainPackRatWindow::CMainPackRatWindow(HWND hCallingWnd, LPGAMESTRUCT lpGameStru
 		pGameSound = new CSound(this, GAME_THEME,
 		                        SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 		if (pGameSound != nullptr)
-			(*pGameSound).midiLoopPlaySegment(2310, 29400, 0, FMT_MILLISEC);
+			pGameSound->midiLoopPlaySegment(2310, 29400, 0, FMT_MILLISEC);
 	} // end if pGameSound
 
 	if (m_lpGameStruct->bPlayingMetagame) {
@@ -764,7 +764,7 @@ CMainPackRatWindow::CMainPackRatWindow(HWND hCallingWnd, LPGAMESTRUCT lpGameStru
 	bStart = false;
 	bInLoop = false;
 	EndWaitCursor();
-	(*this).SetFocus();
+	(this)->SetFocus();
 }
 
 void CMainPackRatWindow::initStatics() {
@@ -1360,7 +1360,7 @@ void CMainPackRatWindow::KillPlayer(bool bFirstTime) {
 			}
 			cMessageBoxDlg.SetInitialOptions(4, m_lScore);
 			cMessageBoxDlg.DoModal();
-			(*this).SetFocus();
+			(this)->SetFocus();
 			m_nPDirection = 0;
 			m_nNextDir = 0;
 			m_bSuspend = true;
@@ -1387,7 +1387,7 @@ void CMainPackRatWindow::KillPlayer(bool bFirstTime) {
 			if (m_lpGameStruct->bSoundEffectsEnabled) {
 				sndPlaySound(nullptr, SND_ASYNC);
 			}
-			(*this).SetFocus();
+			(this)->SetFocus();
 		}
 	}
 
@@ -1870,7 +1870,7 @@ void CMainPackRatWindow::SetNewPlayerPos() {
 			}
 			cMessageBoxDlg.SetInitialOptions(5, m_lScore);
 			cMessageBoxDlg.DoModal();
-			(*this).SetFocus();
+			(this)->SetFocus();
 			m_nPDirection = 0;
 			m_nNextDir = 0;
 			m_bSuspend = true;
@@ -1893,7 +1893,7 @@ void CMainPackRatWindow::SetNewPlayerPos() {
 				}
 				cMessageBoxDlg.SetInitialOptions(2, m_lScore);
 				cMessageBoxDlg.DoModal();
-				(*this).SetFocus();
+				(this)->SetFocus();
 				m_bSuspend = true;
 				if (m_lpGameStruct->bPlayingMetagame) {
 					sndPlaySound(nullptr, SND_ASYNC);
@@ -1913,7 +1913,7 @@ void CMainPackRatWindow::SetNewPlayerPos() {
 				}
 				cMessageBoxDlg.SetInitialOptions(1, m_lScore, (m_nGameLevel - 1));
 				cMessageBoxDlg.DoModal();
-				(*this).SetFocus();
+				(this)->SetFocus();
 				SetMaze();
 				m_bSuspend = false;
 			}
@@ -2653,7 +2653,7 @@ void CMainPackRatWindow::ResetGame() {
 	nExtraLives = 4;
 	bEndGame = false;
 	SetMaze();
-	(*this).SetFocus();
+	(this)->SetFocus();
 	return;
 }
 
@@ -2772,7 +2772,7 @@ bool CMainPackRatWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 					pGameSound = new CSound(this, GAME_THEME,
 					                        SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 					if (pGameSound != nullptr)
-						(*pGameSound).midiLoopPlaySegment(2310, 29400, 0, FMT_MILLISEC);
+						pGameSound->midiLoopPlaySegment(2310, 29400, 0, FMT_MILLISEC);
 				}
 			} // end if pGameSound
 			else {
@@ -2804,7 +2804,7 @@ bool CMainPackRatWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 // if the Hols buttons are hit then set then accordingly
 
-	(*this).SetFocus();                         // Reset focus back to the main window
+	(this)->SetFocus();                         // Reset focus back to the main window
 	return true;
 }
 
@@ -2996,7 +2996,7 @@ void CMainPackRatWindow::OnKeyDown(unsigned int nChar, unsigned int nRepCnt, uns
 		CFrameWnd::OnKeyDown(nChar, nRepCnt, nFlags);
 		break;
 	}
-	(*this).SetFocus();
+	(this)->SetFocus();
 	return;
 }
 
@@ -3044,7 +3044,7 @@ void CMainPackRatWindow::MainLoop() {
 	POINT       ptLive;
 	bool        bRedrawLives = false;
 
-	(*this).SetFocus();
+	(this)->SetFocus();
 	while (bEndGame == false) {
 		if (m_bSuspend == false) {
 			if ((nEatTurtle <= (EATTURTLE - (4 * m_nGameLevel))) && (bEatTurtle)) {
@@ -3442,7 +3442,7 @@ void CMainPackRatWindow::ReleaseResources() {
 	CSprite::ClearBackdrop();
 
 	if (pGamePalette) {
-		(*pGamePalette).DeleteObject();         // release the game color palette
+		pGamePalette->DeleteObject();         // release the game color palette
 
 		delete pGamePalette;
 		pGamePalette = nullptr;

--- a/engines/bagel/hodjnpodj/pdq/main.cpp
+++ b/engines/bagel/hodjnpodj/pdq/main.cpp
@@ -776,24 +776,24 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	} else if (birdRect.PtInRect(point)) {
 		pDC = GetDC();
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pMyGamePalette);
-		bSuccess = (*pSprite).LoadCels(pDC, BIRD_ANIM, NUM_BIRD_CELS);
+		pSprite->SharePalette(pMyGamePalette);
+		bSuccess = pSprite->LoadCels(pDC, BIRD_ANIM, NUM_BIRD_CELS);
 		if (!bSuccess) {
 			delete pSprite;
 			ReleaseDC(pDC);
 			return;
 		}
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
-		if ((*pGameParams).bSoundEffectsEnabled) {
+		if (pGameParams->bSoundEffectsEnabled) {
 			if ((pEffect = new CSound((CWnd *)this, WAV_BIRD, SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE | SOUND_QUEUE)) != nullptr) {
 				pEffect->play();
 			}
 		}
-		(*pSprite).SetCel(NUM_BIRD_CELS);
+		pSprite->SetCel(NUM_BIRD_CELS);
 		for (i = 0; i < NUM_BIRD_CELS; i++) {
-			(*pSprite).PaintSprite(pDC, BIRD_X, BIRD_Y);
+			pSprite->PaintSprite(pDC, BIRD_X, BIRD_Y);
 			CSound::handleMessages();
 			Sleep(BIRD_SLEEP);
 		}
@@ -804,24 +804,24 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	} else if (horse1Rect.PtInRect(point)) {
 		pDC = GetDC();
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pMyGamePalette);
-		bSuccess = (*pSprite).LoadCels(pDC, HORSE1_ANIM, NUM_HORSE1_CELS);
+		pSprite->SharePalette(pMyGamePalette);
+		bSuccess = pSprite->LoadCels(pDC, HORSE1_ANIM, NUM_HORSE1_CELS);
 		if (!bSuccess) {
 			delete pSprite;
 			ReleaseDC(pDC);
 			return;
 		}
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
-		if ((*pGameParams).bSoundEffectsEnabled) {
+		if (pGameParams->bSoundEffectsEnabled) {
 			if ((pEffect = new CSound((CWnd *)this, WAV_HORSE1, SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE | SOUND_QUEUE)) != nullptr) {
 				pEffect->play();
 			}
 		}
-		(*pSprite).SetCel(NUM_HORSE1_CELS);
+		pSprite->SetCel(NUM_HORSE1_CELS);
 		for (i = 0; i < NUM_HORSE1_CELS; i++) {
-			(*pSprite).PaintSprite(pDC, HORSE1_X, HORSE1_Y);
+			pSprite->PaintSprite(pDC, HORSE1_X, HORSE1_Y);
 			CSound::handleMessages();
 			Sleep(HORSE1_SLEEP);
 		}
@@ -833,24 +833,24 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	} else if (horse2Rect.PtInRect(point)) {
 		pDC = GetDC();
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pMyGamePalette);
-		bSuccess = (*pSprite).LoadCels(pDC, HORSE2_ANIM, NUM_HORSE2_CELS);
+		pSprite->SharePalette(pMyGamePalette);
+		bSuccess = pSprite->LoadCels(pDC, HORSE2_ANIM, NUM_HORSE2_CELS);
 		if (!bSuccess) {
 			delete pSprite;
 			ReleaseDC(pDC);
 			return;
 		}
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
-		if ((*pGameParams).bSoundEffectsEnabled) {
+		if (pGameParams->bSoundEffectsEnabled) {
 			if ((pEffect = new CSound((CWnd *)this, WAV_HORSE2, SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE | SOUND_QUEUE)) != nullptr) {
 				pEffect->play();
 			}
 		}
-		(*pSprite).SetCel(NUM_HORSE2_CELS);
+		pSprite->SetCel(NUM_HORSE2_CELS);
 		for (i = 0; i < NUM_HORSE2_CELS; i++) {
-			(*pSprite).PaintSprite(pDC, HORSE2_X, HORSE2_Y);
+			pSprite->PaintSprite(pDC, HORSE2_X, HORSE2_Y);
 			CSound::handleMessages();
 			Sleep(HORSE2_SLEEP);
 		}
@@ -862,24 +862,24 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	} else if (flowerRect.PtInRect(point)) {
 		pDC = GetDC();
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pMyGamePalette);
-		bSuccess = (*pSprite).LoadCels(pDC, FLOWER_ANIM, NUM_FLOWER_CELS);
+		pSprite->SharePalette(pMyGamePalette);
+		bSuccess = pSprite->LoadCels(pDC, FLOWER_ANIM, NUM_FLOWER_CELS);
 		if (!bSuccess) {
 			delete pSprite;
 			ReleaseDC(pDC);
 			return;
 		}
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
-		if ((*pGameParams).bSoundEffectsEnabled) {
+		if (pGameParams->bSoundEffectsEnabled) {
 			if ((pEffect = new CSound((CWnd *)this, WAV_FLOWER, SOUND_WAVE | SOUND_ASYNCH | SOUND_AUTODELETE | SOUND_QUEUE)) != nullptr) {
 				pEffect->play();
 			}
 		}
-		(*pSprite).SetCel(NUM_FLOWER_CELS);
+		pSprite->SetCel(NUM_FLOWER_CELS);
 		for (i = 0; i < NUM_FLOWER_CELS; i++) {
-			(*pSprite).PaintSprite(pDC, FLOWER_X, FLOWER_Y);
+			pSprite->PaintSprite(pDC, FLOWER_X, FLOWER_Y);
 			CSound::handleMessages();
 			Sleep(FLOWER_SLEEP);
 		}

--- a/engines/bagel/hodjnpodj/pdq/usercfg.cpp
+++ b/engines/bagel/hodjnpodj/pdq/usercfg.cpp
@@ -286,23 +286,23 @@ bool CUserCfgDlg::OnInitDialog() {
 	ReleaseDC(pDC);
 
 	if ((pOKButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pOKButton).SetPalette(m_pPalette);                        // set the palette to use
-		(*pOKButton).SetControl(IDOK, this);            // tie to the dialog control
+		pOKButton->SetPalette(m_pPalette);                        // set the palette to use
+		pOKButton->SetControl(IDOK, this);            // tie to the dialog control
 	}
 
 	if ((pCancelButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pCancelButton).SetPalette(m_pPalette);                        // set the palette to use
-		(*pCancelButton).SetControl(IDCANCEL, this);            // tie to the dialog control
+		pCancelButton->SetPalette(m_pPalette);                        // set the palette to use
+		pCancelButton->SetControl(IDCANCEL, this);            // tie to the dialog control
 	}
 
 	if ((pDefaultsButton = new CColorButton) != nullptr) {                 // build a color QUIT button to let us exit
-		(*pDefaultsButton).SetPalette(m_pPalette);                      // set the palette to use
-		(*pDefaultsButton).SetControl(ID_RESET, this);              // tie to the dialog control
+		pDefaultsButton->SetPalette(m_pPalette);                      // set the palette to use
+		pDefaultsButton->SetControl(ID_RESET, this);              // tie to the dialog control
 	}
 
 	if ((pFixedButton = new CCheckButton) != nullptr) {        // build a color QUIT button to let us exit
-		(*pFixedButton).SetPalette(m_pPalette);             // set the palette to use
-		(*pFixedButton).SetControl(ID_FIXED, this);         // tie to the dialog control
+		pFixedButton->SetPalette(m_pPalette);             // set the palette to use
+		pFixedButton->SetControl(ID_FIXED, this);         // tie to the dialog control
 	}
 
 	if ((m_pNamesButton = new CCheckButton) != nullptr) {

--- a/engines/bagel/hodjnpodj/peggle/game.cpp
+++ b/engines/bagel/hodjnpodj/peggle/game.cpp
@@ -178,14 +178,14 @@ CMainWindow::CMainWindow(HWND hCallingApp) {
 
 // Acquire the shared palete for our game from the splash screen art
 	pDibDoc = new CDibDoc();
-	bSuccess = (*pDibDoc).OpenDocument(BoardSpec[BoardSelected - BOARD_BASE]);
+	bSuccess = pDibDoc->OpenDocument(BoardSpec[BoardSelected - BOARD_BASE]);
 	ASSERT(bSuccess);
 
-	pGamePalette = (*pDibDoc).DetachPalette();
+	pGamePalette = pDibDoc->DetachPalette();
 	delete pDibDoc;
 
 	pDC = GetDC();
-	pPalOld = (*pDC).SelectPalette(pGamePalette, false);
+	pPalOld = pDC->SelectPalette(pGamePalette, false);
 
 	pScrollButton = new CBmpButton;             // build a bitmapped OKAY button for resetting
 	ASSERT(pScrollButton);                            // ... the sprites, again as an example
@@ -193,65 +193,65 @@ CMainWindow::CMainWindow(HWND hCallingApp) {
 	                   SCROLL_BUTTON_Y,
 	                   SCROLL_BUTTON_X + SCROLL_BUTTON_DX - 1,
 	                   SCROLL_BUTTON_Y + SCROLL_BUTTON_DY - 1);
-	bSuccess = (*pScrollButton).Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, ScrollRect, this, IDC_SCROLL);
+	bSuccess = pScrollButton->Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, ScrollRect, this, IDC_SCROLL);
 	ASSERT(bSuccess);
-	bSuccess = (*pScrollButton).LoadBitmaps("SCROLLUP", "SCROLLDOWN", "SCROLLFOCUS", "SCROLLDISABLED");
+	bSuccess = pScrollButton->LoadBitmaps("SCROLLUP", "SCROLLDOWN", "SCROLLFOCUS", "SCROLLDISABLED");
 	ASSERT(bSuccess);
 
 	pShotGlass = new CSprite;
 
-	(*pShotGlass).SharePalette(pGamePalette);
-	bSuccess = (*pShotGlass).LoadResourceSprite(pDC, "SHOTGLASS");
+	pShotGlass->SharePalette(pGamePalette);
+	bSuccess = pShotGlass->LoadResourceSprite(pDC, "SHOTGLASS");
 	ASSERT(bSuccess);
-	(*pShotGlass).SetMasked(true);
-	(*pShotGlass).SetMobile(true);
-	(*pShotGlass).SetTypeCode(SPRITE_GLASS);
+	pShotGlass->SetMasked(true);
+	pShotGlass->SetMobile(true);
+	pShotGlass->SetTypeCode(SPRITE_GLASS);
 
 	pTableSlot = new CSprite;
 
-	(*pTableSlot).SharePalette(pGamePalette);
-	bSuccess = (*pTableSlot).LoadResourceSprite(pDC, "TABLESLOT");
+	pTableSlot->SharePalette(pGamePalette);
+	bSuccess = pTableSlot->LoadResourceSprite(pDC, "TABLESLOT");
 	ASSERT(bSuccess);
-	(*pTableSlot).SetMasked(true);
-	(*pTableSlot).SetMobile(true);
-	(*pTableSlot).SetTypeCode(SPRITE_HOLE);
+	pTableSlot->SetMasked(true);
+	pTableSlot->SetMobile(true);
+	pTableSlot->SetTypeCode(SPRITE_HOLE);
 
 	pInvalidSlot = new CSprite;
 
-	(*pInvalidSlot).SharePalette(pGamePalette);
-	bSuccess = (*pInvalidSlot).LoadResourceSprite(pDC, "INVALIDSLOT");
+	pInvalidSlot->SharePalette(pGamePalette);
+	bSuccess = pInvalidSlot->LoadResourceSprite(pDC, "INVALIDSLOT");
 	ASSERT(bSuccess);
-	(*pInvalidSlot).SetMasked(true);
-	(*pInvalidSlot).SetMobile(true);
-	(*pInvalidSlot).SetTypeCode(SPRITE_INVALID);
+	pInvalidSlot->SetMasked(true);
+	pInvalidSlot->SetMobile(true);
+	pInvalidSlot->SetTypeCode(SPRITE_INVALID);
 
 	pCursorSprite = new CSprite;
 
-	(*pCursorSprite).SharePalette(pGamePalette);
-	bSuccess = (*pCursorSprite).LoadResourceSprite(pDC, "SHOTGLASS");
+	pCursorSprite->SharePalette(pGamePalette);
+	bSuccess = pCursorSprite->LoadResourceSprite(pDC, "SHOTGLASS");
 	ASSERT(bSuccess);
-	(*pCursorSprite).SetMasked(true);
-	(*pCursorSprite).SetMobile(true);
+	pCursorSprite->SetMasked(true);
+	pCursorSprite->SetMobile(true);
 
 	//srand((unsigned)time(nullptr));
 
-	if ((*pGameInfo).bPlayingMetagame)
+	if (pGameInfo->bPlayingMetagame)
 		bRandomBoard = true;
 //		BoardSelected = (brand() % BOARD_COUNT) + BOARD_BASE;
 
 	SetUpBoard(pDC);
 
-	(*pDC).SelectPalette(pPalOld, false);
+	pDC->SelectPalette(pPalOld, false);
 	ReleaseDC(pDC);
 
-	if ((*pGameInfo).bMusicEnabled) {
+	if (pGameInfo->bMusicEnabled) {
 		if ((pGameSound = new CSound(this, GAME_THEME,
 		                            SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END))) {
-			(*pGameSound).midiLoopPlaySegment(1000, 30000, 0, FMT_MILLISEC);
+			pGameSound->midiLoopPlaySegment(1000, 30000, 0, FMT_MILLISEC);
 		} // end if pGameSound
 	}
 
-	if ((*pGameInfo).bPlayingMetagame == false) {
+	if (pGameInfo->bPlayingMetagame == false) {
 		PostMessage(WM_COMMAND, IDC_SCROLL, BN_CLICKED);
 	}
 
@@ -332,15 +332,15 @@ void CMainWindow::SplashScreen() {
 		rcDIB.top = rcDIB.left = 0;
 		rcDIB.right = cxDIB;
 		rcDIB.bottom = cyDIB;
-		PaintDIB((*pDC).m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
+		PaintDIB(pDC->m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);
 	}
 
 	pSprite = CSprite::GetSpriteChain();
 	while (pSprite) {
-		(*pSprite).ClearBackground();
-		bSuccess = (*pSprite).RefreshSprite(pDC);
+		pSprite->ClearBackground();
+		bSuccess = pSprite->RefreshSprite(pDC);
 		ASSERT(bSuccess);
-		pSprite = (*pSprite).GetNextSprite();
+		pSprite = pSprite->GetNextSprite();
 	}
 
 	ReleaseDC(pDC);
@@ -401,18 +401,18 @@ void SetUpBoard(CDC *pDC) {
 		for (i = 0; i < GRID_SIZE; i++) {
 			pNewSprite = nullptr;
 			if (fState[i][j] == PEGGED)
-				pNewSprite = (*pShotGlass).DuplicateSprite(pDC);
+				pNewSprite = pShotGlass->DuplicateSprite(pDC);
 			else if (fState[i][j] == EMPTY)
-				pNewSprite = (*pTableSlot).DuplicateSprite(pDC);
+				pNewSprite = pTableSlot->DuplicateSprite(pDC);
 			else
 //		if ((fState[i][j] == NO_HOLE) && ((BoardSelected == CROSS) || (BoardSelected == CROSS_PLUS)))
-				pNewSprite = (*pInvalidSlot).DuplicateSprite(pDC);
+				pNewSprite = pInvalidSlot->DuplicateSprite(pDC);
 			ASSERT(pNewSprite != nullptr);
 			cPoint = CMainWindow::GridToPoint(i, j);
-			if ((*pNewSprite).GetTypeCode() == SPRITE_HOLE)
+			if (pNewSprite->GetTypeCode() == SPRITE_HOLE)
 				cPoint.x -= (SPRITE_SIZE_DX >> 1);
-			(*pNewSprite).SetPosition(cPoint);
-			(*pNewSprite).LinkSprite();
+			pNewSprite->SetPosition(cPoint);
+			pNewSprite->LinkSprite();
 		}
 	}
 
@@ -437,7 +437,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 	CDC         *pDC;
 	CPoint      sprite_loc;
 	CRules      RulesDlg((CWnd *)this, RULESSPEC, pGamePalette,
-	                     ((*pGameInfo).bSoundEffectsEnabled ? NARRATIVESPEC : nullptr));
+	                     (pGameInfo->bSoundEffectsEnabled ? NARRATIVESPEC : nullptr));
 	COptions    COptionsWind((CWnd *)this, pGamePalette, IDD_OPTIONS_DIALOG) ;
 
 
@@ -453,12 +453,12 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 		case IDC_RULES:
 			bIgnoreScroll = true;
-			(*pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+			pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 			RulesDlg.DoModal();                          // invoke the help dialog box
 			break;
 
 		case IDC_NEWGAME:
-			if (!(*pGameInfo).bPlayingMetagame) {
+			if (!pGameInfo->bPlayingMetagame) {
 				pDC = GetDC();
 				SetUpBoard(pDC);
 				ReleaseDC(pDC);
@@ -468,23 +468,23 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 		case IDC_SCROLL:
 			if (bIgnoreScroll) {
-				(*pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+				pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 				break;
 			}
 			bIgnoreScroll = true;
-			(*pScrollButton).SendMessage(BM_SETSTATE, true, 0L);
+			pScrollButton->SendMessage(BM_SETSTATE, true, 0L);
 			SendDlgItemMessage(IDC_SCROLL, BM_SETSTATE, true, 0L);
 
 			switch (COptionsWind.DoModal()) {
 
 			case IDC_RETURN:
-				(*pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				bIgnoreScroll = false;
 				break;
 
 			case IDC_RESTART:
 			case IDC_NEWGAME:
-				(*pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				bIgnoreScroll = false;
 				pDC = GetDC();
 				SetUpBoard(pDC);
@@ -497,17 +497,17 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 				return false;
 
 			default:
-				(*pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+				pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 				bIgnoreScroll = false;
 
 			} //end switch(ComDlg.DoModal())
 
-			if ((*pGameInfo).bMusicEnabled) {
+			if (pGameInfo->bMusicEnabled) {
 				if (pGameSound == nullptr) {
 					pGameSound = new CSound(this, GAME_THEME,
 					                        SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 					if (pGameSound != nullptr)
-						(*pGameSound).midiLoopPlaySegment(6370, 33000, 0, FMT_MILLISEC);
+						pGameSound->midiLoopPlaySegment(6370, 33000, 0, FMT_MILLISEC);
 				}
 			} // end if pGameSound
 			else {
@@ -522,7 +522,7 @@ bool CMainWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 
 	}
 
-	(*this).SetFocus();                     // Reset focus back to the main window
+	(this)->SetFocus();                     // Reset focus back to the main window
 	return true;
 }
 
@@ -553,11 +553,11 @@ void CMainWindow::OnSysChar(unsigned int nChar, unsigned int nRepCnt, unsigned i
 void CMainWindow::OnKeyDown(unsigned int nChar, unsigned int nRepCnt, unsigned int nFlags) {
 	if (nChar == VK_F1) {                                  // F1 key is hit
 		SendMessage(WM_COMMAND, IDC_RULES, BN_CLICKED);  // Activate the Options dialog
-		(*pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+		pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 		bIgnoreScroll = false;
 	} else if (nChar == VK_F2) {                                 // F2 key is hit
 		SendMessage(WM_COMMAND, IDC_SCROLL, BN_CLICKED);     // Activate the Options dialog
-		(*pScrollButton).SendMessage(BM_SETSTATE, false, 0L);
+		pScrollButton->SendMessage(BM_SETSTATE, false, 0L);
 		bIgnoreScroll = false;
 	}
 }
@@ -576,7 +576,7 @@ void CMainWindow::OnMouseMove(unsigned int nFlags, CPoint point) {
 		real_loc.x = point.x - (SPRITE_SIZE_DX / 2);
 		real_loc.y = point.y - (SPRITE_SIZE_DY / 2);
 		pDC = GetDC();
-		(*pCursorSprite).PaintSprite(pDC, real_loc);
+		pCursorSprite->PaintSprite(pDC, real_loc);
 		ReleaseDC(pDC);
 	}
 
@@ -627,7 +627,7 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint myPoint) {
 	candlefrRect.SetRect(CANDLEFR_X, CANDLEFR_Y, CANDLEFR_X + CANDLEFR_DX, CANDLEFR_Y + CANDLEFR_DY);
 
 
-	if (((*pGameInfo).bPlayingMetagame == false) && titleRect.PtInRect(myPoint)) {
+	if ((pGameInfo->bPlayingMetagame == false) && titleRect.PtInRect(myPoint)) {
 		if (!(counter & 0x01))
 			UndoTurn();
 		else {
@@ -636,7 +636,7 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint myPoint) {
 			ReleaseDC(pDC);
 		}
 		SendMessage(WM_COMMAND, IDC_NEWGAME, BN_CLICKED);
-	} else if (((*pGameInfo).bPlayingMetagame == false) && bottleRect.PtInRect(myPoint)) {
+	} else if ((pGameInfo->bPlayingMetagame == false) && bottleRect.PtInRect(myPoint)) {
 		if (!(counter & 0x01))
 			UndoTurn();
 		else {
@@ -649,25 +649,25 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint myPoint) {
 		sndPlaySound(nullptr, 0);
 		pDC = GetDC();
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pGamePalette);
-		bSuccess = (*pSprite).LoadCels(pDC, "art\\dart.bmp", NUM_DART_CELS);
+		pSprite->SharePalette(pGamePalette);
+		bSuccess = pSprite->LoadCels(pDC, "art\\dart.bmp", NUM_DART_CELS);
 		if (!bSuccess) {
 			delete pSprite;
 			ReleaseDC(pDC);
 			return;
 		}
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
-		if ((*pGameInfo).bSoundEffectsEnabled) {
+		if (pGameInfo->bSoundEffectsEnabled) {
 			pEffect = new CSound((CWnd *)this, "sound\\darts.wav",                // Load up the sound file as a
 			                     SOUND_WAVE | SOUND_QUEUE | SOUND_ASYNCH | SOUND_AUTODELETE);    //...Wave file, to delete itself
 		}
 		for (i = 0; i < NUM_DART_CELS; i++) {
-			(*pSprite).PaintSprite(pDC, DART_X, DART_Y);
+			pSprite->PaintSprite(pDC, DART_X, DART_Y);
 			Sleep(DART_SLEEP - (i));     // * 2
 			if ((i == 0) && (pEffect != nullptr)) {
-				bSuccess = (*pEffect).play();                                                       //...play the narration
+				bSuccess = pEffect->play();                                                       //...play the narration
 				if (!bSuccess)
 					delete pEffect;
 			}
@@ -681,28 +681,28 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint myPoint) {
 		sndPlaySound(nullptr, 0);
 		pDC = GetDC();
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pGamePalette);
-		bSuccess = (*pSprite).LoadCels(pDC, "art\\keg.bmp", NUM_KEG_CELS);
+		pSprite->SharePalette(pGamePalette);
+		bSuccess = pSprite->LoadCels(pDC, "art\\keg.bmp", NUM_KEG_CELS);
 		if (!bSuccess) {
 			delete pSprite;
 			ReleaseDC(pDC);
 			return;
 		}
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
-		if ((*pGameInfo).bSoundEffectsEnabled) {
+		if (pGameInfo->bSoundEffectsEnabled) {
 			pEffect = new CSound((CWnd *)this, "sound\\barglass.wav",             // Load up the sound file as a
 			                     SOUND_WAVE | SOUND_QUEUE | SOUND_ASYNCH | SOUND_AUTODELETE);                //...Wave file, to delete itself
 		}
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
-		(*pSprite).SetCel(NUM_KEG_CELS - KEG_CEL_OFFSET);
+		pSprite->SetCel(NUM_KEG_CELS - KEG_CEL_OFFSET);
 		for (i = 0; i < NUM_KEG_CELS; i++) {
-			(*pSprite).PaintSprite(pDC, KEG_X, KEG_Y);
+			pSprite->PaintSprite(pDC, KEG_X, KEG_Y);
 			Sleep(KEG_SLEEP);
 		}
 		if (pSprite != nullptr)
@@ -714,87 +714,87 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint myPoint) {
 		sndPlaySound(nullptr, 0);
 		pDC = GetDC();
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pGamePalette);
-		bSuccess = (*pSprite).LoadCels(pDC, "art\\stool.bmp", NUM_STOOL_CELS);
+		pSprite->SharePalette(pGamePalette);
+		bSuccess = pSprite->LoadCels(pDC, "art\\stool.bmp", NUM_STOOL_CELS);
 		if (!bSuccess) {
 			delete pSprite;
 			ReleaseDC(pDC);
 			return;
 		}
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
-		if ((*pGameInfo).bSoundEffectsEnabled) {
+		if (pGameInfo->bSoundEffectsEnabled) {
 			pEffect = new CSound((CWnd *)this, "sound\\chrdance.wav",             // Load up the sound file as a
 			                     SOUND_WAVE | SOUND_QUEUE |  SOUND_ASYNCH | SOUND_AUTODELETE);               //...Wave file, to delete itself
 		}
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
 		for (i = 0; i < NUM_STOOL_CELS; i++) {
-			(*pSprite).PaintSprite(pDC, STOOL_X, STOOL_Y);
+			pSprite->PaintSprite(pDC, STOOL_X, STOOL_Y);
 			Sleep(STOOL_SLEEP);
 		}
 
 		delete pSprite;
 		ReleaseDC(pDC);
 
-	} else if (oarRect.PtInRect(myPoint) && (*pGameInfo).bSoundEffectsEnabled) {
+	} else if (oarRect.PtInRect(myPoint) && pGameInfo->bSoundEffectsEnabled) {
 		CSound::waitWaveSounds();
 		sndPlaySound(nullptr, 0);
 		pEffect = new CSound((CWnd *)this, OAR_SOUND,                                // Load up the sound file as a
 		                     SOUND_WAVE | SOUND_QUEUE |  SOUND_ASYNCH | SOUND_AUTODELETE);   //...Wave file, to delete itself
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
-	} else if (netRect.PtInRect(myPoint) && (*pGameInfo).bSoundEffectsEnabled) {
+	} else if (netRect.PtInRect(myPoint) && pGameInfo->bSoundEffectsEnabled) {
 		CSound::waitWaveSounds();
 		sndPlaySound(nullptr, 0);
 		pEffect = new CSound((CWnd *)this, NET_SOUND,                                // Load up the sound file as a
 		                     SOUND_WAVE | SOUND_QUEUE |  SOUND_ASYNCH | SOUND_AUTODELETE);   //...Wave file, to delete itself
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
-	} else if (signRect.PtInRect(myPoint) && (*pGameInfo).bSoundEffectsEnabled) {
+	} else if (signRect.PtInRect(myPoint) && pGameInfo->bSoundEffectsEnabled) {
 		CSound::waitWaveSounds();
 		sndPlaySound(nullptr, 0);
 		pEffect = new CSound((CWnd *)this, SIGN_SOUND,                               // Load up the sound file as a
 		                     SOUND_WAVE | SOUND_QUEUE |  SOUND_ASYNCH | SOUND_AUTODELETE);   //...Wave file, to delete itself
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
-	} else if (tableRect.PtInRect(myPoint) && (*pGameInfo).bSoundEffectsEnabled) {
+	} else if (tableRect.PtInRect(myPoint) && pGameInfo->bSoundEffectsEnabled) {
 		CSound::waitWaveSounds();
 		sndPlaySound(nullptr, 0);
 		pEffect = new CSound((CWnd *)this, TABLE_SOUND,                              // Load up the sound file as a
 		                     SOUND_WAVE | SOUND_QUEUE |  SOUND_ASYNCH | SOUND_AUTODELETE);   //...Wave file, to delete itself
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
-	} else if ((candlenrRect.PtInRect(myPoint) || candlefrRect.PtInRect(myPoint)) && (*pGameInfo).bSoundEffectsEnabled) {
+	} else if ((candlenrRect.PtInRect(myPoint) || candlefrRect.PtInRect(myPoint)) && pGameInfo->bSoundEffectsEnabled) {
 		CSound::waitWaveSounds();
 		sndPlaySound(nullptr, 0);
 		pEffect = new CSound((CWnd *)this, CANDLE_SOUND,                                 // Load up the sound file as a
 		                     SOUND_WAVE | SOUND_QUEUE |  SOUND_ASYNCH | SOUND_AUTODELETE);   //...Wave file, to delete itself
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
 	} else if (!(counter & 0x01)) {
 		pSprite = CSprite::Touched(myPoint);
 		if (pSprite != nullptr) {
-			sprite_loc = (*pSprite).GetPosition();
+			sprite_loc = pSprite->GetPosition();
 			grid_loc = PointToGrid(sprite_loc);
 			if (fState [grid_loc.x][grid_loc.y] == PEGGED) {
 				counter += 1;
@@ -803,12 +803,12 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint myPoint) {
 				pDC = GetDC();
 				UpdatePegPosition(pDC, pTableSlot, grid_loc.x, grid_loc.y);
 				if (counter % 2)
-					(*pCursorSprite).PaintSprite(pDC, sprite_loc);
+					pCursorSprite->PaintSprite(pDC, sprite_loc);
 				ReleaseDC(pDC);
 				bPegMoving = true;
 			} else {             // illegal move
 //			    MessageBeep(-1);
-				if ((*pGameInfo).bSoundEffectsEnabled)
+				if (pGameInfo->bSoundEffectsEnabled)
 					sndPlaySound(nullptr, 0);
 				sndPlaySound(WAV_NOMOVE, SND_ASYNC);
 			}
@@ -818,8 +818,8 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint myPoint) {
 		oldy = Moves[counter].y;
 		pSprite = CSprite::Touched(myPoint);
 		if (pSprite != nullptr) {
-			sprite_loc = (*pSprite).GetPosition();
-			if ((*pSprite).GetTypeCode() == SPRITE_HOLE)
+			sprite_loc = pSprite->GetPosition();
+			if (pSprite->GetTypeCode() == SPRITE_HOLE)
 				sprite_loc.x += (SPRITE_SIZE_DX >> 1);
 			grid_loc = PointToGrid(sprite_loc);
 			newx = grid_loc.x;
@@ -843,7 +843,7 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint myPoint) {
 						Moves[counter].y = newy ;
 						pDC = GetDC();
 
-						(*pCursorSprite).EraseSprite(pDC);
+						pCursorSprite->EraseSprite(pDC);
 
 						UpdatePegPosition(pDC, pShotGlass, newx, newy);
 
@@ -851,7 +851,7 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint myPoint) {
 
 						ReleaseDC(pDC);
 
-						if ((*pGameInfo).bSoundEffectsEnabled) {
+						if (pGameInfo->bSoundEffectsEnabled) {
 							sndPlaySound(nullptr, 0);
 							sndPlaySound(WAV_MOVE, SND_ASYNC);
 						}
@@ -920,13 +920,13 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint myPoint) {
 							#endif
 
 							if (score == 25) {
-								if ((*pGameInfo).bSoundEffectsEnabled) {
+								if (pGameInfo->bSoundEffectsEnabled) {
 									sndPlaySound(nullptr, 0);
 									sndPlaySound(WAV_WON, SND_ASYNC);
 								}
 								score_blurb = "You have won!";
 							} else {
-								if ((*pGameInfo).bSoundEffectsEnabled) {
+								if (pGameInfo->bSoundEffectsEnabled) {
 									sndPlaySound(nullptr, 0);
 									sndPlaySound(WAV_DONE, SND_ASYNC);
 								}
@@ -942,11 +942,11 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint myPoint) {
 //						UpdateWindow();
 //						GameOverDlg.DoModal();
 
-							if ((*pGameInfo).bPlayingMetagame) {
+							if (pGameInfo->bPlayingMetagame) {
 								#ifndef SHOW_CURSOR
 								::ShowCursor(false);
 								#endif
-								(*pGameInfo).lScore += score;
+								pGameInfo->lScore += score;
 								PostMessage(WM_CLOSE, 0, 0);
 							} else {
 								pDC = GetDC();
@@ -988,12 +988,12 @@ void CMainWindow::OnLButtonDown(unsigned int nFlags, CPoint myPoint) {
 		} else {
 			counter -= 1;
 //			MessageBeep(-1);
-			if ((*pGameInfo).bSoundEffectsEnabled) {
+			if (pGameInfo->bSoundEffectsEnabled) {
 				sndPlaySound(nullptr, 0);
 				sndPlaySound(WAV_NOMOVE, SND_ASYNC);
 			}
 			pDC = GetDC();
-			(*pCursorSprite).EraseSprite(pDC);
+			pCursorSprite->EraseSprite(pDC);
 
 			UpdatePegPosition(pDC, pShotGlass, oldx, oldy);
 
@@ -1082,15 +1082,15 @@ void CMainWindow::UpdatePegPosition(CDC *pDC, CSprite *pBaseSprite, int x, int y
 	hotspot_loc.y = sprite_loc.y + (SPRITE_SIZE_DY / 2);
 	pSprite = CSprite::Touched(hotspot_loc);
 	ASSERT(pSprite != nullptr);
-	(*pSprite).EraseSprite(pDC);
-	(*pSprite).UnlinkSprite();
+	pSprite->EraseSprite(pDC);
+	pSprite->UnlinkSprite();
 	delete pSprite;
-	pSprite = (*pBaseSprite).DuplicateSprite(pDC);
+	pSprite = pBaseSprite->DuplicateSprite(pDC);
 	ASSERT(pSprite != nullptr);
-	(*pSprite).LinkSprite();
-	if ((*pSprite).GetTypeCode() == SPRITE_HOLE)
+	pSprite->LinkSprite();
+	if (pSprite->GetTypeCode() == SPRITE_HOLE)
 		sprite_loc.x -= (SPRITE_SIZE_DX >> 1);
-	(*pSprite).PaintSprite(pDC, sprite_loc.x, sprite_loc.y);
+	pSprite->PaintSprite(pDC, sprite_loc.x, sprite_loc.y);
 }
 
 
@@ -1100,7 +1100,7 @@ void CMainWindow::UndoTurn() {
 	        neighborx, neighbory;
 
 	if (counter > 0) {
-		if ((*pGameInfo).bSoundEffectsEnabled) {
+		if (pGameInfo->bSoundEffectsEnabled) {
 			sndPlaySound(nullptr, 0);
 			sndPlaySound(WAV_UNDO, SND_ASYNC);
 		}
@@ -1109,7 +1109,7 @@ void CMainWindow::UndoTurn() {
 		newy = Moves[counter].y;
 		counter -= 1;
 		pDC = GetDC();
-		(*pCursorSprite).EraseSprite(pDC);
+		pCursorSprite->EraseSprite(pDC);
 		oldx = Moves[counter].x;
 		oldy = Moves[counter].y;
 		neighborx = (oldx + newx) / 2 ;
@@ -1142,12 +1142,12 @@ void CMainWindow::UndoMove(CDC *pDC) {
 	bPegMoving = false;
 
 //MessageBeep(-1);
-	if ((*pGameInfo).bSoundEffectsEnabled)  {
+	if (pGameInfo->bSoundEffectsEnabled)  {
 		sndPlaySound(nullptr, 0);
 		sndPlaySound(WAV_NOMOVE, SND_ASYNC);
 	}
 
-	(*pCursorSprite).EraseSprite(pDC);
+	pCursorSprite->EraseSprite(pDC);
 
 	UpdatePegPosition(pDC, pShotGlass, oldx, oldy);
 }
@@ -1290,10 +1290,10 @@ void CMainWindow::OnClose() {
 	pDC = GetDC();
 	myRect.SetRect(0, 0, GAME_WIDTH, GAME_HEIGHT);
 	myBrush.CreateStockObject(BLACK_BRUSH);
-	(*pDC).FillRect(&myRect, &myBrush);
+	pDC->FillRect(&myRect, &myBrush);
 	ReleaseDC(pDC);
 
-	if ((*pGameInfo).bMusicEnabled) {
+	if (pGameInfo->bMusicEnabled) {
 		CSound::clearSounds();
 	}
 
@@ -1307,7 +1307,7 @@ void setup_cursor() {
 
 	pMyApp = AfxGetApp();
 
-	hNewCursor = (*pMyApp).LoadStandardCursor(IDC_ARROW);
+	hNewCursor = pMyApp->LoadStandardCursor(IDC_ARROW);
 
 	ASSERT(hNewCursor != nullptr);
 	MFC::SetCursor(hNewCursor);
@@ -1319,7 +1319,7 @@ void set_wait_cursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).BeginWaitCursor();
+	pMyApp->BeginWaitCursor();
 }
 
 
@@ -1328,7 +1328,7 @@ void reset_wait_cursor() {
 
 	pMyApp = AfxGetApp();
 
-	(*pMyApp).EndWaitCursor();
+	pMyApp->EndWaitCursor();
 }
 
 } // namespace Peggle

--- a/engines/bagel/hodjnpodj/peggle/options.cpp
+++ b/engines/bagel/hodjnpodj/peggle/options.cpp
@@ -54,7 +54,7 @@ void COptions::OnMouseMove(unsigned int nFlags, CPoint point) {
 void COptions::OnClickedRules() {
 	CWnd    *pControl = nullptr;
 
-	CRules  RulesDlg(this, RULESSPEC, pOptionsPalette, ((*pGameInfo).bSoundEffectsEnabled ? NARRATIVESPEC : nullptr));
+	CRules  RulesDlg(this, RULESSPEC, pOptionsPalette, (pGameInfo->bSoundEffectsEnabled ? NARRATIVESPEC : nullptr));
 	RulesDlg.DoModal();                      // invoke the help dialog box
 	SetDefID(IDC_OPTIONS_OPTIONS);
 	SetDefID(IDC_OPTIONS_RETURN);

--- a/engines/bagel/hodjnpodj/peggle/optndlg.cpp
+++ b/engines/bagel/hodjnpodj/peggle/optndlg.cpp
@@ -103,58 +103,58 @@ bool COptnDlg::OnInitDialog() {
 	m_pTriButton = new CBmpButton;
 	ASSERT(m_pTriButton != nullptr);
 	myRect.SetRect(TRIANGLE_X, TRIANGLE_Y, TRIANGLE_X + OPTN_BUTTON_WIDTH, TRIANGLE_Y + OPTN_BUTTON_HEIGHT);
-	bSuccess = (*m_pTriButton).Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, myRect, this, IDC_SUB_TRIANGLE);
+	bSuccess = m_pTriButton->Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, myRect, this, IDC_SUB_TRIANGLE);
 	ASSERT(bSuccess);
-	bSuccess = (*m_pTriButton).LoadBitmaps("TRIUP", "TRIDOWN", nullptr, nullptr);
+	bSuccess = m_pTriButton->LoadBitmaps("TRIUP", "TRIDOWN", nullptr, nullptr);
 	ASSERT(bSuccess);
 
 	m_pCroButton = new CBmpButton;
 	ASSERT(m_pCroButton != nullptr);
 	myRect.SetRect(CROSS_X, CROSS_Y, CROSS_X + OPTN_BUTTON_WIDTH, CROSS_Y + OPTN_BUTTON_HEIGHT);
-	bSuccess = (*m_pCroButton).Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, myRect, this, IDC_SUB_CROSS);
+	bSuccess = m_pCroButton->Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, myRect, this, IDC_SUB_CROSS);
 	ASSERT(bSuccess);
-	bSuccess = (*m_pCroButton).LoadBitmaps("CROUP", "CRODOWN", nullptr, nullptr);
+	bSuccess = m_pCroButton->LoadBitmaps("CROUP", "CRODOWN", nullptr, nullptr);
 	ASSERT(bSuccess);
 
 	m_pTriPButton = new CBmpButton;
 	ASSERT(m_pTriPButton != nullptr);
 	myRect.SetRect(TRIANGLEPLUS_X, TRIANGLEPLUS_Y,
 	               TRIANGLEPLUS_X + OPTN_BUTTON_WIDTH, TRIANGLEPLUS_Y + OPTN_BUTTON_HEIGHT);
-	bSuccess = (*m_pTriPButton).Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, myRect, this, IDC_SUB_TRIANGLEPLUS);
+	bSuccess = m_pTriPButton->Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, myRect, this, IDC_SUB_TRIANGLEPLUS);
 	ASSERT(bSuccess);
-	bSuccess = (*m_pTriPButton).LoadBitmaps("TRIPUP", "TRIPDOWN", nullptr, nullptr);
+	bSuccess = m_pTriPButton->LoadBitmaps("TRIPUP", "TRIPDOWN", nullptr, nullptr);
 	ASSERT(bSuccess);
 
 	m_pCroPButton = new CBmpButton;
 	ASSERT(m_pCroPButton != nullptr);
 	myRect.SetRect(CROSSPLUS_X, CROSSPLUS_Y, CROSSPLUS_X + OPTN_BUTTON_WIDTH, CROSSPLUS_Y + OPTN_BUTTON_HEIGHT);
-	bSuccess = (*m_pCroPButton).Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, myRect, this, IDC_SUB_CROSSPLUS);
+	bSuccess = m_pCroPButton->Create(nullptr, BS_OWNERDRAW | WS_CHILD | WS_VISIBLE, myRect, this, IDC_SUB_CROSSPLUS);
 	ASSERT(bSuccess);
-	bSuccess = (*m_pCroPButton).LoadBitmaps("CROPUP", "CROPDOWN", nullptr, nullptr);
+	bSuccess = m_pCroPButton->LoadBitmaps("CROPUP", "CROPDOWN", nullptr, nullptr);
 	ASSERT(bSuccess);
 
 	if ((pRandomButton = new CCheckButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pRandomButton).SetPalette(pSubOptionsPalette);                        // set the palette to use
-		(*pRandomButton).SetControl(IDC_RANDOM, this);              // tie to the dialog control
+		pRandomButton->SetPalette(pSubOptionsPalette);                        // set the palette to use
+		pRandomButton->SetControl(IDC_RANDOM, this);              // tie to the dialog control
 	}
 	((CWnd *)this)->CheckDlgButton(IDC_RANDOM, m_bRandom);       // Set the Auto option box
 
 	if (!m_bRandom) {                                                // If not randomly selecting board
 		switch (chNewBoard) {
 		case CROSS:
-			(*m_pCroButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pCroButton->SendMessage(BM_SETSTATE, true, 0L);
 			break;
 
 		case CROSS_PLUS:
-			(*m_pCroPButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pCroPButton->SendMessage(BM_SETSTATE, true, 0L);
 			break;
 
 		case TRIANGLE:
-			(*m_pTriButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pTriButton->SendMessage(BM_SETSTATE, true, 0L);
 			break;
 
 		default:                                        //case TRIANGLE_PLUS:
-			(*m_pTriPButton).SendMessage(BM_SETSTATE, true, 0L);
+			m_pTriPButton->SendMessage(BM_SETSTATE, true, 0L);
 			break;
 		} // end switch
 	}
@@ -170,9 +170,9 @@ void COptnDlg::OnDestroy() {
 		delete m_pDlgBackground;
 		m_pDlgBackground = nullptr;
 
-		bUpdateNeeded = (*m_pDlgParentWnd).GetUpdateRect(nullptr, false);
+		bUpdateNeeded = m_pDlgParentWnd->GetUpdateRect(nullptr, false);
 		if (bUpdateNeeded)
-			(*m_pDlgParentWnd).ValidateRect(nullptr);
+			m_pDlgParentWnd->ValidateRect(nullptr);
 	}
 
 	if (pRandomButton != nullptr) {                        // release the button
@@ -228,10 +228,10 @@ void COptnDlg::OnRandom() {
 	m_bRandom = !m_bRandom;
 	((CWnd *)this)->CheckDlgButton(IDC_RANDOM, m_bRandom);
 
-	(*m_pCroPButton).SendMessage(BM_SETSTATE, false, 0L);
-	(*m_pTriButton).SendMessage(BM_SETSTATE, false, 0L);
-	(*m_pTriPButton).SendMessage(BM_SETSTATE, false, 0L);
-	(*m_pCroButton).SendMessage(BM_SETSTATE, false, 0L);
+	m_pCroPButton->SendMessage(BM_SETSTATE, false, 0L);
+	m_pTriButton->SendMessage(BM_SETSTATE, false, 0L);
+	m_pTriPButton->SendMessage(BM_SETSTATE, false, 0L);
+	m_pCroButton->SendMessage(BM_SETSTATE, false, 0L);
 }
 
 void COptnDlg::OnClickedCross() {
@@ -241,11 +241,11 @@ void COptnDlg::OnClickedCross() {
 	}
 	chNewBoard = CROSS;
 
-	(*m_pCroPButton).SendMessage(BM_SETSTATE, false, 0L);
-	(*m_pTriButton).SendMessage(BM_SETSTATE, false, 0L);
-	(*m_pTriPButton).SendMessage(BM_SETSTATE, false, 0L);
+	m_pCroPButton->SendMessage(BM_SETSTATE, false, 0L);
+	m_pTriButton->SendMessage(BM_SETSTATE, false, 0L);
+	m_pTriPButton->SendMessage(BM_SETSTATE, false, 0L);
 
-	(*m_pCroButton).SendMessage(BM_SETSTATE, true, 0L);
+	m_pCroButton->SendMessage(BM_SETSTATE, true, 0L);
 }
 
 
@@ -256,11 +256,11 @@ void COptnDlg::OnClickedCrossPlus() {
 	}
 	chNewBoard = CROSS_PLUS;
 
-	(*m_pCroButton).SendMessage(BM_SETSTATE, false, 0L);
-	(*m_pTriButton).SendMessage(BM_SETSTATE, false, 0L);
-	(*m_pTriPButton).SendMessage(BM_SETSTATE, false, 0L);
+	m_pCroButton->SendMessage(BM_SETSTATE, false, 0L);
+	m_pTriButton->SendMessage(BM_SETSTATE, false, 0L);
+	m_pTriPButton->SendMessage(BM_SETSTATE, false, 0L);
 
-	(*m_pCroPButton).SendMessage(BM_SETSTATE, true, 0L);
+	m_pCroPButton->SendMessage(BM_SETSTATE, true, 0L);
 }
 
 
@@ -271,11 +271,11 @@ void COptnDlg::OnClickedTriangle() {
 	}
 	chNewBoard = TRIANGLE;
 
-	(*m_pCroButton).SendMessage(BM_SETSTATE, false, 0L);
-	(*m_pCroPButton).SendMessage(BM_SETSTATE, false, 0L);
-	(*m_pTriPButton).SendMessage(BM_SETSTATE, false, 0L);
+	m_pCroButton->SendMessage(BM_SETSTATE, false, 0L);
+	m_pCroPButton->SendMessage(BM_SETSTATE, false, 0L);
+	m_pTriPButton->SendMessage(BM_SETSTATE, false, 0L);
 
-	(*m_pTriButton).SendMessage(BM_SETSTATE, true, 0L);
+	m_pTriButton->SendMessage(BM_SETSTATE, true, 0L);
 }
 
 
@@ -286,11 +286,11 @@ void COptnDlg::OnClickedTrianglePlus() {
 	}
 	chNewBoard = TRIANGLE_PLUS;
 
-	(*m_pCroButton).SendMessage(BM_SETSTATE, false, 0L);
-	(*m_pCroPButton).SendMessage(BM_SETSTATE, false, 0L);
-	(*m_pTriButton).SendMessage(BM_SETSTATE, false, 0L);
+	m_pCroButton->SendMessage(BM_SETSTATE, false, 0L);
+	m_pCroPButton->SendMessage(BM_SETSTATE, false, 0L);
+	m_pTriButton->SendMessage(BM_SETSTATE, false, 0L);
 
-	(*m_pTriPButton).SendMessage(BM_SETSTATE, true, 0L);
+	m_pTriPButton->SendMessage(BM_SETSTATE, true, 0L);
 }
 
 } // namespace Peggle

--- a/engines/bagel/hodjnpodj/peggle/optsub.cpp
+++ b/engines/bagel/hodjnpodj/peggle/optsub.cpp
@@ -125,7 +125,7 @@ bool COptions::OnInitDialog() {
 	}  // use it
 
 	// get the parent window's rectangular bounds
-	(*pMainWnd).GetWindowRect(&cWindRect);  // get pos/size of parent
+	pMainWnd->GetWindowRect(&cWindRect);  // get pos/size of parent
 //	((CWnd *)this)->GetWindowRect(&cDlgRect);  // get pos/size of dialog
 	cDlgRect.SetRect(0, 0, 222, 210);
 
@@ -149,60 +149,60 @@ bool COptions::OnInitDialog() {
 	if (m_iDlgId == IDD_OPTIONS_DIALOG) {
 		pRulesButton = new CColorButton();
 		ASSERT(pRulesButton != nullptr);
-		(*pRulesButton).SetPalette(pOptionsPalette);
-		bSuccess = (*pRulesButton).SetControl(IDC_OPTIONS_RULES, this);
+		pRulesButton->SetPalette(pOptionsPalette);
+		bSuccess = pRulesButton->SetControl(IDC_OPTIONS_RULES, this);
 
 		pNewgameButton = new CColorButton();
 		ASSERT(pNewgameButton != nullptr);
-		(*pNewgameButton).SetPalette(pOptionsPalette);
-		bSuccess = (*pNewgameButton).SetControl(IDC_OPTIONS_NEWGAME, this);
+		pNewgameButton->SetPalette(pOptionsPalette);
+		bSuccess = pNewgameButton->SetControl(IDC_OPTIONS_NEWGAME, this);
 
 		pOptionsButton = new CColorButton();
 		ASSERT(pOptionsButton != nullptr);
-		(*pOptionsButton).SetPalette(pOptionsPalette);
-		bSuccess = (*pOptionsButton).SetControl(IDC_OPTIONS_OPTIONS, this);
+		pOptionsButton->SetPalette(pOptionsPalette);
+		bSuccess = pOptionsButton->SetControl(IDC_OPTIONS_OPTIONS, this);
 
 		pAudioButton = new CColorButton();
 		ASSERT(pAudioButton != nullptr);
-		(*pAudioButton).SetPalette(pOptionsPalette);
-		bSuccess = (*pAudioButton).SetControl(IDC_OPTIONS_AUDIO, this);
+		pAudioButton->SetPalette(pOptionsPalette);
+		bSuccess = pAudioButton->SetControl(IDC_OPTIONS_AUDIO, this);
 
 		pReturnButton = new CColorButton();
 		ASSERT(pReturnButton != nullptr);
-		(*pReturnButton).SetPalette(pOptionsPalette);
-		bSuccess = (*pReturnButton).SetControl(IDC_OPTIONS_RETURN, this);
+		pReturnButton->SetPalette(pOptionsPalette);
+		bSuccess = pReturnButton->SetControl(IDC_OPTIONS_RETURN, this);
 
 		pQuitButton = new CColorButton();
 		ASSERT(pQuitButton != nullptr);
-		(*pQuitButton).SetPalette(pOptionsPalette);
-		bSuccess = (*pQuitButton).SetControl(IDC_OPTIONS_QUIT, this);
+		pQuitButton->SetPalette(pOptionsPalette);
+		bSuccess = pQuitButton->SetControl(IDC_OPTIONS_QUIT, this);
 	} else if (m_iDlgId == IDD_SUBOPTIONS) {
 		pOkayButton = new CColorButton();
 		ASSERT(pOkayButton != nullptr);
-		(*pOkayButton).SetPalette(pOptionsPalette);
-		bSuccess = (*pOkayButton).SetControl(IDC_SUB_OKAY, this);
+		pOkayButton->SetPalette(pOptionsPalette);
+		bSuccess = pOkayButton->SetControl(IDC_SUB_OKAY, this);
 
 		pCancelButton = new CColorButton();
 		ASSERT(pCancelButton != nullptr);
-		(*pCancelButton).SetPalette(pOptionsPalette);
-		bSuccess = (*pCancelButton).SetControl(IDC_SUB_CANCEL, this);
+		pCancelButton->SetPalette(pOptionsPalette);
+		bSuccess = pCancelButton->SetControl(IDC_SUB_CANCEL, this);
 	}
 
 	if (g_engine->isDemo()) {
 		if (m_iDlgId == IDD_OPTIONS_DIALOG) {
 			pButton = GetDlgItem(IDC_OPTIONS_OPTIONS);      // get the window for the options button
 			ASSERT(pButton != nullptr);                        // ... and verify we have it
-			(*pButton).EnableWindow(false);
+			pButton->EnableWindow(false);
 		}
 	} else {
-		if ((*pGameInfo).bPlayingMetagame) {
+		if (pGameInfo->bPlayingMetagame) {
 			if (m_iDlgId == IDD_OPTIONS_DIALOG) {
 				pButton = GetDlgItem(IDC_OPTIONS_OPTIONS);      // get the window for the options button
 				ASSERT(pButton != nullptr);                        // ... and verify we have it
-				(*pButton).EnableWindow(false);
+				pButton->EnableWindow(false);
 				pButton = GetDlgItem(IDC_OPTIONS_NEWGAME);      // get the window for the options button
 				ASSERT(pButton != nullptr);                        // ... and verify we have it
-				(*pButton).EnableWindow(false);
+				pButton->EnableWindow(false);
 			}
 		}
 	}
@@ -248,9 +248,9 @@ void COptions::OnDestroy() {
 		delete m_pDlgBackground;
 		m_pDlgBackground = nullptr;
 
-		bUpdateNeeded = (*m_pDlgParentWnd).GetUpdateRect(nullptr, false);
+		bUpdateNeeded = m_pDlgParentWnd->GetUpdateRect(nullptr, false);
 		if (bUpdateNeeded)
-			(*m_pDlgParentWnd).ValidateRect(nullptr);
+			m_pDlgParentWnd->ValidateRect(nullptr);
 	}
 
 	CDialog::OnDestroy();
@@ -356,15 +356,15 @@ void COptions::RefreshBackground() {
 	pDC = GetDC();
 
 	if (pOptionsPalette != nullptr) {
-		pPalOld = (*pDC).SelectPalette(pOptionsPalette, false);
-		(*pDC).RealizePalette();
+		pPalOld = pDC->SelectPalette(pOptionsPalette, false);
+		pDC->RealizePalette();
 	}
 
 	bSuccess = PaintBitmap(pDC, pOptionsPalette, m_pDlgBackground, 0, 0);
 	ASSERT(bSuccess);
 
 	if (pOptionsPalette != nullptr)
-		(*pDC).SelectPalette(pPalOld, false);
+		pDC->SelectPalette(pPalOld, false);
 
 	ReleaseDC(pDC);
 }

--- a/engines/bagel/hodjnpodj/poker/c1btndlg.cpp
+++ b/engines/bagel/hodjnpodj/poker/c1btndlg.cpp
@@ -141,7 +141,7 @@ bool C1ButtonDialog::OnInitDialog() {
 	);
 
 	if ((m_cTextMessage1 = new CText()) != nullptr) {
-		bAssertCheck = (*m_cTextMessage1).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+		bAssertCheck = m_cTextMessage1->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	}
 
@@ -153,7 +153,7 @@ bool C1ButtonDialog::OnInitDialog() {
 	                 );
 
 	if ((m_cTextMessage2 = new CText()) != nullptr) {
-		bAssertCheck = (*m_cTextMessage2).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+		bAssertCheck = m_cTextMessage2->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	}
 
@@ -172,9 +172,9 @@ bool C1ButtonDialog::OnInitDialog() {
 	ReleaseDC(pDC);
 
 	if ((m_pButton1 = new CColorButton) != nullptr) {            // build the first color button
-		(*m_pButton1).SetPalette(m_pPalette);                 // set the palette to use
-		(*m_pButton1).SetControl(IDOK, this);                 // tie to the dialog control
-		(*m_pButton1).SetWindowText(m_pszButton1Text);
+		m_pButton1->SetPalette(m_pPalette);                 // set the palette to use
+		m_pButton1->SetControl(IDOK, this);                 // tie to the dialog control
+		m_pButton1->SetWindowText(m_pszButton1Text);
 	}
 
 	return true;  // return true  unless you set the focus to a control
@@ -191,17 +191,17 @@ void C1ButtonDialog::OnPaint() {
 	pDC = GetDC();
 
 	if (m_pszMessage1 != nullptr) {
-		bAssertCheck = (*m_cTextMessage1).DisplayString(pDC, m_pszMessage1, 21, FW_BOLD, TEXT_COLOR);
+		bAssertCheck = m_cTextMessage1->DisplayString(pDC, m_pszMessage1, 21, FW_BOLD, TEXT_COLOR);
 		ASSERT(bAssertCheck);
 	}
 
 	if (m_pszMessage2 != nullptr) {
-		bAssertCheck = (*m_cTextMessage2).DisplayString(pDC, m_pszMessage2, 21, FW_BOLD, TEXT_COLOR);
+		bAssertCheck = m_cTextMessage2->DisplayString(pDC, m_pszMessage2, 21, FW_BOLD, TEXT_COLOR);
 		ASSERT(bAssertCheck);
 	}
 
 	if (m_pszMessage3 != nullptr) {
-		bAssertCheck = (*m_cTextMessage3).DisplayString(pDC, m_pszMessage3, 21, FW_BOLD, TEXT_COLOR);
+		bAssertCheck = m_cTextMessage3->DisplayString(pDC, m_pszMessage3, 21, FW_BOLD, TEXT_COLOR);
 		ASSERT(bAssertCheck);
 	}
 

--- a/engines/bagel/hodjnpodj/poker/poker.cpp
+++ b/engines/bagel/hodjnpodj/poker/poker.cpp
@@ -261,7 +261,7 @@ CMainPokerWindow::CMainPokerWindow(HWND hCallingWnd, LPGAMESTRUCT lpGameStruct) 
 	ASSERT(pDibDoc);                                // ... and verify we got it
 	bTestDibDoc = pDibDoc->OpenDocument(SPLASHSPEC);    // next load in the actual DIB based artwork
 	ASSERT(bTestDibDoc);
-	pGamePalette = (*pDibDoc).DetachPalette();      // grab its palette and save it for later use
+	pGamePalette = pDibDoc->DetachPalette();      // grab its palette and save it for later use
 	delete pDibDoc;                                 // now discard the splash screen
 
 // set window coordinates to center game on screeen
@@ -429,7 +429,7 @@ CMainPokerWindow::CMainPokerWindow(HWND hCallingWnd, LPGAMESTRUCT lpGameStruct) 
 		pGameSound = new CSound(this, GAME_THEME,
 		                        SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 		if (pGameSound != nullptr)
-			(*pGameSound).midiLoopPlaySegment(6370, 33000, 0, FMT_MILLISEC);
+			pGameSound->midiLoopPlaySegment(6370, 33000, 0, FMT_MILLISEC);
 	} // end if pGameSound
 
 	bFirstTime = true;
@@ -660,7 +660,7 @@ void CMainPokerWindow::SplashScreen() {
 	rcDIB.top = rcDIB.left = 0;             // setup the source rectangle from which
 	rcDIB.right = cxDIB;                // ... we'll do the painting
 	rcDIB.bottom = cyDIB;
-	PaintDIB((*pDC).m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);    // transfer the image to the screen
+	PaintDIB(pDC->m_hDC, &rcDest, hDIB, &rcDIB, pGamePalette);    // transfer the image to the screen
 
 	rectDisplayUser.SetRect(USER_AMOUNT_X, USER_AMOUNT_Y, USER_AMOUNT_X + AMOUNT_WIDTH, USER_AMOUNT_Y + AMOUNT_HEIGHT);
 	rectDisplayBet.SetRect(POT_AMOUNT_X, POT_AMOUNT_Y, POT_AMOUNT_X + AMOUNT_WIDTH, POT_AMOUNT_Y + AMOUNT_HEIGHT);
@@ -846,7 +846,7 @@ void CALLBACK lpfnOptionCallback(CWnd * pWnd) {                          // do t
 	switch (nOption) {
 
 	case ID_SETPAYOFFS:                     // if Winning Ratio's button was hit, popup the Payoff dialog
-		(*pWnd).UpdateWindow();
+		pWnd->UpdateWindow();
 		nSetPayOff = dlgPayOff.DoModal();
 		nPayOff = nSetPayOff;
 		pcwndPoker->SetPayOffs(nSetPayOff);              // the return is what set of payoffs was selected was clicked
@@ -855,7 +855,7 @@ void CALLBACK lpfnOptionCallback(CWnd * pWnd) {                          // do t
 
 	case ID_SETUSERAMT:                     // if Set Amount button was hit, popup the Set Amount dialog
 		dlgSetAmt.SetInitialOptions(pcwndPoker->m_lUserAmount);
-		(*pWnd).UpdateWindow();
+		pWnd->UpdateWindow();
 		nSetAmount = dlgSetAmt.DoModal();
 		if (nSetAmount != 0)   {             // the return is what the amount was set to, set m_lUserAmount to it
 			pcwndPoker->m_lUserAmount = nSetAmount;
@@ -916,7 +916,7 @@ bool CMainPokerWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 					pGameSound = new CSound(this, GAME_THEME,
 					                        SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 					if (pGameSound != nullptr)
-						(*pGameSound).midiLoopPlaySegment(6370, 33000, 0, FMT_MILLISEC);
+						pGameSound->midiLoopPlaySegment(6370, 33000, 0, FMT_MILLISEC);
 				}
 			} // end if pGameSound
 			else {
@@ -1087,7 +1087,7 @@ bool CMainPokerWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 		}
 
 
-	(*this).SetFocus();                         // Reset focus back to the main window
+	(this)->SetFocus();                         // Reset focus back to the main window
 	return true;
 }
 
@@ -1132,14 +1132,14 @@ void CMainPokerWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 		              CLOCK_X, CLOCK_Y, CLOCK_SLEEP, m_bPlaySounds);
 	} else if (rBoom.PtInRect(point))  {
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pGamePalette);
-		bSuccess = (*pSprite).LoadCels(pDC, BOOM_ANIM, BOOM_FRAMES);
+		pSprite->SharePalette(pGamePalette);
+		bSuccess = pSprite->LoadCels(pDC, BOOM_ANIM, BOOM_FRAMES);
 		if (!bSuccess) {
 			delete pSprite;
 			return;
 		}
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
 		CSound::waitWaveSounds();
 		sndPlaySound(nullptr, 0);
@@ -1149,13 +1149,13 @@ void CMainPokerWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 			                     SOUND_WAVE | SOUND_ASYNCH | SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
 		}
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
-		(*pSprite).SetCel(BOOM_FRAMES);
+		pSprite->SetCel(BOOM_FRAMES);
 		for (i = 0; i < 13; i++) {
-			(*pSprite).PaintSprite(pDC, BOOM_X, BOOM_Y);
+			pSprite->PaintSprite(pDC, BOOM_X, BOOM_Y);
 			Sleep(BOOM_SLEEP);
 		}
 
@@ -1164,13 +1164,13 @@ void CMainPokerWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 			                     SOUND_WAVE | SOUND_ASYNCH | SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
 		}
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
 //		(*pSprite).SetCel( nNumCels );
 		while (i < BOOM_FRAMES) {
-			(*pSprite).PaintSprite(pDC, BOOM_X, BOOM_Y);
+			pSprite->PaintSprite(pDC, BOOM_X, BOOM_Y);
 			Sleep(BOOM_SLEEP);
 			i++;
 		}
@@ -1185,7 +1185,7 @@ void CMainPokerWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 			                     SOUND_WAVE | SOUND_ASYNCH | SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
 		}
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
@@ -1198,7 +1198,7 @@ void CMainPokerWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 			                     SOUND_WAVE | SOUND_ASYNCH | SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
 		}
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
@@ -1211,7 +1211,7 @@ void CMainPokerWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 			                     SOUND_WAVE | SOUND_ASYNCH | SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
 		}
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
@@ -1224,7 +1224,7 @@ void CMainPokerWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 			                     SOUND_WAVE | SOUND_ASYNCH | SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
 		}
 		if (pEffect != nullptr) {
-			bSuccess = (*pEffect).play();
+			bSuccess = pEffect->play();
 			if (!bSuccess)
 				delete pEffect;
 		}
@@ -2241,7 +2241,7 @@ void CMainPokerWindow::ReleaseResources() {
 			delete apHold[i];
 	}
 
-	(*pGamePalette).DeleteObject();         // release the game color palette
+	pGamePalette->DeleteObject();         // release the game color palette
 	delete pGamePalette;
 
 }
@@ -2347,27 +2347,27 @@ void PlayEasterEgg(CDC *pDC, CWnd *pWnd, CPalette *pPalette,
 	int     i;
 
 	pSprite = new CSprite;
-	(*pSprite).SharePalette(pPalette);
-	bSuccess = (*pSprite).LoadCels(pDC, pszAnimFile, nNumCels);
+	pSprite->SharePalette(pPalette);
+	bSuccess = pSprite->LoadCels(pDC, pszAnimFile, nNumCels);
 	if (!bSuccess) {
 		delete pSprite;
 		return;
 	}
-	(*pSprite).SetMasked(false);
-	(*pSprite).SetMobile(false);
+	pSprite->SetMasked(false);
+	pSprite->SetMobile(false);
 
 	if (bPlaySound) {
 		pEffect = new CSound(pWnd, pszSoundFile,                                 // Load up the sound file as a
 		                     SOUND_WAVE | SOUND_ASYNCH | SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
 	}
 	if (pEffect != nullptr) {
-		bSuccess = (*pEffect).play();
+		bSuccess = pEffect->play();
 		if (!bSuccess)
 			delete pEffect;
 	}
-	(*pSprite).SetCel(nNumCels);
+	pSprite->SetCel(nNumCels);
 	for (i = 0; i < nNumCels; i++) {
-		(*pSprite).PaintSprite(pDC, nXLoc, nYLoc);
+		pSprite->PaintSprite(pDC, nXLoc, nYLoc);
 		Sleep(nSleep);
 	}
 

--- a/engines/bagel/hodjnpodj/riddles/riddles.cpp
+++ b/engines/bagel/hodjnpodj/riddles/riddles.cpp
@@ -281,7 +281,7 @@ CRiddlesWindow::CRiddlesWindow() :
 			//
 			m_pSoundTrack = new CSound(this, "sound\\riddles.mid", SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
 			if (m_pSoundTrack != nullptr) {
-				(*m_pSoundTrack).midiLoopPlaySegment(1930, 32870, 0, FMT_MILLISEC);
+				m_pSoundTrack->midiLoopPlaySegment(1930, 32870, 0, FMT_MILLISEC);
 			} else {
 				errCode = ERR_MEMORY;
 			}
@@ -520,7 +520,7 @@ bool CRiddlesWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 					}
 					if (m_pSoundTrack != nullptr) {
 						if (!m_pSoundTrack->playing())
-							(*m_pSoundTrack).midiLoopPlaySegment(1930, 32870, 0, FMT_MILLISEC);
+							m_pSoundTrack->midiLoopPlaySegment(1930, 32870, 0, FMT_MILLISEC);
 					}
 				}
 
@@ -1377,7 +1377,7 @@ void CRiddlesWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 	} else if (animRect.PtInRect(point)) {
 		pDC = GetDC();
 		pSprite = new CSprite;
-		(*pSprite).SharePalette(pGamePalette);
+		pSprite->SharePalette(pGamePalette);
 		nSelector = brand() % 3;                     // Pick one of the 3 easter eggs randomly
 		switch (nSelector) {
 
@@ -1406,19 +1406,19 @@ void CRiddlesWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 			break;
 		} // end Switch
 
-		bSuccess = (*pSprite).LoadCels(pDC, animBuf, nNumCels);
+		bSuccess = pSprite->LoadCels(pDC, animBuf, nNumCels);
 		ASSERT(bSuccess);
-		(*pSprite).SetMasked(false);
-		(*pSprite).SetMobile(false);
+		pSprite->SetMasked(false);
+		pSprite->SetMobile(false);
 
 		if (bSuccess) {
 			if (pGameParams->bSoundEffectsEnabled) {
 				pEffect = new CSound((CWnd *)this, soundBuf,                                // Load up the sound file as a
 				                     SOUND_WAVE | SOUND_QUEUE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-				(*pEffect).play();                                                          //...play the sound effect
+				pEffect->play();                                                          //...play the sound effect
 			}
 			for (i = 0; i < nNumCels; i++) {
-				(*pSprite).PaintSprite(pDC, animLoc.x, animLoc.y);
+				pSprite->PaintSprite(pDC, animLoc.x, animLoc.y);
 				Sleep(ANIM_SLEEP);
 			}
 		} // end if bSuccess
@@ -1432,7 +1432,7 @@ void CRiddlesWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 		if (pGameParams->bSoundEffectsEnabled) {
 			pEffect = new CSound((CWnd *)this, COLUMN_WAV,                              // Load up the sound file as a
 			                     SOUND_WAVE | SOUND_QUEUE | SOUND_ASYNCH | SOUND_AUTODELETE);  //...Wave file, to delete itself
-			(*pEffect).play();                                                          //...play the sound effect
+			pEffect->play();                                                          //...play the sound effect
 		}
 	} else {
 

--- a/engines/bagel/hodjnpodj/riddles/usercfg.cpp
+++ b/engines/bagel/hodjnpodj/riddles/usercfg.cpp
@@ -296,18 +296,18 @@ bool CUserCfgDlg::OnInitDialog() {
 	ReleaseDC(pDC);
 
 	if ((pOKButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pOKButton).SetPalette(m_pPalette);                        // set the palette to use
-		(*pOKButton).SetControl(IDOK, this);            // tie to the dialog control
+		pOKButton->SetPalette(m_pPalette);                        // set the palette to use
+		pOKButton->SetControl(IDOK, this);            // tie to the dialog control
 	}
 
 	if ((pCancelButton = new CColorButton) != nullptr) {                   // build a color QUIT button to let us exit
-		(*pCancelButton).SetPalette(m_pPalette);                        // set the palette to use
-		(*pCancelButton).SetControl(IDCANCEL, this);            // tie to the dialog control
+		pCancelButton->SetPalette(m_pPalette);                        // set the palette to use
+		pCancelButton->SetControl(IDCANCEL, this);            // tie to the dialog control
 	}
 
 	if ((pDefaultsButton = new CColorButton) != nullptr) {                 // build a color QUIT button to let us exit
-		(*pDefaultsButton).SetPalette(m_pPalette);                      // set the palette to use
-		(*pDefaultsButton).SetControl(ID_RESET, this);              // tie to the dialog control
+		pDefaultsButton->SetPalette(m_pPalette);                      // set the palette to use
+		pDefaultsButton->SetControl(ID_RESET, this);              // tie to the dialog control
 	}
 
 	m_bSave = false;

--- a/engines/bagel/hodjnpodj/wordsearch/c1btndlg.cpp
+++ b/engines/bagel/hodjnpodj/wordsearch/c1btndlg.cpp
@@ -145,7 +145,7 @@ bool C1ButtonDialog::OnInitDialog() {
 	);
 
 	if ((m_cTextMessage1 = new CText()) != nullptr) {
-		bAssertCheck = (*m_cTextMessage1).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+		bAssertCheck = m_cTextMessage1->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	}
 
@@ -158,7 +158,7 @@ bool C1ButtonDialog::OnInitDialog() {
 	);
 
 	if ((m_cTextMessage2 = new CText()) != nullptr) {
-		bAssertCheck = (*m_cTextMessage2).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+		bAssertCheck = m_cTextMessage2->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	}
 
@@ -172,7 +172,7 @@ bool C1ButtonDialog::OnInitDialog() {
 		    nStat_row_offset + (12 * i) + nStatHeight
 		);
 		if ((m_cWordList[i] = new CText()) != nullptr) {
-			bAssertCheck = (*m_cWordList[i]).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+			bAssertCheck = m_cWordList[i]->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 			ASSERT(bAssertCheck);   // initialize the text objext
 		}
 	}
@@ -180,9 +180,9 @@ bool C1ButtonDialog::OnInitDialog() {
 	ReleaseDC(pDC);
 
 	if ((m_pButton1 = new CColorButton) != nullptr) {            // build the first color button
-		(*m_pButton1).SetPalette(m_pPalette);                 // set the palette to use
-		(*m_pButton1).SetControl(IDOK, this);                 // tie to the dialog control
-		(*m_pButton1).SetWindowText(m_pszButton1Text);
+		m_pButton1->SetPalette(m_pPalette);                 // set the palette to use
+		m_pButton1->SetControl(IDOK, this);                 // tie to the dialog control
+		m_pButton1->SetWindowText(m_pszButton1Text);
 	}
 
 	return true;  // return true  unless you set the focus to a control

--- a/engines/bagel/hodjnpodj/wordsearch/clongdlg.cpp
+++ b/engines/bagel/hodjnpodj/wordsearch/clongdlg.cpp
@@ -147,7 +147,7 @@ bool CLongDialog::OnInitDialog() {
 	);
 
 	if ((m_cTextMessage1 = new CText()) != nullptr) {
-		bAssertCheck = (*m_cTextMessage1).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+		bAssertCheck = m_cTextMessage1->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	}
 
@@ -160,7 +160,7 @@ bool CLongDialog::OnInitDialog() {
 	);
 
 	if ((m_cTextMessage2 = new CText()) != nullptr) {
-		bAssertCheck = (*m_cTextMessage2).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+		bAssertCheck = m_cTextMessage2->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 		ASSERT(bAssertCheck);   // initialize the text objext
 	}
 
@@ -174,7 +174,7 @@ bool CLongDialog::OnInitDialog() {
 		    nStat_row_offset + (12 * i) + nStatHeight
 		);
 		if ((m_cWordList[i] = new CText()) != nullptr) {
-			bAssertCheck = (*m_cWordList[i]).SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
+			bAssertCheck = m_cWordList[i]->SetupText(pDC, m_pPalette, &statsRect, JUSTIFY_CENTER);
 			ASSERT(bAssertCheck);   // initialize the text objext
 		}
 	}
@@ -182,9 +182,9 @@ bool CLongDialog::OnInitDialog() {
 	ReleaseDC(pDC);
 
 	if ((m_pButton1 = new CColorButton) != nullptr) {            // build the first color button
-		(*m_pButton1).SetPalette(m_pPalette);                 // set the palette to use
-		(*m_pButton1).SetControl(IDOK, this);                 // tie to the dialog control
-		(*m_pButton1).SetWindowText(m_pszButton1Text);
+		m_pButton1->SetPalette(m_pPalette);                 // set the palette to use
+		m_pButton1->SetControl(IDOK, this);                 // tie to the dialog control
+		m_pButton1->SetWindowText(m_pszButton1Text);
 	}
 
 	return true;  // return true  unless you set the focus to a control

--- a/engines/bagel/hodjnpodj/wordsearch/wordsearch.cpp
+++ b/engines/bagel/hodjnpodj/wordsearch/wordsearch.cpp
@@ -282,7 +282,7 @@ CMainWSWindow::CMainWSWindow(HWND hCallingWnd, LPGAMESTRUCT lpGameStruct) :
 	if (m_lpGameStruct->bMusicEnabled) {
 		pGameSound = new CSound(this, GAME_THEME,
 		                        SOUND_MIDI | SOUND_LOOP | SOUND_DONT_LOOP_TO_END);
-		(*pGameSound).midiLoopPlaySegment(500, 31500, 0, FMT_MILLISEC);
+		pGameSound->midiLoopPlaySegment(500, 31500, 0, FMT_MILLISEC);
 	} // end if pGameSound
 
 	EndWaitCursor();
@@ -860,7 +860,7 @@ bool CMainWSWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 				}
 				if (pGameSound != nullptr) {
 					if (!pGameSound->playing())
-						(*pGameSound).midiLoopPlaySegment(500, 31500, 0, FMT_MILLISEC);
+						pGameSound->midiLoopPlaySegment(500, 31500, 0, FMT_MILLISEC);
 				}
 			}
 			if (bResetGame && !m_lpGameStruct->bPlayingMetagame)
@@ -876,7 +876,7 @@ bool CMainWSWindow::OnCommand(WPARAM wParam, LPARAM lParam) {
 		}
 	}
 
-	(*this).SetFocus();                         // Reset focus back to the main window
+	(this)->SetFocus();                         // Reset focus back to the main window
 	return true;
 }
 
@@ -907,17 +907,17 @@ void CMainWSWindow::OnLButtonDown(unsigned int nFlags, CPoint point) {
 		CSound::waitWaveSounds();
 		sndPlaySound(nullptr, 0);
 		PlayEasterEgg(pDC, (CWnd *)this, pGamePalette, CHICKEN_ANIM, CHICKEN_WAV, NUM_CHICKEN_CELS,
-		              CHICKEN_X, CHICKEN_Y, CHICKEN_SLEEP, (*m_lpGameStruct).bSoundEffectsEnabled);
+		              CHICKEN_X, CHICKEN_Y, CHICKEN_SLEEP, m_lpGameStruct->bSoundEffectsEnabled);
 	} else if (rCow.PtInRect(point)) {
 		CSound::waitWaveSounds();
 		sndPlaySound(nullptr, 0);
 		PlayEasterEgg(pDC, (CWnd *)this, pGamePalette, COW_ANIM, COW_WAV, NUM_COW_CELS,
-		              COW_X, COW_Y, COW_SLEEP, (*m_lpGameStruct).bSoundEffectsEnabled);
-	} else if (rPig.PtInRect(point) && (*m_lpGameStruct).bSoundEffectsEnabled) {
+		              COW_X, COW_Y, COW_SLEEP, m_lpGameStruct->bSoundEffectsEnabled);
+	} else if (rPig.PtInRect(point) && m_lpGameStruct->bSoundEffectsEnabled) {
 		CSound::waitWaveSounds();
 		sndPlaySound(nullptr, 0);
 		sndPlaySound(PIG_WAV, SND_ASYNC);
-	} else if (rFlower.PtInRect(point) && (*m_lpGameStruct).bSoundEffectsEnabled) {
+	} else if (rFlower.PtInRect(point) && m_lpGameStruct->bSoundEffectsEnabled) {
 		CSound::waitWaveSounds();
 		sndPlaySound(nullptr, 0);
 		sndPlaySound(FLOWER_WAV, SND_ASYNC);
@@ -1210,7 +1210,7 @@ void CMainWSWindow::OnLButtonUp(unsigned int nFlags, CPoint point) {
 			}
 
 			if (bFoundWord) {
-				if ((*m_lpGameStruct).bSoundEffectsEnabled) {
+				if (m_lpGameStruct->bSoundEffectsEnabled) {
 					sndPlaySound(nullptr, 0);
 					sndPlaySound(FIND_WAV, SND_ASYNC);
 				}
@@ -1289,7 +1289,7 @@ void CMainWSWindow::OnLButtonUp(unsigned int nFlags, CPoint point) {
 				} while ((ptTemp.x != ptCurrPosInGrid.x) || (ptTemp.y != ptCurrPosInGrid.y));
 			} // end if bWordFound
 			else {
-				if ((*m_lpGameStruct).bSoundEffectsEnabled) {
+				if (m_lpGameStruct->bSoundEffectsEnabled) {
 					sndPlaySound(nullptr, 0);
 					sndPlaySound(NOPE_WAV, SND_SYNC);
 					sndPlaySound(TRYAGAIN_WAV, SND_SYNC);
@@ -1302,7 +1302,7 @@ void CMainWSWindow::OnLButtonUp(unsigned int nFlags, CPoint point) {
 			CMsgDlg     msgGameOver((CWnd *)this, pGamePalette);
 			KillTimer(GAMETIMER);
 			m_bNoGrid = true;
-			if ((*m_lpGameStruct).bSoundEffectsEnabled) {
+			if (m_lpGameStruct->bSoundEffectsEnabled) {
 				sndPlaySound(nullptr, 0);
 				sndPlaySound(ALLFOUND_WAV, SND_SYNC);            // play sound
 			}
@@ -1376,7 +1376,7 @@ void CMainWSWindow::OnTimer(uintptr nWhichTimer) {
 
 			ReleaseDC(pDC);
 			m_bNoGrid = true;
-			if ((*m_lpGameStruct).bSoundEffectsEnabled) {
+			if (m_lpGameStruct->bSoundEffectsEnabled) {
 				sndPlaySound(nullptr, 0);
 				sndPlaySound(TIMEOUT_WAV, SND_SYNC);             // play sound
 			}
@@ -1390,7 +1390,7 @@ void CMainWSWindow::OnTimer(uintptr nWhichTimer) {
 			CDC *pDC = GetDC();
 			lCurrentTimer++;
 			nLastCell++;
-			if ((*m_lpGameStruct).bSoundEffectsEnabled) {
+			if (m_lpGameStruct->bSoundEffectsEnabled) {
 				sndPlaySound(nullptr, 0);
 				sndPlaySound(TICK_WAV, SND_ASYNC);
 			}
@@ -1708,27 +1708,27 @@ void PlayEasterEgg(CDC *pDC, CWnd *pWnd, CPalette *pPalette,
 	int     i;
 
 	pSprite = new CSprite;
-	(*pSprite).SharePalette(pPalette);
-	bSuccess = (*pSprite).LoadCels(pDC, pszAnimFile, nNumCels);
+	pSprite->SharePalette(pPalette);
+	bSuccess = pSprite->LoadCels(pDC, pszAnimFile, nNumCels);
 	if (!bSuccess) {
 		delete pSprite;
 		return;
 	}
-	(*pSprite).SetMasked(false);
-	(*pSprite).SetMobile(false);
+	pSprite->SetMasked(false);
+	pSprite->SetMobile(false);
 
 	if (bPlaySound) {
 		pEffect = new CSound(pWnd, pszSoundFile,                                 // Load up the sound file as a
 		                     SOUND_WAVE | SOUND_ASYNCH | SOUND_QUEUE | SOUND_AUTODELETE);    //...Wave file, to delete itself
 	}
 	if (pEffect != nullptr) {
-		bSuccess = (*pEffect).play();
+		bSuccess = pEffect->play();
 		if (!bSuccess)
 			delete pEffect;
 	}
-	(*pSprite).SetCel(-1);           // nNumCels
+	pSprite->SetCel(-1);           // nNumCels
 	for (i = 0; i < nNumCels; i++) {
-		(*pSprite).PaintSprite(pDC, nXLoc, nYLoc);
+		pSprite->PaintSprite(pDC, nXLoc, nYLoc);
 		Sleep(nSleep);
 	}
 

--- a/engines/bolt/ssprite.cpp
+++ b/engines/bolt/ssprite.cpp
@@ -297,8 +297,8 @@ bool BoltEngine::sSpriteAlive(SSprite *sprite) {
 }
 
 void BoltEngine::getSSpriteLoc(SSprite *sprite, Common::Point *out) {
-	(*out).x = sprite->x;
-	(*out).y = sprite->y;
+	out->x = sprite->x;
+	out->y = sprite->y;
 }
 
 void BoltEngine::getSSpriteAccel(SSprite *sprite, int16 *out) {

--- a/engines/composer/saveload.cpp
+++ b/engines/composer/saveload.cpp
@@ -199,9 +199,9 @@ void ComposerEngine::sync<Pipe *>(Common::Serializer &ser, Pipe *&data, Common::
 	} else {
 		ser.syncAsUint32LE(tmp);
 		for (Pipe::DelMap::iterator i = data->_bufferedResources.begin(); i != data->_bufferedResources.end(); i++) {
-			uint32 key = (*i)._key;
+			uint32 key = i->_key;
 			ser.syncAsUint32LE(key);
-			syncList<uint16>(ser, (*i)._value, minVersion, maxVersion);
+			syncList<uint16>(ser, i->_value, minVersion, maxVersion);
 		}
 	}
 }
@@ -299,7 +299,7 @@ Common::Error ComposerEngine::loadGameState(int slot) {
 	// Unload all Libraries
 	Common::Array<uint16> libIds;
 	for (Common::List<Library>::iterator i = _libraries.begin(); i != _libraries.end(); i++)
-		libIds.push_back((*i)._id);
+		libIds.push_back(i->_id);
 	for (uint32 i = 0; i < libIds.size(); i++)
 		unloadLibrary(libIds[i]);
 

--- a/engines/crab/TMX/TMXTileSet.cpp
+++ b/engines/crab/TMX/TMXTileSet.cpp
@@ -135,7 +135,7 @@ void TileSetGroup::preDraw(MapLayer &layer, const Vector2i &tileSize, Graphics::
 	for (rOuter = layer._boundRect.begin(); rOuter != layer._boundRect.end(); ++rOuter) {
 		rInner = rOuter;
 		while (++rInner != layer._boundRect.end()) {
-			if ((*rOuter).collide(*rInner)) {
+			if (rOuter->collide(*rInner)) {
 					rOuter->extend(*rInner);
 				layer._boundRect.erase(rInner);
 				rInner = rOuter;

--- a/engines/cruise/gfxModule.cpp
+++ b/engines/cruise/gfxModule.cpp
@@ -251,7 +251,7 @@ static void mergeClipRects() {
 		rInner = rOuter;
 		while (++rInner != _vm->_dirtyRects.end()) {
 
-			if ((*rOuter).intersects(*rInner)) {
+			if (rOuter->intersects(*rInner)) {
 				// these two rectangles overlap, so translate it to a bigger rectangle
 				// that contains both of them
 				unionRectangle(*rOuter, *rOuter, *rInner);

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -713,7 +713,7 @@ bool Lingo::execute(int targetFrame) {
 			break;
 		}
 
-		if (!_abort && _state->pc >= (*_state->script).size()) {
+		if (!_abort && _state->pc >= _state->script->size()) {
 			warning("Lingo::execute(): Bad PC (%d)", _state->pc);
 			break;
 		}

--- a/engines/director/tests.cpp
+++ b/engines/director/tests.cpp
@@ -216,7 +216,7 @@ void Window::enqueueAllMovies() {
 	}
 
 	for (Common::FSList::const_iterator file = files.begin(); file != files.end(); ++file)
-		_movieQueue.push_back((*file).getName());
+		_movieQueue.push_back(file->getName());
 
 	Common::sort(_movieQueue.begin(), _movieQueue.end());
 

--- a/engines/freescape/area.cpp
+++ b/engines/freescape/area.cpp
@@ -926,7 +926,7 @@ void Area::changeObjectID(uint16 objectID, uint16 newObjectID) {
 	_addedObjects.erase(objectID);
 	_addedObjects[newObjectID] = obj;
 
-	(*_objectsByID).erase(objectID);
+	_objectsByID->erase(objectID);
 	(*_objectsByID)[newObjectID] = obj;
 }
 

--- a/engines/glk/detection.cpp
+++ b/engines/glk/detection.cpp
@@ -203,7 +203,7 @@ Common::String GlkMetaEngineDetection::findFileByGameId(const Common::String &ga
 
 		// If a detection was found with the correct game Id, we have a winner
 		if (!games.empty() && games.front().gameId == gameId)
-			return (*i).getName();
+			return i->getName();
 	}
 
 	// No match found

--- a/engines/glk/quest/geas_file.cpp
+++ b/engines/glk/quest/geas_file.cpp
@@ -57,12 +57,12 @@ const GeasBlock *GeasFile::find_by_name(String type, String name) const {
 const GeasBlock &GeasFile::block(String type, uint index) const {
 	StringArrayIntMap::const_iterator iter;
 	iter = type_indecies.find(type);
-	if (!(iter != type_indecies.end() && index < (*iter)._value.size()))
+	if (!(iter != type_indecies.end() && index < iter->_value.size()))
 		cerr << "Unable to find type " << type << "\n";
 
-	assert(iter != type_indecies.end() && index < (*iter)._value.size());
+	assert(iter != type_indecies.end() && index < iter->_value.size());
 	//assert (index >= 0 && index < size(type));
-	return blocks[(*iter)._value[index]];
+	return blocks[iter->_value[index]];
 }
 
 uint GeasFile::size(String type) const {
@@ -78,7 +78,7 @@ uint GeasFile::size(String type) const {
 		return 0;
 	}
 	//cerr << "  returning " << (*iter)._value.size() << endl;
-	return (*iter)._value.size();
+	return iter->_value.size();
 }
 
 
@@ -228,7 +228,7 @@ bool GeasFile::get_obj_property(String objname, String propname, String &string_
 		debug_print("Checking nonexistent object <" + objname + "> for property <" + propname + ">");
 		return false;
 	}
-	String objtype = (*obj_types.find(objname))._value;
+	String objtype = obj_types.find(objname)->_value;
 
 	const GeasBlock *geasBlock = find_by_name(objtype, objname);
 
@@ -355,7 +355,7 @@ bool GeasFile::obj_of_type(String objname, String typenamex) const {
 		            typenamex + ">");
 		return false;
 	}
-	String objtype = (*obj_types.find(objname))._value;
+	String objtype = obj_types.find(objname)->_value;
 
 	const GeasBlock *geasBlock = find_by_name(objtype, objname);
 
@@ -422,7 +422,7 @@ bool GeasFile::get_obj_action(String objname, String propname, String &string_rv
 		debug_print("Checking nonexistent object <" + objname + "> for action <" + propname + ">.");
 		return false;
 	}
-	String objtype = (*obj_types.find(objname))._value;
+	String objtype = obj_types.find(objname)->_value;
 
 	//reserved_words *rw;
 

--- a/engines/glk/quest/read_file.cpp
+++ b/engines/glk/quest/read_file.cpp
@@ -407,9 +407,9 @@ Common::WriteStream &operator<<(Common::WriteStream &o, const GeasFile &gf) {
 	*/
 	o << "Geas File\n";
 	for (StringArrayIntMap::const_iterator i = gf.type_indecies.begin(); i != gf.type_indecies.end(); i ++) {
-		o << "Blocks of type " << (*i)._key << "\n";
-		for (uint j = 0; j < (*i)._value.size(); j ++)
-			o << gf.blocks[(*i)._value[j]];
+		o << "Blocks of type " << i->_key << "\n";
+		for (uint j = 0; j < i->_value.size(); j ++)
+			o << gf.blocks[i->_value[j]];
 		o << "\n";
 	}
 

--- a/engines/glk/quest/reserved_words.h
+++ b/engines/glk/quest/reserved_words.h
@@ -71,7 +71,7 @@ public:
 		for (StringBoolMap::iterator i = _data.begin(); i != _data.end(); ++i) {
 			if (i != _data.begin())
 				o.writeString(", ");
-			o.writeString((*i)._key);
+			o.writeString(i->_key);
 		}
 
 		o.writeString("}");

--- a/engines/glk/scott/scott.cpp
+++ b/engines/glk/scott/scott.cpp
@@ -1498,7 +1498,7 @@ void Scott::listExits() {
 	writeToRoomDescriptionStream("\n\n%s", _G(_sys)[EXITS].c_str());
 
 	while (ct < 6) {
-		if ((&_G(_rooms)[MY_LOC])->_exits[ct] != 0) {
+		if (_G(_rooms)[MY_LOC]._exits[ct] != 0) {
 			if (f) {
 				writeToRoomDescriptionStream("%s", _G(_sys)[EXITS_DELIMITER].c_str());
 			}
@@ -1518,7 +1518,7 @@ void Scott::listExitsSpectrumStyle() {
 	int f = 0;
 
 	while (ct < 6) {
-		if ((&_G(_rooms)[MY_LOC])->_exits[ct] != 0) {
+		if (_G(_rooms)[MY_LOC]._exits[ct] != 0) {
 			if (f == 0) {
 				writeToRoomDescriptionStream("\n\n%s", _G(_sys)[EXITS].c_str());
 			} else {

--- a/engines/glk/zcode/sound_folder.cpp
+++ b/engines/glk/zcode/sound_folder.cpp
@@ -54,7 +54,7 @@ bool SoundSubfolder::hasFile(const Common::Path &path) const {
 int SoundSubfolder::listMembers(Common::ArchiveMemberList &list) const {
 	int total = 0;
 	for (FileMap::iterator i = _filenames.begin(); i != _filenames.end(); ++i) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember((*i)._key, *this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, *this)));
 		++total;
 	}
 
@@ -120,7 +120,7 @@ int SoundZip::listMembers(Common::ArchiveMemberList &list) const {
 	int total = 0;
 
 	for (FileMap::iterator i = _filenames.begin(); i != _filenames.end(); ++i) {
-		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember((*i)._key, *this)));
+		list.push_back(Common::ArchiveMemberList::value_type(new Common::GenericArchiveMember(i->_key, *this)));
 		++total;
 	}
 

--- a/engines/grim/actor.cpp
+++ b/engines/grim/actor.cpp
@@ -2454,7 +2454,7 @@ void Actor::activateShadow(bool active, SetShadow *setShadow) {
 
 		Common::List<Common::String>::iterator it;
 		for (it = setShadow->_sectorNames.begin(); it != setShadow->_sectorNames.end(); ++it) {
-			addShadowPlane((*it).c_str(), g_grim->getCurrSet(), shadowId);
+			addShadowPlane(it->c_str(), g_grim->getCurrSet(), shadowId);
 		}
 	}
 }

--- a/engines/grim/emi/sound/emisound.cpp
+++ b/engines/grim/emi/sound/emisound.cpp
@@ -826,7 +826,7 @@ void EMISound::pause(bool paused) {
 	}
 
 	for (TrackMap::iterator it = _preloadedTrackMap.begin(); it != _preloadedTrackMap.end(); ++it) {
-		SoundTrack *track = (*it)._value;
+		SoundTrack *track = it->_value;
 		if (!track->isPlaying() || paused == track->isPaused())
 			continue;
 
@@ -1086,7 +1086,7 @@ void EMISound::updateSoundPositions() {
 	}
 
 	for (TrackMap::iterator it = _preloadedTrackMap.begin(); it != _preloadedTrackMap.end(); ++it) {
-		SoundTrack *track = (*it)._value;
+		SoundTrack *track = it->_value;
 		track->updatePosition();
 	}
 }

--- a/engines/grim/gfx_tinygl.cpp
+++ b/engines/grim/gfx_tinygl.cpp
@@ -190,8 +190,8 @@ void GfxTinyGL::flipBuffer(bool opportunistic) {
 
 	if (!dirtyAreas.empty()) {
 		for (Common::List<Common::Rect>::iterator itRect = dirtyAreas.begin(); itRect != dirtyAreas.end(); ++itRect) {
-			g_system->copyRectToScreen(glBuffer.getBasePtr((*itRect).left, (*itRect).top), glBuffer.pitch,
-			                           (*itRect).left, (*itRect).top, (*itRect).width(), (*itRect).height());
+			g_system->copyRectToScreen(glBuffer.getBasePtr(itRect->left, itRect->top), glBuffer.pitch,
+			                           itRect->left, itRect->top, itRect->width(), itRect->height());
 		}
 	}
 

--- a/engines/grim/remastered/lua_remastered.cpp
+++ b/engines/grim/remastered/lua_remastered.cpp
@@ -443,7 +443,7 @@ void Lua_Remastered::FindSaveGames() {
 
 	Common::StringArray::iterator it = saveFiles.begin();
 	for (int i = 0; it != saveFiles.end(); ++it) {
-		const char *filename  = (*it).c_str();
+		const char *filename  = it->c_str();
 		warning("Savefile: %s", filename);
 		SaveGame *savedState = SaveGame::openForLoading(filename);
 
@@ -457,7 +457,7 @@ void Lua_Remastered::FindSaveGames() {
 			}
 			return;
 		}
-		int slot = atoi((*it).c_str() + 6);
+		int slot = atoi(it->c_str() + 6);
 		Common::String str1;
 		Common::String str2;
 		int x;

--- a/engines/grim/sector.cpp
+++ b/engines/grim/sector.cpp
@@ -408,14 +408,14 @@ Common::List<Math::Line3d> Sector::getBridgesTo(Sector *sector) const {
 			//
 			// The value of at least 0.1 was chosen to fix a path finding issue
 			// in set pac when guybrush tried to reach the pile of rocks.
-			if (fabs(getProjectionToPlane((*it).begin()).y() - sector->getProjectionToPlane((*it).begin()).y()) > 0.1f ||
-			    fabs(getProjectionToPlane((*it).end()).y() - sector->getProjectionToPlane((*it).end()).y()) > 0.1f) {
+			if (fabs(getProjectionToPlane(it->begin()).y() - sector->getProjectionToPlane(it->begin()).y()) > 0.1f ||
+			    fabs(getProjectionToPlane(it->end()).y() - sector->getProjectionToPlane(it->end()).y()) > 0.1f) {
 				it = bridges.erase(it);
 				continue;
 			}
 		} else {
-			if (fabs(getProjectionToPlane((*it).begin()).z() - sector->getProjectionToPlane((*it).begin()).z()) > 0.01f ||
-			    fabs(getProjectionToPlane((*it).end()).z() - sector->getProjectionToPlane((*it).end()).z()) > 0.01f) {
+			if (fabs(getProjectionToPlane(it->begin()).z() - sector->getProjectionToPlane(it->begin()).z()) > 0.01f ||
+			    fabs(getProjectionToPlane(it->end()).z() - sector->getProjectionToPlane(it->end()).z()) > 0.01f) {
 				it = bridges.erase(it);
 				continue;
 			}

--- a/engines/illusions/actor.cpp
+++ b/engines/illusions/actor.cpp
@@ -38,7 +38,7 @@ namespace Illusions {
 
 uint32 DefaultSequences::use(uint32 sequenceId) {
 	ItemsIterator it = Common::find_if(_items.begin(), _items.end(), DefaultSequenceEqual(sequenceId));
-	return it != _items.end() ? (*it)._newSequenceId : sequenceId;
+	return it != _items.end() ? it->_newSequenceId : sequenceId;
 }
 
 void DefaultSequences::set(uint32 sequenceId, uint32 newSequenceId) {
@@ -48,7 +48,7 @@ void DefaultSequences::set(uint32 sequenceId, uint32 newSequenceId) {
 	else if (sequenceId == newSequenceId)
 		_items.remove_at(it - _items.begin());
 	else
-		(*it)._newSequenceId = newSequenceId;
+		it->_newSequenceId = newSequenceId;
 }
 
 // Actor

--- a/engines/illusions/bbdou/bbdou_specialcode.cpp
+++ b/engines/illusions/bbdou/bbdou_specialcode.cpp
@@ -210,7 +210,7 @@ void BbdouSpecialCode::init() {
 void BbdouSpecialCode::run(uint32 specialCodeId, OpCall &opCall) {
 	MapIterator it = _map.find(specialCodeId);
 	if (it != _map.end()) {
-		(*(*it)._value)(opCall);
+		(*it->_value)(opCall);
 	} else {
 		debug("BbdouSpecialCode::run() Unimplemented special code %08X", specialCodeId);
 		_vm->notifyThreadId(opCall._threadId);

--- a/engines/illusions/duckman/duckman_specialcode.cpp
+++ b/engines/illusions/duckman/duckman_specialcode.cpp
@@ -103,7 +103,7 @@ void DuckmanSpecialCode::init() {
 void DuckmanSpecialCode::run(uint32 specialCodeId, OpCall &opCall) {
 	SpecialCodeMapIterator it = _specialCodeMap.find(specialCodeId);
 	if (it != _specialCodeMap.end()) {
-		(*(*it)._value)(opCall);
+		(*it->_value)(opCall);
 	} else {
 		debug("DuckmanSpecialCode::run() Unimplemented special code %08X", specialCodeId);
 		_vm->notifyThreadId(opCall._threadId);

--- a/engines/illusions/resourcesystem.cpp
+++ b/engines/illusions/resourcesystem.cpp
@@ -135,7 +135,7 @@ void ResourceSystem::unloadAllResources() {
 BaseResourceLoader *ResourceSystem::getResourceLoader(uint32 resId) {
 	ResourceLoadersMapIterator it = _resourceLoaders.find(ResourceTypeId(resId));
 	if (it != _resourceLoaders.end())
-		return (*it)._value;
+		return it->_value;
 	error("ResourceSystem::getResourceLoader() Could not find resource loader for resource id %08X", resId);
 }
 

--- a/engines/kyra/gui/gui_eob.cpp
+++ b/engines/kyra/gui/gui_eob.cpp
@@ -3263,9 +3263,9 @@ Common::String GUI_EoB::transferTargetMenu(Common::Array<Common::String> &target
 
 	Common::StringArray::iterator ii = targets.begin();
 	for (int i = 0; i < _savegameListSize; ++i) {
-		int slsize = (*ii).size() + 1;
+		int slsize = ii->size() + 1;
 		_savegameList[i] = new char[slsize];
-		Common::strlcpy(_savegameList[i], (*ii++).c_str(), slsize);
+		Common::strlcpy(_savegameList[i], (ii++)->c_str(), slsize);
 	}
 
 	const ScreenDim *dm = _screen->getScreenDim(11);

--- a/engines/lure/hotspots.cpp
+++ b/engines/lure/hotspots.cpp
@@ -228,7 +228,7 @@ void Hotspot::setAnimationIndex(int animIndex) {
 	HotspotAnimList::iterator a = r.animRecords().begin();
 	for (int i = 0; i < animIndex; i++)
 		++a;
-	HotspotAnimData *tempAnim = (*a).get();
+	HotspotAnimData *tempAnim = a->get();
 
 	_animId = tempAnim->animRecordId;
 	if (_data)
@@ -3513,7 +3513,7 @@ void HotspotTickHandlers::talkAnimHandler(Hotspot &h) {
 			if (i != entries.end()) ++i;
 
 		for (; i != entries.end(); ++i) {
-			entry = (*i).get();
+			entry = i->get();
 			uint8 flags = (uint8) (entry->descId >> 14);
 			if (flags == 3)
 				// Skip the entry

--- a/engines/lure/res.cpp
+++ b/engines/lure/res.cpp
@@ -371,7 +371,7 @@ RoomExitJoinData *Resources::getExitJoin(uint16 hotspotId) {
 	RoomExitJoinList::iterator i;
 
 	for (i = _exitJoins.begin(); i != _exitJoins.end(); ++i) {
-		RoomExitJoinData *rec = (*i).get();
+		RoomExitJoinData *rec = i->get();
 		if ((rec->hotspots[0].hotspotId == hotspotId) || (rec->hotspots[1].hotspotId == hotspotId))
 			return rec;
 	}
@@ -387,7 +387,7 @@ RoomData *Resources::getRoom(uint16 roomNumber) {
 	RoomDataList::iterator i;
 
 	for (i = _roomData.begin(); i != _roomData.end(); ++i) {
-		RoomData *rec = (*i).get();
+		RoomData *rec = i->get();
 		if (rec->roomNumber == roomNumber) return rec;
 	}
 
@@ -443,7 +443,7 @@ HotspotData *Resources::getHotspot(uint16 hotspotId) {
 	HotspotDataList::iterator i;
 
 	for (i = _hotspotData.begin(); i != _hotspotData.end(); ++i) {
-		HotspotData *rec = (*i).get();
+		HotspotData *rec = i->get();
 		if (rec->hotspotId == hotspotId) return rec;
 	}
 
@@ -454,7 +454,7 @@ Hotspot *Resources::getActiveHotspot(uint16 hotspotId) {
 	HotspotList::iterator i;
 
 	for (i = _activeHotspots.begin(); i != _activeHotspots.end(); ++i) {
-		Hotspot *rec = (*i).get();
+		Hotspot *rec = i->get();
 		if (rec->hotspotId() == hotspotId) return rec;
 	}
 
@@ -466,7 +466,7 @@ HotspotOverrideData *Resources::getHotspotOverride(uint16 hotspotId) {
 	HotspotOverrideList::iterator i;
 
 	for (i = _hotspotOverrides.begin(); i != _hotspotOverrides.end(); ++i) {
-		HotspotOverrideData *rec = (*i).get();
+		HotspotOverrideData *rec = i->get();
 		if (rec->hotspotId == hotspotId) return rec;
 	}
 
@@ -477,7 +477,7 @@ HotspotAnimData *Resources::getAnimation(uint16 animRecordId) {
 	HotspotAnimList::iterator i;
 
 	for (i = _animData.begin(); i != _animData.end(); ++i) {
-		HotspotAnimData *rec = (*i).get();
+		HotspotAnimData *rec = i->get();
 		if (rec->animRecordId == animRecordId) return rec;
 	}
 
@@ -489,7 +489,7 @@ int Resources::getAnimationIndex(HotspotAnimData *animData) {
 	int index = 0;
 
 	for (i = _animData.begin(); i != _animData.end(); ++i, ++index) {
-		HotspotAnimData *rec = (*i).get();
+		HotspotAnimData *rec = i->get();
 		if (rec == animData)
 			return index;
 	}
@@ -508,7 +508,7 @@ uint16 Resources::getHotspotAction(uint16 actionsOffset, Action action) {
 TalkHeaderData *Resources::getTalkHeader(uint16 hotspotId) {
 	TalkHeaderList::iterator i;
 	for (i = _talkHeaders.begin(); i != _talkHeaders.end(); ++i) {
-		TalkHeaderData *rec = (*i).get();
+		TalkHeaderData *rec = i->get();
 		if (rec->characterId == hotspotId) return rec;
 	}
 	return nullptr;
@@ -695,7 +695,7 @@ void Resources::deactivateHotspot(Hotspot *hotspot) {
 	HotspotList::iterator i = _activeHotspots.begin();
 
 	while (i != _activeHotspots.end()) {
-		Hotspot *h = (*i).get();
+		Hotspot *h = i->get();
 		if (h == hotspot) {
 			_activeHotspots.erase(i);
 			break;
@@ -738,7 +738,7 @@ void Resources::setTalkData(uint16 offset) {
 
 	TalkDataList::iterator i;
 	for (i = _talkData.begin(); i != _talkData.end(); ++i) {
-		TalkData *rec = (*i).get();
+		TalkData *rec = i->get();
 		if (rec->recordId == offset) {
 			_activeTalkData = rec;
 			return;

--- a/engines/lure/res_struct.cpp
+++ b/engines/lure/res_struct.cpp
@@ -147,7 +147,7 @@ bool RoomExitData::insideRect(int16 xp, int16 yp) {
 RoomExitData *RoomExitList::checkExits(int16 xp, int16 yp) {
 	iterator i;
 	for (i = begin(); i != end(); ++i) {
-		RoomExitData *rec = (*i).get();
+		RoomExitData *rec = i->get();
 		if (rec->insideRect(xp, yp)) {
 			return rec;
 		}
@@ -624,7 +624,7 @@ HotspotActionList::HotspotActionList(uint16 id, byte *data) {
 HotspotActionList *HotspotActionSet::getActions(uint16 recordId) {
 	HotspotActionSet::iterator i;
 	for (i = begin(); i != end(); ++i) {
-		HotspotActionList *list = (*i).get();
+		HotspotActionList *list = i->get();
 		if (list->recordId == recordId) return list;
 	}
 
@@ -690,7 +690,7 @@ TalkEntryData *TalkData::getResponse(int index) {
 		++i;
 	}
 
-	return (*i).get();
+	return i->get();
 }
 
 // The following class acts as a container for all the NPC conversations
@@ -901,9 +901,9 @@ CharacterScheduleEntry *CharacterScheduleEntry::next() {
 	if (_parent) {
 		CharacterScheduleSet::iterator i;
 		for (i = _parent->begin(); i != _parent->end(); ++i) {
-			if ((*i).get() == this) {
+			if (i->get() == this) {
 				++i;
-				CharacterScheduleEntry *result = (i == _parent->end()) ? nullptr : (*i).get();
+				CharacterScheduleEntry *result = (i == _parent->end()) ? nullptr : i->get();
 				return result;
 			}
 		}
@@ -950,7 +950,7 @@ CharacterScheduleEntry *CharacterScheduleList::getEntry(uint16 id, CharacterSche
 
 		if (i == end())
 			error("Invalid index %d specified for support data set", id >> 8);
-		currentSet = (*i).get();
+		currentSet = i->get();
 	}
 
 	// Get the indexed instruction in the specified set
@@ -963,7 +963,7 @@ CharacterScheduleEntry *CharacterScheduleList::getEntry(uint16 id, CharacterSche
 	if (i == currentSet->end())
 		error("Invalid index %d specified within support data set", id & 0x3ff);
 
-	return (*i).get();
+	return i->get();
 }
 
 uint16 CharacterScheduleSet::getId(CharacterScheduleEntry *rec) {
@@ -973,7 +973,7 @@ uint16 CharacterScheduleSet::getId(CharacterScheduleEntry *rec) {
 
 	iterator i;
 	for (i = begin(); i != end(); ++i, ++result)
-		if ((*i).get() == rec) break;
+		if (i->get() == rec) break;
 	if (i == end())
 		error("Parent child relationship missing in character schedule set");
 	return result;
@@ -1003,7 +1003,7 @@ RandomActionSet::~RandomActionSet() {
 RandomActionSet *RandomActionList::getRoom(uint16 roomNumber) {
 	iterator i;
 	for (i = begin(); i != end(); ++i) {
-		RandomActionSet *v = (*i).get();
+		RandomActionSet *v = i->get();
 		if (v->roomNumber() == roomNumber)
 			return v;
 	}
@@ -1482,7 +1482,7 @@ void CurrentActionStack::copyFrom(CurrentActionStack &stack) {
 	ActionsList::iterator i;
 
 	for (i = stack._actions.begin(); i != stack._actions.end(); ++i) {
-		CurrentActionEntry *rec = (*i).get();
+		CurrentActionEntry *rec = i->get();
 		_actions.push_back(ActionsList::value_type(new CurrentActionEntry(rec)));
 	}
 }

--- a/engines/lure/room.cpp
+++ b/engines/lure/room.cpp
@@ -177,7 +177,7 @@ void Room::checkRoomHotspots() {
 	// Loop for each range of hotspot Ids
 	for (int ctr = 0; ctr < 4; ++ctr) {
 		for (i = list.begin(); i != list.end(); ++i) {
-			entry = (*i).get();
+			entry = i->get();
 			if ((entry->hotspotId < rangeStart[ctr]) || (entry->hotspotId > rangeEnd[ctr]))
 				// Hotspot outside range, so skip it
 				continue;

--- a/engines/lure/sound.cpp
+++ b/engines/lure/sound.cpp
@@ -368,7 +368,7 @@ SoundDescResource *SoundManager::findSound(uint8 soundNumber) {
 	SoundListIterator i;
 
 	for (i = _activeSounds.begin(); i != _activeSounds.end(); ++i) {
-		SoundDescResource *rec = (*i).get();
+		SoundDescResource *rec = i->get();
 
 		if (rec->soundNumber == soundNumber) {
 			debugC(ERROR_INTERMEDIATE, kLureDebugSounds, "SoundManager::findSound - sound found");
@@ -462,7 +462,7 @@ void SoundManager::pause() {
 
 	MusicListIterator i;
 	for (i = _playingSounds.begin(); i != _playingSounds.end(); ++i) {
-		(**i).pauseMusic();
+		(*i)->pauseMusic();
 	}
 
 	_soundMutex.unlock();
@@ -478,7 +478,7 @@ void SoundManager::resume() {
 
 	MusicListIterator i;
 	for (i = _playingSounds.begin(); i != _playingSounds.end(); ++i) {
-		(**i).resumeMusic();
+		(*i)->resumeMusic();
 	}
 
 	_soundMutex.unlock();

--- a/engines/m4/adv_r/adv_file.cpp
+++ b/engines/m4/adv_r/adv_file.cpp
@@ -174,9 +174,9 @@ bool kernel_load_room(int minPalEntry, int maxPalEntry, SceneDef *rdef, GrBuff *
 	}
 
 	if (*scr_orig_data) {
-		Buffer *scr_orig_data_buffer = (**scr_orig_data).get_buffer();
+		Buffer *scr_orig_data_buffer = (*scr_orig_data)->get_buffer();
 		RestoreEdgeList(scr_orig_data_buffer);
-		(**scr_orig_data).release();
+		(*scr_orig_data)->release();
 	} else
 		RestoreEdgeList(nullptr);
 
@@ -269,7 +269,7 @@ bool load_background(SysFile *pic_file, GrBuff **loadBuffer, RGB8 *palette) {
 
 	*loadBuffer = new GrBuff(file_x, file_y);
 
-	Buffer *theBuff = (**loadBuffer).get_buffer();
+	Buffer *theBuff = (*loadBuffer)->get_buffer();
 
 	for (int i = 0; i < num_y_tiles; i++) {
 		for (int j = 0; j < num_x_tiles; j++) {
@@ -289,7 +289,7 @@ bool load_background(SysFile *pic_file, GrBuff **loadBuffer, RGB8 *palette) {
 		}
 	}
 
-	(**loadBuffer).release();
+	(*loadBuffer)->release();
 	return true;
 }
 
@@ -351,19 +351,19 @@ static void recreate_animation_draw_screen(GrBuff **loadBuf) {
 		_G(gameDrawBuff) = nullptr;
 		_G(game_buff_ptr) = nullptr;
 	}
-	_G(gameDrawBuff) = new GrBuff((**loadBuf).w, (**loadBuf).h);
+	_G(gameDrawBuff) = new GrBuff((*loadBuf)->w, (*loadBuf)->h);
 	gui_GrBuff_register(_G(kernel).letter_box_x, _G(kernel).letter_box_y, _G(gameDrawBuff), SF_BACKGRND | SF_GET_ALL | SF_BLOCK_NONE, nullptr);
 	gui_buffer_activate((Buffer *)_G(gameDrawBuff));
 	vmng_screen_to_back((void *)_G(gameDrawBuff));
 	_G(game_buff_ptr) = vmng_screen_find(_G(gameDrawBuff), nullptr);
 
-	Buffer *theBuff = (**loadBuf).get_buffer();
-	Buffer *game_buff = (*_G(gameDrawBuff)).get_buffer();
+	Buffer *theBuff = (*loadBuf)->get_buffer();
+	Buffer *game_buff = (_G(gameDrawBuff))->get_buffer();
 	gr_buffer_rect_copy_2(theBuff, game_buff, 0, 0, 0, 0,
-		imath_min((**loadBuf).w, game_buff->w), imath_min((**loadBuf).h, game_buff->h));
+		imath_min((*loadBuf)->w, game_buff->w), imath_min((*loadBuf)->h, game_buff->h));
 
-	(**loadBuf).release();
-	(*_G(gameDrawBuff)).release();
+	(*loadBuf)->release();
+	(_G(gameDrawBuff))->release();
 }
 
 static void troll_for_colors(RGB8 *newPal, uint8 minPalEntry, uint8 maxPalEntry) {

--- a/engines/m4/wscript/ws_load.cpp
+++ b/engines/m4/wscript/ws_load.cpp
@@ -1427,7 +1427,7 @@ static int32 GetSSHeaderInfo(SysFile *sysFile, uint32 **data, RGB8 *myPalette) {
 
 	// *data contains header + offsets, therefore, we must scan ahead
 	// and find out how many cels are here...
-	if (!(*sysFile).seek_ahead((CELS_COUNT - CELS_SRC_SIZE - 1) << 2)) {
+	if (!sysFile->seek_ahead((CELS_COUNT - CELS_SRC_SIZE - 1) << 2)) {
 		ws_LogErrorMsg(FL, "Failed to seek ahead in the stream.");
 		return -1;
 	}
@@ -1441,7 +1441,7 @@ static int32 GetSSHeaderInfo(SysFile *sysFile, uint32 **data, RGB8 *myPalette) {
 	}
 
 	// Now, seek backwards to where we left off
-	if (!(*sysFile).seek_ahead((CELS_SRC_SIZE - CELS_COUNT) * 4)) {
+	if (!sysFile->seek_ahead((CELS_SRC_SIZE - CELS_COUNT) * 4)) {
 		ws_LogErrorMsg(FL, "Failed to seek backwards in the stream.");
 		return -1;
 	}
@@ -1468,7 +1468,7 @@ static int32 GetSSHeaderInfo(SysFile *sysFile, uint32 **data, RGB8 *myPalette) {
 	}
 
 	// Find out how far into the stream we are, and return that value
-	const int32 dataOffset = (*sysFile).get_pos();
+	const int32 dataOffset = sysFile->get_pos();
 	return dataOffset;
 }
 

--- a/engines/macventure/gui.cpp
+++ b/engines/macventure/gui.cpp
@@ -1367,8 +1367,8 @@ WindowReference Gui::findObjWindow(ObjID objID) {
 void Gui::checkSelect(const WindowData &data, Common::Point pos, const Common::Rect &clickRect, WindowReference ref, bool shiftPressed, bool isDoubleClick) {
 	ObjID child = 0;
 	for (Common::Array<DrawableObject>::const_iterator it = data.children.begin(); it != data.children.end(); it++) {
-		if (canBeSelected((*it).obj, clickRect, ref)) {
-			child = (*it).obj;
+		if (canBeSelected(it->obj, clickRect, ref)) {
+			child = it->obj;
 		}
 	}
 	if (child != 0 || data.refcon == kMainGameWindow) {
@@ -1460,8 +1460,8 @@ void Gui::handleDragRelease(bool shiftPressed, bool isDoubleClick) {
 			Common::Rect clickRect = calculateClickRect(_cursor->getPos() + data.scrollPos, win->getInnerDimensions());
 
 			for (Common::Array<DrawableObject>::const_iterator it = data.children.begin(); it != data.children.end(); it++) {
-				if (canBeSelected((*it).obj, clickRect, destinationWindow)) {
-					child = (*it).obj;
+				if (canBeSelected(it->obj, clickRect, destinationWindow)) {
+					child = it->obj;
 				}
 			}
 

--- a/engines/macventure/macventure.cpp
+++ b/engines/macventure/macventure.cpp
@@ -1167,7 +1167,7 @@ void MacVentureEngine::zoomObject(ObjID objID) {
 bool MacVentureEngine::isObjEnqueued(ObjID objID) {
 	Common::Array<QueuedObject>::const_iterator it;
 	for (it = _objQueue.begin(); it != _objQueue.end(); it++) {
-		if ((*it).id == kUpdateObject && (*it).object == objID) {
+		if (it->id == kUpdateObject && it->object == objID) {
 			return true;
 		}
 	}

--- a/engines/made/database.cpp
+++ b/engines/made/database.cpp
@@ -328,7 +328,7 @@ int16 *GameDatabase::findObjectPropertyCached(int16 objectIndex, int16 propertyI
 	ObjectPropertyCacheMap::iterator iter = _objectPropertyCache.find(id);
 	int16 *propertyPtr = nullptr;
 	if (iter != _objectPropertyCache.end()) {
-		propertyPtr = (*iter)._value;
+		propertyPtr = iter->_value;
 	} else {
 		propertyPtr = findObjectProperty(objectIndex, propertyId, propertyFlag);
 		_objectPropertyCache[id] = propertyPtr;

--- a/engines/mm/mm1/game/use_item.cpp
+++ b/engines/mm/mm1/game/use_item.cpp
@@ -54,8 +54,8 @@ Common::String UseItem::combatUseItem(Inventory &inv, Inventory::Entry &invEntry
 				applyItemBonus(item->_tempBonus_id, item->_tempBonus_value);
 
 				if (g_globals->_combatEffectCtr)
-					(isEquipped ? &g_globals->_currCharacter->_equipped :
-						&g_globals->_currCharacter->_backpack)->removeCharge(&invEntry);
+					(isEquipped ? g_globals->_currCharacter->_equipped :
+						g_globals->_currCharacter->_backpack).removeCharge(&invEntry);
 
 				g_globals->_party.updateAC();
 				msg = STRING["dialogs.character.use_combat.done"];
@@ -104,8 +104,8 @@ Common::String UseItem::nonCombatUseItem(Inventory &inv, Inventory::Entry &invEn
 				applyItemBonus (item->_tempBonus_id, item->_tempBonus_value);
 
 				if (g_globals->_nonCombatEffectCtr)
-					(isEquipped ? &g_globals->_currCharacter->_equipped :
-						&g_globals->_currCharacter->_backpack)->removeCharge(&invEntry);
+					(isEquipped ? g_globals->_currCharacter->_equipped :
+						g_globals->_currCharacter->_backpack).removeCharge(&invEntry);
 
 				g_globals->_party.updateAC();
 				msg = STRING["spells.done"];

--- a/engines/mm/xeen/files.cpp
+++ b/engines/mm/xeen/files.cpp
@@ -102,7 +102,7 @@ SaveArchive::SaveArchive(Party *party) : BaseCCArchive(), _party(party), _data(n
 
 SaveArchive::~SaveArchive() {
 	for (Common::HashMap<uint16, Common::MemoryWriteStreamDynamic *>::iterator it = _newData.begin(); it != _newData.end(); ++it) {
-		delete (*it)._value;
+		delete it->_value;
 	}
 	delete[] _data;
 }

--- a/engines/mm/xeen/scripts.cpp
+++ b/engines/mm/xeen/scripts.cpp
@@ -89,7 +89,7 @@ void MazeEvents::synchronize(XeenSerializer &s) {
 		}
 	} else {
 		for (uint i = 0; i < size(); ++i)
-			(*this).operator[](i).synchronize(s);
+			(this)->operator[](i).synchronize(s);
 	}
 }
 

--- a/engines/myst3/gfx_tinygl.cpp
+++ b/engines/myst3/gfx_tinygl.cpp
@@ -278,8 +278,8 @@ void TinyGLRenderer::flipBuffer() {
 
 	if (!dirtyAreas.empty()) {
 		for (Common::List<Common::Rect>::iterator itRect = dirtyAreas.begin(); itRect != dirtyAreas.end(); ++itRect) {
-			g_system->copyRectToScreen(glBuffer.getBasePtr((*itRect).left, (*itRect).top), glBuffer.pitch,
-			                           (*itRect).left, (*itRect).top, (*itRect).width(), (*itRect).height());
+			g_system->copyRectToScreen(glBuffer.getBasePtr(itRect->left, itRect->top), glBuffer.pitch,
+			                           itRect->left, itRect->top, itRect->width(), itRect->height());
 		}
 	}
 }

--- a/engines/nancy/graphics.cpp
+++ b/engines/nancy/graphics.cpp
@@ -105,7 +105,7 @@ void GraphicsManager::draw(bool updateScreen) {
 	// Filter out dirty rects that are completely inside others to reduce overdraw
 	for (auto outer = _dirtyRects.begin(); outer != _dirtyRects.end(); ++outer) {
 		for (auto inner = _dirtyRects.begin(); inner != _dirtyRects.end(); ++inner) {
-			if (inner != outer && (*outer).contains(*inner)) {
+			if (inner != outer && outer->contains(*inner)) {
 				_dirtyRects.erase(inner);
 				break;
 			}

--- a/engines/neverhood/resource.cpp
+++ b/engines/neverhood/resource.cpp
@@ -558,7 +558,7 @@ MessageList *DataResource::getMessageListAtPos(int16 klaymenX, int16 klaymenY, i
 
 DataResource::DRDirectoryItem *DataResource::findDRDirectoryItem(uint32 nameHash, uint16 type) {
 	for (Common::Array<DRDirectoryItem>::iterator it = _directory.begin(); it != _directory.end(); it++)
-		if ((*it).nameHash == nameHash && (*it).type == type)
+		if (it->nameHash == nameHash && it->type == type)
 			return &(*it);
 	return nullptr;
 }

--- a/engines/neverhood/resourceman.cpp
+++ b/engines/neverhood/resourceman.cpp
@@ -94,7 +94,7 @@ bool ResourceMan::addNhcArchive(const Common::Path &filename) {
 
 ResourceFileEntry *ResourceMan::findEntrySimple(uint32 fileHash) {
 	EntriesMap::iterator p = _entries.find(fileHash);
-	return p != _entries.end() ? &(*p)._value : nullptr;
+	return p != _entries.end() ? &p->_value : nullptr;
 }
 
 ResourceFileEntry *ResourceMan::findEntry(uint32 fileHash, ResourceFileEntry **firstEntry) {
@@ -242,7 +242,7 @@ void ResourceMan::unloadResource(ResourceHandle &resourceHandle) {
 
 void ResourceMan::purgeResources() {
 	for (Common::HashMap<uint32, ResourceData*>::iterator it = _data.begin(); it != _data.end(); ++it) {
-		ResourceData *resourceData = (*it)._value;
+		ResourceData *resourceData = it->_value;
 		if (resourceData->dataRefCount == 0) {
 			delete[] resourceData->data;
 			resourceData->data = nullptr;

--- a/engines/neverhood/scene.cpp
+++ b/engines/neverhood/scene.cpp
@@ -556,7 +556,7 @@ HitRect *Scene::findHitRectAtPos(int16 x, int16 y) {
 	static HitRect kDefaultHitRect = {NRect(), 0x5000};
 	if (_hitRects)
 		for (HitRectList::iterator it = _hitRects->begin(); it != _hitRects->end(); it++)
-			if ((*it).rect.contains(x, y))
+			if (it->rect.contains(x, y))
 				return &(*it);
 	return &kDefaultHitRect;
 }

--- a/engines/parallaction/walk.cpp
+++ b/engines/parallaction/walk.cpp
@@ -326,7 +326,7 @@ void PathWalker_NS::walk() {
 	PointList::iterator it = _walkPath.begin();
 	if (it != _walkPath.end()) {
 		if (*it == curPos) {
-			debugC(1, kDebugWalk, "walk reached node (%i, %i)", (*it).x, (*it).y);
+			debugC(1, kDebugWalk, "walk reached node (%i, %i)", it->x, it->y);
 			it = _walkPath.erase(it);
 		}
 	}

--- a/engines/pink/screen.cpp
+++ b/engines/pink/screen.cpp
@@ -294,7 +294,7 @@ void Screen::mergeDirtyRects() {
 	for (rOuter = _dirtyRects.begin(); rOuter != _dirtyRects.end(); ++rOuter) {
 		rInner = rOuter;
 		while (++rInner != _dirtyRects.end()) {
-			if ((*rOuter).intersects(*rInner)) {
+			if (rOuter->intersects(*rInner)) {
 				// These two rectangles overlap, so merge them
 				rOuter->extend(*rInner);
 

--- a/engines/qdengine/qdcore/qd_trigger_element.cpp
+++ b/engines/qdengine/qdcore/qd_trigger_element.cpp
@@ -215,7 +215,7 @@ bool qdTriggerElement::add_child(qdTriggerElementPtr p, int link_type, bool auto
 
 bool qdTriggerElement::remove_parent(qdTriggerElementPtr p) {
 	for (auto it = _parents.begin(); it != _parents.end(); it++) {
-		if ((*it).element() == p) {
+		if (it->element() == p) {
 			_parents.erase(it);
 			return true;
 		}
@@ -225,7 +225,7 @@ bool qdTriggerElement::remove_parent(qdTriggerElementPtr p) {
 
 bool qdTriggerElement::remove_child(qdTriggerElementPtr p) {
 	for (auto it = _children.begin(); it != _children.end(); it++) {
-		if ((*it).element() == p) {
+		if (it->element() == p) {
 			_children.erase(it);
 			return true;
 		}

--- a/engines/saga2/audio.cpp
+++ b/engines/saga2/audio.cpp
@@ -694,7 +694,7 @@ bool AudioInterface::saying(uint32 s) {
 		return true;
 
 	for (Common::List<SoundInstance>::iterator it = _speechQueue.begin(); it != _speechQueue.end(); ++it)
-		if ((*it).seg == s)
+		if (it->seg == s)
 			return true;
 
 	return false;

--- a/engines/sci/console.cpp
+++ b/engines/sci/console.cpp
@@ -1505,7 +1505,7 @@ bool Console::cmdMapInstrument(int argc, const char **argv) {
 	if (Mt32dynamicMappings != nullptr) {
 		const Mt32ToGmMapList::iterator end = Mt32dynamicMappings->end();
 		for (Mt32ToGmMapList::iterator it = Mt32dynamicMappings->begin(); it != end; ++it) {
-			debugPrintf("\"%s\" -> %d / %d\n", (*it).name, (*it).gmInstr, (*it).gmRhythmKey);
+			debugPrintf("\"%s\" -> %d / %d\n", it->name, it->gmInstr, it->gmRhythmKey);
 		}
 	}
 
@@ -2426,44 +2426,44 @@ bool Console::cmdPrintSegmentTable(int argc, const char **argv) {
 
 			switch (mobj->getType()) {
 			case SEG_TYPE_SCRIPT:
-				debugPrintf("S  script.%03d l:%d ", (*(Script *)mobj).getScriptNumber(), (*(Script *)mobj).getLockers());
+				debugPrintf("S  script.%03d l:%d ", ((Script *)mobj)->getScriptNumber(), ((Script *)mobj)->getLockers());
 				break;
 
 			case SEG_TYPE_CLONES:
-				debugPrintf("C  clones (%d allocd)", (*(CloneTable *)mobj).entries_used);
+				debugPrintf("C  clones (%d allocd)", ((CloneTable *)mobj)->entries_used);
 				break;
 
 			case SEG_TYPE_LOCALS:
-				debugPrintf("V  locals %03d", (*(LocalVariables *)mobj).script_id);
+				debugPrintf("V  locals %03d", ((LocalVariables *)mobj)->script_id);
 				break;
 
 			case SEG_TYPE_STACK:
-				debugPrintf("D  data stack (%d)", (*(DataStack *)mobj)._capacity);
+				debugPrintf("D  data stack (%d)", ((DataStack *)mobj)->_capacity);
 				break;
 
 			case SEG_TYPE_LISTS:
-				debugPrintf("L  lists (%d)", (*(ListTable *)mobj).entries_used);
+				debugPrintf("L  lists (%d)", ((ListTable *)mobj)->entries_used);
 				break;
 
 			case SEG_TYPE_NODES:
-				debugPrintf("N  nodes (%d)", (*(NodeTable *)mobj).entries_used);
+				debugPrintf("N  nodes (%d)", ((NodeTable *)mobj)->entries_used);
 				break;
 
 			case SEG_TYPE_HUNK:
-				debugPrintf("H  hunk (%d)", (*(HunkTable *)mobj).entries_used);
+				debugPrintf("H  hunk (%d)", ((HunkTable *)mobj)->entries_used);
 				break;
 
 			case SEG_TYPE_DYNMEM:
-				debugPrintf("M  dynmem: %d bytes", (*(DynMem *)mobj)._size);
+				debugPrintf("M  dynmem: %d bytes", ((DynMem *)mobj)->_size);
 				break;
 
 #ifdef ENABLE_SCI32
 			case SEG_TYPE_ARRAY:
-				debugPrintf("A  SCI32 arrays (%d)", (*(ArrayTable *)mobj).entries_used);
+				debugPrintf("A  SCI32 arrays (%d)", ((ArrayTable *)mobj)->entries_used);
 				break;
 
 			case SEG_TYPE_BITMAP:
-				debugPrintf("T  SCI32 bitmaps (%d)", (*(BitmapTable *)mobj).entries_used);
+				debugPrintf("T  SCI32 bitmaps (%d)", ((BitmapTable *)mobj)->entries_used);
 				break;
 #endif
 
@@ -2569,7 +2569,7 @@ bool Console::segmentInfo(int nr) {
 	break;
 
 	case SEG_TYPE_NODES: {
-		debugPrintf("nodes (total %d)\n", (*(NodeTable *)mobj).entries_used);
+		debugPrintf("nodes (total %d)\n", ((NodeTable *)mobj)->entries_used);
 		break;
 	}
 
@@ -2587,9 +2587,9 @@ bool Console::segmentInfo(int nr) {
 
 	case SEG_TYPE_DYNMEM: {
 		debugPrintf("dynmem (%s): %d bytes\n",
-		          (*(DynMem *)mobj)._description.c_str(), (*(DynMem *)mobj)._size);
+		          ((DynMem *)mobj)->_description.c_str(), ((DynMem *)mobj)->_size);
 
-		Common::hexdump((*(DynMem *)mobj)._buf, (*(DynMem *)mobj)._size, 16, 0);
+		Common::hexdump(((DynMem *)mobj)->_buf, ((DynMem *)mobj)->_size, 16, 0);
 	}
 	break;
 

--- a/engines/sci/engine/gc.cpp
+++ b/engines/sci/engine/gc.cpp
@@ -112,10 +112,10 @@ AddrSet *findAllActiveReferences(EngineState *s) {
 	Common::List<ExecStack>::const_iterator iter = s->_executionStack.reverse_begin();
 
 	// Skip fake kernel stack frame if it's on top
-	if ((*iter).type == EXEC_STACK_TYPE_KERNEL)
+	if (iter->type == EXEC_STACK_TYPE_KERNEL)
 		--iter;
 
-	assert((iter != s->_executionStack.end()) && ((*iter).type != EXEC_STACK_TYPE_KERNEL));
+	assert((iter != s->_executionStack.end()) && (iter->type != EXEC_STACK_TYPE_KERNEL));
 
 	const StackPtr sp = iter->sp;
 

--- a/engines/sci/engine/kernel.cpp
+++ b/engines/sci/engine/kernel.cpp
@@ -391,9 +391,9 @@ uint16 Kernel::findRegType(reg_t reg) {
 
 	switch (mobj->getType()) {
 	case SEG_TYPE_SCRIPT:
-		if (reg.getOffset() <= (*(Script *)mobj).getBufSize() &&
+		if (reg.getOffset() <= ((Script *)mobj)->getBufSize() &&
 			reg.getOffset() >= (uint)-SCRIPT_OBJECT_MAGIC_OFFSET &&
-			(*(Script *)mobj).offsetIsObject(reg.getOffset())) {
+			((Script *)mobj)->offsetIsObject(reg.getOffset())) {
 			result |= ((Script *)mobj)->getObject(reg.getOffset()) ? SIG_TYPE_OBJECT : SIG_TYPE_REFERENCE;
 		} else
 			result |= SIG_TYPE_REFERENCE;

--- a/engines/sci/sound/drivers/midi.cpp
+++ b/engines/sci/sound/drivers/midi.cpp
@@ -268,8 +268,8 @@ MidiPlayer_Midi::~MidiPlayer_Midi() {
 
 	const Mt32ToGmMapList::iterator end = Mt32dynamicMappings->end();
 	for (Mt32ToGmMapList::iterator it = Mt32dynamicMappings->begin(); it != end; ++it) {
-		delete[] (*it).name;
-		(*it).name = nullptr;
+		delete[] it->name;
+		it->name = nullptr;
 	}
 
 	Mt32dynamicMappings->clear();
@@ -1085,7 +1085,7 @@ byte MidiPlayer_Midi::lookupGmInstrument(const char *iname) {
 	if (Mt32dynamicMappings != nullptr) {
 		const Mt32ToGmMapList::iterator end = Mt32dynamicMappings->end();
 		for (Mt32ToGmMapList::iterator it = Mt32dynamicMappings->begin(); it != end; ++it) {
-			if (scumm_strnicmp(iname, (*it).name, 10) == 0)
+			if (scumm_strnicmp(iname, it->name, 10) == 0)
 				return getGmInstrument((*it));
 		}
 	}
@@ -1105,8 +1105,8 @@ byte MidiPlayer_Midi::lookupGmRhythmKey(const char *iname) {
 	if (Mt32dynamicMappings != nullptr) {
 		const Mt32ToGmMapList::iterator end = Mt32dynamicMappings->end();
 		for (Mt32ToGmMapList::iterator it = Mt32dynamicMappings->begin(); it != end; ++it) {
-			if (scumm_strnicmp(iname, (*it).name, 10) == 0)
-				return (*it).gmRhythmKey;
+			if (scumm_strnicmp(iname, it->name, 10) == 0)
+				return it->gmRhythmKey;
 		}
 	}
 

--- a/engines/scumm/imuse_digi/dimuse_files.cpp
+++ b/engines/scumm/imuse_digi/dimuse_files.cpp
@@ -314,7 +314,7 @@ void IMuseDigiFilesHandler::closeAllSounds() {
 	ImuseDigiSndMgr::SoundDesc *s = _sound->getSounds();
 	for (int i = 0; i < MAX_IMUSE_SOUNDS; i++) {
 		if (s[i].inUse) {
-			closeSound((&s[i])->soundId);
+			closeSound(s[i].soundId);
 		}
 	}
 

--- a/engines/scumm/scumm.cpp
+++ b/engines/scumm/scumm.cpp
@@ -2824,8 +2824,8 @@ Common::Error ScummEngine::go() {
 		filenames = saveFileMan->listSavefiles(_targetName + "-chase???.???");
 
 		for (Common::StringArray::const_iterator file = filenames.begin(); file != filenames.end(); ++file) {
-			Common::String from = (*file).c_str();
-			Common::String to = (*file).c_str();
+			Common::String from = file->c_str();
+			Common::String to = file->c_str();
 			to.insertString("000-", from.size() - 12);
 			saveFileMan->renameSavefile(from, to);
 		}

--- a/engines/scumm/soundse.cpp
+++ b/engines/scumm/soundse.cpp
@@ -245,7 +245,7 @@ void SoundSE::indexSpeechXSBFile() {
 		Common::String name = f->readString(0);
 		name.toLowercase();
 
-		if (index < (*audioIndex).size()) {
+		if (index < audioIndex->size()) {
 			(*audioIndex)[index].name = name;
 			_nameToIndexMISpeech[name] = index;
 			//debug("indexSpeechXSBFile: %s -> index %d", name.c_str(), index);
@@ -764,7 +764,7 @@ Audio::SeekableAudioStream *SoundSE::getAudioStreamFromIndex(int32 index, SoundS
 	AudioIndex *audioIndex = getAudioEntries(type);
 	AudioEntry audioEntry = {};
 
-	if (index < 0 || index >= (int32)(*audioIndex).size())
+	if (index < 0 || index >= (int32)audioIndex->size())
 		return nullptr;
 
 	audioEntry = (*audioIndex)[index];

--- a/engines/sherlock/music.cpp
+++ b/engines/sherlock/music.cpp
@@ -627,8 +627,8 @@ void Music::getSongNames(Common::StringArray &songs) {
 		Common::StringArray fileList;
 		_vm->_res->getResourceNames("music.lib", fileList);
 		for (Common::StringArray::iterator i = fileList.begin(); i != fileList.end(); ++i) {
-			if ((*i).matchString("*.XMI", true)) {
-				(*i).erase((*i).size() - 4);
+			if (i->matchString("*.XMI", true)) {
+				i->erase(i->size() - 4);
 				songs.push_back(*i);
 			}
 		}

--- a/engines/sherlock/scalpel/tsage/resources.cpp
+++ b/engines/sherlock/scalpel/tsage/resources.cpp
@@ -98,7 +98,7 @@ Common::SeekableReadStream *TLib::getResource(uint16 id, bool suppressErrors) {
 	ResourceEntry *re = nullptr;
 	ResourceList::iterator iter;
 	for (iter = _resources.begin(); iter != _resources.end(); ++iter) {
-		if ((*iter).id == id) {
+		if (iter->id == id) {
 			re = &(*iter);
 			break;
 		}
@@ -215,7 +215,7 @@ Common::SeekableReadStream *TLib::getResource(uint16 id, bool suppressErrors) {
  */
 Common::SeekableReadStream *TLib::getResource(ResourceType resType, uint16 resNum, uint16 rlbNum, bool suppressErrors) {
 	SectionList::iterator i = _sections.begin();
-	while ((i != _sections.end()) && ((*i).resType != resType || (*i).resNum != resNum))
+	while ((i != _sections.end()) && (i->resType != resType || i->resNum != resNum))
 		++i;
 	if (i == _sections.end()) {
 		if (suppressErrors)
@@ -223,7 +223,7 @@ Common::SeekableReadStream *TLib::getResource(ResourceType resType, uint16 resNu
 		error("Unknown resource type %d num %d", resType, resNum);
 	}
 
-	loadSection((*i).fileOffset);
+	loadSection(i->fileOffset);
 
 	return getResource(rlbNum, suppressErrors);
 }
@@ -234,20 +234,20 @@ Common::SeekableReadStream *TLib::getResource(ResourceType resType, uint16 resNu
 uint32 TLib::getResourceStart(ResourceType resType, uint16 resNum, uint16 rlbNum, ResourceEntry &entry) {
 	// Find the correct section
 	SectionList::iterator i = _sections.begin();
-	while ((i != _sections.end()) && ((*i).resType != resType || (*i).resNum != resNum))
+	while ((i != _sections.end()) && (i->resType != resType || i->resNum != resNum))
 		++i;
 	if (i == _sections.end()) {
 		error("Unknown resource type %d num %d", resType, resNum);
 	}
 
 	// Load in the section index
-	loadSection((*i).fileOffset);
+	loadSection(i->fileOffset);
 
 	// Scan for an entry for the given Id
 	ResourceEntry *re = nullptr;
 	ResourceList::iterator iter;
 	for (iter = _resources.begin(); iter != _resources.end(); ++iter) {
-		if ((*iter).id == rlbNum) {
+		if (iter->id == rlbNum) {
 			re = &(*iter);
 			break;
 		}

--- a/engines/stark/gfx/tinygl.cpp
+++ b/engines/stark/gfx/tinygl.cpp
@@ -95,8 +95,8 @@ void TinyGLDriver::flipBuffer() {
 
 	if (!dirtyAreas.empty()) {
 		for (Common::List<Common::Rect>::iterator itRect = dirtyAreas.begin(); itRect != dirtyAreas.end(); ++itRect) {
-			g_system->copyRectToScreen(glBuffer.getBasePtr((*itRect).left, (*itRect).top), glBuffer.pitch,
-			                           (*itRect).left, (*itRect).top, (*itRect).width(), (*itRect).height());
+			g_system->copyRectToScreen(glBuffer.getBasePtr(itRect->left, itRect->top), glBuffer.pitch,
+			                           itRect->left, itRect->top, itRect->width(), itRect->height());
 		}
 	}
 

--- a/engines/sword25/gfx/animationresource.cpp
+++ b/engines/sword25/gfx/animationresource.cpp
@@ -211,7 +211,7 @@ bool AnimationResource::precacheAllFrames() const {
 			return false;
 		}
 #else
-		Resource *pResource = Kernel::getInstance()->getResourceManager()->requestResource((*iter).fileName);
+		Resource *pResource = Kernel::getInstance()->getResourceManager()->requestResource(iter->fileName);
 		pResource->release(); //unlock precached resource
 #endif
 	}
@@ -231,8 +231,8 @@ bool AnimationResource::computeFeatures() {
 	Common::Array<Frame>::const_iterator iter = _frames.begin();
 	for (; iter != _frames.end(); ++iter) {
 		BitmapResource *pBitmap;
-		if (!(pBitmap = static_cast<BitmapResource *>(Kernel::getInstance()->getResourceManager()->requestResource((*iter).fileName)))) {
-			error("Could not request \"%s\".", (*iter).fileName.c_str());
+		if (!(pBitmap = static_cast<BitmapResource *>(Kernel::getInstance()->getResourceManager()->requestResource(iter->fileName)))) {
+			error("Could not request \"%s\".", iter->fileName.c_str());
 			return false;
 		}
 

--- a/engines/sword25/gfx/image/vectorimagerenderer.cpp
+++ b/engines/sword25/gfx/image/vectorimagerenderer.cpp
@@ -443,8 +443,8 @@ void VectorImage::render(int width, int height) {
 			}
 
 			// Close vectors
-			(*fill0pos).code = ART_END;
-			(*fill1pos).code = ART_END;
+			fill0pos->code = ART_END;
+			fill1pos->code = ART_END;
 
 			drawBez(fill1, fill0, _pixelData, width, height, _boundingBox.left, _boundingBox.top, scaleX, scaleY, -1, _elements[e].getFillStyleColor(s));
 

--- a/engines/sword25/gfx/renderobjectmanager.cpp
+++ b/engines/sword25/gfx/renderobjectmanager.cpp
@@ -50,9 +50,9 @@ void RenderObjectQueue::add(RenderObject *renderObject) {
 
 bool RenderObjectQueue::exists(const RenderObjectQueueItem &renderObjectQueueItem) {
 	for (RenderObjectQueue::iterator it = begin(); it != end(); ++it)
-		if ((*it)._renderObject == renderObjectQueueItem._renderObject &&
-			(*it)._version == renderObjectQueueItem._version &&
-			(*it)._bbox == renderObjectQueueItem._bbox)
+		if (it->_renderObject == renderObjectQueueItem._renderObject &&
+			it->_version == renderObjectQueueItem._version &&
+			it->_bbox == renderObjectQueueItem._bbox)
 			return true;
 	return false;
 }
@@ -105,13 +105,13 @@ bool RenderObjectManager::render() {
 	// Add rectangles of objects which don't exist in this frame any more
 	for (RenderObjectQueue::iterator it = _prevQueue->begin(); it != _prevQueue->end(); ++it) {
 		if (!_currQueue->exists(*it))
-			_uta->addRect((*it)._bbox);
+			_uta->addRect(it->_bbox);
 	}
 
 	// Add rectangles of objects which are different from the previous frame
 	for (RenderObjectQueue::iterator it = _currQueue->begin(); it != _currQueue->end(); ++it) {
 		if (!_prevQueue->exists(*it))
-			_uta->addRect((*it)._bbox);
+			_uta->addRect(it->_bbox);
 	}
 
 	RectangleList *updateRects = _uta->getRectangles();
@@ -125,9 +125,9 @@ bool RenderObjectManager::render() {
 	for (RectangleList::iterator rectIt = updateRects->begin(); rectIt != updateRects->end(); ++rectIt) {
 		int minZ = 0;
 		for (RenderObjectQueue::iterator it = _currQueue->reverse_begin(); it != _currQueue->end(); --it) {
-			if ((*it)._renderObject->isVisible() && (*it)._renderObject->isSolid() &&
-				(*it)._renderObject->getBbox().contains(*rectIt)) {
-				minZ = (*it)._renderObject->getAbsoluteZ();
+			if (it->_renderObject->isVisible() && it->_renderObject->isSolid() &&
+				it->_renderObject->getBbox().contains(*rectIt)) {
+				minZ = it->_renderObject->getAbsoluteZ();
 				break;
 			}
 		}
@@ -138,10 +138,10 @@ bool RenderObjectManager::render() {
 		// Copy updated rectangles to the video screen
 		Graphics::ManagedSurface *backSurface = Kernel::getInstance()->getGfx()->getSurface();
 		for (RectangleList::iterator rectIt = updateRects->begin(); rectIt != updateRects->end(); ++rectIt) {
-			const int x = (*rectIt).left;
-			const int y = (*rectIt).top;
-			const int width = (*rectIt).width();
-			const int height = (*rectIt).height();
+			const int x = rectIt->left;
+			const int y = rectIt->top;
+			const int width = rectIt->width();
+			const int height = rectIt->height();
 			g_system->copyRectToScreen(backSurface->getBasePtr(x, y), backSurface->pitch, x, y, width, height);
 		}
 	}

--- a/engines/sword25/gfx/text.cpp
+++ b/engines/sword25/gfx/text.cpp
@@ -159,14 +159,14 @@ bool Text::doRender(RectangleList *updateRects) {
 	Common::Array<Line>::iterator iter = _lines.begin();
 	for (; iter != _lines.end(); ++iter) {
 		// Determine whether any letters of the current line are affected by the update.
-		Common::Rect checkRect = (*iter).bbox;
+		Common::Rect checkRect = iter->bbox;
 		checkRect.translate(_absoluteX, _absoluteY);
 
 		// Render each letter individually.
-		int curX = _absoluteX + (*iter).bbox.left;
-		int curY = _absoluteY + (*iter).bbox.top;
-		for (uint i = 0; i < (*iter).text.size(); ++i) {
-			Common::Rect curRect = fontPtr->getCharacterRect((byte)(*iter).text[i]);
+		int curX = _absoluteX + iter->bbox.left;
+		int curY = _absoluteY + iter->bbox.top;
+		for (uint i = 0; i < iter->text.size(); ++i) {
+			Common::Rect curRect = fontPtr->getCharacterRect((byte)iter->text[i]);
 
 			Common::Rect renderRect(curX, curY, curX + curRect.width(), curY + curRect.height());
 			renderRect.translate(curRect.left - curX, curRect.top - curY);
@@ -284,7 +284,7 @@ void Text::updateFormat() {
 		_height = 0;
 		Common::Array<Line>::iterator iter = _lines.begin();
 		for (; iter != _lines.end(); ++iter) {
-			Common::Rect &bbox = (*iter).bbox;
+			Common::Rect &bbox = iter->bbox;
 			bbox.left = (_width - bbox.right) / 2;
 			bbox.right = bbox.left + bbox.right;
 			bbox.top = (iter - _lines.begin()) * fontPtr->getLineHeight();

--- a/engines/sword25/math/region.cpp
+++ b/engines/sword25/math/region.cpp
@@ -287,9 +287,9 @@ bool Region::isLineOfSight(const Vertex &a, const Vertex &b) const {
 
 	// The line must be within the contour polygon, and outside of any hole polygons
 	Common::Array<Polygon>::const_iterator iter = _polygons.begin();
-	if (!(*iter).isLineInterior(a, b)) return false;
+	if (!iter->isLineInterior(a, b)) return false;
 	for (iter++; iter != _polygons.end(); iter++)
-		if (!(*iter).isLineExterior(a, b)) return false;
+		if (!iter->isLineExterior(a, b)) return false;
 
 	return true;
 }

--- a/engines/sword25/math/walkregion.cpp
+++ b/engines/sword25/math/walkregion.cpp
@@ -104,8 +104,8 @@ static void initDijkstraNodes(DijkstraNode::Container &dijkstraNodes, const Regi
 	DijkstraNode::Iter dijkstraIter = dijkstraNodes.begin();
 	for (Common::Array<Vertex>::const_iterator nodesIter = nodes.begin();
 	        nodesIter != nodes.end(); nodesIter++, dijkstraIter++) {
-		(*dijkstraIter).parentIter = dijkstraNodes.end();
-		if (region.isLineOfSight(*nodesIter, start))(*dijkstraIter).cost = (*nodesIter).distance(start);
+		dijkstraIter->parentIter = dijkstraNodes.end();
+		if (region.isLineOfSight(*nodesIter, start))dijkstraIter->cost = nodesIter->distance(start);
 	}
 	assert(dijkstraIter == dijkstraNodes.end());
 }
@@ -115,8 +115,8 @@ static DijkstraNode::Iter chooseClosestNode(DijkstraNode::Container &nodes) {
 	int minCost = Infinity;
 
 	for (DijkstraNode::Iter iter = nodes.begin(); iter != nodes.end(); iter++) {
-		if (!(*iter).chosen && (*iter).cost < minCost) {
-			minCost = (*iter).cost;
+		if (!iter->chosen && iter->cost < minCost) {
+			minCost = iter->cost;
 			closestNodeInter = iter;
 		}
 	}
@@ -135,7 +135,7 @@ static void relaxNodes(DijkstraNode::Container &nodes,
 	for (uint i = 0; i < nodes.size(); i++) {
 		int cost = visibilityMatrix[curNodeIndex][i];
 		if (!nodes[i].chosen && cost != Infinity) {
-			int totalCost = (*curNodeIter).cost + cost;
+			int totalCost = curNodeIter->cost + cost;
 			if (totalCost < nodes[i].cost) {
 				nodes[i].parentIter = curNodeIter;
 				nodes[i].cost = totalCost;
@@ -150,7 +150,7 @@ static void relaxEndPoint(const Vertex &curNodePos,
 						  DijkstraNode &endPoint,
 						  const Region &region) {
 	if (region.isLineOfSight(curNodePos, endPointPos)) {
-		int totalCost = (*curNodeIter).cost + curNodePos.distance(endPointPos);
+		int totalCost = curNodeIter->cost + curNodePos.distance(endPointPos);
 		if (totalCost < endPoint.cost) {
 			endPoint.parentIter = curNodeIter;
 			endPoint.cost = totalCost;
@@ -192,17 +192,17 @@ bool WalkRegion::findPath(const Vertex &start, const Vertex &end, BS_Path &path)
 			return false;
 
 		// If the destination point is closer than the point cost, scan can stop
-		(*nodeInter).chosen = true;
-		if (endPoint.cost <= (*nodeInter).cost) {
+		nodeInter->chosen = true;
+		if (endPoint.cost <= nodeInter->cost) {
 			// Insert the end point in the list
 			path.push_back(end);
 
 			// The list is done in reverse order and inserted into the path
 			DijkstraNode::ConstIter curNode = endPoint.parentIter;
 			while (curNode != dijkstraNodes.end()) {
-				assert((*curNode).chosen);
+				assert(curNode->chosen);
 				path.push_back(_nodes[curNode - dijkstraNodes.begin()]);
-				curNode = (*curNode).parentIter;
+				curNode = curNode->parentIter;
 			}
 
 			// The starting point is inserted into the path

--- a/engines/tetraedge/te/te_renderer_tinygl.cpp
+++ b/engines/tetraedge/te/te_renderer_tinygl.cpp
@@ -407,8 +407,8 @@ void TeRendererTinyGL::updateScreen() {
 
       if (!dirtyAreas.empty()) {
           for (Common::List<Common::Rect>::iterator itRect = dirtyAreas.begin(); itRect != dirtyAreas.end(); ++itRect) {
-              g_system->copyRectToScreen(glBuffer.getBasePtr((*itRect).left, (*itRect).top), glBuffer.pitch,
-                                         (*itRect).left, (*itRect).top, (*itRect).width(), (*itRect).height());
+              g_system->copyRectToScreen(glBuffer.getBasePtr(itRect->left, itRect->top), glBuffer.pitch,
+                                         itRect->left, itRect->top, itRect->width(), itRect->height());
           }
       }
 

--- a/engines/titanic/sound/qmixer.cpp
+++ b/engines/titanic/sound/qmixer.cpp
@@ -73,7 +73,7 @@ void QMixer::qsWaveMixFlushChannel(int iChannel, uint flags) {
 		Common::List<SoundEntry>::iterator i;
 		Common::List<SoundEntry> &sounds = _channels[iChannel]._sounds;
 		for (i = sounds.begin(); i != sounds.end(); ++i)
-			_mixer->stopHandle((*i)._soundHandle);
+			_mixer->stopHandle(i->_soundHandle);
 
 		sounds.clear();
 	}

--- a/engines/toltecs/menu.cpp
+++ b/engines/toltecs/menu.cpp
@@ -217,15 +217,15 @@ void MenuSystem::handleKeyDown(const Common::KeyState& kbd) {
 
 ItemID MenuSystem::findItemAt(int x, int y) {
 	for (Common::Array<Item>::iterator iter = _items.begin(); iter != _items.end(); ++iter) {
-		if ((*iter).enabled && (*iter).rect.contains(x, y - _top))
-			return (*iter).id;
+		if (iter->enabled && iter->rect.contains(x, y - _top))
+			return iter->id;
 	}
 	return kItemIdNone;
 }
 
 MenuSystem::Item *MenuSystem::getItem(ItemID id) {
 	for (Common::Array<Item>::iterator iter = _items.begin(); iter != _items.end(); ++iter) {
-		if ((*iter).id == id)
+		if (iter->id == id)
 			return &(*iter);
 	}
 	return NULL;
@@ -353,8 +353,8 @@ void MenuSystem::initMenu(MenuID menuID) {
 	}
 
 	for (Common::Array<Item>::iterator iter = _items.begin(); iter != _items.end(); ++iter) {
-		if ((*iter).enabled)
-			drawItem((*iter).id, false);
+		if (iter->enabled)
+			drawItem(iter->id, false);
 	}
 
 	// Check if the mouse is already over an item

--- a/engines/toltecs/render.cpp
+++ b/engines/toltecs/render.cpp
@@ -62,7 +62,7 @@ void RenderQueue::addSprite(SpriteDrawItem &sprite) {
 
 	// Add sprite sorted by priority
 	RenderQueueArray::iterator iter = _currQueue->begin();
-	while (iter != _currQueue->end() && (*iter).priority <= item.priority) {
+	while (iter != _currQueue->end() && iter->priority <= item.priority) {
 		++iter;
 	}
 	_currQueue->insert(iter, item);
@@ -101,7 +101,7 @@ void RenderQueue::addMask(SegmapMaskRect &mask) {
 	// Only add the mask if a sprite intersects its rect
 	if (rectIntersectsItem(item.rect)) {
 		RenderQueueArray::iterator iter = _currQueue->begin();
-		while (iter != _currQueue->end() && (*iter).priority <= item.priority) {
+		while (iter != _currQueue->end() && iter->priority <= item.priority) {
 			++iter;
 		}
 		_currQueue->insert(iter, item);

--- a/engines/toltecs/resource.cpp
+++ b/engines/toltecs/resource.cpp
@@ -102,7 +102,7 @@ Resource *ResourceCache::load(uint resIndex) {
 	ResourceMap::iterator item = _cache.find(resIndex);
 	if (item != _cache.end()) {
 		debug(1, "ResourceCache::load(%d) From cache", resIndex);
-		return (*item)._value;
+		return item->_value;
 	} else {
 		debug(1, "ResourceCache::load(%d) From disk", resIndex);
 

--- a/engines/tony/gfxcore.cpp
+++ b/engines/tony/gfxcore.cpp
@@ -398,11 +398,11 @@ void RMGfxTargetBuffer::mergeDirtyRects() {
 		rInner = rOuter;
 		while (++rInner != _dirtyRects.end()) {
 
-			if ((*rOuter).intersects(*rInner)) {
+			if (rOuter->intersects(*rInner)) {
 				// these two rectangles overlap or
 				// are next to each other - merge them
 
-				(*rOuter).extend(*rInner);
+				rOuter->extend(*rInner);
 
 				// remove the inner rect from the list
 				_dirtyRects.erase(rInner);

--- a/engines/tsage/core.cpp
+++ b/engines/tsage/core.cpp
@@ -3933,8 +3933,8 @@ void SceneRegions::load(int sceneNum) {
 
 int SceneRegions::indexOf(const Common::Point &pt) {
 	for (SceneRegions::iterator i = begin(); i != end(); ++i) {
-		if ((*i).contains(pt))
-			return (*i)._regionId;
+		if (i->contains(pt))
+			return i->_regionId;
 	}
 
 	return 0;

--- a/engines/tsage/debugger.cpp
+++ b/engines/tsage/debugger.cpp
@@ -299,7 +299,7 @@ bool Debugger::Cmd_Hotspots(int argc, const char **argv) {
 		} else {
 			// Scene uses a region, so get it and use it to fill out only the correct parts
 			SceneRegions::iterator ri = g_globals->_sceneRegions.begin();
-			while ((ri != g_globals->_sceneRegions.end()) && ((*ri)._regionId != o->_sceneRegionId))
+			while ((ri != g_globals->_sceneRegions.end()) && (ri->_regionId != o->_sceneRegionId))
 				++ri;
 
 			if (ri != g_globals->_sceneRegions.end()) {

--- a/engines/tsage/resources.cpp
+++ b/engines/tsage/resources.cpp
@@ -236,7 +236,7 @@ byte *TLib::getResource(uint16 id, bool suppressErrors) {
 	ResourceEntry *re = NULL;
 	ResourceList::iterator iter;
 	for (iter = _resources.begin(); iter != _resources.end(); ++iter) {
-		if ((*iter).id == id) {
+		if (iter->id == id) {
 			re = &(*iter);
 			break;
 		}
@@ -353,7 +353,7 @@ byte *TLib::getResource(uint16 id, bool suppressErrors) {
  */
 byte *TLib::getResource(ResourceType resType, uint16 resNum, uint16 rlbNum, bool suppressErrors) {
 	SectionList::iterator i = _sections.begin();
-	while ((i != _sections.end()) && ((*i).resType != resType || (*i).resNum != resNum))
+	while ((i != _sections.end()) && (i->resType != resType || i->resNum != resNum))
 		++i;
 	if (i == _sections.end()) {
 		if (suppressErrors)
@@ -361,7 +361,7 @@ byte *TLib::getResource(ResourceType resType, uint16 resNum, uint16 rlbNum, bool
 		error("Unknown resource type %d num %d", resType, resNum);
 	}
 
-	loadSection((*i).fileOffset);
+	loadSection(i->fileOffset);
 
 	return getResource(rlbNum, suppressErrors);
 }
@@ -372,20 +372,20 @@ byte *TLib::getResource(ResourceType resType, uint16 resNum, uint16 rlbNum, bool
 uint32 TLib::getResourceStart(ResourceType resType, uint16 resNum, uint16 rlbNum, ResourceEntry &entry) {
 	// Find the correct section
 	SectionList::iterator i = _sections.begin();
-	while ((i != _sections.end()) && ((*i).resType != resType || (*i).resNum != resNum))
+	while ((i != _sections.end()) && (i->resType != resType || i->resNum != resNum))
 		++i;
 	if (i == _sections.end()) {
 		error("Unknown resource type %d num %d", resType, resNum);
 	}
 
 	// Load in the section index
-	loadSection((*i).fileOffset);
+	loadSection(i->fileOffset);
 
 	// Scan for an entry for the given Id
 	ResourceEntry *re = NULL;
 	ResourceList::iterator iter;
 	for (iter = _resources.begin(); iter != _resources.end(); ++iter) {
-		if ((*iter).id == rlbNum) {
+		if (iter->id == rlbNum) {
 			re = &(*iter);
 			break;
 		}

--- a/engines/twp/clipper/clipper.cpp
+++ b/engines/twp/clipper/clipper.cpp
@@ -1199,7 +1199,7 @@ void ClipperBase::DisposeLocalMinimaList() {
 //------------------------------------------------------------------------------
 
 bool ClipperBase::PopLocalMinima(cInt Y, const LocalMinimum *&locMin) {
-	if (m_CurrentLM == m_MinimaList.end() || (*m_CurrentLM).Y != Y)
+	if (m_CurrentLM == m_MinimaList.end() || m_CurrentLM->Y != Y)
 		return false;
 	locMin = &(*m_CurrentLM);
 	++m_CurrentLM;

--- a/engines/ultima/nuvie/conf/configuration.cpp
+++ b/engines/ultima/nuvie/conf/configuration.cpp
@@ -301,7 +301,7 @@ void Configuration::load(GameId gameId, bool isEnhanced) {
 	const Common::ConfigManager::Domain &domain = *ConfMan.getActiveDomain();
 	Common::ConfigManager::Domain::const_iterator it;
 	for (it = domain.begin(); it != domain.end(); ++it) {
-		_settings[(*it)._key] = (*it)._value;
+		_settings[it->_key] = it->_value;
 	}
 }
 

--- a/engines/ultima/nuvie/core/effect_manager.cpp
+++ b/engines/ultima/nuvie/core/effect_manager.cpp
@@ -100,8 +100,8 @@ void EffectManager::unwatch_effect(CallBack *callback_target, Effect *watch) {
 	if (!watched.empty()) {
 		WatchIterator i = watched.begin();
 		while (i != watched.end())
-			if ((*i).watcher == callback_target
-			        && ((*i).effect == watch || watch == nullptr)) {
+			if (i->watcher == callback_target
+			        && (i->effect == watch || watch == nullptr)) {
 				i = watched.erase(i); // resume from next element
 			} else ++i;
 	}
@@ -124,7 +124,7 @@ EffectManager::EffectWatch *EffectManager::find_effect_watch(Effect *effect) {
 	if (!watched.empty()) {
 		WatchIterator i = watched.begin();
 		while (i != watched.end())
-			if ((*i).effect == effect)
+			if (i->effect == effect)
 				return (&(*i));
 			else ++i;
 	}

--- a/engines/ultima/nuvie/files/nuvie_file_list.cpp
+++ b/engines/ultima/nuvie/files/nuvie_file_list.cpp
@@ -80,7 +80,7 @@ const Common::String *NuvieFileList::get_latest() const {
 	iter = file_list.begin();
 
 	if (iter != file_list.end()) {
-		return &((*iter).filename);
+		return &(iter->filename);
 	}
 
 	return nullptr;

--- a/engines/ultima/nuvie/gui/widgets/converse_gump.cpp
+++ b/engines/ultima/nuvie/gui/widgets/converse_gump.cpp
@@ -479,7 +479,7 @@ Common::String ConverseGump::get_token_at_cursor() {
 	Common::List<MsgText>::iterator iter;
 	for (iter = keyword_list->begin(); iter != keyword_list->end(); i++, iter++) {
 		if (i == cursor_position) {
-			Common::String keyword = (*iter).s;
+			Common::String keyword = iter->s;
 			if (!is_permanent_keyword(keyword)) {
 				keyword_list->erase(iter);
 				if (permit_input)

--- a/engines/ultima/nuvie/keybinding/keys.cpp
+++ b/engines/ultima/nuvie/keybinding/keys.cpp
@@ -393,7 +393,7 @@ ActionType KeyBinder::get_ActionType(const Common::KeyState &key) {
 		ActionType actionType = {&doNothingAction, 0};
 		return actionType;
 	}
-	return (*sdlkey_index)._value;
+	return sdlkey_index->_value;
 }
 
 ActionKeyType KeyBinder::GetActionKeyType(ActionType a) {
@@ -426,7 +426,7 @@ bool KeyBinder::HandleEvent(const Common::Event *ev) {
 	key.flags &= ~Common::KBD_STICKY;
 	KeyMap::iterator sdlkey_index = get_sdlkey_index(key);
 	if (sdlkey_index != _bindings.end())
-		return DoAction((*sdlkey_index)._value);
+		return DoAction(sdlkey_index->_value);
 	// Avoid modifier keys being detected as invalid input
 	if (ev->kbd.keycode != Common::KEYCODE_LALT && ev->kbd.keycode != Common::KEYCODE_RALT
 	        && ev->kbd.keycode != Common::KEYCODE_LCTRL && ev->kbd.keycode != Common::KEYCODE_RCTRL
@@ -599,7 +599,7 @@ void KeyBinder::ParseLine(const char *line) {
 				ParseKeyMap::iterator key_index;
 				key_index = _keys.find(t);
 				if (key_index != _keys.end()) {
-					k.keycode = (*key_index)._value;
+					k.keycode = key_index->_value;
 				} else {
 					::error("Keybinder: unsupported key: %s", keycode.c_str());
 				}

--- a/engines/ultima/nuvie/sound/custom_sfx_manager.cpp
+++ b/engines/ultima/nuvie/sound/custom_sfx_manager.cpp
@@ -85,7 +85,7 @@ bool CustomSfxManager::playSfxLooping(SfxIdType sfx_id, Audio::SoundHandle *hand
 
 	it = sfx_map.find((uint16)sfx_id);
 	if (it != sfx_map.end()) {
-		playSoundSample((*it)._value, handle, volume);
+		playSoundSample(it->_value, handle, volume);
 		return true;
 	}
 

--- a/engines/ultima/nuvie/sound/sound_manager.cpp
+++ b/engines/ultima/nuvie/sound/sound_manager.cpp
@@ -369,7 +369,7 @@ bool SoundManager::groupAddSong(const char *group, Song *song) {
 			psc->m_Sounds.push_back(song);	// add this sound to the collection
 			m_MusicMap[group] = psc;		// insert this pair into the map
 		} else {
-			psc = (*it)._value;				// yes, get the existing
+			psc = it->_value;				// yes, get the existing
 			psc->m_Sounds.push_back(song);	// add this sound to the collection
 		}
 	}
@@ -630,7 +630,7 @@ void SoundManager::musicStop() {
 
 Common::List < SoundManagerSfx >::iterator SoundManagerSfx_find(Common::List < SoundManagerSfx >::iterator first, Common::List < SoundManagerSfx >::iterator last, const SfxIdType &value) {
 	for (; first != last; first++) {
-		if ((*first).sfx_id == value)
+		if (first->sfx_id == value)
 			break;
 	}
 	return first;
@@ -785,7 +785,7 @@ Sound *SoundManager::RequestTileSound(int id) {
 	it = m_TileSampleMap.find(id);
 	if (it != m_TileSampleMap.end()) {
 		SoundCollection *psc;
-		psc = (*it)._value;
+		psc = it->_value;
 		return psc->Select();
 	}
 	return nullptr;
@@ -796,7 +796,7 @@ Sound *SoundManager::RequestObjectSound(int id) {
 	it = m_ObjectSampleMap.find(id);
 	if (it != m_ObjectSampleMap.end()) {
 		SoundCollection *psc;
-		psc = (*it)._value;
+		psc = it->_value;
 		return psc->Select();
 	}
 	return nullptr;
@@ -818,7 +818,7 @@ Sound *SoundManager::RequestSong(const Common::String &group) {
 	it = m_MusicMap.find(group);
 	if (it != m_MusicMap.end()) {
 		SoundCollection *psc;
-		psc = (*it)._value;
+		psc = it->_value;
 		return psc->Select();
 	}
 	return nullptr;

--- a/engines/ultima/shared/conf/xml_node.cpp
+++ b/engines/ultima/shared/conf/xml_node.cpp
@@ -146,7 +146,7 @@ void XMLNode::xmlAssign(const Common::String &key, const Common::String &value) 
 	t->_parent = this;
 	t->_id = k2;
 	_nodeList.push_back(t);
-	(*t).xmlAssign(k, value);
+	t->xmlAssign(k, value);
 }
 
 

--- a/engines/voyeur/screen.cpp
+++ b/engines/voyeur/screen.cpp
@@ -234,7 +234,7 @@ void Screen::sDrawPic(DisplayResource *srcDisplay, DisplayResource *destDisplay,
 				r.setWidth(width2);
 				r.setHeight(height1);
 
-				(*destViewPort->_rectListPtr[destViewPort->_pageIndex]).push_back(r);
+				destViewPort->_rectListPtr[destViewPort->_pageIndex]->push_back(r);
 				++destViewPort->_rectListCount[destViewPort->_pageIndex];
 			}
 		} else {

--- a/engines/wintermute/base/gfx/tinygl/base_render_tinygl.cpp
+++ b/engines/wintermute/base/gfx/tinygl/base_render_tinygl.cpp
@@ -156,7 +156,7 @@ bool BaseRenderTinyGL::flip() {
 
 	if (!dirtyAreas.empty()) {
 		for (Common::List<Common::Rect>::iterator itRect = dirtyAreas.begin(); itRect != dirtyAreas.end(); ++itRect) {
-			g_system->copyRectToScreen(glBuffer.getBasePtr((*itRect).left, (*itRect).top), glBuffer.pitch, (*itRect).left, (*itRect).top, (*itRect).width(), (*itRect).height());
+			g_system->copyRectToScreen(glBuffer.getBasePtr(itRect->left, itRect->top), glBuffer.pitch, itRect->left, itRect->top, itRect->width(), itRect->height());
 		}
 	}
 

--- a/engines/wintermute/base/gfx/xmath.h
+++ b/engines/wintermute/base/gfx/xmath.h
@@ -203,22 +203,22 @@ DXMatrix *DXMatrixShadow(DXMatrix *pout, const DXVector4 *plight, const DXPlane 
 DXVector2 *DXVec2TransformCoord(DXVector2 *pout, const DXVector2 *pv, const DXMatrix *pm);
 
 static inline DXMatrix *DXMatrixIdentity(DXMatrix *pout) {
-	(*pout)._m[0][1] = 0.0f;
-	(*pout)._m[0][2] = 0.0f;
-	(*pout)._m[0][3] = 0.0f;
-	(*pout)._m[1][0] = 0.0f;
-	(*pout)._m[1][2] = 0.0f;
-	(*pout)._m[1][3] = 0.0f;
-	(*pout)._m[2][0] = 0.0f;
-	(*pout)._m[2][1] = 0.0f;
-	(*pout)._m[2][3] = 0.0f;
-	(*pout)._m[3][0] = 0.0f;
-	(*pout)._m[3][1] = 0.0f;
-	(*pout)._m[3][2] = 0.0f;
-	(*pout)._m[0][0] = 1.0f;
-	(*pout)._m[1][1] = 1.0f;
-	(*pout)._m[2][2] = 1.0f;
-	(*pout)._m[3][3] = 1.0f;
+	pout->_m[0][1] = 0.0f;
+	pout->_m[0][2] = 0.0f;
+	pout->_m[0][3] = 0.0f;
+	pout->_m[1][0] = 0.0f;
+	pout->_m[1][2] = 0.0f;
+	pout->_m[1][3] = 0.0f;
+	pout->_m[2][0] = 0.0f;
+	pout->_m[2][1] = 0.0f;
+	pout->_m[2][3] = 0.0f;
+	pout->_m[3][0] = 0.0f;
+	pout->_m[3][1] = 0.0f;
+	pout->_m[3][2] = 0.0f;
+	pout->_m[0][0] = 1.0f;
+	pout->_m[1][1] = 1.0f;
+	pout->_m[2][2] = 1.0f;
+	pout->_m[3][3] = 1.0f;
 	return pout;
 }
 

--- a/engines/wintermute/ext/plugin_event.h
+++ b/engines/wintermute/ext/plugin_event.h
@@ -52,7 +52,7 @@ public:
 
 	void subscribeEvent(PluginEventEntry &event) {
 		for (auto it = _entries.begin(); it != _entries.end(); ++it) {
-			if (event._type == (*it)._type && event._callback == (*it)._callback) {
+			if (event._type == it->_type && event._callback == it->_callback) {
 				break;
 			}
 		}
@@ -61,7 +61,7 @@ public:
 
 	void unsubscribeEvent(PluginEventEntry &event) {
 		for (auto it = _entries.begin(); it != _entries.end(); ++it) {
-			if (event._type == (*it)._type && event._callback == (*it)._callback) {
+			if (event._type == it->_type && event._callback == it->_callback) {
 				_entries.erase(it);
 				break;
 			}
@@ -70,8 +70,8 @@ public:
 
 	void applyEvent(EWmeEvent type, void *eventData) {
 		for (auto it = _entries.begin(); it != _entries.end(); ++it) {
-			if (type == (*it)._type && (*it)._callback != nullptr) {
-				(*it)._callback(eventData, (*it)._plugin);
+			if (type == it->_type && it->_callback != nullptr) {
+				it->_callback(eventData, it->_plugin);
 			}
 		}
 	}

--- a/engines/wintermute/system/sys_class_registry.cpp
+++ b/engines/wintermute/system/sys_class_registry.cpp
@@ -113,7 +113,7 @@ bool SystemClassRegistry::registerInstance(const char *className, void *instance
 		return false;
 	}
 
-	SystemInstance *inst = (*mapIt)._value->addInstance(instance, _count++);
+	SystemInstance *inst = mapIt->_value->addInstance(instance, _count++);
 	return (inst != nullptr);
 }
 
@@ -137,7 +137,7 @@ bool SystemClassRegistry::unregisterInstance(const char *className, void *instan
 	if (mapIt == _nameMap.end()) {
 		return false;
 	}
-	(*mapIt)._value->removeInstance(instance);
+	mapIt->_value->removeInstance(instance);
 
 	InstanceMap::iterator instIt = _instanceMap.find(instance);
 	if (instIt != _instanceMap.end()) {
@@ -161,7 +161,7 @@ bool SystemClassRegistry::getPointerID(void *pointer, int *classID, int *instanc
 	}
 
 
-	SystemInstance *inst = (*it)._value;
+	SystemInstance *inst = it->_value;
 	*instanceID = inst->getId();
 	*classID = inst->getClass()->getId();
 
@@ -174,7 +174,7 @@ void *SystemClassRegistry::idToPointer(int classID, int instanceID) {
 	if (it == _savedInstanceMap.end()) {
 		return nullptr;
 	} else {
-		return (*it)._value->getInstance();
+		return it->_value->getInstance();
 	}
 }
 
@@ -247,7 +247,7 @@ bool SystemClassRegistry::loadTable(BaseGame *game, BasePersistenceManager *pers
 
 		NameMap::iterator mapIt = _nameMap.find(className);
 		if (mapIt != _nameMap.end()) {
-			(*mapIt)._value->loadTable(game,  persistMgr);
+			mapIt->_value->loadTable(game,  persistMgr);
 		}
 	}
 
@@ -328,7 +328,7 @@ bool SystemClassRegistry::enumInstances(SYS_INSTANCE_CALLBACK lpCallback, const 
 		return STATUS_FAILED;
 	}
 
-	(*mapIt)._value->instanceCallback(lpCallback, lpData);
+	mapIt->_value->instanceCallback(lpCallback, lpData);
 	return STATUS_OK;
 }
 

--- a/engines/zvision/scripting/effects/animation_effect.cpp
+++ b/engines/zvision/scripting/effects/animation_effect.cpp
@@ -57,11 +57,11 @@ AnimationEffect::~AnimationEffect() {
 
 	PlayNodes::iterator it = _playList.begin();
 	if (it != _playList.end()) {
-		_engine->getScriptManager()->setStateValue((*it).slot, 2);
+		_engine->getScriptManager()->setStateValue(it->slot, 2);
 
-		if ((*it)._scaled) {
-			(*it)._scaled->free();
-			delete(*it)._scaled;
+		if (it->_scaled) {
+			it->_scaled->free();
+			delete it->_scaled;
 		}
 	}
 
@@ -197,10 +197,10 @@ void AnimationEffect::addPlayNode(int32 slot, int x, int y, int x2, int y2, int 
 bool AnimationEffect::stop() {
 	PlayNodes::iterator it = _playList.begin();
 	if (it != _playList.end()) {
-		_engine->getScriptManager()->setStateValue((*it).slot, 2);
-		if ((*it)._scaled) {
-			(*it)._scaled->free();
-			delete(*it)._scaled;
+		_engine->getScriptManager()->setStateValue(it->slot, 2);
+		if (it->_scaled) {
+			it->_scaled->free();
+			delete it->_scaled;
 		}
 	}
 

--- a/engines/zvision/scripting/script_manager.cpp
+++ b/engines/zvision/scripting/script_manager.cpp
@@ -869,7 +869,7 @@ void ScriptManager::addEvent(Common::Event event) {
 void ScriptManager::flushEvent(Common::EventType type) {
 	auto event = _controlEvents.begin();
 	while (event != _controlEvents.end()) {
-		if ((*event).type == type)
+		if (event->type == type)
 			event = _controlEvents.erase(event);
 		else
 			event++;

--- a/graphics/dirtyrects.cpp
+++ b/graphics/dirtyrects.cpp
@@ -31,7 +31,7 @@ void DirtyRectList::merge() {
 		rInner = rOuter;
 		while (++rInner != _dirtyRects.end()) {
 
-			if ((*rOuter).intersects(*rInner)) {
+			if (rOuter->intersects(*rInner)) {
 				// These two rectangles overlap, so merge them
 				unionRectangle(*rOuter, *rOuter, *rInner);
 

--- a/graphics/macgui/macwindow.cpp
+++ b/graphics/macgui/macwindow.cpp
@@ -696,7 +696,7 @@ void MacWindow::mergeDirtyRects() {
 		rInner = rOuter;
 		while (++rInner != _dirtyRects.end()) {
 
-			if ((*rOuter).intersects(*rInner)) {
+			if (rOuter->intersects(*rInner)) {
 				// These two rectangles overlap, so merge them
 				rOuter->extend(*rInner);
 

--- a/graphics/managed_surface.cpp
+++ b/graphics/managed_surface.cpp
@@ -41,7 +41,7 @@ ManagedSurface::ManagedSurface(const ManagedSurface &surf) :
 		w(_innerSurface.w), h(_innerSurface.h), pitch(_innerSurface.pitch), format(_innerSurface.format),
 		_disposeAfterUse(DisposeAfterUse::NO), _owner(nullptr),
 		_transparentColor(0), _transparentColorSet(false), _palette(nullptr) {
-	(*this).copyFrom(surf);
+	(this)->copyFrom(surf);
 }
 
 ManagedSurface::ManagedSurface(ManagedSurface &&surf) :

--- a/graphics/tinygl/zdirtyrect.cpp
+++ b/graphics/tinygl/zdirtyrect.cpp
@@ -171,8 +171,8 @@ void GLContext::presentBufferDirtyRects(Common::List<Common::Rect> &dirtyAreas) 
 		for (RectangleIterator it1 = rectangles.begin(); it1 != rectangles.end(); ++it1) {
 			for (RectangleIterator it2 = rectangles.begin(); it2 != rectangles.end();) {
 				if (it1 != it2) {
-					if ((*it1).rectangle.intersects((*it2).rectangle)) {
-						(*it1).rectangle.extend((*it2).rectangle);
+					if (it1->rectangle.intersects(it2->rectangle)) {
+						it1->rectangle.extend(it2->rectangle);
 						it2 = rectangles.erase(it2);
 						restartMerge = true;
 					} else {
@@ -189,7 +189,7 @@ void GLContext::presentBufferDirtyRects(Common::List<Common::Rect> &dirtyAreas) 
 		RectangleIterator it2 = it1;
 		it2++;
 		while (it2 != rectangles.end()) {
-			if ((*it1).rectangle.contains((*it2).rectangle)) {
+			if (it1->rectangle.contains(it2->rectangle)) {
 				it2 = rectangles.erase(it2);
 			} else {
 				++it2;

--- a/gui/debugger.cpp
+++ b/gui/debugger.cpp
@@ -642,7 +642,7 @@ bool Debugger::cmdOpenLog(int argc, const char **argv) {
 #ifndef DISABLE_MD5
 struct ArchiveMemberLess {
 	bool operator()(const Common::ArchiveMemberPtr &x, const Common::ArchiveMemberPtr &y) const {
-		return (*x).getName().compareToIgnoreCase((*y).getName()) < 0;
+		return x->getName().compareToIgnoreCase(y->getName()) < 0;
 	}
 };
 

--- a/gui/gui-manager.cpp
+++ b/gui/gui-manager.cpp
@@ -574,7 +574,7 @@ void GuiManager::addToTrash(GuiObject* object, Dialog *parent) {
 
 	for (auto it = _guiObjectTrash.begin(); it != _guiObjectTrash.end(); ++it) {
 		if (it->object == object) {
-			debug(6, "The object %p was already scheduled for deletion, skipping", (void *)(*it).object);
+			debug(6, "The object %p was already scheduled for deletion, skipping", (void *)it->object);
 			return;
 		}
 	}
@@ -1051,9 +1051,9 @@ Graphics::MacWindowManager *GuiManager::getWM() {
 void GuiManager::emptyTrash(Dialog *const activeDialog) {
 	Common::List<GuiObjectTrashItem>::iterator it = _guiObjectTrash.begin();
 	while (it != _guiObjectTrash.end()) {
-		if ((*it).parent == nullptr || (*it).parent == activeDialog) {
-			debug(7, "Delayed deletion of Gui Object %p", (void *)(*it).object);
-			delete (*it).object;
+		if (it->parent == nullptr || it->parent == activeDialog) {
+			debug(7, "Delayed deletion of Gui Object %p", (void *)it->object);
+			delete it->object;
 			it = _guiObjectTrash.erase(it);
 		} else
 			++it;


### PR DESCRIPTION
Replace the `(*x).y` pattern with `x->y` because the former is plain annoying to read.

Assisted-by: [Resharper] [clang-tidy]