### PR TITLE
VIDEO: Make loadStream function of video decoders free stream in case of failure

### DIFF
--- a/engines/bladerunner/vqa_decoder.cpp
+++ b/engines/bladerunner/vqa_decoder.cpp
@@ -182,17 +182,23 @@ bool VQADecoder::loadStream(Common::SeekableReadStream *s) {
 	uint32 type;
 
 	readIFFChunkHeader(s, &chd);
-	if (chd.id != kFORM || !chd.size)
+	if (chd.id != kFORM || !chd.size) {
+		close();
 		return false;
+	}
 
 	type = s->readUint32BE();
 
-	if (type != kWVQA)
+	if (type != kWVQA) {
+		close();
 		return false;
+	}
 
 	do {
-		if (!readIFFChunkHeader(_s, &chd))
+		if (!readIFFChunkHeader(_s, &chd)) {
+			close();
 			return false;
+		}
 
 		bool rc = false;
 		switch (chd.id) {
@@ -212,6 +218,7 @@ bool VQADecoder::loadStream(Common::SeekableReadStream *s) {
 
 		if (!rc) {
 			warning("failed to handle chunk %s", tag2str(chd.id));
+			close();
 			return false;
 		}
 	} while (chd.id != kFINF);

--- a/engines/chewy/video/cfo_decoder.cpp
+++ b/engines/chewy/video/cfo_decoder.cpp
@@ -59,8 +59,10 @@ enum CustomSubChunk {
 bool CfoDecoder::loadStream(Common::SeekableReadStream *stream) {
 	close();
 
-	if (stream->readUint32BE() != MKTAG('C', 'F', 'O', '\0'))
+	if (stream->readUint32BE() != MKTAG('C', 'F', 'O', '\0')) {
+		delete stream;
 		error("Corrupt video resource");
+	}
 
 	stream->readUint32LE();	// always 0
 

--- a/engines/director/castmember/digitalvideo.cpp
+++ b/engines/director/castmember/digitalvideo.cpp
@@ -70,10 +70,7 @@ public:
 			return false;
 		}
 
-		bool result = loadStream(file);
-		if (!result)
-			delete file;
-		return result;
+		return loadStream(file);
 	}
 
 	virtual bool loadStream(Common::SeekableReadStream *stream) override {

--- a/engines/eem/eem.cpp
+++ b/engines/eem/eem.cpp
@@ -1083,11 +1083,10 @@ void EEMEngine::playFlc(const Common::Path &path, bool fadeIn,
 	Video::FlicDecoder flic;
 	Common::ScopedPtr<Common::SeekableReadStream> stream(
 		Common::MacResManager::openFileOrDataFork(path));
-	if (!stream || !flic.loadStream(stream.get())) {
+	if (!stream || !flic.loadStream(stream.release())) {
 		warning("playFlc: %s missing", path.toString().c_str());
 		return;
 	}
-	stream.release();
 
 	const int fw = flic.getWidth();
 	const int fh = flic.getHeight();

--- a/engines/grim/movie/codecs/smush_decoder.cpp
+++ b/engines/grim/movie/codecs/smush_decoder.cpp
@@ -257,6 +257,7 @@ bool SmushDecoder::loadStream(Common::SeekableReadStream *stream) {
 	// Load the video
 	if (!readHeader()) {
 		warning("Failure loading SMUSH-file");
+		close();
 		return false;
 	}
 

--- a/engines/kyra/graphics/vqa.cpp
+++ b/engines/kyra/graphics/vqa.cpp
@@ -73,6 +73,7 @@ bool VQADecoder::loadStream(Common::SeekableReadStream *stream) {
 
 	if (_fileStream->readUint32BE() != MKTAG('F','O','R','M')) {
 		warning("VQADecoder::loadStream(): Cannot find `FORM' tag");
+		close();
 		return false;
 	}
 
@@ -82,6 +83,7 @@ bool VQADecoder::loadStream(Common::SeekableReadStream *stream) {
 
 	if (_fileStream->readUint32BE() != MKTAG('W','V','Q','A')) {
 		warning("VQADecoder::loadStream(): Cannot find `WVQA' tag");
+		close();
 		return false;
 	}
 
@@ -112,10 +114,12 @@ bool VQADecoder::loadStream(Common::SeekableReadStream *stream) {
 		case MKTAG('F','I','N','F'):
 			if (!foundVQHD) {
 				warning("VQADecoder::loadStream(): Found `FINF' before `VQHD'");
+				close();
 				return false;
 			}
 			if (size != 4 * getFrameCount()) {
 				warning("VQADecoder::loadStream(): Expected size %d for `FINF' chunk, but got %u", 4 * getFrameCount(), size);
+				close();
 				return false;
 			}
 			handleFINF(_fileStream);

--- a/engines/nancy/video.cpp
+++ b/engines/nancy/video.cpp
@@ -95,6 +95,7 @@ bool AVFDecoder::loadStream(Common::SeekableReadStream *stream) {
 
 	if (chunkFileFormat != 0x00020000 && chunkFileFormat != 0x00010000) {
 		warning("Unsupported version %d.%d found in AVF", chunkFileFormat >> 16, chunkFileFormat & 0xffff);
+		delete stream;
 		return false;
 	}
 

--- a/engines/pink/cel_decoder.cpp
+++ b/engines/pink/cel_decoder.cpp
@@ -36,6 +36,7 @@ bool CelDecoder::loadStream(Common::SeekableReadStream *stream) {
 	// Check FLC magic number
 	if (frameType != 0xAF12) {
 		warning("FlicDecoder::loadStream(): attempted to load non-FLC data (type = 0x%04X)", frameType);
+		delete stream;
 		return false;
 	}
 
@@ -45,6 +46,7 @@ bool CelDecoder::loadStream(Common::SeekableReadStream *stream) {
 	uint16 colorDepth = stream->readUint16LE();
 	if (colorDepth != 8) {
 		warning("FlicDecoder::loadStream(): attempted to load an FLC with a palette of color depth %d. Only 8-bit color palettes are supported", colorDepth);
+		delete stream;
 		return false;
 	}
 

--- a/engines/tot/decoder/TotFlicDecoder.cpp
+++ b/engines/tot/decoder/TotFlicDecoder.cpp
@@ -43,6 +43,7 @@ bool TotFlicDecoder::loadStream(Common::SeekableReadStream *stream) {
 	// Check FLC magic number
 	if (frameType != FLC_FILE_HEADER) {
 		warning("FlicDecoder::loadStream(): attempted to load non-FLC data (type = 0x%04X)", frameType);
+		delete stream;
 		return false;
 	}
 
@@ -52,6 +53,7 @@ bool TotFlicDecoder::loadStream(Common::SeekableReadStream *stream) {
 	uint16 colorDepth = stream->readUint16LE();
 	if (colorDepth != 8) {
 		warning("FlicDecoder::loadStream(): attempted to load an FLC with a palette of color depth %d. Only 8-bit color palettes are supported", colorDepth);
+		delete stream;
 		return false;
 	}
 

--- a/engines/voyeur/animation.cpp
+++ b/engines/voyeur/animation.cpp
@@ -71,6 +71,7 @@ bool RL2Decoder::loadStream(Common::SeekableReadStream *stream) {
 	// Check RL2 magic number
 	if (!_header.isValid()) {
 		warning("RL2Decoder::loadStream(): attempted to load non-RL2 data (0x%08X)", _header._signature);
+		close();
 		return false;
 	}
 

--- a/engines/voyeur/voyeur.cpp
+++ b/engines/voyeur/voyeur.cpp
@@ -882,24 +882,25 @@ void VoyeurEngine::synchronize(Common::Serializer &s) {
 }
 
 void VoyeurEngine::showLogo8Intro() {
-	Common::File file;
-	if(!file.open("logo8.exe")) {
+	Common::File *file = new Common::File();
+	if(!file->open("logo8.exe")) {
+		delete file;
 		return;
 	}
-	file.seek(2);
-	int lastPageLength = file.readUint16LE();
-	int numPages = file.readUint16LE();
+	file->seek(2);
+	int lastPageLength = file->readUint16LE();
+	int numPages = file->readUint16LE();
 	int exeLength = (numPages - 1) * 512 + lastPageLength;
 
 	// The MVE movie data is appended to the end of the EXE
-	file.seek(exeLength, SEEK_SET);
+	file->seek(exeLength, SEEK_SET);
 
 	Common::Keymapper *keymapper = g_system->getEventManager()->getKeymapper();
 	keymapper->getKeymap("voyeur-default")->setEnabled(false);
 	keymapper->getKeymap("intro")->setEnabled(true);
 
 	Video::MveDecoder *decoder = new Video::MveDecoder();
-	if (decoder->loadStream(&file)) {
+	if (decoder->loadStream(file)) {
 		decoder->setAudioTrack(0);
 		decoder->start();
 
@@ -943,7 +944,6 @@ void VoyeurEngine::showLogo8Intro() {
 	keymapper->getKeymap("intro")->setEnabled(false);
 	keymapper->getKeymap("voyeur-default")->setEnabled(true);
 
-	file.close();
 	delete decoder;
 }
 

--- a/engines/zvision/video/rlf_decoder.cpp
+++ b/engines/zvision/video/rlf_decoder.cpp
@@ -44,6 +44,7 @@ bool RLFDecoder::loadStream(Common::SeekableReadStream *stream) {
 		isValid = true;
 	} else {
 		warning("Invalid rlf stream");
+		delete stream;
 	}
 	debugC(5, kDebugVideo, "~loadStream()");	
 	return isValid;

--- a/video/avi_decoder.cpp
+++ b/video/avi_decoder.cpp
@@ -438,12 +438,14 @@ bool AVIDecoder::loadStream(Common::SeekableReadStream *stream) {
 
 	if (!stream->size()) {
 		debugC(8, kDebugLevelGVideo, "AVIDecoder::loadStream(): skipping empty stream");
+		delete stream;
 		return false;
 	}
 
 	uint32 riffTag = stream->readUint32BE();
 	if (riffTag != ID_RIFF) {
 		warning("Failed to find RIFF header");
+		delete stream;
 		return false;
 	}
 
@@ -452,6 +454,7 @@ bool AVIDecoder::loadStream(Common::SeekableReadStream *stream) {
 
 	if (riffType != ID_AVI) {
 		warning("RIFF not an AVI file");
+		delete stream;
 		return false;
 	}
 

--- a/video/bink_decoder.cpp
+++ b/video/bink_decoder.cpp
@@ -75,8 +75,10 @@ bool BinkDecoder::loadStream(Common::SeekableReadStream *stream) {
 	close();
 
 	uint32 id = stream->readUint32BE();
-	if ((id != kBIKfID) && (id != kBIKgID) && (id != kBIKhID) && (id != kBIKiID))
+	if ((id != kBIKfID) && (id != kBIKgID) && (id != kBIKhID) && (id != kBIKiID)) {
+		delete stream;
 		return false;
+	}
 
 	uint32 fileSize         = stream->readUint32LE() + 8;
 	uint32 frameCount       = stream->readUint32LE();
@@ -84,6 +86,7 @@ bool BinkDecoder::loadStream(Common::SeekableReadStream *stream) {
 
 	if (largestFrameSize > fileSize) {
 		warning("Largest frame size greater than file size");
+		delete stream;
 		return false;
 	}
 
@@ -96,6 +99,7 @@ bool BinkDecoder::loadStream(Common::SeekableReadStream *stream) {
 	uint32 frameRateDen = stream->readUint32LE();
 	if (frameRateNum == 0 || frameRateDen == 0) {
 		warning("Invalid frame rate (%d/%d)", frameRateNum, frameRateDen);
+		delete stream;
 		return false;
 	}
 

--- a/video/dxa_decoder.cpp
+++ b/video/dxa_decoder.cpp
@@ -48,7 +48,7 @@ bool DXADecoder::loadStream(Common::SeekableReadStream *stream) {
 	uint32 tag = stream->readUint32BE();
 
 	if (tag != MKTAG('D','E','X','A')) {
-		close();
+		delete stream;
 		return false;
 	}
 

--- a/video/flic_decoder.cpp
+++ b/video/flic_decoder.cpp
@@ -45,6 +45,7 @@ bool FlicDecoder::loadStream(Common::SeekableReadStream *stream) {
 	// Check FLC magic number
 	if (frameType != 0xAF12) {
 		warning("FlicDecoder::loadStream(): attempted to load non-FLC data (type = 0x%04X)", frameType);
+		delete stream;
 		return false;
 	}
 
@@ -54,6 +55,7 @@ bool FlicDecoder::loadStream(Common::SeekableReadStream *stream) {
 	uint16 colorDepth = stream->readUint16LE();
 	if (colorDepth != 8) {
 		warning("FlicDecoder::loadStream(): attempted to load an FLC with a palette of color depth %d. Only 8-bit color palettes are supported", colorDepth);
+		delete stream;
 		return false;
 	}
 

--- a/video/mve_decoder.cpp
+++ b/video/mve_decoder.cpp
@@ -55,10 +55,21 @@ MveDecoder::MveDecoder()
 
 MveDecoder::~MveDecoder() {
 	close();
+}
+
+void MveDecoder::close() {
+	VideoDecoder::close();
+
+	delete _s;
+	_s = nullptr;
 	delete _audioStream;
+	_audioStream = nullptr;
 	delete[] _frameData;
+	_frameData = nullptr;
 	delete[] _decodingMap;
+	_decodingMap = nullptr;
 	delete[] _skipMap;
+	_skipMap = nullptr;
 }
 
 static const char signature[] = "Interplay MVE File\x1A";
@@ -70,6 +81,7 @@ bool MveDecoder::loadStream(Common::SeekableReadStream *stream) {
 	stream->read(signature_buffer, sizeof(signature_buffer));
 	if (memcmp(signature_buffer, signature, sizeof(signature))) {
 		warning("MveDecoder::loadStream(): attempted to load non-MVE data");
+		delete stream;
 		return false;
 	}
 	_s = stream;
@@ -321,6 +333,7 @@ void MveDecoder::readNextPacket() {
 				assert((flags & 1) == 0);
 				assert((flags & 2) == 0);
 
+				delete _audioStream;
 				_audioStream = Audio::makeQueuingAudioStream(sampleRate, (flags & 2) != 0);
 				addTrack(new MveAudioTrack(this));
 

--- a/video/mve_decoder.h
+++ b/video/mve_decoder.h
@@ -156,6 +156,7 @@ public:
 	MveDecoder();
 	virtual ~MveDecoder();
 
+	void close() override;
 	bool loadStream(Common::SeekableReadStream *stream) override;
 	void setAudioTrack(int track);
 	void applyPalette(PaletteManager *paletteManager);

--- a/video/video_decoder.cpp
+++ b/video/video_decoder.cpp
@@ -84,10 +84,7 @@ bool VideoDecoder::loadFile(const Common::Path &filename) {
 		return false;
 	}
 
-	bool result = loadStream(file);
-	if (!result)
-		delete file;
-	return result;
+	return loadStream(file);
 }
 
 bool VideoDecoder::needsUpdate() const {

--- a/video/video_decoder.h
+++ b/video/video_decoder.h
@@ -72,7 +72,7 @@ public:
 	/**
 	 * Load a video from a generic read stream. The ownership of the
 	 * stream object transfers to this VideoDecoder instance, which is
-	 * hence also responsible for eventually deleting it.
+	 * hence also responsible for eventually deleting it even in case of failure.
 	 *
 	 * Implementations of this function are required to call addTrack()
 	 * for each track in the video upon success.


### PR DESCRIPTION
The loadStream function of video decoders is not consistent across decoders.
Most of them free the stream even in case of failure, while some free it only in case of success.
Also, AVIDecoder frees the stream or not depending on the failure.

This can trigger double free errors when invalid files are met.

I tried to review and make consistent all the video decoders to make them free the stream even in all cases.
I also tried to review every call to loadStream and fix when there would be a double free.

This is not (yet) tested.