### PR TITLE
GRAPHICS: MACGUI: Retain resolved fallback font ID

### DIFF
--- a/graphics/macgui/mactext.cpp
+++ b/graphics/macgui/mactext.cpp
@@ -52,7 +52,8 @@ const Font *MacFontRun::getFont() {
 
 	MacFont macFont = MacFont(fontId, fontSize, textSlant);
 
-	font = wm->_fontMan->getFont(macFont);
+	font = wm->_fontMan->getFont(&macFont);
+	fontId = macFont.getId();
 
 	return font;
 }


### PR DESCRIPTION
Pass the MacFont by pointer so fallback substitutions made by MacFontManager remain visible to the caller. Store the resulting ID in MacFontRun so subsequent text conversion uses the encoding of the font actually being drawn.

This solves a bug where text was converted using the requested font’s encoding but drawn using a fallback font with a different encoding, causing some characters to render incorrectly.