### PR TITLE
DIRECTOR: XOBJ: Implement FileIO read/write mode

### DIFF
--- a/common/memstream.h
+++ b/common/memstream.h
@@ -278,6 +278,62 @@ public:
 };
 
 /**
+ * A dynamically growing memory stream with a shared read/write position.
+ */
+class MemorySeekableReadWriteStreamDynamic : public MemoryWriteStreamDynamic, public SeekableReadStream {
+public:
+	explicit MemorySeekableReadWriteStreamDynamic(DisposeAfterUse::Flag disposeMemory)
+		: MemoryWriteStreamDynamic(disposeMemory), _eos(false) {}
+
+	uint32 read(void *dataPtr, uint32 dataSize) override {
+		uint32 readSize = MIN<uint32>(dataSize, _size - _pos);
+		if (readSize)
+			memcpy(dataPtr, _data + _pos, readSize);
+		_pos += readSize;
+		_ptr = _data ? _data + _pos : nullptr;
+		_eos = readSize < dataSize;
+		return readSize;
+	}
+
+	uint32 write(const void *dataPtr, uint32 dataSize) override {
+		uint32 result = MemoryWriteStreamDynamic::write(dataPtr, dataSize);
+		_eos = false;
+		return result;
+	}
+
+	bool seek(int64 offset, int whence = SEEK_SET) override {
+		switch (whence) {
+		case SEEK_END:
+			offset += _size;
+			break;
+		case SEEK_CUR:
+			offset += _pos;
+			break;
+		case SEEK_SET:
+			break;
+		default:
+			return false;
+		}
+
+		if (offset < 0 || offset > _size)
+			return false;
+
+		_pos = offset;
+		_ptr = _data ? _data + _pos : nullptr;
+		_eos = false;
+		return true;
+	}
+
+	int64 pos() const override { return MemoryWriteStreamDynamic::pos(); }
+	int64 size() const override { return MemoryWriteStreamDynamic::size(); }
+	bool eos() const override { return _eos; }
+	void clearErr() override { _eos = false; }
+
+private:
+	bool _eos;
+};
+
+/**
 * MemoryStream based on RingBuffer. Grows if has insufficient buffer size.
 */
 class MemoryReadWriteStream : public SeekableReadStream, public SeekableWriteStream {

--- a/engines/director/lingo/xlibs/f/fileio.cpp
+++ b/engines/director/lingo/xlibs/f/fileio.cpp
@@ -210,6 +210,8 @@ FileObject::FileObject(ObjectType objType) : Object<FileObject>("FileIO") {
 	_filename = nullptr;
 	_inStream = nullptr;
 	_outStream = nullptr;
+	_readWriteStream = nullptr;
+	_readWriteChanged = false;
 	_lastError = kErrorNone;
 }
 
@@ -218,6 +220,8 @@ FileObject::FileObject(const FileObject &obj) : Object<FileObject>(obj) {
 	_filename = nullptr;
 	_inStream = nullptr;
 	_outStream = nullptr;
+	_readWriteStream = nullptr;
+	_readWriteChanged = false;
 	_lastError = kErrorNone;
 }
 
@@ -237,12 +241,9 @@ Datum FileObject::getProp(const Common::String &propName) {
 }
 
 FileIOError FileObject::open(const Common::String &origpath, const Common::String &mode) {
-	Common::SaveFileManager *saves = g_system->getSavefileManager();
 	Common::String path = origpath;
 	Common::String option = mode;
 	char dirSeparator = g_director->_dirSeparator;
-
-	Common::String prefix = savePrefix();
 
 	if (option.hasPrefix("?")) {
 		option = option.substr(1);
@@ -255,9 +256,33 @@ FileIOError FileObject::open(const Common::String &origpath, const Common::Strin
 		path += ".txt";
 	}
 
+	FileIOOpenMode openMode;
+	if (option.equalsIgnoreCase("read"))
+		openMode = kFileIORead;
+	else if (option.equalsIgnoreCase("write"))
+		openMode = kFileIOWrite;
+	else if (option.equalsIgnoreCase("append"))
+		openMode = kFileIOAppend;
+	else
+		error("Unsupported FileIO option: '%s'", option.c_str());
+
+	return open(origpath, path, openMode, dirSeparator);
+}
+
+FileIOError FileObject::open(const Common::String &origpath, FileIOOpenMode mode) {
+	Common::String path = origpath;
+	if (!path.hasSuffixIgnoreCase(".txt"))
+		path += ".txt";
+	return open(origpath, path, mode, g_director->_dirSeparator);
+}
+
+FileIOError FileObject::open(const Common::String &origpath, const Common::String &path, FileIOOpenMode mode, char dirSeparator) {
+	Common::SaveFileManager *saves = g_system->getSavefileManager();
+	Common::String prefix = savePrefix();
+
 	// We pretend that drive E:\ is a read-only CD-ROM
 	// It helps with CD checks in many games
-	if (option.equalsIgnoreCase("write") || option.equalsIgnoreCase("append")) {
+	if (mode != kFileIORead) {
 		if (origpath.hasPrefixIgnoreCase("E:\\"))
 			return kErrorIO;
 	}
@@ -274,7 +299,7 @@ FileIOError FileObject::open(const Common::String &origpath, const Common::Strin
 	if (!filename.hasPrefixIgnoreCase(prefix))
 		filename = prefix + filenameOrig;
 
-	if (option.equalsIgnoreCase("read")) {
+	if (mode == kFileIORead) {
 		_inStream = saves->openForLoading(filename);
 		if (!_inStream) {
 			// Maybe we're trying to read one of the game files
@@ -285,11 +310,11 @@ FileIOError FileObject::open(const Common::String &origpath, const Common::Strin
 			}
 			_inStream = file;
 		}
-	} else if (option.equalsIgnoreCase("write")) {
+	} else if (mode == kFileIOWrite) {
 		// OutSaveFile is not seekable so create a separate seekable stream
 		// which will be written to the save file upon disposal
 		_outStream = new Common::MemoryWriteStreamDynamic(DisposeAfterUse::YES);
-	} else if (option.equalsIgnoreCase("append")) {
+	} else if (mode == kFileIOAppend) {
 		Common::SeekableReadStream *inFile = saves->openForLoading(filename);
 		if (!inFile) {
 			// Create file if it doesn't exist.
@@ -305,8 +330,22 @@ FileIOError FileObject::open(const Common::String &origpath, const Common::Strin
 			}
 			delete inFile;
 		}
-	} else {
-		error("Unsupported FileIO option: '%s'", option.c_str());
+	} else if (mode == kFileIOReadWrite) {
+		Common::SeekableReadStream *inFile = saves->openForLoading(filename);
+		if (!inFile) {
+			Common::Path location = findPath(origpath);
+			inFile = Common::MacResManager::openFileOrDataFork(location);
+		}
+
+		_readWriteStream = new Common::MemorySeekableReadWriteStreamDynamic(DisposeAfterUse::YES);
+		if (inFile)
+			_readWriteStream->writeStream(inFile);
+		_readWriteStream->seek(0);
+		delete inFile;
+		// These are non-owning views of _readWriteStream used by the existing
+		// FileIO read and write methods.
+		_inStream = _readWriteStream;
+		_outStream = _readWriteStream;
 	}
 
 	_filename = new Common::String(filename);
@@ -319,7 +358,7 @@ void FileObject::clear() {
 		// after the first write. In order to be compatible with the POSIX expectation that
 		// opening a write handle destroys the file, we need to defer the actual save operation
 		// until after we know data has been written.
-		if (_outStream->size()) {
+		if (_outStream->size() && (!_readWriteStream || _readWriteChanged)) {
 			Common::SaveFileManager *saves = g_system->getSavefileManager();
 			Common::OutSaveFile *outFile = saves->openForSaving(*_filename, false);
 			outFile->write(_outStream->getData(), _outStream->size());
@@ -328,17 +367,19 @@ void FileObject::clear() {
 			((SavedArchive *)SearchMan.getArchive(kSavedFilesArchive))->_addFile(*_filename);
 			delete outFile;
 		}
+	}
+	if (_readWriteStream) {
+		delete _readWriteStream;
+	} else {
 		delete _outStream;
-		_outStream = nullptr;
-	}
-	if (_filename) {
-		delete _filename;
-		_filename = nullptr;
-	}
-	if (_inStream) {
 		delete _inStream;
-		_inStream = nullptr;
 	}
+	delete _filename;
+	_readWriteStream = nullptr;
+	_readWriteChanged = false;
+	_outStream = nullptr;
+	_inStream = nullptr;
+	_filename = nullptr;
 }
 
 void FileObject::dispose() {
@@ -393,24 +434,24 @@ void FileIO::m_openFile(int nargs) {
 	Datum d2 = g_lingo->pop();
 
 	int mode = d1.asInt();
-	Common::String option;
+	FileIOOpenMode openMode;
 	switch (mode) {
 	case 0:
-		option = "append";
+		openMode = kFileIOReadWrite;
 		break;
 	case 1:
-		option = "read";
+		openMode = kFileIORead;
 		break;
 	case 2:
-		option = "write";
+		openMode = kFileIOWrite;
 		break;
 	default:
 		warning("FIXME: Mode %d not supported, falling back to read", mode);
-		option = "read";
+		openMode = kFileIORead;
 		break;
 	}
 	Common::String path = d2.asString();
-	me->_lastError = me->open(path, option);
+	me->_lastError = me->open(path, openMode);
 }
 
 void FileIO::m_closeFile(int nargs) {
@@ -580,6 +621,8 @@ void FileIO::m_writeChar(int nargs) {
 	}
 
 	me->_outStream->writeByte(ch);
+	if (me->_readWriteStream)
+		me->_readWriteChanged = true;
 	g_lingo->push(Datum(kErrorNone));
 }
 
@@ -595,6 +638,8 @@ void FileIO::m_writeString(int nargs) {
 	Common::U32String unicodeString = Common::U32String(d.asString(), Common::kUtf8);
 	Common::String encodedString = unicodeString.encode(g_director->getPlatformEncoding());
 	me->_outStream->writeString(encodedString);
+	if (me->_readWriteStream && !encodedString.empty())
+		me->_readWriteChanged = true;
 
 	g_lingo->push(Datum(kErrorNone));
 }

--- a/engines/director/lingo/xlibs/f/fileio.h
+++ b/engines/director/lingo/xlibs/f/fileio.h
@@ -27,6 +27,7 @@ class SeekableReadStream;
 typedef SeekableReadStream InSaveFile;
 class OutSaveFile;
 class MemoryWriteStreamDynamic;
+class MemorySeekableReadWriteStreamDynamic;
 class String;
 }
 
@@ -51,11 +52,20 @@ enum FileIOError {
 	kErrorDirectoryNotFound = -120
 };
 
+enum FileIOOpenMode {
+	kFileIORead,
+	kFileIOWrite,
+	kFileIOAppend,
+	kFileIOReadWrite
+};
+
 class FileObject : public Object<FileObject> {
 public:
 	Common::String *_filename;
 	Common::SeekableReadStream *_inStream;
 	Common::MemoryWriteStreamDynamic *_outStream;
+	Common::MemorySeekableReadWriteStreamDynamic *_readWriteStream;
+	bool _readWriteChanged;
 	FileIOError _lastError;
 
 public:
@@ -67,9 +77,13 @@ public:
 	Datum getProp(const Common::String &propName) override;
 
 	FileIOError open(const Common::String &origpath, const Common::String &mode);
+	FileIOError open(const Common::String &origpath, FileIOOpenMode mode);
 	void clear();
 	FileIOError saveFileError();
 	void dispose() override;
+
+private:
+	FileIOError open(const Common::String &origpath, const Common::String &path, FileIOOpenMode mode, char dirSeparator);
 };
 
 namespace FileIO {

--- a/test/common/memoryseekablereadwritestreamdynamic.h
+++ b/test/common/memoryseekablereadwritestreamdynamic.h
@@ -1,0 +1,40 @@
+#include <cxxtest/TestSuite.h>
+
+#include "common/memstream.h"
+
+class MemorySeekableReadWriteStreamDynamicTestSuite : public CxxTest::TestSuite {
+public:
+	void testReadWriteAndSeek() {
+		Common::MemorySeekableReadWriteStreamDynamic stream(DisposeAfterUse::YES);
+		const char initial[] = "abcdef";
+		TS_ASSERT_EQUALS(stream.write(initial, 6), 6U);
+
+		TS_ASSERT(stream.seek(2));
+		const char replacement[] = "XY";
+		TS_ASSERT_EQUALS(stream.write(replacement, 2), 2U);
+		TS_ASSERT(stream.seek(-3, SEEK_END));
+		TS_ASSERT(stream.seek(-1, SEEK_CUR));
+
+		char result[5] = {};
+		TS_ASSERT_EQUALS(stream.read(result, 4), 4U);
+		TS_ASSERT_EQUALS(memcmp(result, "XYef", 4), 0);
+	}
+
+	void testGrowthAndReread() {
+		Common::MemorySeekableReadWriteStreamDynamic stream(DisposeAfterUse::YES);
+		const char initial[] = "abc";
+		TS_ASSERT_EQUALS(stream.write(initial, 3), 3U);
+		const char extension[] = "defghijklmnopqrstuvwxyz";
+		TS_ASSERT_EQUALS(stream.write(extension, 23), 23U);
+		TS_ASSERT_EQUALS(stream.size(), 26);
+
+		TS_ASSERT(stream.seek(0));
+		char result[27] = {};
+		TS_ASSERT_EQUALS(stream.read(result, 26), 26U);
+		TS_ASSERT_EQUALS(memcmp(result, "abcdefghijklmnopqrstuvwxyz", 26), 0);
+
+		TS_ASSERT(stream.seek(0));
+		TS_ASSERT_EQUALS(stream.read(result, 26), 26U);
+		TS_ASSERT_EQUALS(memcmp(result, "abcdefghijklmnopqrstuvwxyz", 26), 0);
+	}
+};


### PR DESCRIPTION
FileIO mode 0 opens a file for both reading and writing with a shared position. It was treated as append mode, leaving reads without an input stream.

Use a growable read/write stream so reads and writes advance the same position and writes overwrite existing data. Continue opening missing files as empty and retain append behavior for the XObject string API.