### PR TITLE
DIRECTOR: Handle D6 bitmap cast members without updateFlags

### DIFF
--- a/engines/director/castmember/bitmap.cpp
+++ b/engines/director/castmember/bitmap.cpp
@@ -196,7 +196,8 @@ BitmapCastMember::BitmapCastMember(Cast *cast, uint16 castId, Common::SeekableRe
 		_regY = stream.readUint16();
 		_regX = stream.readUint16();
 
-		_updateFlags = stream.readByte();
+		if (stream.pos() < stream.size())
+			_updateFlags = stream.readByte();
 
 		// 22 bytes
 		// This is color image flag


### PR DESCRIPTION
Some Director 6 bitmap cast members in Gary Gadget: Building Cars omit the `updateFlags` byte. Reading it unconditionally caused "Read past dataStream" warnings for those members.

Only read `updateFlags` when data remains in the stream. The field is already initialized to zero, so members without it retain the default value.

Tested with Gary Gadget: Building Cars (`garygadget1`).