### PR TITLE
DIRECTOR: Resolve implicit cast library references

### DIFF
--- a/engines/director/castmember/filmloop.cpp
+++ b/engines/director/castmember/filmloop.cpp
@@ -145,8 +145,8 @@ Common::Array<Channel> *FilmLoopCastMember::getSubChannels(Common::Rect &bbox, u
 		if (src._castId.isNull())
 			continue;
 
-		if (src._cast == nullptr && _cast != nullptr)
-			src.setCast(src._castId);
+		if (src._castId.castLib == -1 && _cast != nullptr)
+			src.setCast(src._castId, _cast->getCastMember(src._castId.member, true));
 
 		debugCN(5, kDebugImages, "FilmLoopCastMember::getSubChannels(): sprite: %d - cast: %s, orig: %d,%d %dx%d",
 				iter, src._castId.asString().c_str(),

--- a/engines/director/movie.cpp
+++ b/engines/director/movie.cpp
@@ -564,8 +564,15 @@ bool Movie::loadCastLibFrom(uint16 libId, Common::Path &filename) {
 	return true;
 }
 
+CastMemberID Movie::resolveCastMemberID(CastMemberID id) const {
+	if (id.castLib == -1)
+		id.castLib = DEFAULT_CAST_LIB;
+	return id;
+}
+
 CastMember *Movie::getCastMember(CastMemberID memberID) {
 	CastMember *result = nullptr;
+	memberID = resolveCastMemberID(memberID);
 	if (memberID.castLib == SHARED_CAST_LIB) {
 		if (_sharedCast)
 			result = _sharedCast->getCastMember(memberID.member);
@@ -585,6 +592,7 @@ CastMember *Movie::getCastMember(CastMemberID memberID) {
 }
 
 Cast *Movie::getCast(CastMemberID memberID) {
+	memberID = resolveCastMemberID(memberID);
 	if (memberID.castLib == SHARED_CAST_LIB)
 		return _sharedCast;
 
@@ -612,6 +620,7 @@ Cast *Movie::getCastByLibResourceID(uint32 libresourceID) {
 CastMember* Movie::createOrReplaceCastMember(CastMemberID memberID, CastMember* cast) {
 	warning("Movie::createOrReplaceCastMember: stubbed: functions only handles create");
 	CastMember *result = nullptr;
+	memberID = resolveCastMemberID(memberID);
 
 	if (_casts.contains(memberID.castLib)) {
 		// Delete existing cast member
@@ -624,6 +633,7 @@ CastMember* Movie::createOrReplaceCastMember(CastMemberID memberID, CastMember* 
 }
 
 bool Movie::eraseCastMember(CastMemberID memberID) {
+	memberID = resolveCastMemberID(memberID);
 	if (_casts.contains(memberID.castLib)) {
 		bool result = _casts.getVal(memberID.castLib)->eraseCastMember(memberID.member);
 		_score->refreshPointersForCastMemberID(memberID);
@@ -636,6 +646,8 @@ bool Movie::eraseCastMember(CastMemberID memberID) {
 bool Movie::duplicateCastMember(CastMemberID source, CastMemberID target) {
 	Cast *sourceCast = nullptr;
 	Cast *targetCast = nullptr;
+	source = resolveCastMemberID(source);
+	target = resolveCastMemberID(target);
 	if (_casts.contains(source.castLib)) {
 		if (_casts[source.castLib]->getCastMember(source.member)) {
 			sourceCast = _casts[source.castLib];
@@ -760,6 +772,7 @@ CastMemberID Movie::getCastMemberIDByNameAndType(const Common::String &name, int
 
 CastMemberInfo *Movie::getCastMemberInfo(CastMemberID memberID) {
 	CastMemberInfo *result = nullptr;
+	memberID = resolveCastMemberID(memberID);
 	if (_casts.contains(memberID.castLib)) {
 		result = _casts.getVal(memberID.castLib)->getCastMemberInfo(memberID.member);
 		if (result == nullptr && _sharedCast) {
@@ -778,6 +791,7 @@ bool Movie::isValidCastMember(CastMemberID memberID, CastType type) {
 
 const Stxt *Movie::getStxt(CastMemberID memberID) {
 	const Stxt *result = nullptr;
+	memberID = resolveCastMemberID(memberID);
 	if (_casts.contains(memberID.castLib)) {
 		result = _casts.getVal(memberID.castLib)->getStxt(memberID.member);
 		if (result == nullptr && _sharedCast) {
@@ -810,6 +824,7 @@ LingoArchive *Movie::getSharedLingoArch() {
 
 ScriptContext *Movie::getScriptContext(ScriptType type, CastMemberID id) {
 	ScriptContext *result = nullptr;
+	id = resolveCastMemberID(id);
 	if (_casts.contains(id.castLib)) {
 		result = _casts.getVal(id.castLib)->_lingoArchive->getScriptContext(type, id.member);
 		if (result == nullptr && _sharedCast) {

--- a/engines/director/movie.h
+++ b/engines/director/movie.h
@@ -150,6 +150,7 @@ public:
 
 private:
 	void loadFileInfo(Common::SeekableReadStreamEndian &stream);
+	CastMemberID resolveCastMemberID(CastMemberID id) const;
 
 	void queueEvent(Common::Queue<LingoEvent> &queue, LEvent event, int targetId = 0, Common::Point pos = Common::Point(-1, -1));
 	void queueSpriteEvent(Common::Queue<LingoEvent> &queue, LEvent event, int eventId, int spriteId);

--- a/engines/director/sprite.cpp
+++ b/engines/director/sprite.cpp
@@ -567,6 +567,10 @@ bool Sprite::checkSpriteType() {
 }
 
 void Sprite::setCast(CastMemberID memberID, bool replaceDims) {
+	setCast(memberID, _movie->getCastMember(memberID), replaceDims);
+}
+
+void Sprite::setCast(CastMemberID memberID, CastMember *cast, bool replaceDims) {
 	/**
 	 * There are two things we need to take into account here:
 	 *   1. The cast member's type
@@ -584,7 +588,7 @@ void Sprite::setCast(CastMemberID memberID, bool replaceDims) {
 	if (_cast) {
 		_cast->decRefCount();
 	}
-	_cast = _movie->getCastMember(_castId);
+	_cast = cast;
 	//As QDShapes don't have an associated cast, we must not change their _SpriteType.
 	if (g_director->getVersion() >= 400 && !isQDShape() && _castId != CastMemberID(0, 0))
 		_spriteType = kCastMemberSprite;

--- a/engines/director/sprite.h
+++ b/engines/director/sprite.h
@@ -121,6 +121,7 @@ public:
 	void setPattern(uint16 pattern);
 
 	void setCast(CastMemberID memberID, bool replaceDims = true);
+	void setCast(CastMemberID memberID, CastMember *cast, bool replaceDims = true);
 	bool isQDShape();
 	Graphics::Surface *getQDMatte();
 	void createQDMatte();


### PR DESCRIPTION
Movie score references use -1 for the default cast library. Resolve these IDs at movie lookup boundaries while retaining their stored values for score writes.

Film loop score references use -1 for their enclosing cast. Pass the resolved member to Sprite::setCast so the stored library reference is retained while the member pointer uses the existing refcount ownership.