### PR TITLE
CHAMBER: Fix format specifier warning in SCR_TRAP

### DIFF
--- a/engines/chamber/script.cpp
+++ b/engines/chamber/script.cpp
@@ -116,7 +116,7 @@ uint16 CMD_TRAP(void) {
 }
 
 uint16 SCR_TRAP(void) {
-	warning("SCR TRAP 0x%02X @ 0x%lX", *script_ptr, script_ptr - templ_data);
+	warning("SCR TRAP 0x%02X @ 0x%X", *script_ptr, (uint32)(script_ptr - templ_data));
 	promptWait();
 	for (;;) ;
 	return 0;


### PR DESCRIPTION
In `engines/chamber/script.cpp:119`, pointer subtraction `(script_ptr - temp_data)` yields `ptrdiff_t`.

On 64-bit Windows (MSYS UCRT64), this resolved to `long long int`, trigerring a `-Wformat` compiler warning against `%lX` (which expects a 32-bit `long unsigned int`).

Fix this by casting the offset difference to `(uint32)` and changing the format specifier to `%X`. 