### PR TITLE
DIRECTOR: LINGO: Report whether deleteProp removed an entry

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1010,23 +1010,30 @@ void LB::b_deleteProp(int nargs) {
 	Datum prop = g_lingo->pop();
 	Datum list = g_lingo->pop();
 	TYPECHECK2(list, ARRAY, PARRAY);
+	bool deleted = false;
 
 	switch (list.type) {
-	case ARRAY:
-		g_lingo->push(list);
-		g_lingo->push(prop);
-		b_deleteAt(nargs);
+	case ARRAY: {
+		int index = prop.asInt();
+		if (index > 0 && index <= (int)list.u.farr->arr.size()) {
+			list.u.farr->arr.remove_at(index - 1);
+			deleted = true;
+		}
 		break;
+	}
 	case PARRAY: {
 		int index = LC::compareArrays(LC::eqData, list, prop, true).u.i;
 		if (index > 0) {
 			list.u.parr->arr.remove_at(index - 1);
+			deleted = true;
 		}
 		break;
 	}
 	default:
 		break;
 	}
+
+	g_lingo->_theResult = deleted ? 1 : 0;
 }
 
 

--- a/engines/director/lingo/tests/lists.lingo
+++ b/engines/director/lingo/tests/lists.lingo
@@ -231,6 +231,21 @@ scummvmAssertEqual(testList, [5, "URGH", 3, 1])
 
 
 -- deleteProp
+set testList to [1, 2, 3, 4]
+deleteProp testList, 3
+scummvmAssertEqual(testList, [1, 2, 4])
+scummvmAssertEqual(the result, 1)
+deleteProp testList, 5
+scummvmAssertEqual(testList, [1, 2, 4])
+scummvmAssertEqual(the result, 0)
+
+set testList to [#a: 1, #b: 2, #c: 3]
+deleteProp testList, #b
+scummvmAssertEqual(testList, [#a: 1, #c: 3])
+scummvmAssertEqual(the result, 1)
+deleteProp testList, #missing
+scummvmAssertEqual(testList, [#a: 1, #c: 3])
+scummvmAssertEqual(the result, 0)
 
 
 -- findPos


### PR DESCRIPTION
deleteProp did not update the result after operating on either kind of list. It also delegated ordinary lists to deleteAt, which could attempt to remove an invalid index.

Remove entries directly after validating the index or property, and set the result to indicate whether an entry was removed.