### PR TITLE
DIRECTOR: Retain embedded sound resource sizes

### DIFF
--- a/engines/director/castmember/sound.cpp
+++ b/engines/director/castmember/sound.cpp
@@ -104,6 +104,7 @@ void SoundCastMember::load() {
 				if (!sndFormat)
 					sndFormat = new MoaSoundFormatDecoder();
 				sndFormat->loadSampleStream(*sndData);
+				_size = sndData->size();
 				delete sndData;
 			} else if (it.tag == MKTAG('e', 'd', 'i', 'M')) {
 				Common::SeekableReadStreamEndian *sndData = _cast->getResource(it.tag, it.index);
@@ -112,6 +113,7 @@ void SoundCastMember::load() {
 				if (!_audio) {
 					if (format.equalsIgnoreCase("kMoaCfFormat_AIFF")) {
 						_audio = new MoaStreamDecoder(format, sndData);
+						_size = sndData->size();
 						_loaded = true;
 						return;
 					} else {


### PR DESCRIPTION
D6 and D7 sound cast members can store media in sndS or ediM child resources. Record the child resource size so the Lingo size property reports the sound data rather than the empty CASt record.