### PR TITLE
VIDEO: Fix double free on AVIDecoder::loadStream failure

### DIFF
--- a/video/avi_decoder.cpp
+++ b/video/avi_decoder.cpp
@@ -476,12 +476,16 @@ bool AVIDecoder::loadStream(Common::SeekableReadStream *stream) {
 
 	if (!_decodedHeader) {
 		warning("Failed to parse AVI header");
+		// The caller still owns the stream on failure; detach it so close()
+		// does not delete it a second time.
+		_fileStream = nullptr;
 		close();
 		return false;
 	}
 
 	if (!_foundMovieList) {
 		warning("Failed to find 'MOVI' list");
+		_fileStream = nullptr;
 		close();
 		return false;
 	}


### PR DESCRIPTION
`loadStream()` assigns `_fileStream = stream`, then calls `close()` on its two late failure paths. `close()` deletes `_fileStream`, but the caller still owns the stream: `VideoDecoder::loadFile()` deletes it when `loadStream()` returns false.

The second delete runs a virtual destructor through a freed object's vtable pointer. Detach the stream before `close()` on both paths.