### PR TITLE
BACKENDS: Do not link WebMIDI in libretro Emscripten builds

### DIFF
--- a/base/plugins.cpp
+++ b/base/plugins.cpp
@@ -142,7 +142,7 @@ public:
 		LINK_PLUGIN(FLUIDSYNTH)
 		#endif
 
-		#ifdef EMSCRIPTEN
+		#if defined(EMSCRIPTEN) && !defined(__LIBRETRO__)
 		LINK_PLUGIN(WEBMIDI)
 		#endif
 		#ifdef USE_MT32EMU


### PR DESCRIPTION
The WebMIDI driver's `EM_JS` glue needs a `midiOutputMap` global and a `Module.setValue` export, which `dists/emscripten/custom_shell-pre.js` provides. The libretro core is an Emscripten build that does not use that shell, so device enumeration throws during engine startup.

Link it only when not building for libretro, matching the existing `__LIBRETRO__` check a few lines above. libretro reaches MIDI through `LINK_PLUGIN(LIBRETRO_MIDI)` instead.