### PR TITLE
FREESCAPE: Fix sign-comparision warnings in Dark Atari

### DIFF
--- a/engines/freescape/games/dark/atari.cpp
+++ b/engines/freescape/games/dark/atari.cpp
@@ -122,7 +122,7 @@ Common::SeekableReadStream *depackAtariExecutable(Common::SeekableReadStream *fi
 				}
 				count += kAtariPackLiteralBase[i];
 			}
-			if (count + 1 > dst || in.pos < count + 1)
+			if (count + 1u > dst || in.pos < count + 1u)
 				break;
 			for (uint16 i = 0; i <= count; i++)
 				out[--dst] = data[--in.pos];


### PR DESCRIPTION
In `engines/freescape/games/dark/atari.cpp:125`, adding a signed integer literal `1` to `uint16 count` promotes the integer to a signed int.
Comparing this against `uint32 dst` and `uint32 in.pos` gives two `-Wsign-compare` compiler warnings.

Fix this by appending the unsigned literal suffix `u` (in `count + 1u`), keeping the the arithematic expression unsigned to match both operands