### PR TITLE
CHAMBER: take the Hercules blit path only when Hercules was requested

### DIFF
--- a/engines/chamber/cga.cpp
+++ b/engines/chamber/cga.cpp
@@ -172,7 +172,17 @@ void CGARenderer::blitToScreen(int16 dx, int16 dy, int16 w, int16 h) {
 	if (!mainSurface) {
 		mainSurface = new Graphics::Surface();
 	}
-	if (g_vm->_renderMode == Common::kRenderCGA) {
+	/* The block below this one renders into a 720x348 Hercules canvas and
+	 * blits it to the screen at a fixed +40/+74 offset, which is only valid
+	 * when init() took the isCustomHerc branch and called initGraphics(720,
+	 * 348). That branch is driven by _videoMode, but the test here used
+	 * _renderMode, so a user who has not explicitly selected a render mode
+	 * (_renderMode == kRenderDefault, while _videoMode is set to kRenderCGA
+	 * a few lines later in ChamberEngine::ChamberEngine) fell through to the
+	 * Hercules path against a 320x200 screen and tripped
+	 * Surface::copyRectToSurface's bounds assertion (74 + 200 > 200).
+	 * Select the Hercules path only when Hercules was actually requested. */
+	if (g_vm->_renderMode != Common::kRenderHercG && g_vm->_renderMode != Common::kRenderHercA) {
 		if (mainSurface->w != g_vm->_screenW) {
 			mainSurface->free();
 			mainSurface->create(g_vm->_screenW, g_vm->_screenH, Graphics::PixelFormat::createFormatCLUT8());


### PR DESCRIPTION
`CGARenderer::blitToScreen()` guards its 320x200 path with
`_renderMode == kRenderCGA` and otherwise falls through to a 720x348 Hercules
canvas blitted at a fixed +40/+74 offset. Those offsets are only valid when
`init()` called `initGraphics(720, 348)`, and that is decided by `_videoMode`
(`kult.cpp:273`), not `_renderMode`.

The two are set independently in the constructor (`chamber.cpp:72-82`): only
EGA/HercG/HercA copy `_renderMode` into `_videoMode`; everything else, including
`kRenderDefault`, falls through to `_videoMode = kRenderCGA`.

So with no render mode explicitly selected, `_videoMode` is CGA and the screen is
320x200, but `_renderMode` is `kRenderDefault`, the test fails, and the Hercules
path copies 200 rows to destY 74 -- tripping the bounds assertion in
`Surface::copyRectToSurface` (74 + 200 > 200). That is the default configuration,
on every platform.

Select the Hercules path only when Hercules was actually requested:

| `_renderMode` | before | after |
|---|---|---|
| CGA | 320x200 path | unchanged |
| HercG / HercA | Hercules path | unchanged |
| Default, EGA, ... | Hercules path -> assertion | 320x200 path |

Anyone who explicitly selects CGA or Hercules sees identical behaviour; only the
modes that previously asserted are affected.

This fixes the assertion only. The engine's hangs and EGA background corruption
are separate and unaddressed here.