### PR TITLE
DIRECTOR: Skip palette fades after movie switches

### DIFF
--- a/engines/director/score.cpp
+++ b/engines/director/score.cpp
@@ -1048,6 +1048,13 @@ bool Score::renderPrePaletteCycle(RenderMode mode) {
 	if (currentPalette.isNull())
 		return false;
 
+	// A movie switch clears the previous palette ID. Install the new palette
+	// without fading from the outgoing movie's frame.
+	if (_vm->_lastPalette.isNull()) {
+		_vm->setPalette(currentPalette);
+		return false;
+	}
+
 	if (!_currentFrame->_mainChannels.palette.colorCycling &&
 		!_currentFrame->_mainChannels.palette.overTime) {
 


### PR DESCRIPTION
Movie switches clear the last palette ID so custom palettes with reused cast IDs are reloaded. Palette cycling subsequently treats the incoming palette as a transition and fades from the outgoing movie's frame.

Install the incoming palette immediately when no previous palette ID is available. Later palette changes continue to use their authored fades.