### PR TITLE
DIRECTOR: Apply cross-platform mappings to STXT

### DIFF
--- a/engines/director/cast.cpp
+++ b/engines/director/cast.cpp
@@ -2289,6 +2289,32 @@ Common::U32String Cast::decodeString(const Common::String &str) {
 	return fixedStr.decode(encoding);
 }
 
+Common::U32String Cast::decodeStringWithFont(const Common::String &str, uint16 fontId) {
+	Common::Platform targetPlatform = _vm->getPlatform();
+	if (_platform == targetPlatform)
+		return str.decode(detectFontEncoding(_platform, fontId));
+
+	Common::String mapped = str;
+	bool remapChars = true;
+	uint16 targetFontId = fontId;
+	if (_fontMap.contains(fontId)) {
+		remapChars = _fontMap[fontId]->remapChars;
+		targetFontId = _fontMap[fontId]->toFont;
+	}
+
+	if (remapChars) {
+		const CharMap &charMap = _platform == Common::kPlatformMacintosh
+				? _macCharsToWin : _winCharsToMac;
+		for (uint i = 0; i < mapped.size(); i++) {
+			byte value = (byte)mapped[i];
+			if (charMap.contains(value))
+				mapped.setChar(charMap[value], i);
+		}
+	}
+
+	return mapped.decode(detectFontEncoding(targetPlatform, targetFontId));
+}
+
 // Score order, 'Sord' resource
 //
 // Enlists all cast members as they're used in the movie

--- a/engines/director/cast.h
+++ b/engines/director/cast.h
@@ -148,6 +148,7 @@ public:
 
 	Common::CodePage getFileEncoding();
 	Common::U32String decodeString(const Common::String &str);
+	Common::U32String decodeStringWithFont(const Common::String &str, uint16 fontId);
 
 	// Script contexts keep a back-pointer to their owning cast.
 	void registerScriptContext(ScriptContext *ctx) { _liveScriptContexts.setVal(ctx, true); }

--- a/engines/director/fonts.cpp
+++ b/engines/director/fonts.cpp
@@ -96,6 +96,7 @@ void Cast::loadFontMapV4(Common::SeekableReadStreamEndian &stream) {
 
 		// Map cast font ID to window manager font ID
 		FontMapEntry *entry = new FontMapEntry;
+		entry->remapChars = platform != Common::kPlatformUnknown && platform != _vm->getPlatform();
 		if (platform != Common::kPlatformUnknown && platform != _vm->getPlatform() && _fontXPlatformMap.contains(name)) {
 			FontXPlatformInfo *xinfo = _fontXPlatformMap[name];
 			entry->toFont = _vm->_wm->_fontMan->registerFontName(xinfo->toFont, id);

--- a/engines/director/fonts.cpp
+++ b/engines/director/fonts.cpp
@@ -96,7 +96,7 @@ void Cast::loadFontMapV4(Common::SeekableReadStreamEndian &stream) {
 
 		// Map cast font ID to window manager font ID
 		FontMapEntry *entry = new FontMapEntry;
-		if (platform == Common::kPlatformWindows && _fontXPlatformMap.contains(name)) {
+		if (platform != Common::kPlatformUnknown && platform != _vm->getPlatform() && _fontXPlatformMap.contains(name)) {
 			FontXPlatformInfo *xinfo = _fontXPlatformMap[name];
 			entry->toFont = _vm->_wm->_fontMan->registerFontName(xinfo->toFont, id);
 			entry->remapChars = xinfo->remapChars;
@@ -418,16 +418,17 @@ bool Cast::readFXmpLine(Common::SeekableReadStreamEndian &stream) {
 			tok = readFXmpToken(stream);
 		}
 
-		// TODO: We should fill _fontXPlatformMap with mappings matching the current platform.
-		// We only have Mac fonts right now, though, so we'll always use the Win => Mac mappings.
 		// We only handle one fontmap per fromFont (happens in Clone Ranger)
-		if (fromPlatform == Common::kPlatformWindows) {
+		Common::Platform toPlatform = fromPlatform == Common::kPlatformMacintosh
+				? Common::kPlatformWindows : Common::kPlatformMacintosh;
+		if (toPlatform == _vm->getPlatform()) {
 			if (_fontXPlatformMap.contains(fromFont)) {
 				warning("Cast::readFxmpLine: Skip second map for font '%s'", fromFont.c_str());
 				delete info;
 			} else {
 				_fontXPlatformMap[fromFont] = info;
-				debugC(3, kDebugLoading, "Cast::readFXmpLine: Mapping Win font '%s' to Mac font '%s'", fromFont.c_str(), info->toFont.c_str());
+				debugC(3, kDebugLoading, "Cast::readFXmpLine: Mapping %s font '%s' to %s font '%s'",
+					getPlatformAbbrev(fromPlatform), fromFont.c_str(), getPlatformAbbrev(toPlatform), info->toFont.c_str());
 				debugC(4, kDebugLoading, "  Remap characters: %d", info->remapChars);
 				for (auto &it : info->sizeMap) {
 					debugC(4, kDebugLoading, "  Mapping size %d to %d", it._key, it._value);

--- a/engines/director/stxt.cpp
+++ b/engines/director/stxt.cpp
@@ -53,18 +53,6 @@ Stxt::Stxt(Cast *cast, Common::SeekableReadStreamEndian &textStream) : _cast(cas
 	Common::String text = textStream.readString(0, strLen);
 	debugC(3, kDebugText, "Stxt init: offset: %d strLen: %d dataLen: %d textlen: %u", offset, strLen, dataLen, text.size());
 
-	// TODO: Before applying formatting and decoding the text to a U32String,
-	// check if the following hold true:
-	// - The engine platform doesn't match the file platform
-	// - The movie has a valid font table (FXmp)
-	// - The font table has a mapping between the two platforms
-	// - The text has sections written in a font without a Map None qualifier
-	// If yes, then just those sections should be preprocessed by churning the
-	// bytes through the appropriate mapping (e.g. if running a Mac file on
-	// Windows, use the "Mac: => Win:" rules).
-	// Confirmed in real Director 4 that these sections are preprocessed in
-	// the cast member on startup and not faked at text render time.
-
 	uint16 formattingCount = textStream.readUint16();
 	uint32 prevPos = 0;
 
@@ -73,7 +61,7 @@ Stxt::Stxt(Cast *cast, Common::SeekableReadStreamEndian &textStream) : _cast(cas
 	Common::U32String logText;
 
 	while (formattingCount) {
-		uint16 currentFont = _style.fontId;
+		uint16 currentFont = _style.originalFontId;
 		_style.read(textStream, _cast);
 
 		assert(prevPos <= _style.formatStartOffset);  // If this is triggered, we have to implement sorting
@@ -90,8 +78,7 @@ Stxt::Stxt(Cast *cast, Common::SeekableReadStreamEndian &textStream) : _cast(cas
 			prevPos++;
 		}
 		_rtext += textPart;
-		Common::CodePage encoding = detectFontEncoding(cast->_platform, currentFont);
-		Common::U32String u32TextPart(textPart, encoding);
+		Common::U32String u32TextPart = cast->decodeStringWithFont(textPart, currentFont);
 		_ptext += u32TextPart;
 		_ftext += u32TextPart;
 		logText += Common::toPrintable(u32TextPart);
@@ -104,8 +91,7 @@ Stxt::Stxt(Cast *cast, Common::SeekableReadStreamEndian &textStream) : _cast(cas
 	}
 
 	_rtext += text;
-	Common::CodePage encoding = detectFontEncoding(cast->_platform, _style.fontId);
-	Common::U32String u32Text(text, encoding);
+	Common::U32String u32Text = cast->decodeStringWithFont(text, _style.originalFontId);
 	_ptext += u32Text;
 	_ftext += u32Text;
 	logText += Common::toPrintable(u32Text);
@@ -118,7 +104,7 @@ FontStyle::FontStyle() {
 	height = 0;
 	ascent = 0;
 
-	fontId = 0;
+	originalFontId = fontId = 0;
 	textSlant = 0;
 
 	fontSize = 12;
@@ -131,7 +117,7 @@ void FontStyle::read(Common::ReadStreamEndian &stream, Cast *cast) {
 	uint16 originalHeight = height = stream.readUint16();
 	ascent = stream.readUint16();
 
-	uint16 originalFontId = fontId = stream.readUint16();
+	originalFontId = fontId = stream.readUint16();
 	textSlant = stream.readByte();
 	stream.readByte(); // padding
 	fontSize = stream.readUint16();

--- a/engines/director/stxt.h
+++ b/engines/director/stxt.h
@@ -37,6 +37,7 @@ struct FontStyle {
 	uint16 ascent;
 
 	uint16 fontId;
+	uint16 originalFontId;
 	byte textSlant;
 
 	uint16 fontSize;


### PR DESCRIPTION
Select font mappings whose destination matches the emulated platform, then apply the appropriate character map to STXT text unless its source font specifies `Map None`.

Director FXmp resources define platform-specific font substitutions and character mappings, but ScummVM previously retained Windows-to-Mac font mappings only and decoded STXT without applying the character mapping selected for each font.

This fixes characters such as the German `ü` when a Windows projector loads text from a Macintosh-format cast, as seen in *Gary Gadget: Building Cars*.