### PR TITLE
GRAPHICS: MACGUI: Remove ineffective font fallback

### DIFF
--- a/graphics/macgui/macfontmanager.cpp
+++ b/graphics/macgui/macfontmanager.cpp
@@ -558,12 +558,6 @@ const Font *MacFontManager::getFont(MacFont *macFont) {
 		font = FontMan.getFontByName(macFont->getName());
 	}
 
-	if (!font) {
-		debugC(1, kDebugLevelMacGUI, "Cannot load font '%s'", macFont->getName().c_str());
-
-		font = FontMan.getFontByName(MacFont(kMacFontSystem, 12).getName());
-	}
-
 #ifdef USE_FREETYPE2
 	if (!font && !(_mode & MacGUIConstants::kWMModeForceMacFonts)) {
 
@@ -600,6 +594,8 @@ const Font *MacFontManager::getFont(MacFont *macFont) {
 
 	// We found no font, so switching to a safe fallback
 	if (!font) {
+		debugC(1, kDebugLevelMacGUI, "Cannot load font '%s'", macFont->getName().c_str());
+
 		font = macFont->getFallback();
 
 		for (auto &it : _fontInfo) {


### PR DESCRIPTION
MacFont construction does not populate the font name, so looking up the name of a temporary System-12 font always searches for an empty string and fails.

Remove the ineffective lookup and report the missing font only after the TrueType lookup has also failed.