### PR TITLE
DIRECTOR: LINGO: Treat points and rects as lists

### DIFF
--- a/engines/director/lingo/lingo-builtins.cpp
+++ b/engines/director/lingo/lingo-builtins.cpp
@@ -1032,7 +1032,7 @@ void LB::b_deleteProp(int nargs) {
 
 void LB::b_duplicateList(int nargs) {
 	Datum list = g_lingo->pop();
-	TYPECHECK2(list, ARRAY, PARRAY);
+	TYPECHECK4(list, ARRAY, PARRAY, POINT, RECT);
 	g_lingo->push(list.clone());
 }
 
@@ -1200,10 +1200,12 @@ void LB::b_getOne(int nargs) {
 void LB::b_getPos(int nargs) {
 	Datum val = g_lingo->pop();
 	Datum list = g_lingo->pop();
-	TYPECHECK2(list, ARRAY, PARRAY);
+	TYPECHECK4(list, ARRAY, PARRAY, POINT, RECT);
 
 	switch (list.type) {
-	case ARRAY: {
+	case ARRAY:
+	case POINT:
+	case RECT: {
 		Datum d(0);
 		int index = LC::compareArrays(LC::eqDataStrict, list, val, true).u.i;
 		if (index > 0) {
@@ -1316,7 +1318,7 @@ void LB::b_list(int nargs) {
 void LB::b_listP(int nargs) {
 	Datum list = g_lingo->pop();
 	Datum d(0);
-	if (list.type == ARRAY || list.type == PARRAY) {
+	if (list.isArray() || list.type == PARRAY) {
 		d.u.i = 1;
 	}
 	g_lingo->push(d);

--- a/engines/director/lingo/lingo.cpp
+++ b/engines/director/lingo/lingo.cpp
@@ -1344,7 +1344,9 @@ Datum Datum::clone() const {
 	Datum result;
 	switch (type) {
 	case ARRAY:
-		result.type = ARRAY;
+	case POINT:
+	case RECT:
+		result.type = type;
 		result.u.farr = new FArray;
 		for (auto &it : u.farr->arr) {
 			result.u.farr->arr.push_back(it.clone());

--- a/engines/director/lingo/tests/lists.lingo
+++ b/engines/director/lingo/tests/lists.lingo
@@ -343,6 +343,17 @@ scummvmAssertEqual(getProp(testList, 3), #c)
 
 
 -- listP
+scummvmAssertEqual(listP([1, 2]), 1)
+scummvmAssertEqual(listP([#a: 1]), 1)
+scummvmAssertEqual(listP(point(10, 20)), 1)
+scummvmAssertEqual(listP(rect(10, 20, 30, 40)), 1)
+scummvmAssertEqual(listP(10), 0)
+
+-- getPos
+scummvmAssertEqual(getPos(point(10, 20), 20), 2)
+scummvmAssertEqual(getPos(point(10, 20), 30), 0)
+scummvmAssertEqual(getPos(rect(10, 20, 30, 40), 30), 3)
+scummvmAssertEqual(getPos(rect(10, 20, 30, 40), 50), 0)
 
 
 -- max


### PR DESCRIPTION
Director treats point and rect values as lists. Recognize them in listP, allow getPos to search their coordinates, and let duplicate create independent values without losing their types.
