### PR TITLE
DIRECTOR: Normalize built-in palette IDs consistently

### DIFF
--- a/engines/director/director.h
+++ b/engines/director/director.h
@@ -204,6 +204,7 @@ public:
 	void shiftPalette(int startIndex, int endIndex, bool reverse);
 	void syncPalette();
 	void clearPalettes();
+	CastMemberID resolvePaletteId(CastMemberID id) const;
 	PaletteV4 *getPalette(CastMemberID id);
 	bool hasPalette(CastMemberID id);
 	void loadDefaultPalettes();

--- a/engines/director/graphics.cpp
+++ b/engines/director/graphics.cpp
@@ -138,13 +138,18 @@ void DirectorEngine::loadDefaultPalettes() {
 	_loaded4Palette = PaletteV4(CastMemberID(kClutGrayscale, -1), grayscale4Palette, 4);
 }
 
+CastMemberID DirectorEngine::resolvePaletteId(CastMemberID id) const {
+	if (id.member < 0)
+		id.castLib = -1;
+
+	return id;
+}
+
 PaletteV4 *DirectorEngine::getPalette(CastMemberID id) {
 	if (id.isNull())
 		return nullptr;
 
-	// Reference to internal palettes
-	if (id.member < 0)
-		id.castLib = -1; // Ensure we use the default palette set
+	id = resolvePaletteId(id);
 
 	if (!_loadedPalettes.contains(id)) {
 		warning("DirectorEngine::getPalette(): Palette %s not found, hash %x", id.asString().c_str(), id.hash());
@@ -155,9 +160,7 @@ PaletteV4 *DirectorEngine::getPalette(CastMemberID id) {
 }
 
 bool DirectorEngine::hasPalette(CastMemberID id) {
-	// Reference to internal palettes
-	if (id.member < 0)
-		id.castLib = -1; // Ensure we use the default palette set
+	id = resolvePaletteId(id);
 
 	return _loadedPalettes.contains(id);
 }

--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1044,7 +1044,7 @@ bool Score::renderPrePaletteCycle(RenderMode mode) {
 		return false;
 
 	// Skip this if we don't have a palette instruction
-	CastMemberID currentPalette = _currentFrame->_mainChannels.palette.paletteId;
+	CastMemberID currentPalette = _vm->resolvePaletteId(_currentFrame->_mainChannels.palette.paletteId);
 	if (currentPalette.isNull())
 		return false;
 
@@ -1077,7 +1077,7 @@ bool Score::renderPrePaletteCycle(RenderMode mode) {
 		if (_currentFrame->_mainChannels.palette.normal) {
 			// If the target palette ID is the same as the previous palette ID,
 			// a normal fade is a no-op.
-			if (_currentFrame->_mainChannels.palette.paletteId == _vm->_lastPalette) {
+			if (currentPalette == _vm->_lastPalette) {
 				return false;
 			}
 
@@ -1161,7 +1161,7 @@ void Score::setLastPalette() {
 		return;
 
 	bool isCachedPalette = false;
-	CastMemberID currentPalette = _currentFrame->_mainChannels.palette.paletteId;
+	CastMemberID currentPalette = _vm->resolvePaletteId(_currentFrame->_mainChannels.palette.paletteId);
 	// Director allows you to use palette IDs for cast members
 	// that have long since been erased. Check all of them.
 	if (!_vm->hasPalette(currentPalette))
@@ -1170,13 +1170,13 @@ void Score::setLastPalette() {
 	if (currentPalette.isNull()) {
 		// Use the score cached palette ID
 		isCachedPalette = true;
-		currentPalette = _currentFrame->_mainChannels.scoreCachedPaletteId;
+		currentPalette = _vm->resolvePaletteId(_currentFrame->_mainChannels.scoreCachedPaletteId);
 		if (!_vm->hasPalette(currentPalette))
 			currentPalette = CastMemberID();
 		// The cached ID is created before the cast gets loaded; if it's zero,
 		// this corresponds to the movie default palette.
 		if (currentPalette.isNull()) {
-			currentPalette = _vm->getCurrentMovie()->_defaultPalette;
+			currentPalette = _vm->resolvePaletteId(_vm->getCurrentMovie()->_defaultPalette);
 		}
 		// If for whatever reason this doesn't resolve, abort.
 		if (currentPalette.isNull())
@@ -1210,7 +1210,7 @@ void Score::renderPaletteCycle(RenderMode mode) {
 
 	// If the palette is defined in the frame and doesn't match
 	// the current one, set it
-	CastMemberID currentPalette = _currentFrame->_mainChannels.palette.paletteId;
+	CastMemberID currentPalette = _vm->resolvePaletteId(_currentFrame->_mainChannels.palette.paletteId);
 	if (currentPalette.isNull())
 		return;
 


### PR DESCRIPTION
D6+ files commonly use cast library 0 for built-in palettes. ScummVM registers them under cast library -1. Palette lookup handles this, but score state comparisons do not.

Share normalization across palette lookup, transitions, cycling, and cached palette selection while preserving IDs read from the file.